### PR TITLE
Add PicKit4 and SNAP programmers

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -216,8 +216,8 @@ The Atmel DFU bootloader is supported in both, FLIP protocol version 1
 (AT90USB* and ATmega*U* devices), as well as version 2 (Xmega devices).
 See below for some hints about FLIP version 1 protocol behaviour.
 .Pp
-The MPLAB(R) PICkit 4, MPLAB(R) SNAP, and Curiosity Nano boards are
-supported in UPDI mode. The Curiosity Nano board is dubbed
+The MPLAB(R) PICkit 4 and MPLAB(R) SNAP, are supported in ISP, PDI and UPDI mode.
+The Curiosity Nano board is supported in UPDI mode. It is dubbed
 .Dq PICkit on Board ,
 thus the name
 .Pa pkobn_updi .

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1275,9 +1275,41 @@ programmer
 ;
 
 programmer
+  id    = "pickit4_pdi";
+  desc  = "MPLAB(R) PICkit 4 in PDI mode";
+  type  = "jtagice3_pdi";
+  connection_type = usb;
+  usbpid = 0x2177, 0x2178, 0x2179;
+;
+
+programmer
+   id    = "pickit4_isp";
+   desc  = "MPLAB(R) PICkit 4 in ISP mode";
+   type  = "jtagice3_isp";
+   connection_type = usb;
+   usbpid = 0x2177, 0x2178, 0x2179;
+;
+
+programmer
   id    = "snap_updi";
   desc  = "MPLAB(R) SNAP in UPDI mode";
   type  = "jtagice3_updi";
+  connection_type = usb;
+  usbpid = 0x217F, 0x2180, 0x2181;
+;
+
+programmer
+  id    = "snap_pdi";
+  desc  = "MPLAB(R) SNAP in PDI mode";
+  type  = "jtagice3_pdi";
+  connection_type = usb;
+  usbpid = 0x217F, 0x2180, 0x2181;
+;
+
+programmer
+  id    = "snap_isp";
+  desc  = "MPLAB(R) SNAP in ISP mode";
+  type  = "jtagice3_isp";
   connection_type = usb;
   usbpid = 0x217F, 0x2180, 0x2181;
 ;

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -303,8 +303,8 @@ The Atmel DFU bootloader is supported in both, FLIP protocol version 1
 (AT90USB* and ATmega*U* devices), as well as version 2 (Xmega devices).
 See below for some hints about FLIP version 1 protocol behaviour.
 
-The MPLAB(R) PICkit 4, MPLAB(R) SNAP, and Curiosity Nano boards are
-supported in UPDI mode. The Curiosity Nano board is dubbed ``PICkit on
+The MPLAB(R) PICkit 4 and MPLAB(R) SNAP are supported in ISP, PDI and UPDI mode.
+The Curiosity Nano board is supported in UPDI mode. It is dubbed ``PICkit on
 Board'', thus the name @code{pkobn_updi}.
 
 SerialUPDI programmer implementation is based on Microchip's 


### PR DESCRIPTION
The Pickit4 and SNAP programmers can also be used as PDI and ISP programmers. This PR adds ISP and PDI support to the Pickit4 and SNAP programmers.

I can confirm that the ISP and PDI options on both programmers work; I've tested it on actual hardware.