### PR TITLE
Support both userrow and usersig names

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16748,15 +16748,15 @@ part parent    ".avr8x"
     desc		= "AVR8X tiny family common values";
     family_id	= "tinyAVR";
 
-    memory "usersig"
+    memory "userrow"
         size		= 0x20;
         offset		= 0x1300;
         page_size	= 0x20;
         readsize	= 0x100;
     ;
 
-    memory "userrow"
-        alias "usersig";
+    memory "usersig"
+        alias "userrow";
     ;
 ;
 
@@ -16769,15 +16769,15 @@ part parent    ".avr8x"
     desc		= "AVR8X mega family common values";
     family_id	= "megaAVR";
 
-    memory "usersig"
+    memory "userrow"
         size		= 0x40;
         offset		= 0x1300;
         page_size	= 0x40;
         readsize	= 0x100;
     ;
 
-        memory "userrow"
-        alias "usersig";
+    memory "usersig"
+        alias "userrow";
     ;
 ;
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1174,7 +1174,8 @@ static int jtag3_initialize(PROGRAMMER * pgm, AVRPART * p)
 	u32_to_b4(xd.nvm_fuse_offset, m->offset & ~7);
       } else if (matches(m->desc, "lock")) {
 	u32_to_b4(xd.nvm_lock_offset, m->offset);
-      } else if (strcmp(m->desc, "usersig") == 0) {
+      } else if (strcmp(m->desc, "usersig") == 0 ||
+                 strcmp(m->desc, "userrow") == 0) {
 	u32_to_b4(xd.nvm_user_sig_offset, m->offset);
       } else if (strcmp(m->desc, "prodsig") == 0) {
 	u32_to_b4(xd.nvm_prod_sig_offset, m->offset);
@@ -1225,7 +1226,8 @@ static int jtag3_initialize(PROGRAMMER * pgm, AVRPART * p)
         u16_to_b2(xd.eeprom_bytes, m->size);
         u16_to_b2(xd.eeprom_base, m->offset);
       }
