### PR TITLE
Add fuse name aliases to avrdude.conf + tweak update.c

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16628,9 +16628,7 @@ part
     ;
 
     memory "wdtcfg"
-        size		= 1;
-        offset		= 0x1280;
-        readsize  = 1;
+        alias "fuse0";
     ;
 
     memory "fuse1"
@@ -16640,9 +16638,7 @@ part
     ;
 
     memory "bodcfg"
-        size		= 1;
-        offset		= 0x1281;
-        readsize  = 1;
+        alias "fuse1";
     ;
 
     memory "fuse2"
@@ -16652,9 +16648,7 @@ part
     ;
 
     memory "osccfg"
-        size		= 1;
-        offset		= 0x1282;
-        readsize  = 1;
+        alias "fuse2";
     ;
 
     memory "fuse4"
@@ -16664,9 +16658,7 @@ part
     ;
 
     memory "tcd0cfg"
-        size		= 1;
-        offset		= 0x1284;
-        readsize  = 1;
+        alias "fuse4";
     ;
 
     memory "fuse5"
@@ -16676,9 +16668,7 @@ part
     ;
 
     memory "syscfg0"
-        size		= 1;
-        offset		= 0x1285;
-        readsize  = 1;
+        alias "fuse5";
     ;
 
     memory "fuse6"
@@ -16688,9 +16678,7 @@ part
     ;
 
     memory "syscfg1"
-        size		= 1;
-        offset		= 0x1286;
-        readsize  = 1;
+        alias "fuse6";
     ;
 
     memory "fuse7"
@@ -16700,9 +16688,11 @@ part
     ;
 
     memory "append"
-        size		= 1;
-        offset		= 0x1287;
-        readsize  = 1;
+        alias "fuse7";
+    ;
+
+    memory "codesize"
+        alias "fuse7";
     ;
 
     memory "fuse8"
@@ -16712,9 +16702,11 @@ part
     ;
 
     memory "bootend"
-        size		= 1;
-        offset		= 0x1288;
-        readsize  = 1;
+        alias "fuse8";
+    ;
+
+    memory "bootsize"
+        alias "fuse8";
     ;
 
     memory "lock"
@@ -17896,9 +17888,7 @@ part
     ;
 
     memory "wdtcfg"
-        size		= 1;
-        offset		= 0x1050;
-        readsize  = 1;
+        alias "fuse0";
     ;
 
     memory "fuse1"
@@ -17908,9 +17898,7 @@ part
     ;
 
     memory "bodcfg"
-        size		= 1;
-        offset		= 0x1051;
-        readsize  = 1;
+        alias "fuse1";
     ;
 
     memory "fuse2"
@@ -17920,9 +17908,7 @@ part
     ;
 
     memory "osccfg"
-        size		= 1;
-        offset		= 0x1052;
-        readsize  = 1;
+        alias "fuse2";
     ;
 
     memory "fuse4"
@@ -17932,9 +17918,7 @@ part
     ;
 
     memory "tcd0cfg"
-        size		= 1;
-        offset		= 0x1054;
-        readsize  = 1;
+        alias "fuse4";
     ;
 
     memory "fuse5"
@@ -17944,9 +17928,7 @@ part
     ;
 
     memory "syscfg0"
-        size		= 1;
-        offset		= 0x1055;
-        readsize  = 1;
+        alias "fuse5";
     ;
 
     memory "fuse6"
@@ -17956,9 +17938,7 @@ part
     ;
 
     memory "syscfg1"
-        size		= 1;
-        offset		= 0x1056;
-        readsize  = 1;
+        alias "fuse6";
     ;
 
     memory "fuse7"
@@ -17968,15 +17948,11 @@ part
     ;
 
     memory "codesize"
-        size		= 1;
-        offset		= 0x1057;
-        readsize  = 1;
+        alias "fuse7";
     ;
 
     memory "append"
-        size		= 1;
-        offset		= 0x1057;
-        readsize  = 1;
+        alias "fuse7";
     ;
 
     memory "fuse8"
@@ -17986,15 +17962,11 @@ part
     ;
 
     memory "bootsize"
-        size		= 1;
-        offset		= 0x1058;
-        readsize  = 1;
+        alias "fuse8";
     ;
 
     memory "bootend"
-        size		= 1;
-        offset		= 0x1058;
-        readsize  = 1;
+        alias "fuse8";
     ;
 
     memory "lock"

--- a/src/update.c
+++ b/src/update.c
@@ -227,6 +227,13 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     return -1;
   }
 
