### PR TITLE
Disable safemode by default for devices with UPDI

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -340,7 +340,7 @@ default_serial     = "@DEFAULT_SER_PORT@";
 # default_bitclock = 2.5;
 
 # Turn off safemode by default
-#default_safemode  = no;
+default_safemode  = no;
 
 
 #

--- a/src/main.c
+++ b/src/main.c
@@ -993,7 +993,7 @@ int main(int argc, char * argv [])
     safemode = 0;
   }
 
-  if(p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_TPI)) {
+  if(p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_TPI | AVRPART_HAS_UPDI)) {
     safemode = 0;
   }
 


### PR DESCRIPTION
@dbuchwald mentioned when working with the SerialUPDI implementation that safemode wasn't really needed on the "modern" AVRs, since it was next to impossible to bits to flip due to the properties of the UPDI protocol (I think). I took a look in the code and realized that safemode is already disabled for PDI and TPI devices too:

https://github.com/avrdudes/avrdude/blob/de3d7c165992c546ea9f2b53522de932ccca7e8b/src/main.c#L996-L998

So, wouldn't it make sense to disable it for "UPDI targets" as well? At least until safemode actually supports all fuses present on these devices?