### PR TITLE
Print JTAG3 clocks after configuration + string formatting

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1129,7 +1129,7 @@ static int jtag3_initialize(PROGRAMMER * pgm, AVRPART * p)
     if (PDATA(pgm)->set_sck(pgm, parm) < 0)
       return -1;
   }
-
+  jtag3_print_parms1(pgm, progbuf);
   if (conn == PARM3_CONN_JTAG)
   {
     avrdude_message(MSG_NOTICE2, "%s: jtag3_initialize(): "
@@ -2368,10 +2368,8 @@ static void jtag3_display(PROGRAMMER * pgm, const char * p)
   avrdude_message(MSG_INFO, "%sICE firmware version: %d.%02d (rel. %d)\n", p,
 	  parms[1], parms[2],
 	  (parms[3] | (parms[4] << 8)));
-  avrdude_message(MSG_INFO, "%sSerial number   : %s\n", p, resp);
+  avrdude_message(MSG_INFO, "%sSerial number   : %s", p, resp);
   free(resp);
-
-  jtag3_print_parms1(pgm, p);
 }
 
 
@@ -2402,7 +2400,7 @@ static void jtag3_print_parms1(PROGRAMMER * pgm, const char * p)
 
   if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_PDI, buf, 2) < 0)
     return;
-  avrdude_message(MSG_INFO, "%sPDI clock Xmega : %u kHz\n", p,
+  avrdude_message(MSG_INFO, "%sPDI/UPDI clock Xmega : %u kHz\n\n", p,
 	  b2_to_u16(buf));
 }
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2364,8 +2364,8 @@ static void jtag3_display(PROGRAMMER * pgm, const char * p)
   memmove(resp, resp + 3, status - 3);
   resp[status - 3] = 0;
 
-  avrdude_message(MSG_INFO, "%sICE hardware version: %d\n", p, parms[0]);
-  avrdude_message(MSG_INFO, "%sICE firmware version: %d.%02d (rel. %d)\n", p,
+  avrdude_message(MSG_INFO, "%sICE HW version  : %d\n", p, parms[0]);
+  avrdude_message(MSG_INFO, "%sICE FW version  : %d.%02d (rel. %d)\n", p,
 	  parms[1], parms[2],
 	  (parms[3] | (parms[4] << 8)));
   avrdude_message(MSG_INFO, "%sSerial number   : %s", p, resp);
@@ -2381,27 +2381,39 @@ static void jtag3_print_parms1(PROGRAMMER * pgm, const char * p)
     return;
 
   avrdude_message(MSG_INFO, "%sVtarget         : %.2f V\n", p,
-	  b2_to_u16(buf) / 1000.0);
+    b2_to_u16(buf) / 1000.0);
 
   if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_PROG, buf, 2) < 0)
     return;
-  avrdude_message(MSG_INFO, "%sJTAG clock megaAVR/program: %u kHz\n", p,
-	  b2_to_u16(buf));
+
+  if (b2_to_u16(buf) > 0) {
+    avrdude_message(MSG_INFO, "%sJTAG clock megaAVR/program   : %u kHz\n", p,
+      b2_to_u16(buf));
+  }
 
   if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_DEBUG, buf, 2) < 0)
     return;
-  avrdude_message(MSG_INFO, "%sJTAG clock megaAVR/debug:   %u kHz\n", p,
-	  b2_to_u16(buf));
+
+  if (b2_to_u16(buf) > 0) {
+    avrdude_message(MSG_INFO, "%sJTAG clock megaAVR/debug     : %u kHz\n", p,
+      b2_to_u16(buf));
+  }
 
   if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_JTAG, buf, 2) < 0)
     return;
-  avrdude_message(MSG_INFO, "%sJTAG clock Xmega: %u kHz\n", p,
-	  b2_to_u16(buf));
+
+  if (b2_to_u16(buf) > 0) {
+    avrdude_message(MSG_INFO, "%sJTAG clock Xmega             : %u kHz\n", p,
+      b2_to_u16(buf));
+  }
 
   if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_PDI, buf, 2) < 0)
     return;
