### PR TITLE
serbb_win32: fix pointer-to-int-cast warning

### DIFF
--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -308,8 +308,8 @@ static int serbb_open(PROGRAMMER *pgm, char *port)
                         progname, port);
                 return -1;
 	}
-        avrdude_message(MSG_DEBUG, "%s: ser_open(): opened comm port \"%s\", handle 0x%x\n",
-                        progname, port, (int)hComPort);
+        avrdude_message(MSG_DEBUG, "%s: ser_open(): opened comm port \"%s\", handle 0x%p\n",
+                        progname, port, hComPort);
 
         pgm->fd.pfd = (void *)hComPort;
 
@@ -326,8 +326,8 @@ static void serbb_close(PROGRAMMER *pgm)
 		pgm->setpin(pgm, PIN_AVR_RESET, 1);
 		CloseHandle (hComPort);
 	}
-        avrdude_message(MSG_DEBUG, "%s: ser_close(): closed comm port handle 0x%x\n",
-                                progname, (int)hComPort);
+        avrdude_message(MSG_DEBUG, "%s: ser_close(): closed comm port handle 0x%p\n",
+                                progname, hComPort);
 
 	hComPort = INVALID_HANDLE_VALUE;
 }


### PR DESCRIPTION
`HANDLE` is defined as `void*` hence it should be printed as a pointer
i.e. `%p`.