+  AVRMEM_ALIAS * alias_mem = avr_find_memalias(p, mem);
+  char alias_mem_desc[AVR_DESCLEN + 1] = "";
+  if(alias_mem) {
+    strcat(alias_mem_desc, "/");
+    strcat(alias_mem_desc, alias_mem->desc);
+  }
+  
   if (upd->op == DEVICE_READ) {
     /*
      * read out the specified device memory and write it to a file
@@ -238,14 +245,14 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
       return -1;
     }
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: reading %s memory:\n",
-            progname, mem->desc);
+      avrdude_message(MSG_INFO, "%s: reading %s%s memory:\n",
+            progname, mem->desc, alias_mem_desc);
 	  }
     report_progress(0,1,"Reading");
     rc = avr_read(pgm, p, upd->memtype, 0);
     if (rc < 0) {
-      avrdude_message(MSG_INFO, "%s: failed to read all of %s memory, rc=%d\n",
-              progname, mem->desc, rc);
+      avrdude_message(MSG_INFO, "%s: failed to read all of %s%s memory, rc=%d\n",
+              progname, mem->desc, alias_mem_desc, rc);
       return -1;
     }
     report_progress(1,1,NULL);
@@ -288,8 +295,8 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
      * write the buffer contents to the selected memory type
      */
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: writing %s (%d bytes):\n",
-            progname, mem->desc, size);
+      avrdude_message(MSG_INFO, "%s: writing %s%s (%d bytes):\n",
+            progname, mem->desc, alias_mem_desc, size);
 	  }
 
     if (!(flags & UF_NOWRITE)) {
@@ -306,16 +313,16 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     }
 
     if (rc < 0) {
-      avrdude_message(MSG_INFO, "%s: failed to write %s memory, rc=%d\n",
-              progname, mem->desc, rc);
+      avrdude_message(MSG_INFO, "%s: failed to write %s%s memory, rc=%d\n",
+              progname, mem->desc, alias_mem_desc, rc);
       return -1;
     }
 
     vsize = rc;
 
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: %d bytes of %s written\n", progname,
-            vsize, mem->desc);
+      avrdude_message(MSG_INFO, "%s: %d bytes of %s%s written\n", progname,
+            vsize, mem->desc, alias_mem_desc);
     }
 
   }
@@ -327,11 +334,11 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     pgm->vfy_led(pgm, ON);
 
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: verifying %s memory against %s:\n",
-            progname, mem->desc, upd->filename);
+      avrdude_message(MSG_INFO, "%s: verifying %s%s memory against %s:\n",
+            progname, mem->desc, alias_mem_desc, upd->filename);
 
-      avrdude_message(MSG_NOTICE2, "%s: load data %s data from input file %s:\n",
-            progname, mem->desc, upd->filename);
+      avrdude_message(MSG_NOTICE2, "%s: load data %s%s data from input file %s:\n",
+            progname, mem->desc, alias_mem_desc, upd->filename);
     }
 
     rc = fileio(FIO_READ, upd->filename, upd->format, p, upd->memtype, -1);
@@ -345,15 +352,15 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     if (quell_progress < 2) {
       avrdude_message(MSG_NOTICE2, "%s: input file %s contains %d bytes\n",
             progname, upd->filename, size);
-      avrdude_message(MSG_NOTICE2, "%s: reading on-chip %s data:\n",
-            progname, mem->desc);
+      avrdude_message(MSG_NOTICE2, "%s: reading on-chip %s%s data:\n",
+            progname, mem->desc, alias_mem_desc);
     }
 
     report_progress (0,1,"Reading");
     rc = avr_read(pgm, p, upd->memtype, v);
     if (rc < 0) {
-      avrdude_message(MSG_INFO, "%s: failed to read all of %s memory, rc=%d\n",
-              progname, mem->desc, rc);
+      avrdude_message(MSG_INFO, "%s: failed to read all of %s%s memory, rc=%d\n",
+              progname, mem->desc, alias_mem_desc, rc);
       pgm->err_led(pgm, ON);
       avr_free_part(v);
       return -1;
@@ -375,8 +382,8 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     }
 
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: %d bytes of %s verified\n",
-              progname, rc, mem->desc);
+      avrdude_message(MSG_INFO, "%s: %d bytes of %s%s verified\n",
+              progname, rc, mem->desc, alias_mem_desc);
     }
 
     pgm->vfy_led(pgm, OFF);


### PR DESCRIPTION
This PR adds fuse name aliases to the megaAVR0, tinyAVR0/1/2, AVR-Dx, and AVR-Ex microcontroller series. It also tweaks update.c so that the alias name is also printed if found in avrdude.conf:

No alias found:
```
avrdude: reading fuse5 memory:

Reading | ################################################## | 100% 0.00s

avrdude: writing output file "<stdout>"
0xc8
avrdude: Leaving NVM programming mode

avrdude done.  Thank you.
```

Alias found:
```
avrdude: reading fuse5/syscfg0 memory:

Reading | ################################################## | 100% 0.00s

avrdude: writing output file "<stdout>"
0xc8
avrdude: Leaving NVM programming mode

avrdude done.  Thank you.
```