### PR TITLE
Add progressbar for read and write command

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -302,6 +302,7 @@ static int cmd_dump(PROGRAMMER * pgm, struct avrpart * p,
     return -1;
   }
 
+  report_progress(0, 1, "Reading");
   for (uint32_t i = 0; i < len; i++) {
     int32_t rc = pgm->read_byte(pgm, p, mem, addr + i, &buf[i]);
     if (rc != 0) {
@@ -312,7 +313,9 @@ static int cmd_dump(PROGRAMMER * pgm, struct avrpart * p,
                 mem->desc);
       return -1;
     }
+    report_progress(i, len, NULL);
   }
+  report_progress(1, 1, NULL);
 
   hexdump_buf(stdout, addr, buf, len);
   fprintf(stdout, "\n");
@@ -508,7 +511,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
     return -1;
   }
 
-  avrdude_message(MSG_NOTICE, "Info: Writing %d bytes starting from address 0x%02x",
+  avrdude_message(MSG_NOTICE, "\nInfo: Writing %d bytes starting from address 0x%02x",
                   len + data.bytes_grown, addr);
   if (write_mode == WRITE_MODE_FILL)
     avrdude_message(MSG_NOTICE, ". Remaining space filled with %s", argv[argc - 2]);
@@ -516,6 +519,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
 
   pgm->err_led(pgm, OFF);
   bool werror = false;
+  report_progress(0, 1, "Writing");
   for (i = 0; i < (len + data.bytes_grown); i++) {
     int32_t rc = avr_write_byte(pgm, p, mem, addr+i, buf[i]);
     if (rc) {
@@ -538,11 +542,12 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
     if (werror) {
       pgm->err_led(pgm, ON);
     }
+
+    report_progress(i, (len + data.bytes_grown), NULL);
   }
+  report_progress(1, 1, NULL);
 
   free(buf);
-
-  fprintf(stdout, "\n");
 
   return 0;
 }


### PR DESCRIPTION
Instead of the terminal "freezing" while reading or writing in terminal mode, show a progress bar of not in quell mode:

```
$ ./avrdude -Cavrdude.conf -v -patmega1284p -cusbasp -t

avrdude: Version 6.99-20211218
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is "avrdude.conf"
         User configuration file is "/Users/hans/.avrduderc"
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : usb
         Using Programmer              : usbasp
         AVR Part                      : ATmega1284P
         Chip Erase delay              : 55000 us
         PAGEL                         : PD7
         BS2                           : PA0
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Timeout                       : 200
         StabDelay                     : 100
         CmdexeDelay                   : 25
         SyncLoops                     : 32
         PollIndex                     : 3
         PollValue                     : 0x53
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           eeprom                 65    10   128    0 no       4096    8      0  9000  9000 0xff 0xff
           flash                  65    10   256    0 yes    131072  256    512  4500  4500 0xff 0xff
           lock                    0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           lfuse                   0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           hfuse                   0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           efuse                   0     0     0    0 no          1    1      0  9000  9000 0x00 0x00
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           calibration             0     0     0    0 no          1    1      0     0     0 0x00 0x00

         Programmer Type : usbasp
         Description     : USBasp, http://www.fischl.de/usbasp/

avrdude: auto set sck period (because given equals null)
avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e9705 (probably m1284p)
avrdude> write eeprom 0 0x80 'a' 'v' 'r' 0xdeadbeef 0x0123456789abcdef 0x55 ... 
>>> write eeprom 0 0x80 'a' 'v' 'r' 0xdeadbeef 0x0123456789abcdef 0x55 ... 

Info: Writing 128 bytes starting from address 0x00. Remaining space filled with 0x55

Writing | ################################################## | 100% 0.72s

avrdude> read eeprom 0 0x100
>>> read eeprom 0 0x100 

Reading | ################################################## | 100% 0.17s

0000  61 76 72 ef be ad de ef  cd ab 89 67 45 23 01 55  |avr........gE#.U|
0010  55 55 55 55 55 55 55 55  55 55 55 55 55 55 55 55  |UUUUUUUUUUUUUUUU|
0020  55 55 55 55 55 55 55 55  55 55 55 55 55 55 55 55  |UUUUUUUUUUUUUUUU|
0030  55 55 55 55 55 55 55 55  55 55 55 55 55 55 55 55  |UUUUUUUUUUUUUUUU|
0040  55 55 55 55 55 55 55 55  55 55 55 55 55 55 55 55  |UUUUUUUUUUUUUUUU|
0050  55 55 55 55 55 55 55 55  55 55 55 55 55 55 55 55  |UUUUUUUUUUUUUUUU|
0060  55 55 55 55 55 55 55 55  55 55 55 55 55 55 55 55  |UUUUUUUUUUUUUUUU|
0070  55 55 55 55 55 55 55 55  55 55 55 55 55 55 55 55  |UUUUUUUUUUUUUUUU|
0080  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0090  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00a0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00b0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00c0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00d0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00e0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
00f0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|

avrdude> 


```