### PR TITLE
Tweak programmer info formatting strings

### DIFF
--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -1275,8 +1275,8 @@ static void jtagmkI_display(PROGRAMMER * pgm, const char * p)
       jtagmkI_getparm(pgm, PARM_SW_VERSION, &fw) < 0)
     return;
 
-  avrdude_message(MSG_INFO, "%sICE hardware version: 0x%02x\n", p, hw);
-  avrdude_message(MSG_INFO, "%sICE firmware version: 0x%02x\n", p, fw);
+  avrdude_message(MSG_INFO, "%sICE HW version: 0x%02x\n", p, hw);
+  avrdude_message(MSG_INFO, "%sICE FW version: 0x%02x\n", p, fw);
 
   jtagmkI_print_parms1(pgm, p);
 
@@ -1320,9 +1320,9 @@ static void jtagmkI_print_parms1(PROGRAMMER * pgm, const char * p)
     clk = 1e6;
   }
 
-  avrdude_message(MSG_INFO, "%sVtarget         : %.1f V\n", p,
+  avrdude_message(MSG_INFO, "%sVtarget       : %.1f V\n", p,
 	  6.25 * (unsigned)vtarget / 255.0);
-  avrdude_message(MSG_INFO, "%sJTAG clock      : %s (%.1f us)\n", p, clkstr,
+  avrdude_message(MSG_INFO, "%sJTAG clock    : %s (%.1f us)\n", p, clkstr,
 	  1.0e6 / clk);
 
   return;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2688,11 +2688,11 @@ static void jtagmkII_display(PROGRAMMER * pgm, const char * p)
       jtagmkII_getparm(pgm, PAR_FW_VERSION, fw) < 0)
     return;
 
-  avrdude_message(MSG_INFO, "%sM_MCU hardware version: %d\n", p, hw[0]);
-  avrdude_message(MSG_INFO, "%sM_MCU firmware version: %d.%02d\n", p, fw[1], fw[0]);
-  avrdude_message(MSG_INFO, "%sS_MCU hardware version: %d\n", p, hw[1]);
-  avrdude_message(MSG_INFO, "%sS_MCU firmware version: %d.%02d\n", p, fw[3], fw[2]);
-  avrdude_message(MSG_INFO, "%sSerial number:          %02x:%02x:%02x:%02x:%02x:%02x\n",
+  avrdude_message(MSG_INFO, "%sM_MCU HW version: %d\n", p, hw[0]);
+  avrdude_message(MSG_INFO, "%sM_MCU FW version: %d.%02d\n", p, fw[1], fw[0]);
+  avrdude_message(MSG_INFO, "%sS_MCU HW version: %d\n", p, hw[1]);
+  avrdude_message(MSG_INFO, "%sS_MCU FW version: %d.%02d\n", p, fw[3], fw[2]);
+  avrdude_message(MSG_INFO, "%sSerial number   : %02x:%02x:%02x:%02x:%02x:%02x\n",
 	  p, PDATA(pgm)->serno[0], PDATA(pgm)->serno[1], PDATA(pgm)->serno[2], PDATA(pgm)->serno[3], PDATA(pgm)->serno[4], PDATA(pgm)->serno[5]);
 
   jtagmkII_print_parms1(pgm, p);


### PR DESCRIPTION
Now all colons are on a straight line, just like #853 did to all jtag3 compatible programmers