### PR TITLE
Add serial_drain() to updi_physical_send_double_break().

### DIFF
--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -161,6 +161,11 @@ static int updi_physical_send_double_break(PROGRAMMER * pgm)
 
   updi_set_rtsdtr_mode(pgm);
 
+  /*
+   * drain any extraneous input
+   */
+  serial_drain(&pgm->fd, 0);
+
   return 0;
 }
 


### PR DESCRIPTION
This is needed here on FreeBSD.