### PR TITLE
Shorten timing of arduino open and serial drain functions

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -93,7 +93,8 @@ static int arduino_open(PROGRAMMER * pgm, char * port)
   /* Clear DTR and RTS to unload the RESET capacitor 
    * (for example in Arduino) */
   serial_set_dtr_rts(&pgm->fd, 0);
-  usleep(250*1000);
+  /* 25 ms is ample for dis/charging the capacitor between reset and DTR/RTS */
+  usleep(25*1000);
   /* Set DTR and RTS back to high */
   serial_set_dtr_rts(&pgm->fd, 1);
   usleep(50*1000);

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -505,7 +505,7 @@ static int ser_drain(union filedescriptor *fd, int display)
   unsigned char buf;
 
   timeout.tv_sec = 0;
-  timeout.tv_usec = 250000;
+  timeout.tv_usec = 100*1000;
 
   if (display) {
     avrdude_message(MSG_INFO, "drain>");


### PR DESCRIPTION
This changes enables bootloaders to exit after a short time (256 ms) rather
than the current minium waiting time of 512 ms. After Reset, control can be
handed to the sketch faster, which is important in some applications.