### PR TITLE
CMake: use CMAKE_CURRENT_BINARY_DIR to locate avrdude.conf

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,5 +268,5 @@ install(TARGETS libavrdude
     ARCHIVE DESTINATION lib
     PUBLIC_HEADER DESTINATION include COMPONENT dev
     )
-install(FILES "${PROJECT_BINARY_DIR}/avrdude.conf" TYPE SYSCONF)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.conf" TYPE SYSCONF)
 install(FILES avrdude.1 TYPE MAN)


### PR DESCRIPTION
With the split `CMakeLists.txt` infrastructure avrdude.conf
will be created in the `build/src` and not `build` folder. Hence,
fix its location in the install command.