### PR TITLE
Reduce verbosity when setting fuses and uploading programs

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -330,7 +330,7 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
       avrdude_message(MSG_INFO, "%s: verifying %s memory against %s:\n",
             progname, mem->desc, upd->filename);
 
-      avrdude_message(MSG_INFO, "%s: load data %s data from input file %s:\n",
+      avrdude_message(MSG_NOTICE2, "%s: load data %s data from input file %s:\n",
             progname, mem->desc, upd->filename);
     }
 
@@ -343,9 +343,9 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     v = avr_dup_part(p);
     size = rc;
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: input file %s contains %d bytes\n",
+      avrdude_message(MSG_NOTICE2, "%s: input file %s contains %d bytes\n",
             progname, upd->filename, size);
-      avrdude_message(MSG_INFO, "%s: reading on-chip %s data:\n",
+      avrdude_message(MSG_NOTICE2, "%s: reading on-chip %s data:\n",
             progname, mem->desc);
     }
 
@@ -363,7 +363,7 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
 
 
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: verifying ...\n", progname);
+      avrdude_message(MSG_NOTICE2, "%s: verifying ...\n", progname);
     }
     rc = avr_verify(p, v, upd->memtype, size);
     if (rc < 0) {


### PR DESCRIPTION
On targets that have multiple fuses to write, the Avrdude output tends to become quite long. This PR reduces the verbosity slightly when no or a single -v flag has been provided.

Output with this PR (178 lines total):

<details>

```
./avrdude -C avrdude.conf -patmega4809 -cserialupdi -P /dev/cu.u* -Uflash:w:/var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex:i -Ufuse0:w:0x00:m -Ufuse1:w:0x54:m -Ufuse2:w:0x01:m -Ufuse4:w:0x00:m -Ufuse5:w:0b11001001:m -Ufuse6:w:0x06:m -Ufuse7:w:0x00:m -Ufuse8:w:0x00:m -Ulock:w:0xC5:m -v

avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : /dev/cu.usbserial-1410
         Using Programmer              : serialupdi
         AVR Part                      : ATmega4809
         Chip Erase delay              : 0 us
         PAGEL                         : P00
         BS2                           : P00
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         serial program mode           : yes
         parallel program mode         : yes
         Timeout                       : 0
         StabDelay                     : 0
         CmdexeDelay                   : 0
         SyncLoops                     : 0
         ByteDelay                     : 0
         PollIndex                     : 0
         PollValue                     : 0x00
         Memory Detail                 :

                                  Block Poll               Page                       Polled
           Memory Type Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           signature      0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig        0     0     0    0 no         61   61      0     0     0 0x00 0x00
           fuses          0     0     0    0 no          9   10      0     0     0 0x00 0x00
           fuse0          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse1          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse4          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse6          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse7          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse8          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           lock           0     0     0    0 no          1    1      0     0     0 0x00 0x00
           data           0     0     0    0 no          0    1      0     0     0 0x00 0x00
           usersig        0     0     0    0 no         64   64      0     0     0 0x00 0x00
           flash          0     0     0    0 no      49152  128      0     0     0 0x00 0x00
           eeprom         0     0     0    0 no        256   64      0     0     0 0x00 0x00

         Programmer Type : serialupdi
         Description     : SerialUPDI

avrdude: UPDI link initialization OK
avrdude: NVM type 0: 16-bit, page oriented write
avrdude: Entering NVM programming mode
avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.02s

avrdude: Device signature = 0x1e9651 (probably m4809)
avrdude: NOTE: "flash" memory has been specified, an erase cycle will be performed
         To disable this feature, specify the -D option.
avrdude: erasing chip
avrdude: reading input file "/var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex"
avrdude: writing flash (776 bytes):

Writing | ################################################## | 100% 0.28s

avrdude: 776 bytes of flash written
avrdude: verifying flash memory against /var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex:

Reading | ################################################## | 100% 0.15s

avrdude: 776 bytes of flash verified
avrdude: reading input file "0x00"
avrdude: writing fuse0 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse0 written
avrdude: verifying fuse0 memory against 0x00:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse0 verified
avrdude: reading input file "0x54"
avrdude: writing fuse1 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse1 written
avrdude: verifying fuse1 memory against 0x54:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse1 verified
avrdude: reading input file "0x01"
avrdude: writing fuse2 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse2 written
avrdude: verifying fuse2 memory against 0x01:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse2 verified
avrdude: reading input file "0x00"
avrdude: writing fuse4 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse4 written
avrdude: verifying fuse4 memory against 0x00:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse4 verified
avrdude: reading input file "0b11001001"
avrdude: writing fuse5 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse5 written
avrdude: verifying fuse5 memory against 0b11001001:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse5 verified
avrdude: reading input file "0x06"
avrdude: writing fuse6 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse6 written
avrdude: verifying fuse6 memory against 0x06:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse6 verified
avrdude: reading input file "0x00"
avrdude: writing fuse7 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse7 written
avrdude: verifying fuse7 memory against 0x00:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse7 verified
avrdude: reading input file "0x00"
avrdude: writing fuse8 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse8 written
avrdude: verifying fuse8 memory against 0x00:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of fuse8 verified
avrdude: reading input file "0xC5"
avrdude: writing lock (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of lock written
avrdude: verifying lock memory against 0xC5:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of lock verified

avrdude: safemode: Fuses OK (E:FF, H:FF, L:FF)
avrdude: Leaving NVM programming mode

avrdude done.  Thank you.
```

</details>

<br/>

Output without this PR (218 lines total):

<details>

```
./avrdude -C avrdude.conf -patmega4809 -cserialupdi -P /dev/cu.u* -Uflash:w:/var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex:i -Ufuse0:w:0x00:m -Ufuse1:w:0x54:m -Ufuse2:w:0x01:m -Ufuse4:w:0x00:m -Ufuse5:w:0b11001001:m -Ufuse6:w:0x06:m -Ufuse7:w:0x00:m -Ufuse8:w:0x00:m -Ulock:w:0xC5:m -v

avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : /dev/cu.usbserial-1410
         Using Programmer              : serialupdi
         AVR Part                      : ATmega4809
         Chip Erase delay              : 0 us
         PAGEL                         : P00
         BS2                           : P00
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         serial program mode           : yes
         parallel program mode         : yes
         Timeout                       : 0
         StabDelay                     : 0
         CmdexeDelay                   : 0
         SyncLoops                     : 0
         ByteDelay                     : 0
         PollIndex                     : 0
         PollValue                     : 0x00
         Memory Detail                 :

                                  Block Poll               Page                       Polled
           Memory Type Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           signature      0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig        0     0     0    0 no         61   61      0     0     0 0x00 0x00
           fuses          0     0     0    0 no          9   10      0     0     0 0x00 0x00
           fuse0          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse1          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse4          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse6          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse7          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse8          0     0     0    0 no          1    1      0     0     0 0x00 0x00
           lock           0     0     0    0 no          1    1      0     0     0 0x00 0x00
           data           0     0     0    0 no          0    1      0     0     0 0x00 0x00
           usersig        0     0     0    0 no         64   64      0     0     0 0x00 0x00
           flash          0     0     0    0 no      49152  128      0     0     0 0x00 0x00
           eeprom         0     0     0    0 no        256   64      0     0     0 0x00 0x00

         Programmer Type : serialupdi
         Description     : SerialUPDI

avrdude: UPDI link initialization OK
avrdude: NVM type 0: 16-bit, page oriented write
avrdude: Entering NVM programming mode
avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.02s

avrdude: Device signature = 0x1e9651 (probably m4809)
avrdude: NOTE: "flash" memory has been specified, an erase cycle will be performed
         To disable this feature, specify the -D option.
avrdude: erasing chip
avrdude: reading input file "/var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex"
avrdude: writing flash (776 bytes):

Writing | ################################################## | 100% 0.28s

avrdude: 776 bytes of flash written
avrdude: verifying flash memory against /var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex:
avrdude: load data flash data from input file /var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex:
avrdude: input file /var/folders/6l/ypg6qbw172v1s4vtt6g990tw0000gn/T/file.hex contains 776 bytes
avrdude: reading on-chip flash data:

Reading | ################################################## | 100% 0.15s

avrdude: verifying ...
avrdude: 776 bytes of flash verified
avrdude: reading input file "0x00"
avrdude: writing fuse0 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse0 written
avrdude: verifying fuse0 memory against 0x00:
avrdude: load data fuse0 data from input file 0x00:
avrdude: input file 0x00 contains 1 bytes
avrdude: reading on-chip fuse0 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse0 verified
avrdude: reading input file "0x54"
avrdude: writing fuse1 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse1 written
avrdude: verifying fuse1 memory against 0x54:
avrdude: load data fuse1 data from input file 0x54:
avrdude: input file 0x54 contains 1 bytes
avrdude: reading on-chip fuse1 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse1 verified
avrdude: reading input file "0x01"
avrdude: writing fuse2 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse2 written
avrdude: verifying fuse2 memory against 0x01:
avrdude: load data fuse2 data from input file 0x01:
avrdude: input file 0x01 contains 1 bytes
avrdude: reading on-chip fuse2 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse2 verified
avrdude: reading input file "0x00"
avrdude: writing fuse4 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse4 written
avrdude: verifying fuse4 memory against 0x00:
avrdude: load data fuse4 data from input file 0x00:
avrdude: input file 0x00 contains 1 bytes
avrdude: reading on-chip fuse4 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse4 verified
avrdude: reading input file "0b11001001"
avrdude: writing fuse5 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse5 written
avrdude: verifying fuse5 memory against 0b11001001:
avrdude: load data fuse5 data from input file 0b11001001:
avrdude: input file 0b11001001 contains 1 bytes
avrdude: reading on-chip fuse5 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse5 verified
avrdude: reading input file "0x06"
avrdude: writing fuse6 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse6 written
avrdude: verifying fuse6 memory against 0x06:
avrdude: load data fuse6 data from input file 0x06:
avrdude: input file 0x06 contains 1 bytes
avrdude: reading on-chip fuse6 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse6 verified
avrdude: reading input file "0x00"
avrdude: writing fuse7 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse7 written
avrdude: verifying fuse7 memory against 0x00:
avrdude: load data fuse7 data from input file 0x00:
avrdude: input file 0x00 contains 1 bytes
avrdude: reading on-chip fuse7 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse7 verified
avrdude: reading input file "0x00"
avrdude: writing fuse8 (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of fuse8 written
avrdude: verifying fuse8 memory against 0x00:
avrdude: load data fuse8 data from input file 0x00:
avrdude: input file 0x00 contains 1 bytes
avrdude: reading on-chip fuse8 data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of fuse8 verified
avrdude: reading input file "0xC5"
avrdude: writing lock (1 bytes):

Writing | ################################################## | 100% 0.03s

avrdude: 1 bytes of lock written
avrdude: verifying lock memory against 0xC5:
avrdude: load data lock data from input file 0xC5:
avrdude: input file 0xC5 contains 1 bytes
avrdude: reading on-chip lock data:

Reading | ################################################## | 100% 0.00s

avrdude: verifying ...
avrdude: 1 bytes of lock verified

avrdude: safemode: Fuses OK (E:FF, H:FF, L:FF)
avrdude: Leaving NVM programming mode

avrdude done.  Thank you.
```

</details>