### PR TITLE
Update documentation link to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ avrdude -c arduino -P COM1 -b 115200 -p atmega328p -D -U flash:w:objs/blink.hex:
 
 There are many different programmers and options that may be required for the programming to succeed.
 
-For more information, refer to the [AVRDUDE documentation](http://download.savannah.gnu.org/releases/avrdude/avrdude-doc-6.4.pdf).
+For more information, refer to the [AVRDUDE documentation](https://avrdudes.github.io/avrdude/).


### PR DESCRIPTION
The project documentation is now hosted on GitHub pages. Pointing the documentation link to the documentation site home page will offer the reader easy access to the documentation for the latest and previous releases while also avoiding the maintenance burden of updating the readme on every release