### PR TITLE
jtagmkii: Reduce the number of sync attempts to 10 + print number of attempts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,7 @@ Changes since version 6.4:
     - PicKit4 / SNAP (now also in ISP and PDI mode)
     - Teensy bootloader (PR #802)
     - Micronucleus bootloader (PR #786)
+    - ft232h (generic variant, PR #842)
 
   * Issues fixed:
 
@@ -99,6 +100,7 @@ Changes since version 6.4:
     - Added missing RTS/DTR management feature to serialupdi
       programmer #811
     - Add missing tinyAVR-2, AVR DD and AVR EA targets #836
+    - Add a new programmer ft232h #842
 
   * Internals:
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -675,7 +675,7 @@ int jtagmkII_recv(PROGRAMMER * pgm, unsigned char **msg) {
 
 int jtagmkII_getsync(PROGRAMMER * pgm, int mode) {
   int tries;
-#define MAXTRIES 33
+#define MAXTRIES 10
   unsigned char buf[3], *resp, c = 0xff;
   int status;
   unsigned int fwver, hwver;
@@ -696,15 +696,14 @@ int jtagmkII_getsync(PROGRAMMER * pgm, int mode) {
 
     /* Get the sign-on information. */
     buf[0] = CMND_GET_SIGN_ON;
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_getsync(): Sending sign-on command: ",
-	      progname);
+    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_getsync() attempt %d of %d: Sending sign-on command: ",
+	      progname, tries + 1, MAXTRIES);
     jtagmkII_send(pgm, buf, 1);
 
     status = jtagmkII_recv(pgm, &resp);
     if (status <= 0) {
-	avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): sign-on command: "
-		"status %d\n",
-		progname, status);
+	    avrdude_message(MSG_INFO, "%s: jtagmkII_getsync() attempt %d of %d: sign-on command: status %d\n",
+		      progname, tries + 1, MAXTRIES, status);
     } else if (verbose >= 3) {
       putc('\n', stderr);
       jtagmkII_prmsg(pgm, resp, status);


### PR DESCRIPTION
This PR is mainly for jtag2updi programmer that uses a "1200bps touch" to enter programming mode, such as the [Arduino Nano Every](https://store-usa.arduino.cc/products/arduino-nano-every).

Instead of waiting a long time if the 1200bps thing didn't work out, there are now only 10 attempts instead of 34, and the number of attempts is now printed on the screen. It's now also more similar to the message that's printed out when Avrdude can't connect to an stk500 programmer: `avrdude: stk500_getsync() attempt 1 of 10: not in sync: resp=0x00`.

Current output:
```
$ ./avrdude -C avrdude.conf -v -patmega4809 -cjtag2updi -P /dev/cu.usbserial

avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : /dev/cu.usbserial
         Using Programmer              : jtag2updi
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): sign-on command: status -1
avrdude: jtagmkII_getsync(): timeout/error communicating with programmer (status -1)
avrdude: opening programmer "jtag2updi" on port "/dev/cu.usbserial" failed

avrdude done.  Thank you.
```

With PR:
```
$ ./avrdude -C avrdude.conf -v -patmega4809 -cjtag2updi -P /dev/cu.usbserial
avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : /dev/cu.usbserial
         Using Programmer              : jtag2updi
avrdude: jtagmkII_getsync() attempt 1 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 2 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 3 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 4 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 5 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 6 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 7 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 8 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 9 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync() attempt 10 of 10: sign-on command: status -1
avrdude: jtagmkII_getsync(): timeout/error communicating with programmer (status -1)
avrdude: opening programmer "jtag2updi" on port "/dev/cu.usbserial" failed
```