### PR TITLE
CMake: enable dynamic-link library for libavrdude

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -586,6 +586,8 @@ add_library(libavrdude
     ${BISON_Parser_OUTPUTS}
     )
     
+set_target_properties(libavrdude PROPERTIES PREFIX "")
+
 target_include_directories(libavrdude
     PUBLIC
     "${PROJECT_SOURCE_DIR}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ option(HAVE_PARPORT "Enable parallel port support" OFF)
 option(USE_EXTERNAL "Use external libraries from AVRDUDE GitHub repositories" OFF)
 option(USE_LIBUSBWIN32 "Prefer libusb-win32 over libusb" OFF)
 option(DEBUG_CMAKE "Enable debugging output for this CMake project" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 include(CheckIncludeFile)
 include(CheckSymbolExists)
@@ -476,7 +477,7 @@ endif()
 # Project
 # =====================================
 
-add_library(libavrdude STATIC
+add_library(libavrdude
     ac_cfg.h
     arduino.h
     arduino.c


### PR DESCRIPTION
Add on option `BUILD_SHARED_LIBS` to also build a DLL variant
of the `libavrdude` library. Turn it off by default to preserve
current behavior.