### PR TITLE
buspirate: fix invalidScanfArgType_int warning

### DIFF
--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -857,7 +857,8 @@ static int buspirate_cmd_ascii(struct programmer_t *pgm,
 {
 	char buf[25];
 	char *rcvd;
-	int spi_write, spi_read, i = 0;
+	int i = 0;
+	unsigned int spi_write, spi_read;
 
 	snprintf(buf, sizeof(buf), "0x%02x 0x%02x 0x%02x 0x%02x\n",
 		cmd[0], cmd[1], cmd[2], cmd[3]);


### PR DESCRIPTION
"%x" specifies an `unsigned int`, hence change the type of `spi_write`, `spi_read`
accordingly.