### PR TITLE
Minor terminal write improvements

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -506,6 +506,12 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
     return -1;
   }
 
+  avrdude_message(MSG_NOTICE, "Info: Writing %d bytes starting from address 0x%02x",
+                  len + data.bytes_grown, addr);
+  if (write_mode == WRITE_MODE_FILL)
+    avrdude_message(MSG_NOTICE, ". Remaining space filled with %s", argv[argc - 2]);
+  avrdude_message(MSG_NOTICE, "\n");
+
   pgm->err_led(pgm, OFF);
   bool werror = false;
   for (i = 0; i < (len + data.bytes_grown); i++) {

--- a/src/term.c
+++ b/src/term.c
@@ -364,7 +364,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
     return -1;
   }
 
-  uint8_t * buf = malloc(mem->size);
+  uint8_t * buf = malloc(mem->size + 0x10);
   if (buf == NULL) {
     avrdude_message(MSG_INFO, "%s (write): out of memory\n", progname);
     return -1;

--- a/src/term.c
+++ b/src/term.c
@@ -378,6 +378,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
     if (*end_ptr || (end_ptr == argv[3])) {
       avrdude_message(MSG_INFO, "%s (write ...): can't parse address \"%s\"\n",
             progname, argv[3]);
+      free(buf);
       return -1;
     }
   } else {
@@ -503,6 +504,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
     avrdude_message(MSG_INFO, "%s (write): selected address and # bytes exceed "
                     "range for %s memory\n",
                     progname, memtype);
+    free(buf);
     return -1;
   }
 


### PR DESCRIPTION
Fix potential crash due to buffer overflow.
Fix potential memory leak due to missing free()'s
Add write info when writing to memory in verbose mode.