### PR TITLE
Ignore ctags index file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ avrdude
 libtool
 ltmain.sh
 ylwrap
+tags
 
 *.o
 *.lo


### PR DESCRIPTION
ctags creates an index file called `tags`.