### PR TITLE
buspirate: fix -Wtautological-constant-out-of-range-compare

### DIFF
--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -195,7 +195,7 @@ static char *buspirate_readline_noexit(struct programmer_t *pgm, char *buf, size
 			continue;
 		if (*buf_p == '\n')
 			break;
-		if (*buf_p == EOF) {
+		if ((int)*buf_p == EOF) {
 			*buf_p = '\0';
 			break;
 		}


### PR DESCRIPTION
When compiling with clang 11.0.1 the following warning appears:

buspirate.c:198:14: warning: result of comparison of constant -1 with expression of type 'char' is always false [-Wtautological-constant-out-of-range-compare]
                if (*buf_p == EOF) {
                    ~~~~~~ ^  ~~~
Cast `char` to `int` to match the EOF type.