### PR TITLE
FreeBSD/CMake include location fixes ftdi1 build problem.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ if (HAVE_LIBUSB AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     set(HAVE_LIBUSB_1_0 ${HAVE_LIBUSB})
 endif()
 
+# FreeBSD include directories append.
+IF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+    include_directories(AFTER SYSTEM "/usr/local/include")
+endif()
+
 find_library(HAVE_LIBUSB_WIN32 NAMES libusb0.a usb0)
 
 if(HAVE_LIBUSB OR HAVE_LIBUSB_1_0 OR HAVE_LIBUSB_WIN32)


### PR DESCRIPTION
This commit appends `/usr/local/include` include location on FreeBSD.
This fixes missing `libftdi1/ftdi.h` build error.

Fixed build problem:
```
% rm -rf build; cmake -B build; cmake --build build
-- The C compiler identification is Clang 11.0.1
-- The CXX compiler identification is Clang 11.0.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Git: /usr/local/bin/git (found version "2.35.1")
-- Found FLEX: /usr/bin/flex (found version "2.6.4")
-- Found BISON: /usr/local/bin/bison (found version "3.8.2")
-- Looking for libelf.h
-- Looking for libelf.h - found
-- Looking for libelf/libelf.h
-- Looking for libelf/libelf.h - not found
-- Looking for usb.h
-- Looking for usb.h - found
-- Looking for lusb0_usb.h
-- Looking for lusb0_usb.h - not found
-- Looking for libusb.h
-- Looking for libusb.h - found
-- Looking for libusb-1.0/libusb.h
-- Looking for libusb-1.0/libusb.h - not found
-- Looking for hidapi/hidapi.h
-- Looking for hidapi/hidapi.h - not found
-- Looking for ftdi_tcioflush
-- Looking for ftdi_tcioflush - not found
-- Configuration summary:
-- ----------------------
-- DO HAVE    libelf
-- DO HAVE    libusb
-- DO HAVE    libusb_1_0
-- DO HAVE    libhidapi
-- DO HAVE    libftdi (but prefer to use libftdi1)
-- DO HAVE    libftdi1
-- DISABLED   doc
-- DISABLED   parport
-- DISABLED   linuxgpio
-- DISABLED   linuxspi
-- ----------------------
-- Configuring done
-- Generating done
-- Build files have been written to: /XXX/avrdude.git/build
[  1%] [FLEX][Parser] Building scanner with flex 2.6.4
[  3%] [BISON][Parser] Building parser with bison 3.8.2
[  4%] Building C object src/CMakeFiles/libavrdude.dir/arduino.c.o
[  6%] Building C object src/CMakeFiles/libavrdude.dir/avr.c.o
[  8%] Building C object src/CMakeFiles/libavrdude.dir/avr910.c.o
[  9%] Building C object src/CMakeFiles/libavrdude.dir/avrftdi.c.o
In file included from /XXX/avrdude.git/src/avrftdi.c:41:
/XXX/avrdude.git/src/avrftdi_private.h:12:11: fatal error: 'libftdi1/ftdi.h' file not found
          ^~~~~~~~~~~~~~~~~
1 error generated.
gmake[2]: *** [src/CMakeFiles/libavrdude.dir/build.make:129: src/CMakeFiles/libavrdude.dir/avrftdi.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:100: src/CMakeFiles/libavrdude.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>