-  avrdude_message(MSG_INFO, "%sPDI/UPDI clock Xmega : %u kHz\n\n", p,
-	  b2_to_u16(buf));
+
+  if (b2_to_u16(buf) > 0) {
+    avrdude_message(MSG_INFO, "%sPDI/UPDI clock Xmega/megaAVR : %u kHz\n\n", p,
+      b2_to_u16(buf));
+  }
 }
 
 static void jtag3_print_parms(PROGRAMMER * pgm)


### PR DESCRIPTION
For some reason, the default clock settings for the programmer is always printed _before_ they're been configured, typically by providing a -B flag. I've also tweaked the strings a little, and it's only printing clocks that's greater than 0 kHz. Note that the printed clock frequency before this PR is actually incorrect. It's shown as 100kHz, but -B2 sets it to 500kHz. This setting is reflected in terminal mode, as seen below:

Before this PR:
```
./avrdude -C avrdude.conf -cpkobn_updi -pattiny3217 -B2 -v -t

avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : usb
         Using Programmer              : pkobn_updi
         Setting bit clk period        : 2.0
avrdude: Found CMSIS-DAP compliant device, using EDBG protocol
         AVR Part                      : ATtiny3217
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig                 0     0     0    0 no         61   61      0     0     0 0x00 0x00
           fuses                   0     0     0    0 no          9   10      0     0     0 0x00 0x00
           fuse0                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse1                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse4                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse6                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse7                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse8                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           lock                    0     0     0    0 no          1    1      0     0     0 0x00 0x00
           data                    0     0     0    0 no          0    1      0     0     0 0x00 0x00
           usersig                 0     0     0    0 no         32   32      0     0     0 0x00 0x00
           flash                   0     0     0    0 no      32768  128      0     0     0 0x00 0x00
           eeprom                  0     0     0    0 no        256   64      0     0     0 0x00 0x00

         Programmer Type : JTAGICE3_UPDI
         Description     : Curiosity nano (nEDBG) in UPDI mode
         ICE hardware version: 0
         ICE firmware version: 1.21 (rel. 37)
         Serial number   : MCHP3333021800001022
         Vtarget         : 4.21 V
         JTAG clock megaAVR/program: 0 kHz
         JTAG clock megaAVR/debug:   0 kHz
         JTAG clock Xmega: 0 kHz
         PDI clock Xmega : 100 kHz

avrdude: Partial Family_ID returned: "tiny"
avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.07s

avrdude: Device signature = 0x1e9522 (probably t3217)
avrdude> parms
>>> parms 
Vtarget         : 4.21 V
JTAG clock megaAVR/program: 0 kHz
JTAG clock megaAVR/debug:   0 kHz
JTAG clock Xmega: 0 kHz
PDI clock Xmega : 500 kHz
avrdude> 
```

After this PR:
```
./avrdude -C avrdude.conf -cpkobn_updi -pattiny3217 -B2 -v -t

avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : usb
         Using Programmer              : pkobn_updi
         Setting bit clk period        : 2.0
avrdude: Found CMSIS-DAP compliant device, using EDBG protocol
         AVR Part                      : ATtiny3217
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig                 0     0     0    0 no         61   61      0     0     0 0x00 0x00
           fuses                   0     0     0    0 no          9   10      0     0     0 0x00 0x00
           fuse0                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse1                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse4                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse6                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse7                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse8                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           lock                    0     0     0    0 no          1    1      0     0     0 0x00 0x00
           data                    0     0     0    0 no          0    1      0     0     0 0x00 0x00
           usersig                 0     0     0    0 no         32   32      0     0     0 0x00 0x00
           flash                   0     0     0    0 no      32768  128      0     0     0 0x00 0x00
           eeprom                  0     0     0    0 no        256   64      0     0     0 0x00 0x00

         Programmer Type : JTAGICE3_UPDI
         Description     : Curiosity nano (nEDBG) in UPDI mode
         ICE HW version  : 0
         ICE FW version  : 1.21 (rel. 37)
         Serial number   : MCHP3333021800001022
         Vtarget         : 4.21 V
         PDI/UPDI clock Xmega/megaAVR : 500 kHz

avrdude: Partial Family_ID returned: "tiny"
avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e9522 (probably t3217)
avrdude> parms
>>> parms 
Vtarget         : 4.21 V
PDI/UPDI clock Xmega/megaAVR : 500 kHz

avrdude> 
```