-      else if (strcmp(m->desc, "usersig") == 0)
+      else if (strcmp(m->desc, "usersig") == 0 ||
+               strcmp(m->desc, "userrow") == 0)
       {
         u16_to_b2(xd.user_sig_bytes, m->size);
         u16_to_b2(xd.user_sig_base, m->offset);
@@ -1686,9 +1688,10 @@ static int jtag3_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
       cmd[3] = XMEGA_ERASE_BOOT_PAGE;
   } else if (strcmp(m->desc, "eeprom") == 0) {
     cmd[3] = XMEGA_ERASE_EEPROM_PAGE;
-  } else if ( ( strcmp(m->desc, "usersig") == 0 ) ) {
+  } else if (strcmp(m->desc, "usersig") == 0 ||
+             strcmp(m->desc, "userrow") == 0) {
     cmd[3] = XMEGA_ERASE_USERSIG;
-  } else if ( ( strcmp(m->desc, "boot") == 0 ) ) {
+  } else if (strcmp(m->desc, "boot") == 0) {
     cmd[3] = XMEGA_ERASE_BOOT_PAGE;
   } else {
     cmd[3] = XMEGA_ERASE_APP_PAGE;
@@ -1760,9 +1763,10 @@ static int jtag3_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
     }
     cmd[3] = ( p->flags & AVRPART_HAS_PDI ) ? MTYPE_EEPROM_XMEGA : MTYPE_EEPROM_PAGE;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if ( ( strcmp(m->desc, "usersig") == 0 ) ) {
+  } else if (strcmp(m->desc, "usersig") == 0 ||
+             strcmp(m->desc, "userrow") == 0) {
     cmd[3] = MTYPE_USERSIG;
-  } else if ( ( strcmp(m->desc, "boot") == 0 ) ) {
+  } else if (strcmp(m->desc, "boot") == 0) {
     cmd[3] = MTYPE_BOOT_FLASH;
   } else if ( p->flags & AVRPART_HAS_PDI || p->flags & AVRPART_HAS_UPDI ) {
     cmd[3] = MTYPE_FLASH;
@@ -1849,11 +1853,12 @@ static int jtag3_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
     cmd[3] = ( p->flags & AVRPART_HAS_PDI || p->flags & AVRPART_HAS_UPDI ) ? MTYPE_EEPROM : MTYPE_EEPROM_PAGE;
     if (pgm->flag & PGM_FL_IS_DW)
       return -1;
-  } else if ( ( strcmp(m->desc, "prodsig") == 0 ) ) {
+  } else if (strcmp(m->desc, "prodsig") == 0) {
     cmd[3] = MTYPE_PRODSIG;
-  } else if ( ( strcmp(m->desc, "usersig") == 0 ) ) {
+  } else if (strcmp(m->desc, "usersig") == 0 ||
+             strcmp(m->desc, "userrow") == 0) {
     cmd[3] = MTYPE_USERSIG;
-  } else if ( ( strcmp(m->desc, "boot") == 0 ) ) {
+  } else if (strcmp(m->desc, "boot") == 0) {
     cmd[3] = MTYPE_BOOT_FLASH;
   } else if ( p->flags & AVRPART_HAS_PDI ) {
     cmd[3] = MTYPE_FLASH;
@@ -1965,7 +1970,8 @@ static int jtag3_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
     cmd[3] = MTYPE_FUSE_BITS;
     if (!(p->flags & AVRPART_HAS_UPDI))
       addr = mem->offset & 7;
-  } else if (strcmp(mem->desc, "usersig") == 0) {
+  } else if (strcmp(mem->desc, "usersig") == 0 ||
+             strcmp(mem->desc, "userrow") == 0) {
     cmd[3] = MTYPE_USERSIG;
   } else if (strcmp(mem->desc, "prodsig") == 0) {
     cmd[3] = MTYPE_PRODSIG;
@@ -2126,7 +2132,8 @@ static int jtag3_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
     cmd[3] = MTYPE_FUSE_BITS;
     if (!(p->flags & AVRPART_HAS_UPDI))
       addr = mem->offset & 7;
-  } else if (strcmp(mem->desc, "usersig") == 0) {
+  } else if (strcmp(mem->desc, "usersig") == 0 ||
+             strcmp(mem->desc, "userrow") == 0) {
     cmd[3] = MTYPE_USERSIG;
   } else if (strcmp(mem->desc, "prodsig") == 0) {
     cmd[3] = MTYPE_PRODSIG;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1056,7 +1056,8 @@ static void jtagmkII_set_xmega_params(PROGRAMMER * pgm, AVRPART * p)
       u32_to_b4(sendbuf.dd.nvm_fuse_offset, m->offset & ~7);
     } else if (strncmp(m->desc, "lock", 4) == 0) {
       u32_to_b4(sendbuf.dd.nvm_lock_offset, m->offset);
-    } else if (strcmp(m->desc, "usersig") == 0) {
+    } else if (strcmp(m->desc, "usersig") == 0 ||
+               strcmp(m->desc, "userrow") == 0) {
       u32_to_b4(sendbuf.dd.nvm_user_sig_offset, m->offset);
     } else if (strcmp(m->desc, "prodsig") == 0) {
       u32_to_b4(sendbuf.dd.nvm_prod_sig_offset, m->offset);
@@ -1933,9 +1934,10 @@ static int jtagmkII_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
       cmd[1] = XMEGA_ERASE_BOOT_PAGE;
   } else if (strcmp(m->desc, "eeprom") == 0) {
     cmd[1] = XMEGA_ERASE_EEPROM_PAGE;
-  } else if ( ( strcmp(m->desc, "usersig") == 0 ) ) {
+  } else if (strcmp(m->desc, "usersig") == 0 ||
+             strcmp(m->desc, "userrow") == 0) {
     cmd[1] = XMEGA_ERASE_USERSIG;
-  } else if ( ( strcmp(m->desc, "boot") == 0 ) ) {
+  } else if (strcmp(m->desc, "boot") == 0) {
     cmd[1] = XMEGA_ERASE_BOOT_PAGE;
   } else {
     cmd[1] = XMEGA_ERASE_APP_PAGE;
@@ -2044,13 +2046,14 @@ static int jtagmkII_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
       free(cmd);
       return n_bytes;
     }
-    cmd[1] = ( p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI) ) ? MTYPE_EEPROM : MTYPE_EEPROM_PAGE;
+    cmd[1] = (p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI)) ? MTYPE_EEPROM : MTYPE_EEPROM_PAGE;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if ( ( strcmp(m->desc, "usersig") == 0 ) ) {
+  } else if (strcmp(m->desc, "usersig") == 0 ||
+             strcmp(m->desc, "userrow") == 0) {
     cmd[1] = MTYPE_USERSIG;
-  } else if ( ( strcmp(m->desc, "boot") == 0 ) ) {
+  } else if (strcmp(m->desc, "boot") == 0) {
     cmd[1] = MTYPE_BOOT_FLASH;
-  } else if ( p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI) ) {
+  } else if (p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI)) {
     cmd[1] = MTYPE_FLASH;
   } else {
     cmd[1] = MTYPE_SPM;
@@ -2156,16 +2159,17 @@ static int jtagmkII_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
       /* dynamically decide between flash/boot memtype */
       dynamic_memtype = 1;
   } else if (strcmp(m->desc, "eeprom") == 0) {
-    cmd[1] = ( p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI) ) ? MTYPE_EEPROM : MTYPE_EEPROM_PAGE;
+    cmd[1] = (p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI)) ? MTYPE_EEPROM : MTYPE_EEPROM_PAGE;
     if (pgm->flag & PGM_FL_IS_DW)
       return -1;
