### PR TITLE
Set number of connection retry attempts for Arduino/STK500 programmer

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -150,7 +150,7 @@ program memory, but no true chip erase can be performed.
 .Pp
 The Arduino (which is very similar to the STK500 1.x) is supported via
 its own programmer type specification ``arduino''.  This programmer works for
-the Arduino Uno Rev3.
+the Arduino Uno Rev3 or any AVR that runs the Optiboot bootloader.
 .Pp
 The BusPirate is a versatile tool that can also be used as an AVR programmer.
 A single BusPirate can be connected to up to 3 independent AVRs. See
@@ -1030,6 +1030,12 @@ only if your
 .Ar AVR910
 programmer creates errors during initial sequence. 
 .El
+.It Ar Arduino
+.Bl -tag -offset indent -width indent
+.It Ar attemps[=<1..99>]
+Specify how many connection retry attemps to perform before exiting.
+Defaults to 10 if not specified.
+.El
 .It Ar buspirate
 .Bl -tag -offset indent -width indent
 .It Ar reset={cs,aux,aux2}
@@ -1186,6 +1192,12 @@ line, and the XBee DIN pin (pin 3) must be connected to the MCU's
 .Ql TXD
 line.
 .El
+.It Ar STK500
+.Bl -tag -offset indent -width indent
+.It Ar attemps[=<1..99>]
+Specify how many connection retry attemps to perform before exiting.
+Defaults to 10 if not specified.
+.El
 .It Ar serialupdi
 Extended parameters:
 .Bl -tag -offset indent -width indent
@@ -1267,7 +1279,7 @@ This man page by
 .el Joerg Wunsch.
 .Sh BUGS
 Please report bugs via
-.Dl "http://savannah.nongnu.org/bugs/?group=avrdude" .
+.Dl "https://github.com/avrdudes/avrdude/issues"
 .Pp
 The JTAG ICE programmers currently cannot write to the flash ROM
 one byte at a time.

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -286,7 +286,11 @@ be performed.
 
 The Arduino (which is very similar to the STK500 1.x) is supported via
 its own programmer type specification ``arduino''.  This programmer works for
-the Arduino Uno Rev3.
+the Arduino Uno Rev3 or any AVR that runs the Optiboot bootloader.
+The number of connection retry attempts can be specified as an
+extended parameter. See the section on
+@emph{extended parameters}
+below for details.
 
 The BusPirate is a versatile tool that can also be used as an AVR programmer.
 A single BusPirate can be connected to up to 3 independent AVRs. See
@@ -310,7 +314,7 @@ Board'', thus the name @code{pkobn_updi}.
 SerialUPDI programmer implementation is based on Microchip's 
 @emph{pymcuprog} (@url{https://github.com/microchip-pic-avr-tools/pymcuprog}) 
 utility, but it also contains some performance improvements included in
-Spence Kohde's @emph{DxCore} Arduino core (@url{https://github.com/SpenceKonde/DxCore}).
+Spence Konde's @emph{DxCore} Arduino core (@url{https://github.com/SpenceKonde/DxCore}).
 In a nutshell, this programmer consists of simple USB->UART adapter, diode 
 and couple of resistors. It uses serial connection to provide UPDI interface. 
 @xref{SerialUPDI programmer} for more details and known issues.
@@ -896,6 +900,13 @@ Use
 @samp{no_blockmode} only if your @samp{AVR910} 
 programmer creates errors during initial sequence.
 @end table
+
+@item Arduino
+
+The Arduino programmer type accepts the following extended parameter:
+@table @code
+@item @samp{attemps=VALUE}
+Overide the default number of connection retry attempt by using @var{VALUE}.
 
 @item BusPirate
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1209,7 +1209,8 @@ static void stk500_display(PROGRAMMER * pgm, const char * p)
     }
     avrdude_message(MSG_INFO, "%sTopcard         : %s\n", p, n);
   }
-  stk500_print_parms1(pgm, p);
+  if(strcmp(pgm->type, "Arduino") != 0)
+    stk500_print_parms1(pgm, p);
 
   return;
 }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -47,8 +47,8 @@
 
 struct pdata
 {
-  unsigned char ext_addr_byte; /* Record ext-addr byte set in the
-				* target device (if used) */
+  unsigned char ext_addr_byte; // Record ext-addr byte set in the target device (if used)
+  int retry_attempts; // Number of connection attempts provided by the user
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
@@ -89,6 +89,7 @@ int stk500_getsync(PROGRAMMER * pgm)
 {
   unsigned char buf[32], resp[32];
   int attempt;
+  int max_sync_attempts;
 
   /*
    * get in sync */
@@ -104,16 +105,21 @@ int stk500_getsync(PROGRAMMER * pgm)
   stk500_send(pgm, buf, 2);
   stk500_drain(pgm, 0);
 
-  for (attempt = 0; attempt < MAX_SYNC_ATTEMPTS; attempt++) {
+  if(PDATA(pgm)->retry_attempts)
+    max_sync_attempts = PDATA(pgm)->retry_attempts;
+  else
+    max_sync_attempts = MAX_SYNC_ATTEMPTS;
+
+  for (attempt = 0; attempt < max_sync_attempts; attempt++) {
     stk500_send(pgm, buf, 2);
     stk500_recv(pgm, resp, 1);
     if (resp[0] == Resp_STK_INSYNC){
       break;
     }
     avrdude_message(MSG_INFO, "%s: stk500_getsync() attempt %d of %d: not in sync: resp=0x%02x\n",
-                    progname, attempt + 1, MAX_SYNC_ATTEMPTS, resp[0]);
+                    progname, attempt + 1, max_sync_attempts, resp[0]);
   }
-  if (attempt == MAX_SYNC_ATTEMPTS) {
+  if (attempt == max_sync_attempts) {
     stk500_drain(pgm, 0);
     return -1;
   }
@@ -597,6 +603,30 @@ static int stk500_initialize(PROGRAMMER * pgm, AVRPART * p)
   return pgm->program_enable(pgm, p);
 }
 
+static int stk500_parseextparms(PROGRAMMER * pgm, LISTID extparms)
+ {
+   LNODEID ln;
+   const char *extended_param;
+   int attempts;
+   int rv = 0;
+
+   for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
+     extended_param = ldata(ln);
+
+     if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
+       PDATA(pgm)->retry_attempts = attempts;
+       avrdude_message(MSG_INFO, "%s: serialupdi_parseextparms(): invalid extended parameter '%s'\n",
+                     progname, extended_param);
+       continue;
+     }
+
+     avrdude_message(MSG_INFO, "%s: stk500_parseextparms(): invalid extended parameter '%s'\n",
+                     progname, extended_param);
+     rv = -1;
+   }
+
+   return rv;
+ }
 
 static void stk500_disable(PROGRAMMER * pgm)
 {
@@ -1295,6 +1325,7 @@ void stk500_initpgm(PROGRAMMER * pgm)
    * mandatory functions
    */
   pgm->initialize     = stk500_initialize;
+  pgm->parseextparams = stk500_parseextparms;
   pgm->display        = stk500_display;
   pgm->enable         = stk500_enable;
   pgm->disable        = stk500_disable;


### PR DESCRIPTION
This PR makes it possible to set the number of connection retry attempts for the `arduino` and `stk500` programmer options by utilizing the -x flag. Defaults to 10 attempts if no x flag is specified.

Usage:
```
-x attempts=5
```

Please let me know if you have any feedback, good or constructive 👍 