### PR TITLE
Fix Arduino retry attempts

### DIFF
--- a/src/stk500.c
+++ b/src/stk500.c
@@ -623,8 +623,8 @@ static int stk500_parseextparms(PROGRAMMER * pgm, LISTID extparms)
 
      if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
        PDATA(pgm)->retry_attempts = attempts;
-       avrdude_message(MSG_INFO, "%s: serialupdi_parseextparms(): invalid extended parameter '%s'\n",
-                     progname, extended_param);
+       avrdude_message(MSG_INFO, "%s: Setting number of retry attempts to %d\n",
+                     progname, attempts);
        continue;
      }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -111,6 +111,14 @@ int stk500_getsync(PROGRAMMER * pgm)
     max_sync_attempts = MAX_SYNC_ATTEMPTS;
 
   for (attempt = 0; attempt < max_sync_attempts; attempt++) {
+    // Restart Arduino bootloader for every sync attempt
+    if (strcmp(pgm->type, "Arduino") == 0 && attempt > 0) {
+      serial_set_dtr_rts(&pgm->fd, 0); // Set DTR and RTS low
+      usleep(250*1000);
+      serial_set_dtr_rts(&pgm->fd, 1); // Set DTR and RTS back to high
+      usleep(50*1000);
+      stk500_drain(pgm, 0);
+    }
     stk500_send(pgm, buf, 2);
     stk500_recv(pgm, resp, 1);
     if (resp[0] == Resp_STK_INSYNC){


### PR DESCRIPTION
If the Arduino/Optiboot bootloader can't communicate with Avrdude, it immediately starts running the application, and can't re-sync if no DTR/RTS pulse is issued again. This PR fixes this.

This is what it looks like when I hold down the reset button after trying to upload. Before it would just go through all attempts before failing. Now it will succeed on the next attempt after releasing the reset button:

```
$ ./avrdude -C avrdude.conf -carduino -patmega1284p -v -P /dev/cu.u* -Uflash:w:blink.hex:i -xattempts=20 

avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

avrdude: Setting number of retry attempts to 20
         Using Port                    : /dev/cu.usbserial-1410
         Using Programmer              : arduino
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 1 of 20: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 2 of 20: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 3 of 20: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 4 of 20: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 5 of 20: not in sync: resp=0x00
         AVR Part                      : ATmega1284P
         Chip Erase delay              : 55000 us
         PAGEL                         : PD7
         BS2                           : PA0
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Timeout                       : 200
         StabDelay                     : 100
         CmdexeDelay                   : 25
         SyncLoops                     : 32
         PollIndex                     : 3
         PollValue                     : 0x53
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           eeprom                 65    10   128    0 no       4096    8      0  9000  9000 0xff 0xff
           flash                  65    10   256    0 yes    131072  256    512  4500  4500 0xff 0xff
           lock                    0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           lfuse                   0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           hfuse                   0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           efuse                   0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           calibration             0     0     0    0 no          1    1      0     0     0 0x00 0x00

         Programmer Type : Arduino
         Description     : Arduino
         Hardware Version: 3
         Firmware Version: 8.0

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e9705 (probably m1284p)
avrdude: NOTE: "flash" memory has been specified, an erase cycle will be performed
         To disable this feature, specify the -D option.
avrdude: erasing chip
avrdude: reading input file "blink.hex"
avrdude: writing flash (1160 bytes):

Writing | ################################################## | 100% 0.19s

avrdude: 1160 bytes of flash written
avrdude: verifying flash memory against blink.hex:

Reading | ################################################## | 100% 0.14s

avrdude: 1160 bytes of flash verified

avrdude done.  Thank you.
```

I've also fixed an incorrect message that I mistakenly added in PR #854.