### PR TITLE
Add more memory sections to read from

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16209,6 +16209,42 @@ part
         readsize	= 0x3D;
     ;
 
+    memory "sernum"
+        size		= 10;
+        offset		= 0x1104;
+        readsize	= 1;
+    ;
+
+    memory "osccal16"
+        size		= 2;
+        offset		= 0x1118;
+        readsize	= 1;
+    ;
+
+    memory "osccal20"
+        size		= 2;
+        offset		= 0x111A;
+        readsize	= 1;
+    ;
+
+    memory "tempsense"
+        size		= 2;
+        offset		= 0x1120;
+        readsize	= 1;
+    ;
+
+    memory "osc16err"
+        size		= 2;
+        offset		= 0x1122;
+        readsize	= 1;
+    ;
+
+    memory "osc20err"
+        size		= 2;
+        offset		= 0x1124;
+        readsize	= 1;
+    ;
+
     memory "fuses"
         size		= 9;
         offset		= 0x1280;
@@ -16222,7 +16258,19 @@ part
         readsize  = 1;
     ;
 
+    memory "wdtcfg"
+        size		= 1;
+        offset		= 0x1280;
+        readsize  = 1;
+    ;
+
     memory "fuse1"
+        size		= 1;
+        offset		= 0x1281;
+        readsize  = 1;
+    ;
+
+    memory "bodcfg"
         size		= 1;
         offset		= 0x1281;
         readsize  = 1;
@@ -16234,7 +16282,19 @@ part
         readsize  = 1;
     ;
 
+    memory "osccfg"
+        size		= 1;
+        offset		= 0x1282;
+        readsize  = 1;
+    ;
+
     memory "fuse4"
+        size		= 1;
+        offset		= 0x1284;
+        readsize  = 1;
+    ;
+
+    memory "tcd0cfg"
         size		= 1;
         offset		= 0x1284;
         readsize  = 1;
@@ -16246,7 +16306,19 @@ part
         readsize  = 1;
     ;
 
+    memory "syscfg0"
+        size		= 1;
+        offset		= 0x1285;
+        readsize  = 1;
+    ;
+
     memory "fuse6"
+        size		= 1;
+        offset		= 0x1286;
+        readsize  = 1;
+    ;
+
+    memory "syscfg1"
         size		= 1;
         offset		= 0x1286;
         readsize  = 1;
@@ -16258,7 +16330,19 @@ part
         readsize  = 1;
     ;
 
+    memory "append"
+        size		= 1;
+        offset		= 0x1287;
+        readsize  = 1;
+    ;
+
     memory "fuse8"
+        size		= 1;
+        offset		= 0x1288;
+        readsize  = 1;
+    ;
+
+    memory "bootend"
         size		= 1;
         offset		= 0x1288;
         readsize  = 1;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -17429,6 +17429,18 @@ part
         readsize	= 0x7D;
     ;
 
+    memory "tempsense"
+        size		= 2;
+        offset		= 0x1104;
+        readsize	= 1;
+    ;
+
+    memory "sernum"
+        size		= 16;
+        offset		= 0x1110;
+        readsize	= 1;
+    ;
+
     memory "fuses"
         size		= 9;
         offset		= 0x1050;
@@ -17442,7 +17454,19 @@ part
         readsize  = 1;
     ;
 
+    memory "wdtcfg"
+        size		= 1;
+        offset		= 0x1050;
+        readsize  = 1;
+    ;
+
     memory "fuse1"
+        size		= 1;
+        offset		= 0x1051;
+        readsize  = 1;
+    ;
+
+    memory "bodcfg"
         size		= 1;
         offset		= 0x1051;
         readsize  = 1;
@@ -17454,7 +17478,19 @@ part
         readsize  = 1;
     ;
 
+    memory "osccfg"
+        size		= 1;
+        offset		= 0x1052;
+        readsize  = 1;
+    ;
+
     memory "fuse4"
+        size		= 1;
+        offset		= 0x1054;
+        readsize  = 1;
+    ;
+
+    memory "tcd0cfg"
         size		= 1;
         offset		= 0x1054;
         readsize  = 1;
@@ -17466,7 +17502,19 @@ part
         readsize  = 1;
     ;
 
