### PR TITLE
Assign proper type to msg[] in errstr()

### DIFF
--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -68,7 +68,7 @@ static libusb_context *ctx = NULL;
 
 static const char *errstr(int result)
 {
-	static msg[30];
+	static char msg[30];
 	int n = 0;
 
 	switch (result) {


### PR DESCRIPTION
Obviously, the array ought to be of type char.

Closes Issue #856