### PR TITLE
pindefs: conform to the function declaration

### DIFF
--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -217,7 +217,7 @@ const char * pinmask_to_str(const pinmask_t * const pinmask) {
  * @param[in] size the number of entries in checklist
  * @returns 0 if all pin definitions are valid, -1 otherwise
  */
-int pins_check(const struct programmer_t * const pgm, const struct pin_checklist_t * const checklist, const int size, bool output) {
+int pins_check(const struct programmer_t * const pgm, const struct pin_checklist_t * const checklist, const int size, const bool output) {
   static const struct pindef_t no_valid_pins = {{0}, {0}}; // default value if check list does not contain anything else
   int rv = 0; // return value
   int pinname; // loop counter through pinnames


### PR DESCRIPTION
The last parameter in the `pins_check()` routine is declared as
`const bool`. Add the missing `const` specifier.