### PR TITLE
Remove ac_cfg.h from libavrdude.h

### DIFF
--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "ac_cfg.h"
 #include "avrdude.h"
 #include "libavrdude.h"
 

--- a/src/confwin.c
+++ b/src/confwin.c
@@ -17,6 +17,7 @@
  */
 
 
+#include "ac_cfg.h"
 #include "avrdude.h"
 #include "libavrdude.h"
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "ac_cfg.h"
 #include "avrdude.h"
 #include "libavrdude.h"
 #include "config.h"

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -21,9 +21,6 @@
 #ifndef libavrdude_h
 #define libavrdude_h
 
-/* XXX should go away */
-#include "ac_cfg.h"
-
 #include <stdio.h>
 #include <limits.h>
 #include <stdbool.h>

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "ac_cfg.h"
 #include "avrdude.h"
 #include "libavrdude.h"
 

--- a/src/update.c
+++ b/src/update.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <time.h>
 
+#include "ac_cfg.h"
 #include "avrdude.h"
 #include "libavrdude.h"
 


### PR DESCRIPTION
Inclusion of ac_cfg.h is not needed, and contradicts the library idea.