### PR TITLE
avrftdi: don't use the deprecated ftdi_usb_purge_buffers routine

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ option(DEBUG_CMAKE "Enable debugging output for this CMake project" OFF)
 
 include(CheckIncludeFile)
 include(CheckFunctionExists)
+include(CheckSymbolExists)
 include(GNUInstallDirs)
 
 set(CONFIG_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}")
@@ -177,6 +178,8 @@ find_library(HAVE_LIBFTDI1 NAMES ${PREFERRED_LIBFTDI1})
 if(HAVE_LIBFTDI1)
     set(LIB_LIBFTDI1 ${HAVE_LIBFTDI1})
     set(HAVE_LIBFTDI_TYPE_232H 1)
+    set(CMAKE_REQUIRED_LIBRARIES ${LIB_LIBFTDI1} ${LIB_LIBUSB} ${LIB_LIBUSB_1_0})
+    check_symbol_exists(ftdi_tcioflush "libftdi1/ftdi.h" HAVE_FTDI_TCIOFLUSH)
 endif()
 
 # -------------------------------------

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -720,7 +720,11 @@ static int avrftdi_open(PROGRAMMER * pgm, char *port)
 	/* set SPI mode */
 	E(ftdi_set_bitmode(pdata->ftdic, 0, BITMODE_RESET) < 0, pdata->ftdic);
 	E(ftdi_set_bitmode(pdata->ftdic, pdata->pin_direction & 0xff, BITMODE_MPSSE) < 0, pdata->ftdic);
+#ifdef HAVE_FTDI_TCIOFLUSH
+	E(ftdi_tcioflush(pdata->ftdic), pdata->ftdic);
+#else
 	E(ftdi_usb_purge_buffers(pdata->ftdic), pdata->ftdic);
+#endif
 
 	write_flush(pdata);
 

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -50,6 +50,9 @@
 /* Define if lex/flex has yylex_destroy */
 #cmakedefine HAVE_YYLEX_DESTROY 1
 
+/* Define if ftdi1 has 'ftdi_tcioflush' function. */
+#cmakedefine HAVE_FTDI_TCIOFLUSH 1
+
 /* ----- Libraries and Headers ----- */
 
 /* Define to 1 if the system has the type `uint_t'. */

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -195,7 +195,7 @@ if test x$have_libftdi1 = xyes; then
    LIBFTDI1="-lftdi1"
    AC_DEFINE([HAVE_LIBFTDI1])
    AC_SUBST(LIBFTDI1, $LIBFTDI1)
-   LIBS="${LIBFTDI1}"
+   LIBS="${LIBS} ${LIBFTDI1}"
    AC_CHECK_FUNCS(ftdi_tcioflush)
 else
    if test x$have_libftdi = xyes; then

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -195,6 +195,8 @@ if test x$have_libftdi1 = xyes; then
    LIBFTDI1="-lftdi1"
    AC_DEFINE([HAVE_LIBFTDI1])
    AC_SUBST(LIBFTDI1, $LIBFTDI1)
+   LIBS="${LIBFTDI1}"
+   AC_CHECK_FUNCS(ftdi_tcioflush)
 else
    if test x$have_libftdi = xyes; then
       LIBFTDI="-lftdi -lusb"


### PR DESCRIPTION
Since commit ed46f09c1ccd1351e003a200ba50e3e4778ac478 (Implement
tc[io]flush methods & deprecate broken purge_buffers methods.)
`ftdi_usb_purge_buffers()` routine is deprecated. Use `HAVE_FTDI_TCIOFLUSH`
macro to invoke the newly introduced `ftdi_tcioflush()` routine.