### PR TITLE
Add missing tinyAVR-2, AVR DD and AVR EA targets

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -18410,6 +18410,294 @@ part parent    ".avrdx"
 ;
 
 #------------------------------------------------------------
+# AVR16DD14
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr16dd14";
+    desc      = "AVR16DD14";
+    signature = 0x1E 0x94 0x34;
+
+    memory "flash"
+        size      = 0x4000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR16DD20
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr16dd20";
+    desc      = "AVR16DD20";
+    signature = 0x1E 0x94 0x33;
+
+    memory "flash"
+        size      = 0x4000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR16DD28
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr16dd28";
+    desc      = "AVR16DD28";
+    signature = 0x1E 0x94 0x32;
+
+    memory "flash"
+        size      = 0x4000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR16DD32
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr16dd32";
+    desc      = "AVR16DD32";
+    signature = 0x1E 0x94 0x31;
+
+    memory "flash"
+        size      = 0x4000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32DD14
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr32dd14";
+    desc      = "AVR32DD14";
+    signature = 0x1E 0x95 0x3B;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32DD20
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr32dd20";
+    desc      = "AVR32DD20";
+    signature = 0x1E 0x95 0x3A;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32DD28
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr32dd28";
+    desc      = "AVR32DD28";
+    signature = 0x1E 0x95 0x39;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32DD32
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr32dd28";
+    desc      = "AVR32DD28";
+    signature = 0x1E 0x95 0x38;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64DD14
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr64dd14";
+    desc      = "AVR64DD14";
+    signature = 0x1E 0x96 0x1D;
+
+    memory "flash"
+        size      = 0x10000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64DD20
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr64dd20";
+    desc      = "AVR64DD20";
+    signature = 0x1E 0x96 0x1C;
+
+    memory "flash"
+        size      = 0x10000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64DD28
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr64dd28";
+    desc      = "AVR64DD28";
+    signature = 0x1E 0x96 0x1B;
+
+    memory "flash"
+        size      = 0x10000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64DD32
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id        = "avr64dd32";
+    desc      = "AVR64DD32";
+    signature = 0x1E 0x96 0x1A;
+
+    memory "flash"
+        size      = 0x10000;
+        offset    = 0x800000;
+        page_size = 0x200;
+        readsize  = 0x200;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
 # Logic Green parts
 #------------------------------------------------------------
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -18582,8 +18582,8 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32dd28";
-    desc      = "AVR32DD28";
+    id        = "avr32dd32";
+    desc      = "AVR32DD32";
     signature = 0x1E 0x95 0x38;
 
     memory "flash"
@@ -18691,6 +18691,286 @@ part parent    ".avrdx"
 
     memory "eeprom"
         size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR-Ex family common values
+#------------------------------------------------------------
+
+part parent    ".avrdx"
+    id			= ".avrex";
+    desc		= "AVR-Ex family common values";
+
+    memory "userrow"
+        size      = 0x40;
+        offset    = 0x1080;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR8EA28
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr8ea28";
+    desc      = "AVR8EA28";
+    signature = 0x1E 0x93 0x2C;
+
+    memory "flash"
+        size      = 0x2000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR8EA32
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr8ea32";
+    desc      = "AVR8EA32";
+    signature = 0x1E 0x93 0x2B;
+
+    memory "flash"
+        size      = 0x2000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR16EA28
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr16ea28";
+    desc      = "AVR16EA28";
+    signature = 0x1E 0x94 0x37;
+
+    memory "flash"
+        size      = 0x4000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR16EA32
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr16ea32";
+    desc      = "AVR16EA32";
+    signature = 0x1E 0x94 0x36;
+
+    memory "flash"
+        size      = 0x4000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR16EA48
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr16ea48";
+    desc      = "AVR16EA48";
+    signature = 0x1E 0x94 0x35;
+
+    memory "flash"
+        size      = 0x4000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32EA28
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr32ea28";
+    desc      = "AVR32EA28";
+    signature = 0x1E 0x95 0x3E;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32EA32
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr32ea32";
+    desc      = "AVR32EA32";
+    signature = 0x1E 0x95 0x3D;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32EA48
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr32ea48";
+    desc      = "AVR32EA48";
+    signature = 0x1E 0x95 0x3C;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x800000;
+        page_size = 0x40;
+        readsize  = 0x40;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64EA28
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr64ea28";
+    desc      = "AVR64EA28";
+    signature = 0x1E 0x96 0x20;
+
+    memory "flash"
+        size      = 0x10000;
+        offset    = 0x800000;
+        page_size = 0x80;
+        readsize  = 0x80;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64EA32
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr64ea32";
+    desc      = "AVR64EA32";
+    signature = 0x1E 0x96 0x1F;
+
+    memory "flash"
+        size      = 0x10000;
+        offset    = 0x800000;
+        page_size = 0x80;
+        readsize  = 0x80;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
+        offset    = 0x1400;
+        page_size = 0x1;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64EA48
+#------------------------------------------------------------
+
+part parent    ".avrex"
+    id        = "avr64ea48";
+    desc      = "AVR64EA48";
+    signature = 0x1E 0x96 0x1E;
+
+    memory "flash"
+        size      = 0x10000;
+        offset    = 0x800000;
+        page_size = 0x80;
+        readsize  = 0x80;
+    ;
+
+    memory "eeprom"
+        size      = 0x200;
         offset    = 0x1400;
         page_size = 0x1;
         readsize  = 0x100;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -17519,6 +17519,78 @@ part parent    ".avr8x_tiny"
 ;
 
 #------------------------------------------------------------
