### PR TITLE
Fix avr_read() for page reads

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -331,7 +331,7 @@ int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype,
 
   /* supports "paged load" thru post-increment */
   if ((p->flags & AVRPART_HAS_TPI) && mem->page_size > 1 &&
-      pgm->cmd_tpi != NULL) {
+      mem->size % mem->page_size == 0 && pgm->cmd_tpi != NULL) {
 
     while (avr_tpi_poll_nvmbsy(pgm));
 
@@ -361,7 +361,8 @@ int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype,
     return avr_mem_hiaddr(mem);
   }
 
-  if (pgm->paged_load != NULL && mem->page_size > 1) {
+  if (pgm->paged_load != NULL && mem->page_size > 1 &&
+      mem->size % mem->page_size == 0) {
     /*
      * the programmer supports a paged mode read
      */


### PR DESCRIPTION
Here comes a bugfix for #481. There is a buffer overrun because avr_read() attempts to do page reads for the signature buffer (which only has a size of 3). We may want to round up every memory buffer allocation to the next page size multiple so that page reads can be used, but that is another issue.
 