+    memory "syscfg0"
+        size		= 1;
+        offset		= 0x1055;
+        readsize  = 1;
+    ;
+
     memory "fuse6"
+        size		= 1;
+        offset		= 0x1056;
+        readsize  = 1;
+    ;
+
+    memory "syscfg1"
         size		= 1;
         offset		= 0x1056;
         readsize  = 1;
@@ -17478,7 +17526,31 @@ part
         readsize  = 1;
     ;
 
+    memory "codesize"
+        size		= 1;
+        offset		= 0x1057;
+        readsize  = 1;
+    ;
+
+    memory "append"
+        size		= 1;
+        offset		= 0x1057;
+        readsize  = 1;
+    ;
+
     memory "fuse8"
+        size		= 1;
+        offset		= 0x1058;
+        readsize  = 1;
+    ;
+
+    memory "bootsize"
+        size		= 1;
+        offset		= 0x1058;
+        readsize  = 1;
+    ;
+
+    memory "bootend"
         size		= 1;
         offset		= 0x1058;
         readsize  = 1;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -372,9 +372,10 @@ AVRMEM * avr_locate_mem(AVRPART * p, char * desc)
 }
 
 
-void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, int type,
-                     int verbose)
+void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, AVRPART * p,
+                     int type, int verbose)
 {
+  static unsigned int prev_mem_offset, prev_mem_size;
   int i, j;
   char * optr;
 
@@ -393,17 +394,21 @@ void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, int type,
               "%s----------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------\n",
               prefix, prefix, prefix);
     }