+# ATtiny3224
+#------------------------------------------------------------
+
+part parent    ".avr8x_tiny"
+    id        = "t3224";
+    desc      = "ATtiny3224";
+    signature = 0x1E 0x95 0x28;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x8000;
+        page_size = 0x80;
+        readsize  = 0x100;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x40;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny3226
+#------------------------------------------------------------
+
+part parent    ".avr8x_tiny"
+    id        = "t3226";
+    desc      = "ATtiny3226";
+    signature = 0x1E 0x95 0x27;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x8000;
+        page_size = 0x80;
+        readsize  = 0x100;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x40;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny3227
+#------------------------------------------------------------
+
+part parent    ".avr8x_tiny"
+    id        = "t3227";
+    desc      = "ATtiny3227";
+    signature = 0x1E 0x95 0x26;
+
+    memory "flash"
+        size      = 0x8000;
+        offset    = 0x8000;
+        page_size = 0x80;
+        readsize  = 0x100;
+    ;
+
+    memory "eeprom"
+        size      = 0x100;
+        offset    = 0x1400;
+        page_size = 0x40;
+        readsize  = 0x100;
+    ;
+;
+
+#------------------------------------------------------------
 # ATmega808
 #------------------------------------------------------------
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -18422,7 +18422,7 @@ part parent    ".avrdx"
         size      = 0x4000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18446,7 +18446,7 @@ part parent    ".avrdx"
         size      = 0x4000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18470,7 +18470,7 @@ part parent    ".avrdx"
         size      = 0x4000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18494,7 +18494,7 @@ part parent    ".avrdx"
         size      = 0x4000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18518,7 +18518,7 @@ part parent    ".avrdx"
         size      = 0x8000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18542,7 +18542,7 @@ part parent    ".avrdx"
         size      = 0x8000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18566,7 +18566,7 @@ part parent    ".avrdx"
         size      = 0x8000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18590,7 +18590,7 @@ part parent    ".avrdx"
         size      = 0x8000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18614,7 +18614,7 @@ part parent    ".avrdx"
         size      = 0x10000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18638,7 +18638,7 @@ part parent    ".avrdx"
         size      = 0x10000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18662,7 +18662,7 @@ part parent    ".avrdx"
         size      = 0x10000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18686,7 +18686,7 @@ part parent    ".avrdx"
         size      = 0x10000;
         offset    = 0x800000;
         page_size = 0x200;
-        readsize  = 0x200;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
@@ -18726,13 +18726,13 @@ part parent    ".avrex"
         size      = 0x2000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18750,13 +18750,13 @@ part parent    ".avrex"
         size      = 0x2000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18774,13 +18774,13 @@ part parent    ".avrex"
         size      = 0x4000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18798,13 +18798,13 @@ part parent    ".avrex"
         size      = 0x4000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18822,13 +18822,13 @@ part parent    ".avrex"
         size      = 0x4000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18846,13 +18846,13 @@ part parent    ".avrex"
         size      = 0x8000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18870,13 +18870,13 @@ part parent    ".avrex"
         size      = 0x8000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18894,13 +18894,13 @@ part parent    ".avrex"
         size      = 0x8000;
         offset    = 0x800000;
         page_size = 0x40;
-        readsize  = 0x40;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18918,13 +18918,13 @@ part parent    ".avrex"
         size      = 0x10000;
         offset    = 0x800000;
         page_size = 0x80;
-        readsize  = 0x80;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18942,13 +18942,13 @@ part parent    ".avrex"
         size      = 0x10000;
         offset    = 0x800000;
         page_size = 0x80;
-        readsize  = 0x80;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;
@@ -18966,13 +18966,13 @@ part parent    ".avrex"
         size      = 0x10000;
         offset    = 0x800000;
         page_size = 0x80;
-        readsize  = 0x80;
+        readsize  = 0x100;
     ;
 
     memory "eeprom"
         size      = 0x200;
         offset    = 0x1400;
-        page_size = 0x1;
+        page_size = 0x8;
         readsize  = 0x100;
     ;
 ;


### PR DESCRIPTION
This PR adds the following targets:

* ATtiny3224, ATtiny3226 and ATtiny3227. 
    - These are considered "safe", because I borrowed these from [megaTinyCore](https://github.com/SpenceKonde/megaTinyCore), and they have been tested on actual hardware.
* AVR16DD14/20/28/32, AVR32DD14/20/28/32 and AVR64DD14/20/28/32
* AVR8EA28/32, AVR16EA28/32/48, AVR32EA28/32/48 and AVR64EA28/32/64

For the AVR DD and EA series, I've used the source files from the [`pymcuprog`](https://github.com/microchip-pic-avr-tools/pymcuprog) project to get the necessary details. Please review closely. I've made sure the signature, memory sizes, and page sizes are correct, but please do the same to verify that it is correct. I don't own any DD or EA hardware, and due to the silicon crisis, neither of us won't for a long time I think.



https://github.com/microchip-pic-avr-tools/pymcuprog/tree/main/pymcuprog/deviceinfo/devices