-  } else if ( ( strcmp(m->desc, "prodsig") == 0 ) ) {
+  } else if (strcmp(m->desc, "prodsig") == 0) {
     cmd[1] = MTYPE_PRODSIG;
-  } else if ( ( strcmp(m->desc, "usersig") == 0 ) ) {
+  } else if (strcmp(m->desc, "usersig") == 0 ||
+             strcmp(m->desc, "userrow") == 0) {
     cmd[1] = MTYPE_USERSIG;
-  } else if ( ( strcmp(m->desc, "boot") == 0 ) ) {
+  } else if (strcmp(m->desc, "boot") == 0) {
     cmd[1] = MTYPE_BOOT_FLASH;
-  } else if ( p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI) ) {
+  } else if (p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI)) {
     cmd[1] = MTYPE_FLASH;
   } else {
     cmd[1] = MTYPE_SPM;
@@ -2291,7 +2295,8 @@ static int jtagmkII_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
       unsupp = 1;
   } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
     cmd[1] = MTYPE_FUSE_BITS;
-  } else if (strcmp(mem->desc, "usersig") == 0) {
+  } else if (strcmp(mem->desc, "usersig") == 0 ||
+             strcmp(mem->desc, "userrow") == 0) {
     cmd[1] = MTYPE_USERSIG;
   } else if (strcmp(mem->desc, "prodsig") == 0) {
     cmd[1] = MTYPE_PRODSIG;
@@ -2460,7 +2465,8 @@ static int jtagmkII_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
       unsupp = 1;
   } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
     cmd[1] = MTYPE_FUSE_BITS;
-  } else if (strcmp(mem->desc, "usersig") == 0) {
+  } else if (strcmp(mem->desc, "usersig") == 0 ||
+             strcmp(mem->desc, "userrow") == 0) {
     cmd[1] = MTYPE_USERSIG;
   } else if (strcmp(mem->desc, "prodsig") == 0) {
     cmd[1] = MTYPE_PRODSIG;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3869,7 +3869,8 @@ static int stk600_xprog_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
              * fuses.
              */
             need_erase = 1;
-    } else if (strcmp(mem->desc, "usersig") == 0) {
+    } else if (strcmp(mem->desc, "usersig") == 0 ||
+               strcmp(mem->desc, "userrow") == 0) {
         memcode = XPRG_MEM_TYPE_USERSIG;
     } else {
         avrdude_message(MSG_INFO, "%s: stk600_xprog_write_byte(): unknown memory \"%s\"\n",
@@ -3944,7 +3945,8 @@ static int stk600_xprog_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
     } else if (strcmp(mem->desc, "calibration") == 0 ||
                strcmp(mem->desc, "prodsig") == 0) {
         b[1] = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
-    } else if (strcmp(mem->desc, "usersig") == 0) {
+    } else if (strcmp(mem->desc, "usersig") == 0 ||
+               strcmp(mem->desc, "userrow") == 0) {
         b[1] = XPRG_MEM_TYPE_USERSIG;
     } else {
         avrdude_message(MSG_INFO, "%s: stk600_xprog_read_byte(): unknown memory \"%s\"\n",
@@ -4019,7 +4021,8 @@ static int stk600_xprog_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
     } else if (strcmp(mem->desc, "calibration") == 0 ||
                strcmp(mem->desc, "prodsig") == 0) {
         memtype = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
-    } else if (strcmp(mem->desc, "usersig") == 0) {
+    } else if (strcmp(mem->desc, "usersig") == 0 ||
+               strcmp(mem->desc, "userrow") == 0) {
         memtype = XPRG_MEM_TYPE_USERSIG;
     } else {
         avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_load(): unknown paged memory \"%s\"\n",
@@ -4132,7 +4135,8 @@ static int stk600_xprog_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
     } else if (strcmp(mem->desc, "calibration") == 0) {
         memtype = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
-    } else if (strcmp(mem->desc, "usersig") == 0) {
+    } else if (strcmp(mem->desc, "usersig") == 0 ||
+               strcmp(mem->desc, "userrow") == 0) {
         memtype = XPRG_MEM_TYPE_USERSIG;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
     } else {
@@ -4290,7 +4294,8 @@ static int stk600_xprog_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
       b[1] = XPRG_ERASE_BOOT_PAGE;
     } else if (strcmp(m->desc, "eeprom") == 0) {
       b[1] = XPRG_ERASE_EEPROM_PAGE;
-    } else if (strcmp(m->desc, "usersig") == 0) {
+    } else if (strcmp(m->desc, "usersig") == 0 ||
+               strcmp(m->desc, "userrow") == 0) {
       b[1] = XPRG_ERASE_USERSIG;
     } else {
       avrdude_message(MSG_INFO, "%s: stk600_xprog_page_erase(): unknown paged memory \"%s\"\n",


### PR DESCRIPTION
This PR is a simple fix to address #889. When the first tiny0/1 and mega0 chips were released, the memory this PR deals with was called USERSIG in the datasheet. This turned out to be a conflicting name with the very (but not quite) similar memory found on Xmega targets. The memory has later been renamed to USERROW in the datasheets, and all AVR-Dx/Ex chips has USERROW instead of USERSIG.

Closes #889