-    fprintf(f,
-            "%s%-11s %4d %5d %5d %4d %-6s %6d %4d %6d %5d %5d 0x%02x 0x%02x\n",
-            prefix, m->desc, m->mode, m->delay, m->blocksize, m->pollindex,
-            m->paged ? "yes" : "no",
-            m->size,
-            m->page_size,
-            m->num_pages,
-            m->min_write_delay,
-            m->max_write_delay,
-            m->readback[0],
-            m->readback[1]);
+    if ((prev_mem_offset != m->offset || prev_mem_size != m->size) || (strcmp(p->family_id, "") == 0)) { // Don't print memory aliases
+      prev_mem_offset = m->offset;
+      prev_mem_size = m->size;
+      fprintf(f,
+              "%s%-11s %4d %5d %5d %4d %-6s %6d %4d %6d %5d %5d 0x%02x 0x%02x\n",
+              prefix, m->desc, m->mode, m->delay, m->blocksize, m->pollindex,
+              m->paged ? "yes" : "no",
+              m->size,
+              m->page_size,
+              m->num_pages,
+              m->min_write_delay,
+              m->max_write_delay,
+              m->readback[0],
+              m->readback[1]);
+    }
     if (verbose > 4) {
       avrdude_message(MSG_TRACE2, "%s  Memory Ops:\n"
                       "%s    Oeration     Inst Bit  Bit Type  Bitno  Value\n"
@@ -669,11 +674,11 @@ void avr_display(FILE * f, AVRPART * p, const char * prefix, int verbose)
   }
 
   if (verbose <= 2) {
-    avr_mem_display(px, f, NULL, 0, verbose);
+    avr_mem_display(px, f, NULL, p, 0, verbose);
   }
   for (ln=lfirst(p->mem); ln; ln=lnext(ln)) {
     m = ldata(ln);
-    avr_mem_display(px, f, m, i, verbose);
+    avr_mem_display(px, f, m, p, i, verbose);
   }
 
   if (buf)

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -626,40 +626,33 @@ void avr_display(FILE * f, AVRPART * p, const char * prefix, int verbose)
   LNODEID ln;
   AVRMEM * m;
 
-  fprintf(f,
-          "%sAVR Part                      : %s\n"
-          "%sChip Erase delay              : %d us\n"
-          "%sPAGEL                         : P%02X\n"
-          "%sBS2                           : P%02X\n"
-          "%sRESET disposition             : %s\n"
-          "%sRETRY pulse                   : %s\n"
-          "%sserial program mode           : %s\n"
-          "%sparallel program mode         : %s\n"
-          "%sTimeout                       : %d\n"
-          "%sStabDelay                     : %d\n"
-          "%sCmdexeDelay                   : %d\n"
-          "%sSyncLoops                     : %d\n"
-          "%sByteDelay                     : %d\n"
-          "%sPollIndex                     : %d\n"
-          "%sPollValue                     : 0x%02x\n"
-          "%sMemory Detail                 :\n\n",
-          prefix, p->desc,
-          prefix, p->chip_erase_delay,
-          prefix, p->pagel,
-          prefix, p->bs2,
-          prefix, reset_disp_str(p->reset_disposition),
-          prefix, avr_pin_name(p->retry_pulse),
-          prefix, (p->flags & AVRPART_SERIALOK) ? "yes" : "no",
-          prefix, (p->flags & AVRPART_PARALLELOK) ?
-            ((p->flags & AVRPART_PSEUDOPARALLEL) ? "pseudo" : "yes") : "no",
-          prefix, p->timeout,
-          prefix, p->stabdelay,
-          prefix, p->cmdexedelay,
-          prefix, p->synchloops,
-          prefix, p->bytedelay,
-          prefix, p->pollindex,
-          prefix, p->pollvalue,
-          prefix);
+  fprintf(  f, "%sAVR Part                      : %s\n", prefix, p->desc);
+  if (p->chip_erase_delay)
+    fprintf(f, "%sChip Erase delay              : %d us\n", prefix, p->chip_erase_delay);
+  if (p->pagel)
+    fprintf(f, "%sPAGEL                         : P%02X\n", prefix, p->pagel);
+  if (p->bs2)
+    fprintf(f, "%sBS2                           : P%02X\n", prefix, p->bs2);
+  fprintf(  f, "%sRESET disposition             : %s\n", prefix, reset_disp_str(p->reset_disposition));
+  fprintf(  f, "%sRETRY pulse                   : %s\n", prefix, avr_pin_name(p->retry_pulse));
+  fprintf(  f, "%sSerial program mode           : %s\n", prefix, (p->flags & AVRPART_SERIALOK) ? "yes" : "no");
+  fprintf(  f, "%sParallel program mode         : %s\n", prefix, (p->flags & AVRPART_PARALLELOK) ?
+         ((p->flags & AVRPART_PSEUDOPARALLEL) ? "pseudo" : "yes") : "no");
+  if(p->timeout)
+    fprintf(f, "%sTimeout                       : %d\n", prefix, p->timeout);
+  if(p->stabdelay)
+    fprintf(f, "%sStabDelay                     : %d\n", prefix, p->stabdelay);
+  if(p->cmdexedelay)
+    fprintf(f, "%sCmdexeDelay                   : %d\n", prefix, p->cmdexedelay);
+  if(p->synchloops)
+    fprintf(f, "%sSyncLoops                     : %d\n", prefix, p->synchloops);
+  if(p->bytedelay)
+    fprintf(f, "%sByteDelay                     : %d\n", prefix, p->bytedelay);
+  if(p->pollindex)
+    fprintf(f, "%sPollIndex                     : %d\n", prefix, p->pollindex);
+  if(p->pollvalue)
+    fprintf(f, "%sPollValue                     : 0x%02x\n", prefix, p->pollvalue);
+  fprintf(  f, "%sMemory Detail                 :\n\n", prefix);
 
   px = prefix;
   i = strlen(prefix) + 5;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -320,8 +320,8 @@ int avr_initmem(AVRPART * p);
 AVRMEM * avr_dup_mem(AVRMEM * m);
 void     avr_free_mem(AVRMEM * m);
 AVRMEM * avr_locate_mem(AVRPART * p, char * desc);
-void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, int type,
-                     int verbose);
+void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, AVRPART * p,
+                     int type, int verbose);
 
 /* Functions for AVRPART structures */
 AVRPART * avr_new_part(void);


### PR DESCRIPTION
I thought I'll submit this so you can review this @dl8dtl.

This PR adds more memory sections to read on "modern" megaAVRs  and  tinyAVRs, and it also improves the Avrdude output in verbose mode so that duplicate memory entries don't get printed twice.

I ended up using `p->family_id`, since this field is only present on "modern" megaAVRs  and  tinyAVRs.

Tested on "classic" AVRs, "modern" ones, and xmegas.

Closes #749 