### PR TITLE
Increased timeout passed to `hid_read_timeout()`

### DIFF
--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -291,7 +291,7 @@ static int usbhid_recv(union filedescriptor *fd, unsigned char *buf, size_t nbyt
   if (udev == NULL)
     return -1;
 
-  rv = i = hid_read_timeout(udev, buf, nbytes, 300);
+  rv = i = hid_read_timeout(udev, buf, nbytes, 10000);
   if (i != nbytes)
     avrdude_message(MSG_INFO,
 		    "%s: Short read, read only %d out of %u bytes\n",


### PR DESCRIPTION
This PR resolves https://github.com/avrdudes/avrdude/issues/900. See that issue for more info.

I set the timeout to 10000 as that's what's used in usb_libusb.c:
https://github.com/avrdudes/avrdude/blob/34168759b0b01691c29140b9768e3d65b7bbbf06/src/usb_libusb.c#L400-L404 

I've tested the fix with the following programmers, on a Linux environment:

- Atmel ICE
- Xplained Mini evaluation board for Atmega168PB
