### PR TITLE
Add missing USBtiny derived programmers

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -886,6 +886,24 @@ programmer
   usbpid     = 0x0c9f;
 ;
 
+programmer
+  id    = "arduinoisp";
+  desc  = "Arduino ISP Programmer";
+  type  = "usbtiny";
+  connection_type = usb;
+  usbvid     = 0x2341;
+  usbpid     = 0x0049;
+;
+
+programmer
+  id    = "arduinoisporg";
+  desc  = "Arduino ISP Programmer";
+  type  = "usbtiny";
+  connection_type = usb;
+  usbvid     = 0x2A03;
+  usbpid     = 0x0049;
+;
+
 # commercial version of USBtiny, using a separate VID/PID
 programmer
   id    = "ehajo-isp";
@@ -894,6 +912,16 @@ programmer
   connection_type = usb;
   usbvid     = 0x16D0;
   usbpid     = 0x0BA5;
+;
+
+# commercial version of USBtiny, using a separate VID/PID
+programmer
+  id    = "iseavrprog";
+  desc  = "USBtiny-based USB programmer, https://github.com/IowaScaledEngineering/ckt-avrprogrammer";
+  type  = "usbtiny";
+  connection_type = usb;
+  usbvid     = 0x1209;
+  usbpid     = 0x6570;
 ;
 
 programmer
@@ -912,16 +940,6 @@ programmer
   connection_type = usb;
   usbvid = 0x16C0;
   usbpid = 0x0478;
-;
-
-# commercial version of USBtiny, using a separate VID/PID
-programmer
-  id    = "iseavrprog";
-  desc  = "USBtiny-based USB programmer, https://github.com/IowaScaledEngineering/ckt-avrprogrammer";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x1209;
-  usbpid     = 0x6570;
 ;
 
 programmer


### PR DESCRIPTION
[ArduinoISP](https://www.arduino.cc/en/Main.ArduinoISP) and the [Arduino.org ISP](https://botland.store/avr-programmers/4793-arduino-isp-a000092-programmer-for-arduino-8058333490663.html) are commercial versions of the USBtiny programmer with different USB VIDs/PIDs. I've also grouped all USBtiny based programmers together.

PR based on two patches located here:
https://github.com/arduino/avrdude-build-script/tree/master/avrdude-6.3-patches