### PR TITLE
Avrdude terminal write improvements

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -416,7 +416,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
       int64_t ll;
       uint8_t a[8];
     };
-  } data;
+  } data = {.bytes_grown = 0, .size = 0, .is_float = false, .ll = 0};
 
   for (i = start_offset; i < len + start_offset - data.bytes_grown; i++) {
     data.is_float = false;

--- a/src/term.c
+++ b/src/term.c
@@ -399,21 +399,32 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
 
   if(write_mode == WRITE_MODE_STANDARD) {
     for (i=3; i<argc; i++) {
-      buf[i-3] = strtoul(argv[i], &e, 0);
+      unsigned char write_val = strtoul(argv[i], &e, 0);
       if (*e || (e == argv[i])) {
-        avrdude_message(MSG_INFO, "%s (write): can't parse byte \"%s\"\n",
-                progname, argv[i]);
-        free(buf);
-        return -1;
+        // If passed argument is a single character
+        if(argv[i][1] == '\0') {
+          write_val = argv[i][0];
+        } else {
+          avrdude_message(MSG_INFO, "%s (write): can't parse byte \"%s\"\n",
+                  progname, argv[i]);
+          free(buf);
+          return -1;
+        }
       }
+      buf[i-3] = write_val;
     }
   } else if(write_mode == WRITE_MODE_FILL) {
     unsigned char fill_val = strtoul(argv[4], &e, 0);
     if (*e || (e == argv[4])) {
-        avrdude_message(MSG_INFO, "%s (write ...): can't parse byte \"%s\"\n",
+        // If passed argument is a single character
+        if(argv[4][1] == '\0') {
+          fill_val = argv[4][0];
+        } else {
+          avrdude_message(MSG_INFO, "%s (write ...): can't parse byte \"%s\"\n",
                 progname, argv[4]);
-        free(buf);
-        return -1;
+          free(buf);
+          return -1;
+        }
     }
     for (i = 0; i < len; i++) {
       buf[i] = fill_val;

--- a/src/term.c
+++ b/src/term.c
@@ -416,8 +416,8 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
         if (*e || (e == argv[i])) {
           ptr = NULL;
           // Try single character
-          if (argv[i][1] == '\0') {
-            write_val = argv[i][0];
+          if (argv[i][0] == '\'' && argv[i][2] == '\'') {
+            write_val = argv[i][1];
           } else {
             avrdude_message(MSG_INFO, "%s (write): can't parse data \"%s\"\n",
                   progname, argv[i]);

--- a/src/term.c
+++ b/src/term.c
@@ -424,9 +424,14 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
       } else if (suffix == 'L' || suffix == 'l') {
         argv[i][strlen(argv[i]) - 1] = '\0';
         data.size = 4;
-      } else if ((suffix == 'F' || suffix == 'f') && strncmp(argv[i], "0x", 2) != 0) {
+      } else if ((suffix == 'F' || suffix == 'f') &&
+          strncmp(argv[i], "0x", 2) != 0 && strncmp(argv[i], "-0x", 3) != 0) {
         argv[i][strlen(argv[i]) - 1] = '\0';
+        avrdude_message(MSG_INFO, "snip\n");
         data.size = 4;
+      } else if ((suffix == 'H' && lsuffix == 'H') || (suffix == 'h' && lsuffix == 'h')) {
+        argv[i][strlen(argv[i]) - 2] = '\0';
+        data.size = 1;
       } else if (suffix == 'H' || suffix == 'h' || suffix == 'S' || suffix == 's') {
         argv[i][strlen(argv[i]) - 1] = '\0';
         data.size = 2;

--- a/src/term.c
+++ b/src/term.c
@@ -428,9 +428,9 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
       }
     }
     buf[i - start_offset + bytes_grown]     = (write_val >> 0) & 0xFF;
-    if (write_val > 0xFF || ptr)
+    if (labs(write_val) > 0xFF || ptr)
       buf[i - start_offset + ++bytes_grown] = (write_val >> 8) & 0xFF;
-    if (write_val > 0xFFFF || ptr) {
+    if (labs(write_val) > 0xFFFF || ptr) {
       buf[i - start_offset + ++bytes_grown] = (write_val >> 16) & 0xFF;
       buf[i - start_offset + ++bytes_grown] = (write_val >> 24) & 0xFF;
     }

--- a/src/term.h
+++ b/src/term.h
@@ -27,9 +27,10 @@
 extern "C" {
 #endif
 
-// Macros for determining write mode
-#define WRITE_MODE_STANDARD 0
-#define WRITE_MODE_FILL     1
+typedef enum {
+  WRITE_MODE_STANDARD = 0,
+  WRITE_MODE_FILL     = 1,
+} mode;
 
 int terminal_mode(PROGRAMMER * pgm, struct avrpart * p);
 char * terminal_get_input(const char *prompt);

--- a/src/term.h
+++ b/src/term.h
@@ -27,6 +27,10 @@
 extern "C" {
 #endif
 
+// Macros for determining write mode
+#define WRITE_MODE_STANDARD 0
+#define WRITE_MODE_FILL     1
+
 int terminal_mode(PROGRAMMER * pgm, struct avrpart * p);
 char * terminal_get_input(const char *prompt);
 


### PR DESCRIPTION
I've been working one some improvements regarding the Avrdude terminal write functionality. I have not yet updated any docks; I'd like to get some feedback first.

With this PR it's now possible to fill a memory section, write 8, 16 and 32-bit integers, characters and floats to memory. Negative numbers works too, and everything is stored in little endian.

Any thoughts? I'm all ears!

I have yet to add support for strings in double quotes, but this is quite a bit of work I believe.

#38 related
Closes #879 

```
avrdude: Device signature = 0x1e9650 (probably m4808)
avrdude> write eeprom 0x00 0x100 0xff ...
>>> write eeprom 0x00 0x100 0xff ... 

avrdude> read eeprom 0 256
>>> read eeprom 0 256
0000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0010  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0020  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0030  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0040  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0050  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0060  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0070  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0080  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0090  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00a0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00b0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00c0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00d0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00e0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00f0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|

avrdude> write eeprom 0x00 'H' 'e' 'l' 'l' 'o' 1 2 3
>>> write eeprom 0x00 'H' 'e' 'l' 'l' 'o' 1 2 3 

avrdude> write eeprom 0x10 0x10 'a' 'b' 'c' 'd' ...
>>> write eeprom 0x10 0x10 'a' 'b' 'c' 'd' ... 

avrdude> write eeprom 0x20 0xdeadbeef
>>> write eeprom 0x20 0xdeadbeef 

avrdude> write eeprom 0x30 3.141592
>>> write eeprom 0x30 3.141592 

avrdude> write eeprom 0x40 0x10 'A' 'V' 'R' 0xdeadbeef ...
>>> write eeprom 0x40 0x10 'A' 'V' 'R' 0xdeadbeef ... 

avrdude> read eeprom 0x00 0x100
>>> read eeprom 0x00 0x100 
0000  48 65 6c 6c 6f 01 02 03  ff ff ff ff ff ff ff ff  |Hello...........|
0010  61 62 63 64 64 64 64 64  64 64 64 64 64 64 64 64  |abcddddddddddddd|
0020  ef be ad de ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0030  d8 0e 49 40 ff ff ff ff  ff ff ff ff ff ff ff ff  |..I@............|
0040  41 56 52 ef be ad de ef  be ad de ef be ad de ef  |AVR.............|
0050  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0060  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0070  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0080  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0090  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00a0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00b0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00c0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00d0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00e0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00f0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
```