### PR TITLE
Fix Issue #915 wrong or missing SPI commands in .conf

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -9820,6 +9820,8 @@ part parent "m328"
 
     memory "efuse"
         size = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
                           "x x x x x x x x o o o o o o o o";
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
@@ -9840,15 +9842,77 @@ part parent "m328"
     bs2             = 0xe2;
 
     memory "eeprom"
-        size            = 2048;
+	paged		= no;
         page_size       = 8;
+        size            = 2048;
+	min_write_delay = 3600;
+	max_write_delay = 3600;
+	readback_p1	= 0xff;
+	readback_p2	= 0xff;
+	read = " 1 0 1 0 0 0 0 0",
+	       " 0 0 0 x x a10 a9 a8",
+	       " a7 a6 a5 a4 a3 a2 a1 a0",
+	       " o o o o o o o o";
+
+	write = " 1 1 0 0 0 0 0 0",
+	      	" 0 0 0 x x a10 a9 a8",
+		" a7 a6 a5 a4 a3 a2 a1 a0",
+		" i i i i i i i i";
+
+	loadpage_lo = " 1 1 0 0 0 0 0 1",
+		      " 0 0 0 0 0 0 0 0",
+		      " 0 0 0 0 0 a2 a1 a0",
+		      " i i i i i i i i";
+
+	writepage = " 1 1 0 0 0 0 1 0",
+		    " 0 0 x x x a10 a9 a8",
+		    " a7 a6 a5 a4 a3 0 0 0",
+		    " x x x x x x x x";
+
+	mode		= 0x41;
+	delay		= 20;
+	blocksize	= 4;
+	readsize	= 256;
     ;
 
     memory "flash"
-        paged           = yes;
+	paged		= yes;
         size            = 65536;
         page_size       = 256;
         num_pages       = 256;
+	min_write_delay = 4500;
+	max_write_delay = 4500;
+	readback_p1	= 0xff;
+	readback_p2	= 0xff;
+	read_lo = " 0 0 1 0 0 0 0 0",
+		  " 0 a14 a13 a12 a11 a10 a9 a8",
+		  " a7 a6 a5 a4 a3 a2 a1 a0",
+		  " o o o o o o o o";
+
+	read_hi = " 0 0 1 0 1 0 0 0",
+		  " 0 a14 a13 a12 a11 a10 a9 a8",
+		  " a7 a6 a5 a4 a3 a2 a1 a0",
+		  " o o o o o o o o";
+
+	loadpage_lo = " 0 1 0 0 0 0 0 0",
+		      " 0 0 0 x x x x x",
+		      " x a6 a5 a4 a3 a2 a1 a0",
+		      " i i i i i i i i";
+
+	loadpage_hi = " 0 1 0 0 1 0 0 0",
+		      " 0 0 0 x x x x x",
+		      " x a6 a5 a4 a3 a2 a1 a0",
+		      " i i i i i i i i";
+
+	writepage = " 0 1 0 0 1 1 0 0",
+		    " 0 a14 a13 a12 a11 a10 a9 a8",
+		    " a7 x x x x x x x",
+		    " x x x x x x x x";
+
+	mode		= 0x41;
+	delay		= 6;
+	blocksize	= 128;
+	readsize	= 256;
     ;
 
     memory "efuse"
@@ -12796,7 +12860,7 @@ part
     memory "calibration"
         size            = 1;
         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+                          "0  0  0  0   0  0  0  0   o o o o  o o o o";
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -84,10 +84,6 @@
 #       predelay         = <num> ;
 #       postdelay        = <num> ;
 #       pollmethod       = <num> ;
-#       mode             = <num> ;
-#       delay            = <num> ;
-#       blocksize        = <num> ;
-#       readsize         = <num> ;
 #       hvspcmdexedelay  = <num> ;
 #       # STK500v2 HV programming parameters, from XML
 #       pp_controlstack  = <num>, <num>, ...;   # PP only
@@ -122,6 +118,7 @@
 #
 #       memory <memtype>
 #           paged           = <yes/no> ;          # yes / no
+#           offset          = <num> ;             # memory offset
 #           size            = <num> ;             # bytes
 #           page_size       = <num> ;             # bytes
 #           num_pages       = <num> ;             # numeric
@@ -139,6 +136,10 @@
 #           loadpage_lo     = <instruction format> ;
 #           loadpage_hi     = <instruction format> ;
 #           writepage       = <instruction format> ;
+#           mode            = <num> ;             # STK500 v2 file parameter, to be taken from Atmel's XML files
+#           delay           = <num> ;             # STK500 v2 file parameter, to be taken from Atmel's XML files
+#           blocksize       = <num> ;             # STK500 v2 file parameter, to be taken from Atmel's XML files
+#           readsize        = <num> ;             # STK500 v2 file parameter, to be taken from Atmel's XML files
 #         ;
 #     ;
 #
@@ -191,8 +192,8 @@
 #
 #       'x'  = the bit is ignored on input and output
 #
-#       'a'  = the bit is an address bit, the bit-number matches this bit
-#              specifier's position within the current instruction byte
+#       'a'  = the bit is an address bit; from v 7.0 the bit-number is set to
+#              match the right bit position for the instruction to just work
 #
 #       'aN' = the bit is the Nth address bit, bit-number = N, i.e., a12
 #              is address bit 12 on input, a0 is address bit 0.

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -12731,9 +12731,9 @@ part
     ;
 
     memory "calibration"
-        size            = 2;
+        size            = 1;
         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                          "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -4741,16 +4741,79 @@ part parent "m324p"
     signature        = 0x1e 0x94 0x0a;
 
     memory "eeprom"
+        paged           = no; /* leave this "no" */
+        page_size       = 4;  /* for parallel programming */
         size            = 512;
-        page_size       = 4;
-        ;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+	read            = "  1   0   1   0      0   0   0   0",
+                          "  0   0   x   x      x   0   0  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+	write           = "  1   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   0   0  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          "  i   i   i   i      i   i   i   i";
+
+	loadpage_lo	= "  1   1   0   0      0   0   0   1",
+			  "  0   0   0   0      0   0   0   0",
+			  "  0   0   0   0      0   0  a1  a0",
+			  "  i   i   i   i      i   i   i   i";
+
+	writepage	= "  1   1   0   0      0   0   1   0",
+			  "  0   0   x   x      x   0   0 a8",
+			  " a7  a6  a5  a4     a3  a2   0   0",
+			  "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x41;
+	delay		= 10;
+	blocksize	= 128;
+	readsize	= 256;
+      ;
 
     memory "flash"
         paged           = yes;
         size            = 16384;
         page_size       = 128;
         num_pages       = 128;
-        ;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0      0   0   0   0",
+                          "  0   0   0 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        read_hi         = "  0   0   1   0      1   0   0   0",
+                          "  0   0   0 a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
+                          "  o   o   o   o      o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0      0   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0      1   0   0   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  0   1   0   0      1   1   0   0",
+                          "  0   0   0 a12    a11 a10  a9  a8",
+                          " a7  a6   x   x      x   x   x   x",
+                          "  x   x   x   x      x   x   x   x";
+
+	mode		= 0x21;
+	delay		= 6;
+	blocksize	= 256;
+	readsize	= 256;
+      ;
+
   ;
 
 #------------------------------------------------------------

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2389,11 +2389,13 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8",
-                          "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x 0 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x 0 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2406,25 +2408,21 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x7f;
         readback_p2     = 0x7f;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -3449,15 +3447,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 20;
@@ -4037,15 +4033,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
@@ -4055,10 +4049,9 @@ part
                           "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -4224,15 +4217,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
@@ -4242,10 +4233,9 @@ part
                           "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -4378,24 +4368,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x04;
         delay           = 10;
@@ -4412,15 +4399,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -4430,10 +4415,9 @@ part
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -4562,24 +4546,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x 0 a9 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -4596,15 +4577,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -4614,10 +4593,9 @@ part
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -4875,24 +4853,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x 0 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -4909,15 +4884,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 x x x x x x x a6 a5 a4 a3 a2 a1 a0",
@@ -4927,10 +4900,9 @@ part
                           "0 0 x x x x x x x a6 a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -5256,15 +5228,13 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -5274,10 +5244,9 @@ part
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
         mode            = 0x41;
         delay           = 10;
         blocksize       = 128;
@@ -5325,24 +5294,21 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -5864,15 +5830,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -6113,15 +6077,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
@@ -8547,24 +8509,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x 0 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x 0 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-              "  0   0   x   x      x   x   x  a8",
-              " a7  a6  a5  a4     a3  a2   0   0",
-              "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x 0 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 5;
@@ -8776,15 +8735,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -8794,10 +8751,9 @@ part
                           "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 0 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -8857,8 +8813,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -9042,8 +8998,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -9113,24 +9069,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x x 0 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x 0 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x x 0 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -9146,15 +9099,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
@@ -9164,10 +9115,9 @@ part
                           "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -9299,24 +9249,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x x 0 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x 0 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x x 0 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -10355,15 +10302,13 @@ part parent "pwm3b"
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -10373,10 +10318,9 @@ part parent "pwm3b"
                           "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -10570,8 +10514,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -10749,8 +10693,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -10929,8 +10873,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -11903,8 +11847,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -12093,8 +12037,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -12284,8 +12228,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -12583,8 +12527,8 @@ part
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                          "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -12656,20 +12600,17 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
@@ -12691,15 +12632,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -12709,10 +12648,9 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12846,20 +12784,17 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
@@ -12881,15 +12816,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -12899,10 +12832,9 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -13422,24 +13354,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -13456,15 +13385,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -13474,10 +13401,9 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -13607,24 +13533,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -13641,15 +13564,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -13659,10 +13580,9 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -13794,24 +13714,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -13828,15 +13745,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -13846,10 +13761,9 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -13980,24 +13894,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -14014,15 +13925,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -14032,10 +13941,9 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -14166,24 +14074,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -14200,15 +14105,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = "0 1 0 0 0 0 0 0",
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
@@ -14218,10 +14121,9 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -14597,30 +14499,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0 0 0 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0 0 0 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 0 0 0 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -14814,30 +14711,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "   0   0   1   0      0   0   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          "  a7  a6  a5  a4     a3  a2  a1  a0",
-                          "   o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "   0   0   1   0      1   0   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          "  a7  a6  a5  a4     a3  a2  a1  a0",
-                          "   o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          "  a7 a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0 0 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          "  a7 a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0 0 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "   0   1   0   0      1   1   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          "  a7  a6  a5  a4     a3  a2  a1  a0",
-                          "   0   0   0   0      0   0   0   0";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0";
 
         mode            = 0x41;
         delay           = 10;
@@ -16240,24 +16132,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x 0 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x 0 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         loadpage_lo     = "1 1 0 0 0 0 0 1",
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-           "  0   0   x   x      x   x   x  a8",
-           " a7  a6  a5  a4     a3  a2   0   0",
-           "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x 0 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 5;
@@ -16282,15 +16171,13 @@ part
                           "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
                           "o o o o o o o o";
 
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x 0 0 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x 0 0 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
         writepage       = "0 1 0 0 1 1 0 0",

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2234,11 +2234,11 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     chip_erase_delay    = 20000;
-    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+                          "x x x x  x x x x   x x x x  x x x x";
 
-    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -2347,10 +2347,10 @@ part
     signature           = 0x1e 0x92 0x01;
     chip_erase_delay    = 20000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -2459,10 +2459,10 @@ part
     signature           = 0x1e 0x91 0x01;
     chip_erase_delay    = 20000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -2572,10 +2572,10 @@ part
     signature           = 0x1e 0x91 0x05;
     chip_erase_delay    = 20000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -2698,10 +2698,10 @@ part
     signature           = 0x1e 0x91 0x03;
     chip_erase_delay    = 18000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -2821,10 +2821,10 @@ part
     signature           = 0x1e 0x92 0x03;
     chip_erase_delay    = 20000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -2945,10 +2945,10 @@ part
     signature           = 0x1e 0x92 0x02;
     chip_erase_delay    = 20000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     memory "eeprom"
         size            = 256;
@@ -3026,10 +3026,10 @@ part
     signature           = 0x1e 0x93 0x01;
     chip_erase_delay    = 20000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -3139,10 +3139,10 @@ part
     signature           = 0x1e 0x93 0x03;
     chip_erase_delay    = 20000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -3259,10 +3259,10 @@ part
     signature           = 0x1e 0x97 0x01;
     chip_erase_delay    = 112000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -3397,10 +3397,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -3581,10 +3581,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -3765,10 +3765,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -3949,10 +3949,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -4133,10 +4133,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -4317,10 +4317,10 @@ part
     bs2                 = 0xa0;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -4496,10 +4496,10 @@ part
     bs2                 = 0xa0;
     chip_erase_delay    = 55000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -4803,10 +4803,10 @@ part
     bs2                 = 0xa0;
     chip_erase_delay    = 55000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -5014,10 +5014,10 @@ part
     bs2                 = 0xa0;
     chip_erase_delay    = 55000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -5211,10 +5211,10 @@ part
     allowfullpagebitstream = yes;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     ocdrev              = 2;
 
@@ -5395,10 +5395,10 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -5546,10 +5546,11 @@ part
     signature           = 0x1e 0x94 0x05;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
@@ -5751,10 +5752,11 @@ part
     signature           = 0x1e 0x95 0x03;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
@@ -5998,10 +6000,11 @@ part
     signature           = 0x1e 0x96 0x03;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
@@ -6227,10 +6230,11 @@ part
     bs2                 = 0xa0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
@@ -6395,10 +6399,11 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
@@ -6537,10 +6542,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 10000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -6700,10 +6705,10 @@ part
     signature           = 0x1e 0x93 0x06;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -6855,10 +6860,10 @@ part
     bs2                 = 0xa0;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -7805,10 +7810,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 45000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -8024,10 +8029,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -8243,10 +8248,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-                       "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-                       "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -8464,10 +8469,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 15000;
     pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-                       "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-                       "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -8655,10 +8660,10 @@ part
     chip_erase_delay    = 15000;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -8840,10 +8845,10 @@ part
     chip_erase_delay    = 15000;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -9022,10 +9027,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 15000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -9202,10 +9207,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -9382,10 +9387,10 @@ part
     bs2                 = 0xc2;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-                 "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-                 "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -9710,10 +9715,10 @@ part
     chip_erase_delay    = 9000;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -9905,10 +9910,10 @@ part
     chip_erase_delay    = 9000;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                           "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                           "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -10085,10 +10090,10 @@ part
     chip_erase_delay    = 9000;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -10361,10 +10366,10 @@ part
     chip_erase_delay    = 4500;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -10540,10 +10545,10 @@ part
     chip_erase_delay    = 4500;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -10720,10 +10725,10 @@ part
     chip_erase_delay    = 4500;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -10895,10 +10900,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -11077,10 +11082,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -11272,10 +11277,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -11694,10 +11699,10 @@ part
     chip_erase_delay    = 4500;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -11883,10 +11888,10 @@ part
     chip_erase_delay    = 4500;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -12073,10 +12078,10 @@ part
     chip_erase_delay    = 4500;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -12375,10 +12380,10 @@ part
     chip_erase_delay    = 1000;
 
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -12549,10 +12554,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -12733,10 +12738,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -12917,10 +12922,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -13113,10 +13118,10 @@ part
     bs2                 = 0xA0;
     reset               = dedicated;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -13307,9 +13312,11 @@ part
     chip_erase_delay    = 9000;
     reset               = io;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     pagel               = 0xD7;
     bs2                 = 0xC6;
 
@@ -13486,9 +13493,11 @@ part
     chip_erase_delay    = 9000;
     reset               = io;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     pagel               = 0xD7;
     bs2                 = 0xC6;
 
@@ -13667,9 +13676,11 @@ part
     chip_erase_delay    = 9000;
     reset               = io;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     pagel               = 0xD7;
     bs2                 = 0xC6;
 
@@ -13847,9 +13858,11 @@ part
     chip_erase_delay    = 9000;
     reset               = io;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     pagel               = 0xD7;
     bs2                 = 0xC6;
 
@@ -14027,9 +14040,11 @@ part
     chip_erase_delay    = 9000;
     reset               = io;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
+                          "x x x x  x x x x    x x x x  x x x x";
+
     pagel               = 0xD7;
     bs2                 = 0xC6;
 
@@ -14204,10 +14219,10 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x   x x x x  x x x x";
+                          "x x x x  x x x x   x x x x  x x x x";
 
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                       "x x x x  x x x x   x x x x  x x x x";
+                          "x x x x  x x x x   x x x x  x x x x";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -14418,10 +14433,10 @@ part
     bs2                 = 0xa0;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+                          "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+                          "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -14630,10 +14645,10 @@ part
     bs2                 = 0xa0;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+                          "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
     chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
+                          "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
     timeout             = 200;
     stabdelay           = 100;
@@ -16087,10 +16102,10 @@ part
     reset               = io;
     chip_erase_delay    = 9000;
     pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-                       "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-                       "x x x x x x x x x x x x x x x x";
+                          "x x x x x x x x x x x x x x x x";
 
     timeout             = 200;
     stabdelay           = 100;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -12621,10 +12621,10 @@ part
                 readback_p1     = 0xff;
                 readback_p2     = 0xff;
                 read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                                   "0  0 a4  a3 a2 a1 a0   o o o o  o o o o";
+                                  "0  0 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
 
                 write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                                   "0  0 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+                                  "0  0 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
                 loadpage_lo     = "  1   1   0   0      0   0   0   1",
                                   "  0   0   0   0      0   0   0   0",

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1831,11 +1831,13 @@ part
         max_write_delay = 20000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 8;
@@ -1849,25 +1851,21 @@ part
         max_write_delay = 20000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 5;
@@ -1877,34 +1875,35 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x o o x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x o o x";
 
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 i i 1",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "fuse"
         size            = 1;
-        read            = "0  1  0  1   0  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1  0  1  0   1  1  0  0    1 0 1 x  x x x x",
-                          "x  x  x  x   x  x  x  x    i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 x x x x x",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -1972,21 +1971,21 @@ part
         max_write_delay = 4000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 5;
@@ -2003,30 +2002,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  0  0  0  0   0  0  0 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  0  0  0  0   0  0  0 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  0  0  0  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  0  0  0  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  0  0  0  0   0  0  0 a8",
-                          " a7 a6 a5 a4   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 0 0 a8 a7 a6 a5 a4 x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -2036,8 +2030,9 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0    0 0 0 x  x x x x",
-                          "x  x  x  x   x  x a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
@@ -2045,17 +2040,18 @@ part
         min_write_delay = 4500;
         max_write_delay = 4500;
 
-        read            = "0  1  0  1   1  0  0  0    0 0 0 0  0 0 0 0",
-                          "x  x  x  x   x  x  x  x    o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1  0  1  0   1  1  0  0    1 1 1 x  x x x x",
-                          "x  x  x  x   x  x  x  x    1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 2;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                          "0  0  0  0   0  0  0 a0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 0 x x x x x 0 0 0 0 0 0 0 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lfuse"
@@ -2063,11 +2059,11 @@ part
         min_write_delay = 4500;
         max_write_delay = 4500;
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
     ;
 
     memory "hfuse"
@@ -2075,11 +2071,11 @@ part
         min_write_delay = 4500;
         max_write_delay = 4500;
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
     ;
 ;
 
@@ -2146,11 +2142,13 @@ part
         max_write_delay = 8200;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 10;
@@ -2164,25 +2162,21 @@ part
         max_write_delay = 4100;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 5;
@@ -2192,34 +2186,35 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x o o x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x o o x";
 
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 i i 1",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "fuse"
         size            = 1;
-        read            = "0  1  0  1   0  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    o o o o  x x o o";
+        read            = "0 1 0 1 0 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   o o o o x x o o";
 
-        write           = "1  0  1  0   1  1  0  0    1 0 1 x  x x x x",
-                          "x  x  x  x   x  x  x  x    i i i i  1 1 i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 x x x x x",
+                          "x x x x x x x x   i i i i 1 1 i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -2282,11 +2277,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1 0  1  0   0  0  0  0   x x x x  x x x x",
-                          "x x a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1 1  0  0   0  0  0  0   x x x x  x x x x",
-                          "x x a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 20;
@@ -2299,25 +2296,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x02;
         delay           = 15;
@@ -2326,8 +2319,9 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
@@ -2336,8 +2330,8 @@ part
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
     ;
 ;
 
@@ -2439,16 +2433,17 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
     ;
     memory "lock"
         size            = 1;
-        write           = "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -2508,11 +2503,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2525,25 +2522,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x7f;
         readback_p2     = 0x7f;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2552,16 +2545,17 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x i i x",
-                          "x x x x  x x x x  x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x i i x",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -2622,11 +2616,13 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2640,25 +2636,21 @@ part
         max_write_delay = 20000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2668,29 +2660,30 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
         pwroff_after_write = yes;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 i i i i i",
+                          "x x x x x x x x   x x x x x x x x";
     ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x o o x";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
     ;
 ;
 
@@ -2749,11 +2742,13 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 0  0 0 0 0",
-                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0 x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0   0 0 0 0  0 0 0 0",
-                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0 x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2766,25 +2761,21 @@ part
         max_write_delay = 20000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2793,28 +2784,29 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   o o o x  x x x o";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   o o o x x x x o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 1  1 1 1 i",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 1 1 1 1 i",
+                          "x x x x x x x x   x x x x x x x x";
     ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   o o o x  x x x o";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   o o o x x x x o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
     ;
 ;
 
@@ -2873,11 +2865,13 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2890,25 +2884,21 @@ part
         max_write_delay = 20000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -2917,29 +2907,30 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
         pwroff_after_write = yes;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 i i i i i",
+                          "x x x x x x x x   x x x x x x x x";
     ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x o o x";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
     ;
 ;
 
@@ -2967,11 +2958,13 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
     ;
     memory "flash"
         size            = 4096;
@@ -2979,50 +2972,47 @@ part
         max_write_delay = 20000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 i i i i i",
+                          "x x x x x x x x   x x x x x x x x";
     ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x o o x";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
     ;
 ;
 
@@ -3081,11 +3071,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8",
-                          "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -3098,25 +3090,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x7f;
         readback_p2     = 0x7f;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -3125,16 +3113,17 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
     ;
     memory "lock"
         size            = 1;
-        write           = "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -3194,11 +3183,13 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -3211,25 +3202,21 @@ part
         max_write_delay = 20000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_lo        = "0 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        write_hi        = "0 1 0 0 1 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -3238,24 +3225,25 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "fuse"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  o";
-        write           = "1  0  1  0   1  1  0  0   1  0  1  1   1  1  1  i",
-                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x x x o";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 1 1 1 1 i",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
     memory "lock"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x  x  x   o  o  x  x   x  x  x  x";
-        write           = "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   o o x x x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -3315,15 +3303,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -3340,30 +3326,25 @@ part
         max_write_delay = 56000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x11;
         delay           = 70;
@@ -3373,30 +3354,31 @@ part
 
     memory "fuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0  x x x x  x x x x",
-                          "x x x x  x x x x  x x o x  o 1 o o";
+        read            = "0 1 0 1 0 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x o x o 1 o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 1  i 1 i i",
-                          "x x x x  x x x x  x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 1 i 1 i i",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x o o x";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 i i 1",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -3492,31 +3474,26 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -3526,58 +3503,60 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x x i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 4;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -3657,15 +3636,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 12;
@@ -3682,30 +3659,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -3715,58 +3687,60 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x x i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 4;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -3847,25 +3821,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
 
         mode            = 0x41;
@@ -3883,30 +3853,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -3916,58 +3881,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -4039,25 +4005,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
 
         mode            = 0x41;
@@ -4085,15 +4047,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -4108,58 +4068,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -4231,25 +4192,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
 
         mode            = 0x41;
@@ -4277,15 +4234,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -4300,58 +4255,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -4432,10 +4388,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   x   x      x   x  a9  a8",
@@ -4467,15 +4422,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "  0   0 a13 a12    a11 a10  a9  a8",
@@ -4490,46 +4443,48 @@ part
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "calibration"
         size            = 4;
 
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 0 x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -4617,10 +4572,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   x   x      x a10  a9  a8",
@@ -4652,15 +4606,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "  0 a14 a13 a12    a11 a10  a9  a8",
@@ -4675,33 +4627,33 @@ part
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -4709,26 +4661,27 @@ part
     memory "efuse"
         size            = 1;
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 1 1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
 
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -4749,25 +4702,21 @@ part parent "m324p"
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   0   0  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   0   0  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x 0 0 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   0   0 a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x 0 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -4784,30 +4733,25 @@ part parent "m324p"
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0   0 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0   0 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -4941,10 +4885,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   x   x    a11 a10  a9  a8",
@@ -4976,15 +4919,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -4999,33 +4940,33 @@ part
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -5033,26 +4974,27 @@ part
     memory "efuse"
         size            = 1;
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 1 1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
 
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -5150,25 +5092,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -5185,30 +5123,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -5218,33 +5151,33 @@ part
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -5252,26 +5185,27 @@ part
     memory "efuse"
         size            = 1;
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 1 1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
 
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -5332,15 +5266,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "  0   0 a13 a12    a11 a10  a9  a8",
@@ -5403,10 +5335,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   x   x      x   x  a9  a8",
@@ -5423,11 +5354,11 @@ part
         size            = 1;
         min_write_delay = 16000;
         max_write_delay = 16000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
@@ -5435,11 +5366,11 @@ part
         min_write_delay = 16000;
         max_write_delay = 16000;
 
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
@@ -5447,11 +5378,11 @@ part
         min_write_delay = 16000;
         max_write_delay = 16000;
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 1 1 i i i";
     ;
 
     memory "lock"
@@ -5459,25 +5390,26 @@ part
         min_write_delay = 16000;
         max_write_delay = 16000;
 
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "signature"
         size            = 3;
 
-        read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
 
-        read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -5540,15 +5472,13 @@ part
         max_write_delay = 4000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
         mode            = 0x41;
         delay           = 20;
         blocksize       = 4;
@@ -5564,30 +5494,25 @@ part
         max_write_delay = 16000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x11;
         delay           = 20;
@@ -5599,45 +5524,46 @@ part
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o x x  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o x x o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i 1 1  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i 1 1 i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   x x x x  1 o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   x x x x 1 o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   1 1 1 1  1 i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   1 1 1 1 1 i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  0 x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x 0 x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0   x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -5702,25 +5628,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -5737,30 +5659,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -5772,54 +5689,55 @@ part
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -5915,25 +5833,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x a9 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -5960,18 +5874,18 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "0 1 0 0 1 1 0 0   x x a13 a12 a11 a10 a9 a8   a7 a6 x x x x x x   x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x a13 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -5983,56 +5897,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -6167,25 +6082,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -6212,18 +6123,18 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "0 1 0 0 1 1 0 0   x a14 a13 a12 a11 a10 a9 a8   a7 x x x x x x x   x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -6235,56 +6146,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -6402,25 +6314,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x a9 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x04;
         delay           = 10;
@@ -6437,30 +6345,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -6472,45 +6375,47 @@ part
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 4;
-        read            = "0 0 1 1  1 0 0 0    0 0 x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -6569,15 +6474,13 @@ part
         max_write_delay = 3400;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 5;
@@ -6594,30 +6497,25 @@ part
         max_write_delay = 14000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 16;
@@ -6629,27 +6527,28 @@ part
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x o x o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x o x o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 x  x x x x",
-                          "x x x x  x x x x   1 i 1 i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 x x x x x",
+                          "x x x x x x x x   1 i 1 i i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -6720,15 +6619,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 20;
@@ -6744,30 +6641,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 0 x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 0 x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 10;
@@ -6779,45 +6671,47 @@ part
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 4;
-        read            = "0  0  1  1   1  0  0  0   0  0  x  x   x  x  x  x",
-                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -6886,15 +6780,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 20;
@@ -6910,30 +6802,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 0 x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 0 x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -6945,45 +6832,47 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 4;
-        read            = "0 0 1 1  1 0 0 0     0 0 x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -7046,15 +6935,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 20;
@@ -7070,30 +6957,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 0 x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 0 x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -7105,45 +6987,47 @@ part
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 4;
-        read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -7204,11 +7088,13 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         mode            = 0x04;
         delay           = 10;
@@ -7225,30 +7111,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x21;
         delay           = 6;
@@ -7258,47 +7139,49 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x x o o";
 
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 1 i i",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  x x x i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   x x x i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 4;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -7370,21 +7253,21 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -7402,30 +7285,25 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x x x x a9 a8 a7 a6 a5 a4 x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -7435,58 +7313,59 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x x o o";
 
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 1 i i",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -7567,21 +7446,21 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read            = " 1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -7599,30 +7478,25 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read_lo         = "  0  0  1  0   0   0  0  0",
-                          "  x  x  x  x   x a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0  0  1  0   1   0  0  0",
-                          "  x  x  x  x   x a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1  0  0",
-                          "  x  x  x  x   x a10 a9 a8",
-                          " a7 a6 a5  x   x   x  x  x",
-                          "  x  x  x  x   x   x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -7632,58 +7506,59 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x x o o";
 
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 1 i i",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -7764,21 +7639,21 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read            = " 1  0  1  0   0  0  0  0    x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    o o o o  o o o  o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1  1  0  0   0  0  0  0    x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i  i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -7796,30 +7671,25 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read_lo         = "  0  0  1  0   0   0  0  0",
-                          "  x  x  x  x a11 a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0  0  1  0   1   0  0  0",
-                          "  x  x  x  x a11 a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1  0  0",
-                          "  x  x  x  x a11 a10 a9 a8",
-                          " a7 a6 a5  x   x   x  x  x",
-                          "  x  x  x  x   x   x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -7829,58 +7699,59 @@ part
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
+        read            = "0 1 0 1 1 0 0 0   x x x x x x x x",
+                          "x x x x x x x x   x x x x x x o o";
 
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 1 1 1 i i",
+                          "x x x x x x x x   x x x x x x x x";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -8019,25 +7890,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -8053,30 +7920,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0    0 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0    0 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -8088,56 +7950,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -8246,25 +8109,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -8280,30 +8139,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -8315,56 +8169,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -8473,25 +8328,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -8508,30 +8359,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                          " 0 0 0 a12 a11 a10 a9 a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = " 0 0 1 0 1 0 0 0",
-                           " 0 0 0 a12 a11 a10 a9 a8",
-                           " a7 a6 a5 a4 a3 a2 a1 a0",
-                           " o o o o o o o o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = " 0 1 0 0 1 1 0 0",
-                          " 0 0 0 a12 a11 a10 a9 a8",
-                          " a7 a6 x x x x x x",
-                          " x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -8544,56 +8390,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x x x x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-                          "x x x x x x x x 1 1 i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-                          "0 0 0 0 0 0 0 0 o o o o o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-                          "x x x x x x a1 a0 o o o o o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -8710,10 +8557,9 @@ part
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                   "  0   0   0   0      0   0   0   0",
-                   "  0   0   0   0      0   0  a1  a0",
-                   "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
               "  0   0   x   x      x   x   x  a8",
@@ -8735,30 +8581,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                          " 0 0 0 0 a11 a10 a9 a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = " 0 0 1 0 1 0 0 0",
-                           " 0 0 0 0 a11 a10 a9 a8",
-                           " a7 a6 a5 a4 a3 a2 a1 a0",
-                           " o o o o o o o o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x x a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x x a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = " 0 1 0 0 1 1 0 0",
-                          " 0 0 0 0 a11 a10 a9 a8",
-                          " a7 a6 a5 x x x x x",
-                          " x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -8771,56 +8612,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x 1 1 1 i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 i i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-                          "x x x x x x x x 1 1 i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-                          "0 0 0 0 0 0 0 0 o o o o o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-                          "x x x x x x a1 a0 o o o o o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -8902,19 +8744,23 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         # semi-automatically corrected: check part/datasheet
-        write           = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-        "  0   0   0   0      0   0   0   0",
-        "  0   0   0   0      0   0  a1  a0",
-        "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -8940,15 +8786,13 @@ part
                            " a7  a6  a5  a4   a3  a2   a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0  1  0  0   1   1   0  0",
                            "  0  0  0  0  a11 a10 a9 a8",
@@ -8963,49 +8807,50 @@ part
 #   ATtiny87 has Signature Bytes: 0x1E 0x93 0x87.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   x x x x x x i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -9087,19 +8932,23 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         # semi-automatically corrected: check part/datasheet
-        write           = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-        "  0   0   0   0      0   0   0   0",
-        "  0   0   0   0      0   0  a1  a0",
-        "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -9115,30 +8964,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  a12  a11 a10 a9 a8",
-                           " a7 a6 x  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -9148,49 +8992,50 @@ part
 #   ATtiny167 has Signature Bytes: 0x1E 0x94 0x87.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   x x x x x x i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -9278,10 +9123,9 @@ part
                           "  x  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   x   x      x   x   x   x",
@@ -9312,15 +9156,13 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  o   o   o   o    o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "  0   0   0   0    a11 a10  a9  a8",
@@ -9337,56 +9179,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   1 1 1 1  1 1 1 i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 1 1 1 1 i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -9466,10 +9309,9 @@ part
                           "  x  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   x   x      x   x   x   x",
@@ -9490,30 +9332,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -9525,56 +9362,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -9644,25 +9482,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-               " 0 0 0 x x x a9 a8",
-               " a7 a6 a5 a4 a3 a2 a1 a0",
-               " o o o o o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1 1 0 0 0 0 0 0",
-                " 0 0 0 x x x a9 a8",
-                " a7 a6 a5 a4 a3 a2 a1 a0",
-                " i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = " 1 1 0 0 0 0 0 1",
-                      " 0 0 0 0 0 0 0 0",
-                      " 0 0 0 0 0 0 a1 a0",
-                      " i i i i i i i i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = " 1 1 0 0 0 0 1 0",
-                    " 0 0 x x x x a9 a8",
-                    " a7 a6 a5 a4 a3 a2 0 0",
-                    " x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x a9 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -9679,30 +9513,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                  " 0 0 a13 a12 a11 a10 a9 a8",
-                  " a7 a6 a5 a4 a3 a2 a1 a0",
-                  " o o o o o o o o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = " 0 0 1 0 1 0 0 0",
-                  " 0 0 a13 a12 a11 a10 a9 a8",
-                  " a7 a6 a5 a4 a3 a2 a1 a0",
-                  " o o o o o o o o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                      " 0 0 0 x x x x x",
-                      " x x a5 a4 a3 a2 a1 a0",
-                      " i i i i i i i i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                      " 0 0 0 x x x x x",
-                      " x x a5 a4 a3 a2 a1 a0",
-                      " i i i i i i i i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = " 0 1 0 0 1 1 0 0",
-                    " 0 0 a13 a12 a11 a10 a9 a8",
-                    " a7 a6 x x x x x x",
-                    " x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 a13 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -9715,56 +9544,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-               "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-                "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-               "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-                "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-               "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                "x x x x x x x x x x x x x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-               "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-                "x x x x x x x x 1 1 i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-               "0 0 0 0 0 0 0 0 o o o o o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-               "x x x x x x a1 a0 o o o o o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -9791,11 +9621,11 @@ part parent "m328"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-               "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                "x x x x x x x x x x x x i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
     ;
 ;
 
@@ -9815,10 +9645,10 @@ part parent "m328"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x i i i i i i";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x i i i i i i";
     ;
 ;
 
@@ -9842,25 +9672,21 @@ part parent "m328"
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-               " 0 0 0 x x a10 a9 a8",
-               " a7 a6 a5 a4 a3 a2 a1 a0",
-               " o o o o o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = " 1 1 0 0 0 0 0 0",
-                " 0 0 0 x x a10 a9 a8",
-                " a7 a6 a5 a4 a3 a2 a1 a0",
-                " i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = " 1 1 0 0 0 0 0 1",
-                      " 0 0 0 0 0 0 0 0",
-                      " 0 0 0 0 0 a2 a1 a0",
-                      " i i i i i i i i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = " 1 1 0 0 0 0 1 0",
-                    " 0 0 x x x a10 a9 a8",
-                    " a7 a6 a5 a4 a3 0 0 0",
-                    " x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -9877,30 +9703,25 @@ part parent "m328"
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                  " 0 a14 a13 a12 a11 a10 a9 a8",
-                  " a7 a6 a5 a4 a3 a2 a1 a0",
-                  " o o o o o o o o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = " 0 0 1 0 1 0 0 0",
-                  " 0 a14 a13 a12 a11 a10 a9 a8",
-                  " a7 a6 a5 a4 a3 a2 a1 a0",
-                  " o o o o o o o o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                      " 0 0 0 x x x x x",
-                      " x a6 a5 a4 a3 a2 a1 a0",
-                      " i i i i i i i i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                      " 0 0 0 x x x x x",
-                      " x a6 a5 a4 a3 a2 a1 a0",
-                      " i i i i i i i i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = " 0 1 0 0 1 1 0 0",
-                    " 0 a14 a13 a12 a11 a10 a9 a8",
-                    " a7 x x x x x x x",
-                    " x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -9912,11 +9733,11 @@ part parent "m328"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x i i i i i i";
     ;
 ;
 
@@ -9988,21 +9809,21 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10018,33 +9839,28 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
 # The information in the data sheet of April/2004 is wrong, this works:
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
 # The information in the data sheet of April/2004 is wrong, this works:
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
 # The information in the data sheet of April/2004 is wrong, this works:
-        writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0  0 a9 a8",
-                           " a7 a6 a5 a4   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10054,48 +9870,49 @@ part
 #   ATtiny2313 has Signature Bytes: 0x1E 0x91 0x0A.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -10104,8 +9921,9 @@ part
 
     memory "calibration"
         size            = 2;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 0 x x x x x 0 0 0 0 0 0 0 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -10186,21 +10004,21 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1   0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1   1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10216,30 +10034,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1  0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5  x   x   x  x  x",
-                           "  x  x  x  x   x   x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10249,56 +10062,58 @@ part
 #   ATtiny4313 has Signature Bytes: 0x1E 0x92 0x0D.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 2;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0",
+                          "0 0 0 x x x x x 0 0 0 0 0 0 0 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -10367,19 +10182,22 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0  o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0  i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10395,30 +10213,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0   a11 a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0   a11 a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1   0   0",
-                           "  0  0  0  0   a11 a10 a9  a8",
-                           " a7 a6 a5  x   x   x   x   x",
-                           "  x  x  x  x   x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10428,57 +10241,58 @@ part
 #   AT90PWM2 has Signature Bytes: 0x1E 0x93 0x81.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -10551,15 +10365,13 @@ part parent "pwm3b"
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "  0   0 a13 a12    a11 a10  a9  a8",
@@ -10651,21 +10463,21 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10681,30 +10493,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0  0 a9 a8",
-                           " a7 a6 a5 a4   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10714,48 +10521,49 @@ part
 #   ATtiny25 has Signature Bytes: 0x1E 0x91 0x08.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -10834,21 +10642,21 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10864,30 +10672,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -10897,48 +10700,49 @@ part
 #   ATtiny45 has Signature Bytes: 0x1E 0x92 0x08. (Data sheet 2586C-AVR-06/05 (doc2586.pdf) indicates otherwise!)
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -11018,21 +10822,21 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -11048,30 +10852,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -11081,48 +10880,49 @@ part
 #   ATtiny85 has Signature Bytes: 0x1E 0x93 0x08.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -11202,25 +11002,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -11237,30 +11033,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -11270,58 +11061,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -11392,25 +11184,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -11427,30 +11215,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -11460,58 +11243,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -11595,25 +11379,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -11630,35 +11410,29 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
-        load_ext_addr   = "  0   1   0   0      1   1   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   0 a16",
-                          "  0   0   0   0      0   0   0   0";
+        load_ext_addr   = "0 1 0 0 1 1 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 a16",
+                          "0 0 0 0 0 0 0 0";
 
         mode            = 0x41;
         delay           = 10;
@@ -11668,58 +11442,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -11758,30 +11533,25 @@ part parent "m2561"
         max_write_delay = 50000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -11809,25 +11579,21 @@ part parent "m2561"
         max_write_delay = 13000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -11873,30 +11639,25 @@ part parent "m128rfa1"
         max_write_delay = 50000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -11912,25 +11673,21 @@ part parent "m128rfa1"
         max_write_delay = 13000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -12039,21 +11796,21 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x x a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12069,30 +11826,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x x a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0  0 a9 a8",
-                           " a7 a6 a5 a4   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12102,48 +11854,49 @@ part
 #   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   x x x x x x i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -12232,19 +11985,22 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x x   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12260,30 +12016,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12293,48 +12044,49 @@ part
 #   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   x x x x x x i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -12423,19 +12175,22 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12451,30 +12206,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12484,49 +12234,50 @@ part
 #   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   x x x x x x i i";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -12565,30 +12316,25 @@ part parent "t44"
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x x x a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5 a4  a3  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12598,11 +12344,11 @@ part parent "t44"
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -12626,30 +12372,25 @@ part parent "t84"
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x x x a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5 a4  a3  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 a11 a10 a9 a8 a7 a6 a5 a4 a3 x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -12659,11 +12400,11 @@ part parent "t84"
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -12734,21 +12475,21 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                                  "0  0 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 x x x x x 0 0 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                                  "0  0 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x 0 0 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                                  "  0   0   0   0      0   0   0   0",
-                                  "  0   0   0   0      0   0  a1  a0",
-                                  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                                  "  0   0   x   x      x   x   x   x",
-                                  "  0   0  a5  a4     a3  a2   0   0",
-                                  "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x x x x 0 0 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 5;
@@ -12765,30 +12506,25 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0    0  a10 a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0    0  a10 a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                          "  0   0   0   x    x   x   x   x",
-                          "  x   x   x  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                          "  0   0   0   x    x   x   x   x",
-                          "  x   x   x  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 x x x x x x x x a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  0  0  0  0   0 a10 a9 a8",
-                          " a7 a6 a5  x   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -12797,49 +12533,50 @@ part
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                          "x x x x  x x x x  1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x x x i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x x x x i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;
@@ -12935,7 +12672,9 @@ part
                           "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x 0 0 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x 0 0 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -12962,15 +12701,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           " a15 a14 a13 a12    a11 a10  a9  a8",
@@ -12985,58 +12722,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 1 i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   0 0 o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   0 0 o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -13124,7 +12862,9 @@ part
                           "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x 0 a9 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x 0 a9 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -13151,15 +12891,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           " a15 a14 a13 a12    a11 a10  a9  a8",
@@ -13174,58 +12912,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   1 1 1 1 i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -13297,25 +13036,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x x a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x x a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -13332,30 +13067,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -13365,58 +13095,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -13501,23 +13232,22 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "x x x x a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "1 1 0 0 0 0 1 0   0 0 x x a11 a10 a9 a8   a7 a6 a5 a4 a3 0 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -13534,30 +13264,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "a15 a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -13567,58 +13292,59 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   x x x x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "x x x x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -13706,10 +13432,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
@@ -13741,15 +13466,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -13764,57 +13487,58 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -13893,10 +13617,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
@@ -13928,15 +13651,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -13951,57 +13672,58 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -14082,10 +13804,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
@@ -14117,15 +13838,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -14140,57 +13859,58 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 #------------------------------------------------------------
@@ -14270,10 +13990,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
@@ -14305,15 +14024,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -14328,57 +14045,58 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -14458,10 +14176,9 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
@@ -14493,15 +14210,13 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  0   1   0   0      1   1   0   0",
                           "a15 a14 a13 a12    a11 a10  a9  a8",
@@ -14516,57 +14231,58 @@ part
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   i i i i i i i i";
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 
@@ -14639,25 +14355,21 @@ part
         max_write_delay = 3600;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0      0   0   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 x a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0      0   0   x  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 0 x a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 20;
@@ -14674,30 +14386,25 @@ part
         max_write_delay = 4500;
         readback_p1     = 0x00;
         readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "0 1 0 0 0 0 0 0",
+                          "0 0 0 0 x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_hi     = "0 1 0 0 1 0 0 0",
+                          "0 0 0 0 x x x x x x a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "x x x a12 a11 a10 a9 a8 a7 a6 x x x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -14709,56 +14416,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x x i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 i i i i i i";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 0 0 0 0 0 x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
     ;
 ;
 
@@ -14858,25 +14566,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0      0   0  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 0 a9 a8 a7 a6 a5 a4 a3 a2 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -14926,33 +14630,33 @@ part
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -14960,26 +14664,27 @@ part
     memory "efuse"
         size            = 1;
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "0 0 0 0 0 0 0 0   1 1 1 1 1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
-                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
 
-        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -15078,25 +14783,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        read            = "1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        write           = "1 1 0 0 0 0 0 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
+                          "i i i i i i i i";
 
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
+        writepage       = "1 1 0 0 0 0 1 0",
+                          "0 0 0 0 0 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 10;
@@ -15146,33 +14847,33 @@ part
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   1 1 i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0   i i i i i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
@@ -15180,26 +14881,27 @@ part
     memory "efuse"
         size            = 1;
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "0 0 0 0 0 0 0 0   1 1 1 1 1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
-                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "o o o o o o o o";
     ;
 
     memory "calibration"
         size            = 1;
 
-        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 ;
 
@@ -16548,10 +16250,9 @@ part
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
 
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-           "  0   0   0   0      0   0   0   0",
-           "  0   0   0   0      0   0  a1  a0",
-           "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "1 1 0 0 0 0 0 1",
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
+                          "i i i i i i i i";
 
         writepage       = "  1   1   0   0      0   0   1   0",
            "  0   0   x   x      x   x   x  a8",
@@ -16573,15 +16274,13 @@ part
         max_write_delay = 4500;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                          " 0 0 0 a12 a11 a10 a9 a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
+        read_lo         = "0 0 1 0 0 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
-        read_hi         = " 0 0 1 0 1 0 0 0",
-                           " 0 0 0 a12 a11 a10 a9 a8",
-                           " a7 a6 a5 a4 a3 a2 a1 a0",
-                           " o o o o o o o o";
+        read_hi         = "0 0 1 0 1 0 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 a3 a2 a1 a0",
+                          "o o o o o o o o";
 
         loadpage_lo     = " 0 1 0 0 0 0 0 0",
                           " 0 0 0 x x x x x",
@@ -16594,7 +16293,9 @@ part
                           " i i i i i i i i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage       = "0 1 0 0 1 1 0 0   0 0 0 a12 a11 a10 a9 a8   a7 a6 a5 a4 x x x x   x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0",
+                          "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 x x x x",
+                          "x x x x x x x x";
 
         mode            = 0x41;
         delay           = 6;
@@ -16607,56 +16308,57 @@ part
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 1 0 0 0",
+                          "x x x x x x x x   i i i i i i i i";
     ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 0 0 0 0   0 0 0 0 1 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x x i i i i i";
+        write           = "1 0 1 0 1 1 0 0   1 0 1 0 0 1 0 0",
+                          "x x x x x x x x   x x x i i i i i";
     ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
+        read            = "0 1 0 1 1 0 0 0   0 0 0 0 0 0 0 0",
+                          "x x x x x x x x   o o o o o o o o";
 
-        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-                          "x x x x x x x x 1 1 1 1 1 1 i i";
+        write           = "1 0 1 0 1 1 0 0   1 1 1 x x x x x",
+                          "x x x x x x x x   1 1 1 1 1 1 i i";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-                          "0 0 0 0 0 0 0 0 o o o o o o o o";
+        read            = "0 0 1 1 1 0 0 0   0 0 0 x x x x x",
+                          "0 0 0 0 0 0 0 0   o o o o o o o o";
     ;
 
     memory "signature"
         size            = 3;
-        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-                          "x x x x x x a1 a0 o o o o o o o o";
+        read            = "0 0 1 1 0 0 0 0",
+                          "0 0 0 x x x x x x x x x x x a1 a0",
+                          "o o o o o o o o";
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -5969,10 +5969,8 @@ part
                           "  x   x  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "0 1 0 0 1 1 0 0   x x a13 a12 a11 a10 a9 a8   a7 a6 x x x x x x   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 6;
@@ -6223,10 +6221,8 @@ part
                           "  x  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "0 1 0 0 1 1 0 0   x a14 a13 a12 a11 a10 a9 a8   a7 x x x x x x x   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 6;
@@ -8908,18 +8904,16 @@ part
          read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
-         write           = "1  1  0  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a8 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        # semi-automatically corrected: check part/datasheet
+        write = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
 
   loadpage_lo   = "  1   1   0   0      0   0   0   1",
         "  0   0   0   0      0   0   0   0",
         "  0   0   0   0      0   0  a1  a0",
         "  i   i   i   i      i   i   i   i";
 
-  writepage = "  1   1   0   0      0   0   1   0",
-        "  0   0   x   x      x   x   x   x",
-        "  0   0  a5  a4     a3  a2   0   0",
-        "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
   mode      = 0x41;
   delay     = 10;
@@ -9095,18 +9089,16 @@ part
          read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
-         write           = "1  1  0  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a8 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+        # semi-automatically corrected: check part/datasheet
+        write = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
 
   loadpage_lo   = "  1   1   0   0      0   0   0   1",
         "  0   0   0   0      0   0   0   0",
         "  0   0   0   0      0   0  a1  a0",
         "  i   i   i   i      i   i   i   i";
 
-  writepage = "  1   1   0   0      0   0   1   0",
-        "  0   0   x   x      x   x   x   x",
-        "  0   0  a5  a4     a3  a2   0   0",
-        "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
   mode      = 0x41;
   delay     = 10;
@@ -10385,10 +10377,8 @@ part
 			  "  0   0   0   0      0   0  a1  a0",
 			  "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 6;
@@ -12252,10 +12242,8 @@ part
 			  "  0   0   0   0      0   0  a1  a0",
 			  "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x x   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 6;
@@ -12445,10 +12433,8 @@ part
 			  "  0   0   0   0      0   0  a1  a0",
 			  "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 6;
@@ -12860,12 +12846,12 @@ part
     memory "calibration"
         size            = 1;
         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                          "0  0  0  0   0  0  0  0   o o o o  o o o o";
+                          "0  0  0  0   0  0  0  a0   o o o o  o o o o";
     ;
 ;
 
 #------------------------------------------------------------
-# ATmega16u4
+# ATmega16U4
 #------------------------------------------------------------
 
 part
@@ -12947,10 +12933,8 @@ part
 			  "  0   0   0   0      0  a2  a1  a0",
 			  "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x x 0 0 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 20;
@@ -13138,10 +13122,8 @@ part
 			  "  0   0   0   0      0  a2  a1  a0",
 			  "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x x 0 a9 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 20;
@@ -13533,10 +13515,8 @@ part
 			  "  0   0   0   0      0  a2  a1  a0",
 			  "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        # semi-automatically corrected: check part/datasheet 
+        writepage = "1 1 0 0 0 0 1 0   0 0 x x a11 a10 a9 a8   a7 a6 a5 a4 a3 0 0 0   x x x x x x x x";
 
 	mode		= 0x41;
 	delay		= 10;
@@ -16612,10 +16592,8 @@ part
                           " x x a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
 
-        writepage       = " 0 1 0 0 1 1 0 0",
-                          " 0 0 0 a12 a11 a10 a9 a8",
-                          " a7 a6 x x x x x x",
-                          " x x x x x x x x";
+        # semi-automatically corrected: check part/datasheet 
+        writepage = "0 1 0 0 1 1 0 0   0 0 0 a12 a11 a10 a9 a8   a7 a6 a5 a4 x x x x   x x x x x x x x";
 
         mode        = 0x41;
         delay       = 6;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -152,7 +152,10 @@
 # using the following syntax. In this case specified integer and
 # string values override parameter values from the parent part. New
 # memory definitions are added to the definitions inherited from the
-# parent.
+# parent. If, however, a new memory definion refers to an existing
+# one of the same name for that part then, in the current code, the
+# existing memory definition is deleted, and all required parameters
+# need be defined for that memory.
 #
 #   part parent <id>                              # quoted string
 #       id               = <id> ;                 # quoted string
@@ -5848,7 +5851,6 @@ part
                           "x x x x x x x x x x a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "0 1 0 0 1 1 0 0",
                           "x x a13 a12 a11 a10 a9 a8 a7 a6 x x x x x x",
                           "x x x x x x x x";
@@ -6096,7 +6098,6 @@ part
                           "x x x x x x x x x a6 a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "0 1 0 0 1 1 0 0",
                           "x a14 a13 a12 a11 a10 a9 a8 a7 x x x x x x x",
                           "x x x x x x x x";
@@ -8712,7 +8713,6 @@ part
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
                           "o o o o o o o o";
 
-        # semi-automatically corrected: check part/datasheet
         write           = "1 1 0 0 0 0 0 0",
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
@@ -8721,7 +8721,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
                           "x x x x x x x x";
@@ -8897,7 +8896,6 @@ part
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
                           "o o o o o o o o";
 
-        # semi-automatically corrected: check part/datasheet
         write           = "1 1 0 0 0 0 0 0",
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 a1 a0",
                           "i i i i i i i i";
@@ -8906,7 +8904,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
                           "x x x x x x x x";
@@ -10146,7 +10143,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
                           "x x x x x x x x";
@@ -11946,7 +11942,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x x x x x a7 a6 a5 a4 a3 a2 0 0",
                           "x x x x x x x x";
@@ -12136,7 +12131,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x x x x a8 a7 a6 a5 a4 a3 a2 0 0",
                           "x x x x x x x x";
@@ -12617,7 +12611,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x x 0 0 a8 a7 a6 a5 a4 a3 a2 0 0",
                           "x x x x x x x x";
@@ -12801,7 +12794,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 0 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x x 0 a9 a8 a7 a6 a5 a4 a3 a2 0 0",
                           "x x x x x x x x";
@@ -13181,7 +13173,6 @@ part
                           "0 0 0 0 0 0 0 0 0 0 0 0 0 a2 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "1 1 0 0 0 0 1 0",
                           "0 0 x x a11 a10 a9 a8 a7 a6 a5 a4 a3 0 0 0",
                           "x x x x x x x x";
@@ -16194,7 +16185,6 @@ part
                           "0 0 0 x x x x x x x 0 0 a3 a2 a1 a0",
                           "i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet
         writepage       = "0 1 0 0 1 1 0 0",
                           "0 0 0 a12 a11 a10 a9 a8 a7 a6 a5 a4 x x x x",
                           "x x x x x x x x";

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -12690,6 +12690,9 @@ part
         size            = 1;
         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                           "x x x x  x x x x  1 1 i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
+                          "x x x x  x x x x   o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
     ;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -36,7 +36,7 @@
 #       vfyled   = <num> ;                          # pin number
 #       usbvid   = <hexnum>;                        # USB VID (Vendor ID)
 #       usbpid   = <hexnum> [, <hexnum> ...]        # USB PID (Product ID) (1)
-#       usbdev   = <interface>;                     # USB interface or other device info 
+#       usbdev   = <interface>;                     # USB interface or other device info
 #       usbvendor = <vendorname>;                   # USB Vendor Name
 #       usbproduct = <productname>;                 # USB Product Name
 #       usbsn    = <serialno>;                      # USB Serial Number
@@ -57,7 +57,7 @@
 #       has_pdi          = <yes/no> ;             # part has PDI i/f
 #       has_updi         = <yes/no> ;             # part has UPDI i/f
 #       has_tpi          = <yes/no> ;             # part has TPI i/f
-#       devicecode       = <num> ;            # deprecated, use stk500_devcode
+#       devicecode       = <num> ;                # deprecated, use stk500_devcode
 #       stk500_devcode   = <num> ;                # numeric
 #       avr910_devcode   = <num> ;                # numeric
 #       signature        = <num> <num> <num> ;    # signature bytes
@@ -148,9 +148,9 @@
 # complain.
 #
 # Parts can also inherit parameters from previously defined parts
-# using the following syntax. In this case specified integer and 
-# string values override parameter values from the parent part. New 
-# memory definitions are added to the definitions inherited from the 
+# using the following syntax. In this case specified integer and
+# string values override parameter values from the parent part. New
+# memory definitions are added to the definitions inherited from the
 # parent.
 #
 #   part parent <id>                              # quoted string
@@ -159,7 +159,7 @@
 #     ;
 #
 # NOTES:
-#   * 'devicecode' is the device code used by the STK500 (see codes 
+#   * 'devicecode' is the device code used by the STK500 (see codes
 #       listed below)
 #   * Not all memory types will implement all instructions.
 #   * AVR Fuse bits and Lock bits are implemented as a type of memory.
@@ -269,8 +269,8 @@
 #define AT86RF401   0xD0
 
 #define AT89START   0xE0
-#define AT89S51	    0xE0
-#define AT89S52	    0xE1
+#define AT89S51     0xE0
+#define AT89S52     0xE1
 
 # The following table lists the devices in the original AVR910
 # appnote:
@@ -322,15 +322,15 @@
 # in the Internet.  These add the following codes (only devices that
 # actually exist are listed):
 
-# ATmega8515	0x3A
-# ATmega128	0x43
-# ATmega64	0x45
-# ATtiny26	0x5E
-# ATmega8535	0x69
-# ATmega32	0x72
-# ATmega16	0x74
-# ATmega8	0x76
-# ATmega169	0x78
+# ATmega8515    0x3A
+# ATmega128     0x43
+# ATmega64      0x45
+# ATtiny26      0x5E
+# ATmega8535    0x69
+# ATmega32      0x72
+# ATmega16      0x74
+# ATmega8       0x76
+# ATmega169     0x78
 
 #
 # Overall avrdude defaults; suitable for ~/.avrduderc
@@ -347,24 +347,24 @@ default_serial     = "@DEFAULT_SER_PORT@";
 # Basically STK500v2 protocol, with some glue to trigger the
 # bootloader.
 programmer
-  id    = "wiring";
-  desc  = "Wiring";
-  type  = "wiring";
-  connection_type = serial;
+    id                  = "wiring";
+    desc                = "Wiring";
+    type                = "wiring";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "arduino";
-  desc  = "Arduino";
-  type  = "arduino";
-  connection_type = serial;
+    id                  = "arduino";
+    desc                = "Arduino";
+    type                = "arduino";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "xbee";
-  desc  = "XBee Series 2 Over-The-Air (XBeeBoot)";
-  type  = "xbee";
-  connection_type = serial;
+    id                  = "xbee";
+    desc                = "XBee Series 2 Over-The-Air (XBeeBoot)";
+    type                = "xbee";
+    connection_type     = serial;
 ;
 
 # this will interface with the chips on these programmers:
@@ -377,7 +377,7 @@ programmer
 # http://dangerousprototypes.com/docs/FT2232_breakout_board
 # http://www.ftdichip.com/Products/Modules/DLPModules.htm,DLP-2232*,DLP-USB1232H
 # http://flashrom.org/FT2232SPI_Programmer
-# 
+#
 # The drivers will look for a specific device and use the first one found.
 # If you have mulitple devices, then look for unique information (like SN)
 # And fill that in here.
@@ -388,21 +388,21 @@ programmer
 # these FTDI ICs has been designed.
 
 programmer
-  id         = "avrftdi";
-  desc       = "FT2232D based generic programmer";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-  usbpid     = 0x6010;
-  usbvendor  = "";
-  usbproduct = "";
-  usbdev     = "A";
-  usbsn      = "";
+    id                  = "avrftdi";
+    desc                = "FT2232D based generic programmer";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0x6010;
+    usbvendor           = "";
+    usbproduct          = "";
+    usbdev              = "A";
+    usbsn               = "";
 #ISP-signals - lower ADBUS-Nibble (default)
-  reset  = 3;
-  sck    = 0;
-  mosi   = 1;
-  miso   = 2;
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
 #LED SIGNALs - higher ADBUS-Nibble
 #  errled = 4;
 #  rdyled = 5;
@@ -414,58 +414,58 @@ programmer
 # This is an implementation of the above with a buffer IC (74AC244) and
 # 4 LEDs directly attached, all active low.
 programmer
-  id         = "2232HIO";
-  desc       = "FT2232H based generic programmer";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-# Note: This PID is reserved for generic H devices and 
+    id                  = "2232HIO";
+    desc                = "FT2232H based generic programmer";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+# Note: This PID is reserved for generic H devices and
 # should be programmed into the EEPROM
 #  usbpid     = 0x8A48;
-  usbpid     = 0x6010;
-  usbdev     = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
-#ISP-signals 
-  reset  = 3;
-  sck    = 0;
-  mosi   = 1;
-  miso   = 2;
-  buff   = ~4;
-#LED SIGNALs 
-  errled = ~ 11;
-  rdyled = ~ 14;
-  pgmled = ~ 13;
-  vfyled = ~ 12;
+    usbpid              = 0x6010;
+    usbdev              = "A";
+    usbvendor           = "";
+    usbproduct          = "";
+    usbsn               = "";
+#ISP-signals
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+    buff                = ~4;
+#LED SIGNALs
+    errled              = ~ 11;
+    rdyled              = ~ 14;
+    pgmled              = ~ 13;
+    vfyled              = ~ 12;
 ;
 
 #The FT4232H can be treated as FT2232H, but it has a different USB
 #device ID of 0x6011.
 programmer parent "avrftdi"
-  id         = "4232h";
-  desc       = "FT4232H based generic programmer";
-  usbpid     = 0x6011;
+    id                  = "4232h";
+    desc                = "FT4232H based generic programmer";
+    usbpid              = 0x6011;
 ;
 
 programmer
-  id         = "jtagkey";
-  desc       = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
+    id                  = "jtagkey";
+    desc                = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
 # Note: This PID is used in all JTAGKey variants
-  usbpid     = 0xCFF8;
-  usbdev     = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
+    usbpid              = 0xCFF8;
+    usbdev              = "A";
+    usbvendor           = "";
+    usbproduct          = "";
+    usbsn               = "";
 #ISP-signals => 20 - Pin connector on JTAGKey
-  reset  = 3; # TMS 7 violet
-  sck    = 0; # TCK 9 white
-  mosi   = 1; # TDI 5 green
-  miso   = 2; # TDO 13 orange
-  buff   = ~4;
+    reset               = 3; # TMS 7 violet
+    sck                 = 0; # TCK 9 white
+    mosi                = 1; # TDI 5 green
+    miso                = 2; # TDO 13 orange
+    buff                = ~4;
 # VTG           VREF 1 brown with red tip
 # GND           GND 20 black
 # The colors are on the 20 pin breakout cable
@@ -473,21 +473,21 @@ programmer
 ;
 
 programmer
-  id         = "ft232h";
-  desc       = "FT232H in MPSSE mode";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-  usbpid     = 0x6014;
-  usbdev     = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
+    id                  = "ft232h";
+    desc                = "FT232H in MPSSE mode";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0x6014;
+    usbdev              = "A";
+    usbvendor           = "";
+    usbproduct          = "";
+    usbsn               = "";
 #ISP-signals
-  sck    = 0; # AD0 (TCK)
-  mosi   = 1; # AD1 (TDI)
-  miso   = 2; # AD2 (TDO)
-  reset  = 3; # AD3 (TMS)
+    sck                 = 0; # AD0 (TCK)
+    mosi                = 1; # AD1 (TDI)
+    miso                = 2; # AD2 (TDO)
+    reset               = 3; # AD3 (TMS)
 ;
 
 # Pin J2-7 (AD0) is SCK
@@ -498,8 +498,8 @@ programmer
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
 programmer parent "ft232h"
-  id    = "um232h";
-  desc  = "UM232H module from FTDI";
+    id                  = "um232h";
+    desc                = "UM232H module from FTDI";
 ;
 
 # Orange (Pin 2) is SCK
@@ -510,13 +510,13 @@ programmer parent "ft232h"
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
 programmer parent "ft232h"
-  id    = "c232hm";
-  desc  = "C232HM cable from FTDI";
+    id                  = "c232hm";
+    desc                = "C232HM cable from FTDI";
 ;
 
 # On the adapter you can read "O-Link". On the PCB is printed "OpenJTAG v3.1"
-# You can find it as "OpenJTAG ARM JTAG USB" in the internet. 
-# (But there are also several projects called Open JTAG, eg. 
+# You can find it as "OpenJTAG ARM JTAG USB" in the internet.
+# (But there are also several projects called Open JTAG, eg.
 # http://www.openjtag.org, which are completely different.)
 #   http://www.100ask.net/shop/english.html (website seems to be outdated)
 #   http://item.taobao.com/item.htm?id=1559277013
@@ -528,121 +528,121 @@ programmer parent "ft232h"
 # or just have a look at ebay ...
 # It is basically the same entry as jtagkey with different usb ids.
 programmer parent "jtagkey"
-  id         = "o-link";
-  desc       = "O-Link, OpenJTAG from www.100ask.net";
-  usbvid     = 0x1457;
-  usbpid     = 0x5118;
-  usbvendor  = "www.100ask.net";
-  usbproduct = "USB<=>JTAG&RS232";
+    id                  = "o-link";
+    desc                = "O-Link, OpenJTAG from www.100ask.net";
+    usbvid              = 0x1457;
+    usbpid              = 0x5118;
+    usbvendor           = "www.100ask.net";
+    usbproduct          = "USB<=>JTAG&RS232";
 ;
 
 # http://wiki.openmoko.org/wiki/Debug_Board_v3
 programmer
-  id    = "openmoko";
-  desc  = "Openmoko debug board (v3)";
-  type  = "avrftdi";
-  usbvid     = 0x1457;
-  usbpid    = 0x5118;
-  usbdev = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
-  reset  = 3; # TMS 7
-  sck    = 0; # TCK 9
-  mosi   = 1; # TDI 5
-  miso   = 2; # TDO 13
+    id                  = "openmoko";
+    desc                = "Openmoko debug board (v3)";
+    type                = "avrftdi";
+    usbvid              = 0x1457;
+    usbpid              = 0x5118;
+    usbdev              = "A";
+    usbvendor           = "";
+    usbproduct          = "";
+    usbsn               = "";
+    reset               = 3; # TMS 7
+    sck                 = 0; # TCK 9
+    mosi                = 1; # TDI 5
+    miso                = 2; # TDO 13
 ;
 
 # Only Rev. A boards.
 # Schematic and user manual: http://www.cs.put.poznan.pl/wswitala/download/pdf/811EVBK.pdf
 programmer
-  id         = "lm3s811";
-  desc       = "Luminary Micro LM3S811 Eval Board (Rev. A)";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-  usbpid     = 0xbcd9;
-  usbvendor  = "LMI";
-  usbproduct = "LM3S811 Evaluation Board";
-  usbdev     = "A";
-  usbsn      = "";
+    id                  = "lm3s811";
+    desc                = "Luminary Micro LM3S811 Eval Board (Rev. A)";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0xbcd9;
+    usbvendor           = "LMI";
+    usbproduct          = "LM3S811 Evaluation Board";
+    usbdev              = "A";
+    usbsn               = "";
 #ISP-signals - lower ACBUS-Nibble (default)
-  reset  = 3;
-  sck    = 0;
-  mosi   = 1;
-  miso   = 2;
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
 # Enable correct buffers
-  buff   = 7;
+    buff                = 7;
 ;
 
 # submitted as bug #46020
 programmer
-  id     = "tumpa";
-  desc   = "TIAO USB Multi-Protocol Adapter";
-  type   = "avrftdi";
-  connection_type = usb;
-  usbvid = 0x0403;
-  usbpid = 0x8A98;
-  usbdev = "A";
-  usbvendor = "TIAO";
-  usbproduct = "";
-  usbsn  = "";
-  sck    = 0; # TCK 9
-  mosi   = 1; # TDI 5
-  miso   = 2; # TDO 13
-  reset  = 3; # TMS 7
+    id                  = "tumpa";
+    desc                = "TIAO USB Multi-Protocol Adapter";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0x8A98;
+    usbdev              = "A";
+    usbvendor           = "TIAO";
+    usbproduct          = "";
+    usbsn               = "";
+    sck                 = 0; # TCK 9
+    mosi                = 1; # TDI 5
+    miso                = 2; # TDO 13
+    reset               = 3; # TMS 7
 ;
 
 programmer
-  id    = "serialupdi";
-  desc  = "SerialUPDI";
-  type  = "serialupdi";
-  connection_type = serial;
+    id                  = "serialupdi";
+    desc                = "SerialUPDI";
+    type                = "serialupdi";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "avrisp";
-  desc  = "Atmel AVR ISP";
-  type  = "stk500";
-  connection_type = serial;
+    id                  = "avrisp";
+    desc                = "Atmel AVR ISP";
+    type                = "stk500";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "avrispv2";
-  desc  = "Atmel AVR ISP V2";
-  type  =  "stk500v2";
-  connection_type = serial;
+    id                  = "avrispv2";
+    desc                = "Atmel AVR ISP V2";
+    type                =  "stk500v2";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "avrispmkII";
-  desc  = "Atmel AVR ISP mkII";
-  type  =  "stk500v2";
-  connection_type = usb;
+    id                  = "avrispmkII";
+    desc                = "Atmel AVR ISP mkII";
+    type                =  "stk500v2";
+    connection_type     = usb;
 ;
 
 programmer parent "avrispmkII"
-  id    = "avrisp2";
+    id                  = "avrisp2";
 ;
 
 programmer
-  id    = "buspirate";
-  desc  = "The Bus Pirate";
-  type  = "buspirate";
-  connection_type = serial;
+    id                  = "buspirate";
+    desc                = "The Bus Pirate";
+    type                = "buspirate";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "buspirate_bb";
-  desc  = "The Bus Pirate (bitbang interface, supports TPI)";
-  type  = "buspirate_bb";
-  connection_type = serial;
+    id                  = "buspirate_bb";
+    desc                = "The Bus Pirate (bitbang interface, supports TPI)";
+    type                = "buspirate_bb";
+    connection_type     = serial;
   # pins are bits in bitbang byte (numbers are 87654321)
   # 1|POWER|PULLUP|AUX|MOSI|CLK|MISO|CS
-  reset  = 1;
-  sck    = 3;
-  mosi   = 4;
-  miso   = 2;
+    reset               = 1;
+    sck                 = 3;
+    mosi                = 4;
+    miso                = 2;
   #vcc    = 7; This is internally set independent of this setting.
 ;
 
@@ -651,138 +651,138 @@ programmer
 # by probing for it.  Better use one of the entries
 # below instead.
 programmer
-  id    = "stk500";
-  desc  = "Atmel STK500";
-  type  = "stk500generic";
-  connection_type = serial;
+    id                  = "stk500";
+    desc                = "Atmel STK500";
+    type                = "stk500generic";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "stk500v1";
-  desc  = "Atmel STK500 Version 1.x firmware";
-  type  = "stk500";
-  connection_type = serial;
+    id                  = "stk500v1";
+    desc                = "Atmel STK500 Version 1.x firmware";
+    type                = "stk500";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "mib510";
-  desc  = "Crossbow MIB510 programming board";
-  type  = "stk500";
-  connection_type = serial;
+    id                  = "mib510";
+    desc                = "Crossbow MIB510 programming board";
+    type                = "stk500";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "stk500v2";
-  desc  = "Atmel STK500 Version 2.x firmware";
-  type  = "stk500v2";
-  connection_type = serial;
+    id                  = "stk500v2";
+    desc                = "Atmel STK500 Version 2.x firmware";
+    type                = "stk500v2";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "stk500pp";
-  desc  = "Atmel STK500 V2 in parallel programming mode";
-  type  = "stk500pp";
-  connection_type = serial;
+    id                  = "stk500pp";
+    desc                = "Atmel STK500 V2 in parallel programming mode";
+    type                = "stk500pp";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "stk500hvsp";
-  desc  = "Atmel STK500 V2 in high-voltage serial programming mode";
-  type  = "stk500hvsp";
-  connection_type = serial;
+    id                  = "stk500hvsp";
+    desc                = "Atmel STK500 V2 in high-voltage serial programming mode";
+    type                = "stk500hvsp";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "stk600";
-  desc  = "Atmel STK600";
-  type  = "stk600";
-  connection_type = usb;
+    id                  = "stk600";
+    desc                = "Atmel STK600";
+    type                = "stk600";
+    connection_type     = usb;
 ;
 
 programmer
-  id    = "stk600pp";
-  desc  = "Atmel STK600 in parallel programming mode";
-  type  = "stk600pp";
-  connection_type = usb;
+    id                  = "stk600pp";
+    desc                = "Atmel STK600 in parallel programming mode";
+    type                = "stk600pp";
+    connection_type     = usb;
 ;
 
 programmer
-  id    = "stk600hvsp";
-  desc  = "Atmel STK600 in high-voltage serial programming mode";
-  type  = "stk600hvsp";
-  connection_type = usb;
+    id                  = "stk600hvsp";
+    desc                = "Atmel STK600 in high-voltage serial programming mode";
+    type                = "stk600hvsp";
+    connection_type     = usb;
 ;
 
 programmer
-  id    = "avr910";
-  desc  = "Atmel Low Cost Serial Programmer";
-  type  = "avr910";
-  connection_type = serial;
+    id                  = "avr910";
+    desc                = "Atmel Low Cost Serial Programmer";
+    type                = "avr910";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "ft245r";
-  desc  = "FT245R Synchronous BitBang";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 1; # D1
-  sck   = 0; # D0
-  mosi  = 2; # D2
-  reset = 4; # D4
+    id                  = "ft245r";
+    desc                = "FT245R Synchronous BitBang";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    miso                = 1; # D1
+    sck                 = 0; # D0
+    mosi                = 2; # D2
+    reset               = 4; # D4
 ;
 
 programmer
-  id    = "ft232r";
-  desc  = "FT232R Synchronous BitBang";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 1;  # RxD
-  sck   = 0;  # TxD
-  mosi  = 2;  # RTS
-  reset = 4;  # DTR
+    id                  = "ft232r";
+    desc                = "FT232R Synchronous BitBang";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    miso                = 1;  # RxD
+    sck                 = 0;  # TxD
+    mosi                = 2;  # RTS
+    reset               = 4;  # DTR
 ;
 
 # see http://www.bitwizard.nl/wiki/index.php/FTDI_ATmega
 programmer
-  id    = "bwmega";
-  desc  = "BitWizard ftdi_atmega builtin programmer";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 5;  # DSR
-  sck   = 6;  # DCD
-  mosi  = 3;  # CTS
-  reset = 7;  # RI
+    id                  = "bwmega";
+    desc                = "BitWizard ftdi_atmega builtin programmer";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    miso                = 5;  # DSR
+    sck                 = 6;  # DCD
+    mosi                = 3;  # CTS
+    reset               = 7;  # RI
 ;
 
 # see http://www.geocities.jp/arduino_diecimila/bootloader/index_en.html
 # Note: pins are numbered from 1!
 programmer
-  id    = "arduino-ft232r";
-  desc  = "Arduino: FT232R connected to ISP";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 3;  # CTS X3(1)
-  sck   = 5;  # DSR X3(2)
-  mosi  = 6;  # DCD X3(3)
-  reset = 7;  # RI  X3(4)
+    id                  = "arduino-ft232r";
+    desc                = "Arduino: FT232R connected to ISP";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    miso                = 3;  # CTS X3(1)
+    sck                 = 5;  # DSR X3(2)
+    mosi                = 6;  # DCD X3(3)
+    reset               = 7;  # RI  X3(4)
 ;
 
 programmer
-  id    = "tc2030";
-  desc  = "Tag-Connect TC2030";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
+    id                  = "tc2030";
+    desc                = "Tag-Connect TC2030";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
   #                      FOR TPI devices:
-  mosi  = 0;  # TxD = D0 (wire to TPIDATA via 1k resistor)
-  miso  = 1;  # RxD = D1 (wire to TPIDATA directly)
-  sck   = 2;  # RTS = D2 (wire to SCK)
-  reset = 3;  # CTS = D3 (wire to ~RESET)
+    mosi                = 0;  # TxD = D0 (wire to TPIDATA via 1k resistor)
+    miso                = 1;  # RxD = D1 (wire to TPIDATA directly)
+    sck                 = 2;  # RTS = D2 (wire to SCK)
+    reset               = 3;  # CTS = D3 (wire to ~RESET)
 ;
 
 # website mentioned above uses this id
 programmer parent "arduino-ft232r"
-  id    = "diecimila";
-  desc  = "alias for arduino-ft232r";
+    id                  = "diecimila";
+    desc                = "alias for arduino-ft232r";
 ;
 
 # There is a ATmega328P kit PCB called "uncompatino".
@@ -792,14 +792,14 @@ programmer parent "arduino-ft232r"
 # http://akizukidenshi.com/catalog/g/gP-07487/
 # http://akizukidenshi.com/download/ds/akizuki/k6096_manual_20130816.pdf
 programmer
-  id    = "uncompatino";
-  desc  = "uncompatino with all pairs of pins shorted";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 3; # cts
-  sck   = 5; # dsr
-  mosi  = 6; # dcd
-  reset = 7; # ri
+    id                  = "uncompatino";
+    desc                = "uncompatino with all pairs of pins shorted";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    miso                = 3; # cts
+    sck                 = 5; # dsr
+    mosi                = 6; # dcd
+    reset               = 7; # ri
 ;
 
 # FTDI USB to serial cable TTL-232R-5V with a custom adapter for ICSP
@@ -813,28 +813,28 @@ programmer
 # TTL-232R TXD 4 Orange -> ICPS RESET (pin 5)
 # TTL-232R RXD 5 Yellow -> ICPS SCK   (pin 3)
 # TTL-232R RTS 6 Green  -> ICPS MISO  (pin 1)
-# Except for VCC and GND, you can connect arbitual pairs as long as 
+# Except for VCC and GND, you can connect arbitual pairs as long as
 # the following table is adjusted.
 programmer
-  id    = "ttl232r";
-  desc  = "FTDI TTL232R-5V with ICSP adapter";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 2; # rts
-  sck   = 1; # rxd
-  mosi  = 3; # cts
-  reset = 0; # txd
+    id                  = "ttl232r";
+    desc                = "FTDI TTL232R-5V with ICSP adapter";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    miso                = 2; # rts
+    sck                 = 1; # rxd
+    mosi                = 3; # cts
+    reset               = 0; # txd
 ;
 
 programmer
-  id    = "usbasp";
-  desc  = "USBasp, http://www.fischl.de/usbasp/";
-  type  = "usbasp";
-  connection_type = usb;
-  usbvid     = 0x16C0; # VOTI
-  usbpid     = 0x05DC; # Obdev's free shared PID
-  usbvendor  = "www.fischl.de";
-  usbproduct = "USBasp";
+    id                  = "usbasp";
+    desc                = "USBasp, http://www.fischl.de/usbasp/";
+    type                = "usbasp";
+    connection_type     = usb;
+    usbvid              = 0x16C0; # VOTI
+    usbpid              = 0x05DC; # Obdev's free shared PID
+    usbvendor           = "www.fischl.de";
+    usbproduct          = "USBasp";
 
   # following variants are autodetected for id "usbasp"
 
@@ -852,23 +852,23 @@ programmer
 ;
 
 programmer
-  id    = "nibobee";
-  desc  = "NIBObee";
-  type  = "usbasp";
-  connection_type = usb;
-  usbvid     = 0x16C0; # VOTI
-  usbpid     = 0x092F; # NIBObee PID
-  usbvendor  = "www.nicai-systems.com";
-  usbproduct = "NIBObee";
+    id                  = "nibobee";
+    desc                = "NIBObee";
+    type                = "usbasp";
+    connection_type     = usb;
+    usbvid              = 0x16C0; # VOTI
+    usbpid              = 0x092F; # NIBObee PID
+    usbvendor           = "www.nicai-systems.com";
+    usbproduct          = "NIBObee";
 ;
 
 programmer
-  id    = "usbasp-clone";
-  desc  = "Any usbasp clone with correct VID/PID";
-  type  = "usbasp";
-  connection_type = usb;
-  usbvid    = 0x16C0; # VOTI
-  usbpid    = 0x05DC; # Obdev's free shared PID
+    id                  = "usbasp-clone";
+    desc                = "Any usbasp clone with correct VID/PID";
+    type                = "usbasp";
+    connection_type     = usb;
+    usbvid              = 0x16C0; # VOTI
+    usbpid              = 0x05DC; # Obdev's free shared PID
   #usbvendor  = "";
   #usbproduct = "";
 ;
@@ -878,120 +878,120 @@ programmer
 # pins of the connector, and MISO (pin 1 of the 6-pin connector)
 # connects to TPIDATA.
 programmer
-  id    = "usbtiny";
-  desc  = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x1781;
-  usbpid     = 0x0c9f;
+    id                  = "usbtiny";
+    desc                = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x1781;
+    usbpid              = 0x0c9f;
 ;
 
 programmer
-  id    = "arduinoisp";
-  desc  = "Arduino ISP Programmer";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x2341;
-  usbpid     = 0x0049;
+    id                  = "arduinoisp";
+    desc                = "Arduino ISP Programmer";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x2341;
+    usbpid              = 0x0049;
 ;
 
 programmer
-  id    = "arduinoisporg";
-  desc  = "Arduino ISP Programmer";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x2A03;
-  usbpid     = 0x0049;
-;
-
-# commercial version of USBtiny, using a separate VID/PID
-programmer
-  id    = "ehajo-isp";
-  desc  = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x16D0;
-  usbpid     = 0x0BA5;
+    id                  = "arduinoisporg";
+    desc                = "Arduino ISP Programmer";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x2A03;
+    usbpid              = 0x0049;
 ;
 
 # commercial version of USBtiny, using a separate VID/PID
 programmer
-  id    = "iseavrprog";
-  desc  = "USBtiny-based USB programmer, https://github.com/IowaScaledEngineering/ckt-avrprogrammer";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x1209;
-  usbpid     = 0x6570;
+    id                  = "ehajo-isp";
+    desc                = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x16D0;
+    usbpid              = 0x0BA5;
+;
+
+# commercial version of USBtiny, using a separate VID/PID
+programmer
+    id                  = "iseavrprog";
+    desc                = "USBtiny-based USB programmer, https://github.com/IowaScaledEngineering/ckt-avrprogrammer";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x1209;
+    usbpid              = 0x6570;
 ;
 
 programmer
-  id = "micronucleus";
-  desc = "Micronucleus Bootloader";
-  type = "micronucleus";
-  connection_type = usb;
-  usbvid = 0x16D0;
-  usbpid = 0x0753;
+    id                  = "micronucleus";
+    desc                = "Micronucleus Bootloader";
+    type                = "micronucleus";
+    connection_type     = usb;
+    usbvid              = 0x16D0;
+    usbpid              = 0x0753;
 ;
 
 programmer
-  id = "teensy";
-  desc = "Teensy Bootloader";
-  type = "teensy";
-  connection_type = usb;
-  usbvid = 0x16C0;
-  usbpid = 0x0478;
+    id                  = "teensy";
+    desc                = "Teensy Bootloader";
+    type                = "teensy";
+    connection_type     = usb;
+    usbvid              = 0x16C0;
+    usbpid              = 0x0478;
 ;
 
 programmer
-  id    = "butterfly";
-  desc  = "Atmel Butterfly Development Board";
-  type  = "butterfly";
-  connection_type = serial;
+    id                  = "butterfly";
+    desc                = "Atmel Butterfly Development Board";
+    type                = "butterfly";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "avr109";
-  desc  = "Atmel AppNote AVR109 Boot Loader";
-  type  = "butterfly";
-  connection_type = serial;
+    id                  = "avr109";
+    desc                = "Atmel AppNote AVR109 Boot Loader";
+    type                = "butterfly";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "avr911";
-  desc  = "Atmel AppNote AVR911 AVROSP";
-  type  = "butterfly";
-  connection_type = serial;
+    id                  = "avr911";
+    desc                = "Atmel AppNote AVR911 AVROSP";
+    type                = "butterfly";
+    connection_type     = serial;
 ;
- 
+
 # suggested in http://forum.mikrokopter.de/topic-post48317.html
 programmer
-  id    = "mkbutterfly";
-  desc  = "Mikrokopter.de Butterfly";
-  type  = "butterfly_mk";
-  connection_type = serial;
+    id                  = "mkbutterfly";
+    desc                = "Mikrokopter.de Butterfly";
+    type                = "butterfly_mk";
+    connection_type     = serial;
 ;
 
 programmer parent "mkbutterfly"
-  id    = "butterfly_mk";
+    id                  = "butterfly_mk";
 ;
 
 programmer
-  id    = "jtagmkI";
-  desc  = "Atmel JTAG ICE (mkI)";
-  baudrate = 115200;    # default is 115200
-  type  = "jtagmki";
-  connection_type = serial;
+    id                  = "jtagmkI";
+    desc                = "Atmel JTAG ICE (mkI)";
+    baudrate            = 115200;    # default is 115200
+    type                = "jtagmki";
+    connection_type     = serial;
 ;
 
 # easier to type
 programmer parent "jtagmkI"
-  id    = "jtag1";
+    id                  = "jtag1";
 ;
 
 # easier to type
 programmer parent "jtag1"
-  id    = "jtag1slow";
-  baudrate = 19200;
+    id                  = "jtag1slow";
+    baudrate            = 19200;
 ;
 
 # The JTAG ICE mkII has both, serial and USB connectivity.  As it is
@@ -1000,397 +1000,397 @@ programmer parent "jtag1"
 # still free to use a serial port with the -P option.
 
 programmer
-  id    = "jtagmkII";
-  desc  = "Atmel JTAG ICE mkII";
-  baudrate = 19200;    # default is 19200
-  type  = "jtagmkii";
-  connection_type = usb;
+    id                  = "jtagmkII";
+    desc                = "Atmel JTAG ICE mkII";
+    baudrate            = 19200;    # default is 19200
+    type                = "jtagmkii";
+    connection_type     = usb;
 ;
 
 # easier to type
 programmer parent "jtagmkII"
-  id    = "jtag2slow";
+    id                  = "jtag2slow";
 ;
 
 # JTAG ICE mkII @ 115200 Bd
 programmer parent "jtag2slow"
-  id    = "jtag2fast";
-  baudrate = 115200;
+    id                  = "jtag2fast";
+    baudrate            = 115200;
 ;
 
 # make the fast one the default, people will love that
 programmer parent "jtag2fast"
-  id    = "jtag2";
+    id                  = "jtag2";
 ;
 
 # JTAG ICE mkII in ISP mode
 programmer
-  id    = "jtag2isp";
-  desc  = "Atmel JTAG ICE mkII in ISP mode";
-  baudrate = 115200;
-  type  = "jtagmkii_isp";
-  connection_type = usb;
+    id                  = "jtag2isp";
+    desc                = "Atmel JTAG ICE mkII in ISP mode";
+    baudrate            = 115200;
+    type                = "jtagmkii_isp";
+    connection_type     = usb;
 ;
 
 # JTAG ICE mkII in debugWire mode
 programmer
-  id    = "jtag2dw";
-  desc  = "Atmel JTAG ICE mkII in debugWire mode";
-  baudrate = 115200;
-  type  = "jtagmkii_dw";
-  connection_type = usb;
+    id                  = "jtag2dw";
+    desc                = "Atmel JTAG ICE mkII in debugWire mode";
+    baudrate            = 115200;
+    type                = "jtagmkii_dw";
+    connection_type     = usb;
 ;
 
 # JTAG ICE mkII in AVR32 mode
 programmer
-  id    = "jtagmkII_avr32";
-  desc  = "Atmel JTAG ICE mkII im AVR32 mode";
-  baudrate = 115200;
-  type  = "jtagmkii_avr32";
-  connection_type = usb;
+    id                  = "jtagmkII_avr32";
+    desc                = "Atmel JTAG ICE mkII im AVR32 mode";
+    baudrate            = 115200;
+    type                = "jtagmkii_avr32";
+    connection_type     = usb;
 ;
 
 # JTAG ICE mkII in AVR32 mode
 programmer
-  id    = "jtag2avr32";
-  desc  = "Atmel JTAG ICE mkII im AVR32 mode";
-  baudrate = 115200;
-  type  = "jtagmkii_avr32";
-  connection_type = usb;
+    id                  = "jtag2avr32";
+    desc                = "Atmel JTAG ICE mkII im AVR32 mode";
+    baudrate            = 115200;
+    type                = "jtagmkii_avr32";
+    connection_type     = usb;
 ;
 
 # JTAG ICE mkII in PDI mode
 programmer
-  id    = "jtag2pdi";
-  desc  = "Atmel JTAG ICE mkII PDI mode";
-  baudrate = 115200;
-  type  = "jtagmkii_pdi";
-  connection_type = usb;
+    id                  = "jtag2pdi";
+    desc                = "Atmel JTAG ICE mkII PDI mode";
+    baudrate            = 115200;
+    type                = "jtagmkii_pdi";
+    connection_type     = usb;
 ;
 
 # AVR Dragon in JTAG mode
 programmer
-  id    = "dragon_jtag";
-  desc  = "Atmel AVR Dragon in JTAG mode";
-  baudrate = 115200;
-  type  = "dragon_jtag";
-  connection_type = usb;
+    id                  = "dragon_jtag";
+    desc                = "Atmel AVR Dragon in JTAG mode";
+    baudrate            = 115200;
+    type                = "dragon_jtag";
+    connection_type     = usb;
 ;
 
 # AVR Dragon in ISP mode
 programmer
-  id    = "dragon_isp";
-  desc  = "Atmel AVR Dragon in ISP mode";
-  baudrate = 115200;
-  type  = "dragon_isp";
-  connection_type = usb;
+    id                  = "dragon_isp";
+    desc                = "Atmel AVR Dragon in ISP mode";
+    baudrate            = 115200;
+    type                = "dragon_isp";
+    connection_type     = usb;
 ;
 
 # AVR Dragon in PP mode
 programmer
-  id    = "dragon_pp";
-  desc  = "Atmel AVR Dragon in PP mode";
-  baudrate = 115200;
-  type  = "dragon_pp";
-  connection_type = usb;
+    id                  = "dragon_pp";
+    desc                = "Atmel AVR Dragon in PP mode";
+    baudrate            = 115200;
+    type                = "dragon_pp";
+    connection_type     = usb;
 ;
 
 # AVR Dragon in HVSP mode
 programmer
-  id    = "dragon_hvsp";
-  desc  = "Atmel AVR Dragon in HVSP mode";
-  baudrate = 115200;
-  type  = "dragon_hvsp";
-  connection_type = usb;
+    id                  = "dragon_hvsp";
+    desc                = "Atmel AVR Dragon in HVSP mode";
+    baudrate            = 115200;
+    type                = "dragon_hvsp";
+    connection_type     = usb;
 ;
 
 # AVR Dragon in debugWire mode
 programmer
-  id    = "dragon_dw";
-  desc  = "Atmel AVR Dragon in debugWire mode";
-  baudrate = 115200;
-  type  = "dragon_dw";
-  connection_type = usb;
+    id                  = "dragon_dw";
+    desc                = "Atmel AVR Dragon in debugWire mode";
+    baudrate            = 115200;
+    type                = "dragon_dw";
+    connection_type     = usb;
 ;
 
 # AVR Dragon in PDI mode
 programmer
-  id    = "dragon_pdi";
-  desc  = "Atmel AVR Dragon in PDI mode";
-  baudrate = 115200;
-  type  = "dragon_pdi";
-  connection_type = usb;
+    id                  = "dragon_pdi";
+    desc                = "Atmel AVR Dragon in PDI mode";
+    baudrate            = 115200;
+    type                = "dragon_pdi";
+    connection_type     = usb;
 ;
 
 programmer
-  id    = "jtag3";
-  desc  = "Atmel AVR JTAGICE3 in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
+    id                  = "jtag3";
+    desc                = "Atmel AVR JTAGICE3 in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
 ;
 
 programmer
-  id    = "jtag3pdi";
-  desc  = "Atmel AVR JTAGICE3 in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
+    id                  = "jtag3pdi";
+    desc                = "Atmel AVR JTAGICE3 in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
 ;
 
 programmer
-  id    = "jtag3updi";
-  desc  = "Atmel AVR JTAGICE3 in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
+    id                  = "jtag3updi";
+    desc                = "Atmel AVR JTAGICE3 in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
 ;
 
 programmer
-  id    = "jtag3dw";
-  desc  = "Atmel AVR JTAGICE3 in debugWIRE mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
+    id                  = "jtag3dw";
+    desc                = "Atmel AVR JTAGICE3 in debugWIRE mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
 ;
 
 programmer
-  id    = "jtag3isp";
-  desc  = "Atmel AVR JTAGICE3 in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
+    id                  = "jtag3isp";
+    desc                = "Atmel AVR JTAGICE3 in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
 ;
 
 programmer
-  id    = "xplainedpro";
-  desc  = "Atmel AVR XplainedPro in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2111;
+    id                  = "xplainedpro";
+    desc                = "Atmel AVR XplainedPro in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2111;
 ;
 
 programmer
-  id    = "xplainedpro_updi";
-  desc  = "Atmel AVR XplainedPro in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2111;
+    id                  = "xplainedpro_updi";
+    desc                = "Atmel AVR XplainedPro in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2111;
 ;
 
 programmer
-  id    = "xplainedmini";
-  desc  = "Atmel AVR XplainedMini in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2145;
+    id                  = "xplainedmini";
+    desc                = "Atmel AVR XplainedMini in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2145;
 ;
 
 programmer
-  id    = "xplainedmini_dw";
-  desc  = "Atmel AVR XplainedMini in debugWIRE mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2145;
+    id                  = "xplainedmini_dw";
+    desc                = "Atmel AVR XplainedMini in debugWIRE mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2145;
 ;
 
 programmer
-  id    = "xplainedmini_updi";
-  desc  = "Atmel AVR XplainedMini in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2145;
+    id                  = "xplainedmini_updi";
+    desc                = "Atmel AVR XplainedMini in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2145;
 ;
 
 programmer
-  id    = "atmelice";
-  desc  = "Atmel-ICE (ARM/AVR) in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2141;
+    id                  = "atmelice";
+    desc                = "Atmel-ICE (ARM/AVR) in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2141;
 ;
 
 programmer
-  id    = "atmelice_pdi";
-  desc  = "Atmel-ICE (ARM/AVR) in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2141;
+    id                  = "atmelice_pdi";
+    desc                = "Atmel-ICE (ARM/AVR) in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2141;
 ;
 
 programmer
-  id    = "atmelice_updi";
-  desc  = "Atmel-ICE (ARM/AVR) in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2141;
+    id                  = "atmelice_updi";
+    desc                = "Atmel-ICE (ARM/AVR) in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2141;
 ;
 
 programmer
-  id    = "atmelice_dw";
-  desc  = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2141;
+    id                  = "atmelice_dw";
+    desc                = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2141;
 ;
 
 programmer
-  id    = "atmelice_isp";
-  desc  = "Atmel-ICE (ARM/AVR) in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2141;
+    id                  = "atmelice_isp";
+    desc                = "Atmel-ICE (ARM/AVR) in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2141;
 ;
 
 programmer
-  id    = "powerdebugger";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2144;
+    id                  = "powerdebugger";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2144;
 ;
 
 programmer
-  id    = "powerdebugger_pdi";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2144;
+    id                  = "powerdebugger_pdi";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2144;
 ;
 
 programmer
-  id    = "powerdebugger_updi";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2144;
+    id                  = "powerdebugger_updi";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2144;
 ;
 
 programmer
-  id    = "powerdebugger_dw";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2144;
+    id                  = "powerdebugger_dw";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2144;
 ;
 
 programmer
-  id    = "powerdebugger_isp";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2144;
+    id                  = "powerdebugger_isp";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2144;
 ;
 
 programmer
-  id    = "pickit4_updi";
-  desc  = "MPLAB(R) PICkit 4 in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2177, 0x2178, 0x2179;
+    id                  = "pickit4_updi";
+    desc                = "MPLAB(R) PICkit 4 in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2177, 0x2178, 0x2179;
 ;
 
 programmer
-  id    = "pickit4_pdi";
-  desc  = "MPLAB(R) PICkit 4 in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2177, 0x2178, 0x2179;
+    id                  = "pickit4_pdi";
+    desc                = "MPLAB(R) PICkit 4 in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2177, 0x2178, 0x2179;
 ;
 
 programmer
-   id    = "pickit4_isp";
-   desc  = "MPLAB(R) PICkit 4 in ISP mode";
-   type  = "jtagice3_isp";
-   connection_type = usb;
-   usbpid = 0x2177, 0x2178, 0x2179;
+    id                  = "pickit4_isp";
+    desc                = "MPLAB(R) PICkit 4 in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2177, 0x2178, 0x2179;
 ;
 
 programmer
-  id    = "snap_updi";
-  desc  = "MPLAB(R) SNAP in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x217F, 0x2180, 0x2181;
+    id                  = "snap_updi";
+    desc                = "MPLAB(R) SNAP in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x217F, 0x2180, 0x2181;
 ;
 
 programmer
-  id    = "snap_pdi";
-  desc  = "MPLAB(R) SNAP in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x217F, 0x2180, 0x2181;
+    id                  = "snap_pdi";
+    desc                = "MPLAB(R) SNAP in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x217F, 0x2180, 0x2181;
 ;
 
 programmer
-  id    = "snap_isp";
-  desc  = "MPLAB(R) SNAP in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x217F, 0x2180, 0x2181;
+    id                  = "snap_isp";
+    desc                = "MPLAB(R) SNAP in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x217F, 0x2180, 0x2181;
 ;
 
 programmer
-  id    = "pkobn_updi";
-  desc  = "Curiosity nano (nEDBG) in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2175;
+    id                  = "pkobn_updi";
+    desc                = "Curiosity nano (nEDBG) in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2175;
 ;
 
 programmer
-  id    = "pavr";
-  desc  = "Jason Kyle's pAVR Serial Programmer";
-  type  = "avr910";
-  connection_type = serial;
+    id                  = "pavr";
+    desc                = "Jason Kyle's pAVR Serial Programmer";
+    type                = "avr910";
+    connection_type     = serial;
 ;
 
 programmer
-  id    = "pickit2";
-  desc  = "MicroChip's PICkit2 Programmer";
-  type  = "pickit2";
-  connection_type = usb;
+    id                  = "pickit2";
+    desc                = "MicroChip's PICkit2 Programmer";
+    type                = "pickit2";
+    connection_type     = usb;
 ;
 
 programmer
-  id    = "flip1";
-  desc  = "FLIP USB DFU protocol version 1 (doc7618)";
-  type  = "flip1";
-  connection_type = usb;
+    id                  = "flip1";
+    desc                = "FLIP USB DFU protocol version 1 (doc7618)";
+    type                = "flip1";
+    connection_type     = usb;
 ;
 
 programmer
-  id    = "flip2";
-  desc  = "FLIP USB DFU protocol version 2 (AVR4023)";
-  type  = "flip2";
-  connection_type = usb;
+    id                  = "flip2";
+    desc                = "FLIP USB DFU protocol version 2 (AVR4023)";
+    type                = "flip2";
+    connection_type     = usb;
 ;
 
 @HAVE_PARPORT_BEGIN@
 # Parallel port programmers.
 
 programmer
-  id    = "bsd";
-  desc  = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
-  type  = "par";
-  connection_type = parallel;
-  vcc   = 2, 3, 4, 5;
-  reset = 7;
-  sck   = 8;
-  mosi  = 9;
-  miso  = 10;
+    id                  = "bsd";
+    desc                = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
+    type                = "par";
+    connection_type     = parallel;
+    vcc                 = 2, 3, 4, 5;
+    reset               = 7;
+    sck                 = 8;
+    mosi                = 9;
+    miso                = 10;
 ;
 
 programmer
-  id    = "stk200";
-  desc  = "STK200";
-  type  = "par";
-  connection_type = parallel;
-  buff  = 4, 5;
-  sck   = 6;
-  mosi  = 7;
-  reset = 9;
-  miso  = 10;
+    id                  = "stk200";
+    desc                = "STK200";
+    type                = "par";
+    connection_type     = parallel;
+    buff                = 4, 5;
+    sck                 = 6;
+    mosi                = 7;
+    reset               = 9;
+    miso                = 10;
 ;
 
 # The programming dongle used by the popular Ponyprog
@@ -1399,177 +1399,177 @@ programmer
 # programming is currently in progress.
 
 programmer parent "stk200"
-  id    = "pony-stk200";
-  desc  = "Pony Prog STK200";
-  pgmled = 8; 
+    id                  = "pony-stk200";
+    desc                = "Pony Prog STK200";
+    pgmled              = 8;
 ;
 
 programmer
-  id    = "dt006";
-  desc  = "Dontronics DT006";
-  type  = "par";
-  connection_type = parallel;
-  reset = 4;
-  sck   = 5;
-  mosi  = 2;
-  miso  = 11;
+    id                  = "dt006";
+    desc                = "Dontronics DT006";
+    type                = "par";
+    connection_type     = parallel;
+    reset               = 4;
+    sck                 = 5;
+    mosi                = 2;
+    miso                = 11;
 ;
 
 programmer parent "dt006"
-  id    = "bascom";
-  desc  = "Bascom SAMPLE programming cable";
+    id                  = "bascom";
+    desc                = "Bascom SAMPLE programming cable";
 ;
 
 programmer
-  id     = "alf";
-  desc   = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
-  type   = "par";
-  connection_type = parallel;
-  vcc    = 2, 3, 4, 5;
-  buff   = 6;
-  reset  = 7;
-  sck    = 8;
-  mosi   = 9;
-  miso   = 10;
-  errled = 1;
-  rdyled = 14;
-  pgmled = 16;
-  vfyled = 17;
+    id                  = "alf";
+    desc                = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
+    type                = "par";
+    connection_type     = parallel;
+    vcc                 = 2, 3, 4, 5;
+    buff                = 6;
+    reset               = 7;
+    sck                 = 8;
+    mosi                = 9;
+    miso                = 10;
+    errled              = 1;
+    rdyled              = 14;
+    pgmled              = 16;
+    vfyled              = 17;
 ;
 
 programmer
-  id    = "sp12";
-  desc  = "Steve Bolt's Programmer";
-  type  = "par";
-  connection_type = parallel;
-  vcc   = 4,5,6,7,8;
-  reset = 3;
-  sck   = 2;
-  mosi  = 9;
-  miso  = 11;
+    id                  = "sp12";
+    desc                = "Steve Bolt's Programmer";
+    type                = "par";
+    connection_type     = parallel;
+    vcc                 = 4,5,6,7,8;
+    reset               = 3;
+    sck                 = 2;
+    mosi                = 9;
+    miso                = 11;
 ;
 
 programmer
-  id     = "picoweb";
-  desc   = "Picoweb Programming Cable, http://www.picoweb.net/";
-  type   = "par";
-  connection_type = parallel;
-  reset  = 2;
-  sck    = 3;
-  mosi   = 4;
-  miso   = 13;
+    id                  = "picoweb";
+    desc                = "Picoweb Programming Cable, http://www.picoweb.net/";
+    type                = "par";
+    connection_type     = parallel;
+    reset               = 2;
+    sck                 = 3;
+    mosi                = 4;
+    miso                = 13;
 ;
 
 programmer
-  id    = "abcmini";
-  desc  = "ABCmini Board, aka Dick Smith HOTCHIP";
-  type  = "par";
-  connection_type = parallel;
-  reset = 4;
-  sck   = 3;
-  mosi  = 2;
-  miso  = 10;
+    id                  = "abcmini";
+    desc                = "ABCmini Board, aka Dick Smith HOTCHIP";
+    type                = "par";
+    connection_type     = parallel;
+    reset               = 4;
+    sck                 = 3;
+    mosi                = 2;
+    miso                = 10;
 ;
 
 programmer
-  id    = "futurlec";
-  desc  = "Futurlec.com programming cable.";
-  type  = "par";
-  connection_type = parallel;
-  reset = 3;
-  sck   = 2;
-  mosi  = 1;
-  miso  = 10;
+    id                  = "futurlec";
+    desc                = "Futurlec.com programming cable.";
+    type                = "par";
+    connection_type     = parallel;
+    reset               = 3;
+    sck                 = 2;
+    mosi                = 1;
+    miso                = 10;
 ;
 
 
 # From the contributor of the "xil" jtag cable:
 # The "vcc" definition isn't really vcc (the cable gets its power from
 # the programming circuit) but is necessary to switch one of the
-# buffer lines (trying to add it to the "buff" lines doesn't work in 
+# buffer lines (trying to add it to the "buff" lines doesn't work in
 # avrdude versions before 5.5j).
 # With this, TMS connects to RESET, TDI to MOSI, TDO to MISO and TCK
 # to SCK (plus vcc/gnd of course)
 programmer
-  id    = "xil";
-  desc  = "Xilinx JTAG cable";
-  type  = "par";
-  connection_type = parallel;
-  mosi  = 2;
-  sck   = 3;
-  reset = 4;
-  buff  = 5;
-  miso  = 13;
-  vcc   = 6;
+    id                  = "xil";
+    desc                = "Xilinx JTAG cable";
+    type                = "par";
+    connection_type     = parallel;
+    mosi                = 2;
+    sck                 = 3;
+    reset               = 4;
+    buff                = 5;
+    miso                = 13;
+    vcc                 = 6;
 ;
 
 
 programmer
-  id = "dapa";
-  desc = "Direct AVR Parallel Access cable";
-  type = "par";
-  connection_type = parallel;
-  vcc   = 3;
-  reset = 16;
-  sck = 1;
-  mosi = 2;
-  miso = 11;
+    id                  = "dapa";
+    desc                = "Direct AVR Parallel Access cable";
+    type                = "par";
+    connection_type     = parallel;
+    vcc                 = 3;
+    reset               = 16;
+    sck                 = 1;
+    mosi                = 2;
+    miso                = 11;
 ;
 
 programmer
-  id    = "atisp";
-  desc  = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
-  type  = "par";
-  connection_type = parallel;
-  reset = ~6;
-  sck   = ~8;
-  mosi  = ~7;
-  miso  = ~10;
+    id                  = "atisp";
+    desc                = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
+    type                = "par";
+    connection_type     = parallel;
+    reset               = ~6;
+    sck                 = ~8;
+    mosi                = ~7;
+    miso                = ~10;
 ;
 
 programmer
-  id    = "ere-isp-avr";
-  desc  = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
-  type  = "par";
-  connection_type = parallel;
-  reset = ~4;
-  sck   = 3;
-  mosi  = 2;
-  miso  = 10;
+    id                  = "ere-isp-avr";
+    desc                = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
+    type                = "par";
+    connection_type     = parallel;
+    reset               = ~4;
+    sck                 = 3;
+    mosi                = 2;
+    miso                = 10;
 ;
 
 programmer
-  id    = "blaster";
-  desc  = "Altera ByteBlaster";
-  type  = "par";
-  connection_type = parallel;
-  sck   = 2;
-  miso  = 11;
-  reset = 3;
-  mosi  = 8;
-  buff  = 14;
+    id                  = "blaster";
+    desc                = "Altera ByteBlaster";
+    type                = "par";
+    connection_type     = parallel;
+    sck                 = 2;
+    miso                = 11;
+    reset               = 3;
+    mosi                = 8;
+    buff                = 14;
 ;
 
 # It is almost same as pony-stk200, except vcc on pin 5 to auto
 # disconnect port (download on http://electropol.free.fr/spip/spip.php?article27)
 programmer parent "pony-stk200"
-  id    = "frank-stk200";
-  desc  = "Frank STK200";
-  buff  = ; # delete buff pin assignment
-  vcc   = 5;
+    id                  = "frank-stk200";
+    desc                = "Frank STK200";
+    buff                = ; # delete buff pin assignment
+    vcc                 = 5;
 ;
 
 # The AT98ISP Cable is a simple parallel dongle for AT89 family.
 # http://www.atmel.com/dyn/products/tools_card.asp?tool_id=2877
 programmer
-  id = "89isp";
-  desc = "Atmel at89isp cable";
-  type = "par";
-  connection_type = parallel;
-  reset = 17;
-  sck = 1;
-  mosi = 2;
-  miso = 10;
+    id                  = "89isp";
+    desc                = "Atmel at89isp cable";
+    type                = "par";
+    connection_type     = parallel;
+    reset               = 17;
+    sck                 = 1;
+    mosi                = 2;
+    miso                = 10;
 ;
 
 @HAVE_PARPORT_END@
@@ -1606,14 +1606,14 @@ programmer
 # suitable since they would release /RESET too early.
 #
 programmer
-   id = "linuxspi";
-   desc = "Use Linux SPI device in /dev/spidev*";
-   type = "linuxspi";
-   reset = 25;    # Pi GPIO number - this is J8:22
+    id                  = "linuxspi";
+    desc                = "Use Linux SPI device in /dev/spidev*";
+    type                = "linuxspi";
+    reset               = 25;    # Pi GPIO number - this is J8:22
 ;
 @HAVE_LINUXSPI_END@
 
-# some ultra cheap programmers use bitbanging on the 
+# some ultra cheap programmers use bitbanging on the
 # serialport.
 #
 # PC - DB9 - Pins for RS232:
@@ -1635,75 +1635,75 @@ programmer
 # reset=!txd sck=rts mosi=dtr miso=cts
 
 programmer
-  id    = "ponyser";
-  desc  = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = ~3;
-  sck   = 7;
-  mosi  = 4;
-  miso  = 8;
+    id                  = "ponyser";
+    desc                = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = ~3;
+    sck                 = 7;
+    mosi                = 4;
+    miso                = 8;
 ;
 
 # Same as above, different name
 # reset=!txd sck=rts mosi=dtr miso=cts
 
 programmer parent "ponyser"
-  id    = "siprog";
-  desc  = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
+    id                  = "siprog";
+    desc                = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
 ;
 
 # unknown (dasa in uisp)
 # reset=rts sck=dtr mosi=txd miso=cts
 
 programmer
-  id    = "dasa";
-  desc  = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = 7;
-  sck   = 4;
-  mosi  = 3;
-  miso  = 8;
+    id                  = "dasa";
+    desc                = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = 7;
+    sck                 = 4;
+    mosi                = 3;
+    miso                = 8;
 ;
 
 # unknown (dasa3 in uisp)
 # reset=!dtr sck=rts mosi=txd miso=cts
 
 programmer
-  id    = "dasa3";
-  desc  = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = ~4;
-  sck   = 7;
-  mosi  = 3;
-  miso  = 8;
+    id                  = "dasa3";
+    desc                = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = ~4;
+    sck                 = 7;
+    mosi                = 3;
+    miso                = 8;
 ;
 
 # C2N232i (jumper configuration "auto")
 # reset=dtr sck=!rts mosi=!txd miso=!cts
 
 programmer
-  id    = "c2n232i";
-  desc  = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = 4;
-  sck   = ~7;
-  mosi  = ~3;
-  miso  = ~8;
+    id                  = "c2n232i";
+    desc                = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = 4;
+    sck                 = ~7;
+    mosi                = ~3;
+    miso                = ~8;
 ;
 
 # JTAG2UPDI
 # https://github.com/ElTangas/jtag2updi
 
 programmer
-  id    = "jtag2updi";
-  desc  = "JTAGv2 to UPDI bridge";
-  type  = "jtagmkii_pdi";
-  connection_type = serial;
-  baudrate = 115200;
+    id                  = "jtag2updi";
+    desc                = "JTAGv2 to UPDI bridge";
+    type                = "jtagmkii_pdi";
+    connection_type     = serial;
+    baudrate            = 115200;
 ;
 
 #
@@ -1723,8 +1723,8 @@ part
     signature           = 0x1e 0x90 0x04;
     chip_erase_delay    = 20000;
 
-    timeout		= 200;
-    hvsp_controlstack     =
+    timeout             = 200;
+    hvsp_controlstack   =
         0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
         0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
@@ -1747,16 +1747,16 @@ part
 
     memory "eeprom"
         size            = 64;
-	blocksize	= 64;
-	readsize	= 256;
-	delay		= 5;
+        blocksize       = 64;
+        readsize        = 256;
+        delay           = 5;
     ;
 
     memory "flash"
         size            = 1024;
-	blocksize	= 128;
-	readsize	= 256;
-	delay		= 3;
+        blocksize       = 128;
+        readsize        = 256;
+        delay           = 3;
     ;
 
     memory "signature"
@@ -1793,16 +1793,16 @@ part
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                           "x x x x  x x x x   x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     hvsp_controlstack   =
         0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
@@ -1836,10 +1836,10 @@ part
         write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
                           "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 8;
-	blocksize	= 64;
-	readsize	= 256;
+        mode            = 0x04;
+        delay           = 8;
+        blocksize       = 64;
+        readsize        = 256;
     ;
 
     memory "flash"
@@ -1868,10 +1868,10 @@ part
                           " a7 a6 a5 a4  a3 a2 a1 a0",
                           "  i  i  i  i   i  i  i  i";
 
-	mode		= 0x04;
-	delay		= 5;
-	blocksize	= 128;
-	readsize	= 256;
+        mode            = 0x04;
+        delay           = 5;
+        blocksize       = 128;
+        readsize        = 256;
     ;
 
     memory "signature"
@@ -1916,11 +1916,11 @@ part
 part
     id                  = "t13";
     desc                = "ATtiny13";
-     has_debugwire = yes;
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x0E, 0x1E;
      eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x0E, 0xB4, 0x0E, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+                     0xBC, 0x0E, 0xB4, 0x0E, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
     stk500_devcode      = 0x14;
     signature           = 0x1e 0x90 0x07;
     chip_erase_delay    = 4000;
@@ -1930,19 +1930,19 @@ part
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                           "x x x x  x x x x   x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
-    hvsp_controlstack     =
-	0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
         0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
@@ -1977,20 +1977,20 @@ part
         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
                           "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x   x  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x   x  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 5;
-	blocksize	= 4;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
     ;
 
     memory "flash"
@@ -2027,10 +2027,10 @@ part
                           " a7 a6 a5 a4   x  x  x  x",
                           "  x  x  x  x   x  x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
     ;
 
     memory "signature"
@@ -2044,7 +2044,7 @@ part
         min_write_delay = 4500;
         max_write_delay = 4500;
 
-	read            = "0  1  0  1   1  0  0  0    0 0 0 0  0 0 0 0",
+        read            = "0  1  0  1   1  0  0  0    0 0 0 0  0 0 0 0",
                           "x  x  x  x   x  x  x  x    o o o o  o o o o";
 
         write           = "1  0  1  0   1  1  0  0    1 1 1 x  x x x x",
@@ -2067,7 +2067,7 @@ part
 
         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                           "x x x x  x x x x  o o o o  o o o o";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -2079,7 +2079,7 @@ part
 
         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                           "x x x x  x x x x  o o o o  o o o o";
-      ;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -2087,9 +2087,9 @@ part
 #------------------------------------------------------------
 
 part parent "t13"
-    id               = "t13a";
-    desc             = "ATtiny13A";
-  ;
+    id                  = "t13a";
+    desc                = "ATtiny13A";
+;
 
 #------------------------------------------------------------
 # ATtiny15
@@ -2108,16 +2108,16 @@ part
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                           "x x x x  x x x x   x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     hvsp_controlstack   =
         0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
@@ -2151,10 +2151,10 @@ part
         write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
                           "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
+        mode            = 0x04;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
     ;
 
     memory "flash"
@@ -2183,10 +2183,10 @@ part
                           " a7 a6 a5 a4  a3 a2 a1 a0",
                           "  i  i  i  i   i  i  i  i";
 
-	mode		= 0x04;
-	delay		= 5;
-	blocksize	= 128;
-	readsize	= 256;
+        mode            = 0x04;
+        delay           = 5;
+        blocksize       = 128;
+        readsize        = 256;
     ;
 
     memory "signature"
@@ -2229,31 +2229,31 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "1200";
-    desc             = "AT90S1200";
-    is_at90s1200     = yes;
-    stk500_devcode   = 0x33;
-    avr910_devcode   = 0x13;
-    signature        = 0x1e 0x90 0x01;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "1200";
+    desc                = "AT90S1200";
+    is_at90s1200        = yes;
+    stk500_devcode      = 0x33;
+    avr910_devcode      = 0x13;
+    signature           = 0x1e 0x90 0x01;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 1;
-    bytedelay		= 0;
-    pollindex		= 0;
-    pollvalue		= 0xFF;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 1;
+    bytedelay           = 0;
+    pollindex           = 0;
+    pollvalue           = 0xFF;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -2281,17 +2281,17 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1 0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = "1 0  1  0   0  0  0  0   x x x x  x x x x",
                           "x x a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1 1  0  0   0  0  0  0   x x x x  x x x x",
                           "x x a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 32;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 20;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
     memory "flash"
         size            = 1024;
         min_write_delay = 4000;
@@ -2318,55 +2318,55 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x02;
-	delay		= 15;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x02;
+        delay           = 15;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
         size            = 1;
-      ;
+    ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
         write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s4414
 #------------------------------------------------------------
 
 part
-    id               = "4414";
-    desc             = "AT90S4414";
-    stk500_devcode   = 0x50;
-    avr910_devcode   = 0x28;
-    signature        = 0x1e 0x92 0x01;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "4414";
+    desc                = "AT90S4414";
+    stk500_devcode      = 0x50;
+    avr910_devcode      = 0x28;
+    signature           = 0x1e 0x92 0x01;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -2394,17 +2394,17 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
+        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8",
                           "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
     memory "flash"
         size            = 4096;
         min_write_delay = 9000;
@@ -2431,55 +2431,55 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
-	size		= 1;
-      ;
+        size            = 1;
+    ;
     memory "lock"
-	size		= 1;
-	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        size            = 1;
+        write           = "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
+                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s2313
 #------------------------------------------------------------
 
 part
-    id               = "2313";
-    desc             = "AT90S2313";
-    stk500_devcode   = 0x40;
-    avr910_devcode   = 0x20;
-    signature        = 0x1e 0x91 0x01;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "2313";
+    desc                = "AT90S2313";
+    stk500_devcode      = 0x40;
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x91 0x01;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -2507,17 +2507,17 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
     memory "flash"
         size            = 2048;
         min_write_delay = 4000;
@@ -2544,56 +2544,56 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
         size            = 1;
-      ;
+    ;
     memory "lock"
         size            = 1;
         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x i i x",
                           "x x x x  x x x x  x x x x  x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s2333
 #------------------------------------------------------------
 
 part
-    id               = "2333";
+    id                  = "2333";
 ##### WARNING: No XML file for device 'AT90S2333'! #####
-    desc             = "AT90S2333";
-    stk500_devcode   = 0x42;
-    avr910_devcode   = 0x34;
-    signature        = 0x1e 0x91 0x05;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    desc                = "AT90S2333";
+    stk500_devcode      = 0x42;
+    avr910_devcode      = 0x34;
+    signature           = 0x1e 0x91 0x05;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -2621,17 +2621,17 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "flash"
         size            = 2048;
@@ -2659,17 +2659,17 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
@@ -2680,7 +2680,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
+    ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
@@ -2690,8 +2690,8 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+    ;
+;
 
 
 #------------------------------------------------------------
@@ -2699,28 +2699,28 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "2343";
-    desc             = "AT90S2343";
-    stk500_devcode   = 0x43;
-    avr910_devcode   = 0x4c;
-    signature        = 0x1e 0x91 0x03;
-    chip_erase_delay = 18000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "2343";
+    desc                = "AT90S2343";
+    stk500_devcode      = 0x43;
+    avr910_devcode      = 0x4c;
+    signature           = 0x1e 0x91 0x03;
+    chip_erase_delay    = 18000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     hvsp_controlstack   =
         0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
@@ -2748,17 +2748,17 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 0  0 0 0 0", 
+        read            = "1  0  1  0   0  0  0  0   0 0 0 0  0 0 0 0",
                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = "1  1  0  0   0  0  0  0   0 0 0 0  0 0 0 0",
                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
     memory "flash"
         size            = 2048;
         min_write_delay = 9000;
@@ -2785,16 +2785,16 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 128;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 128;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
@@ -2804,7 +2804,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 1  1 1 1 i",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
+    ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
@@ -2814,8 +2814,8 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+    ;
+;
 
 
 #------------------------------------------------------------
@@ -2823,28 +2823,28 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "4433";
-    desc             = "AT90S4433";
-    stk500_devcode   = 0x51;
-    avr910_devcode   = 0x30;
-    signature        = 0x1e 0x92 0x03;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "4433";
+    desc                = "AT90S4433";
+    stk500_devcode      = 0x51;
+    avr910_devcode      = 0x30;
+    signature           = 0x1e 0x92 0x03;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -2872,17 +2872,17 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "flash"
         size            = 4096;
         min_write_delay = 9000;
@@ -2909,16 +2909,16 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
@@ -2929,7 +2929,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
+    ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
@@ -2939,25 +2939,25 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s4434
 #------------------------------------------------------------
 
 part
-    id               = "4434";
+    id                  = "4434";
 ##### WARNING: No XML file for device 'AT90S4434'! #####
-    desc             = "AT90S4434";
-    stk500_devcode   = 0x52;
-    avr910_devcode   = 0x6c;
-    signature        = 0x1e 0x92 0x02;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    desc                = "AT90S4434";
+    stk500_devcode      = 0x52;
+    avr910_devcode      = 0x6c;
+    signature           = 0x1e 0x92 0x02;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
     memory "eeprom"
@@ -2966,12 +2966,12 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x",
                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-      ;
+    ;
     memory "flash"
         size            = 4096;
         min_write_delay = 9000;
@@ -2997,12 +2997,12 @@ part
                           "  x   x   x   x    x a10  a9  a8",
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
@@ -3012,7 +3012,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
+    ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
@@ -3022,42 +3022,42 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
                           "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s8515
 #------------------------------------------------------------
 
 part
-    id               = "8515";
-    desc             = "AT90S8515";
-    stk500_devcode   = 0x60;
-    avr910_devcode   = 0x38;
-    signature        = 0x1e 0x93 0x01;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "8515";
+    desc                = "AT90S8515";
+    stk500_devcode      = 0x60;
+    avr910_devcode      = 0x38;
+    signature           = 0x1e 0x93 0x01;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 0;
     latchcycles         = 0;
@@ -3080,17 +3080,17 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
+        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8",
                           "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "flash"
         size            = 8192;
         min_write_delay = 4000;
@@ -3117,55 +3117,55 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
-	size		= 1;
-      ;
+        size            = 1;
+    ;
     memory "lock"
-	size		= 1;
-	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        size            = 1;
+        write           = "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
+                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s8535
 #------------------------------------------------------------
 
 part
-    id               = "8535";
-    desc             = "AT90S8535";
-    stk500_devcode   = 0x61;
-    avr910_devcode   = 0x68;
-    signature        = 0x1e 0x93 0x03;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "8535";
+    desc                = "AT90S8535";
+    stk500_devcode      = 0x61;
+    avr910_devcode      = 0x68;
+    signature           = 0x1e 0x93 0x03;
+    chip_erase_delay    = 20000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -3193,17 +3193,17 @@ part
         max_write_delay = 20000;
         readback_p1     = 0x00;
         readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x a8", 
+        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x a8",
                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "flash"
         size            = 8192;
         min_write_delay = 9000;
@@ -3230,63 +3230,63 @@ part
                           " a7  a6  a5  a4   a3  a2  a1  a0",
                           "  i   i   i   i    i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "fuse"
-	size		= 1;
-	read		= "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  o";
-	write		= "1  0  1  0   1  1  0  0   1  0  1  1   1  1  1  i",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  o";
+        write           = "1  0  1  0   1  1  0  0   1  0  1  1   1  1  1  i",
+                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
     memory "lock"
-	size		= 1;
-	read		= "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
-			  "x  x  x  x   x  x  x  x   o  o  x  x   x  x  x  x";
-	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        size            = 1;
+        read            = "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
+                          "x  x  x  x   x  x  x  x   o  o  x  x   x  x  x  x";
+        write           = "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
+                          "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega103
 #------------------------------------------------------------
 
 part
-    id               = "m103";
-    desc             = "ATmega103";
-    stk500_devcode   = 0xB1;
-    avr910_devcode   = 0x41;
-    signature        = 0x1e 0x97 0x01;
-    chip_erase_delay = 112000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m103";
+    desc                = "ATmega103";
+    stk500_devcode      = 0xB1;
+    avr910_devcode      = 0x41;
+    signature           = 0x1e 0x97 0x01;
+    chip_erase_delay    = 112000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x8E, 0x9E, 0x2E, 0x3E, 0xAE, 0xBE,
@@ -3314,21 +3314,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0x80;
         readback_p2     = 0x7f;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -3364,11 +3364,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x11;
-	delay		= 70;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x11;
+        delay           = 70;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "fuse"
         size            = 1;
@@ -3379,7 +3379,7 @@ part
                           "x x x x  x x x x  x x x x  x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -3390,14 +3390,14 @@ part
                           "x x x x  x x x x   x x x x  x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 
 #------------------------------------------------------------
@@ -3405,32 +3405,32 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m64";
-    desc             = "ATmega64";
-    has_jtag         = yes;
-    stk500_devcode   = 0xA0;
-    avr910_devcode   = 0x45;
-    signature        = 0x1e 0x96 0x02;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m64";
+    desc                = "ATmega64";
+    has_jtag            = yes;
+    stk500_devcode      = 0xA0;
+    avr910_devcode      = 0x45;
+    signature           = 0x1e 0x96 0x02;
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -3473,14 +3473,14 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 20;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -3517,11 +3517,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -3532,7 +3532,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -3543,7 +3543,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -3554,7 +3554,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -3565,61 +3565,61 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 4;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega64A
 #------------------------------------------------------------
 
 part parent "m64"
-    id               = "m64a";
-    desc             = "ATmega64A";
-  ;
+    id                  = "m64a";
+    desc                = "ATmega64A";
+;
 
 #------------------------------------------------------------
 # ATmega128
 #------------------------------------------------------------
 
 part
-    id               = "m128";
-    desc             = "ATmega128";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB2;
-    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x97 0x02;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m128";
+    desc                = "ATmega128";
+    has_jtag            = yes;
+    stk500_devcode      = 0xB2;
+    avr910_devcode      = 0x43;
+    signature           = 0x1e 0x97 0x02;
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -3663,14 +3663,14 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -3706,11 +3706,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -3721,7 +3721,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -3732,7 +3732,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -3743,7 +3743,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -3754,61 +3754,61 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 4;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega128A
 #------------------------------------------------------------
 
 part parent "m128"
-    id               = "m128a";
-    desc             = "ATmega128A";
-  ;
+    id                  = "m128a";
+    desc                = "ATmega128A";
+;
 
 #------------------------------------------------------------
 # AT90CAN128
 #------------------------------------------------------------
 
 part
-    id               = "c128";
-    desc             = "AT90CAN128";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB3;
+    id                  = "c128";
+    desc                = "AT90CAN128";
+    has_jtag            = yes;
+    stk500_devcode      = 0xB3;
 #    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x97 0x81;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    signature           = 0x1e 0x97 0x81;
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -3846,32 +3846,32 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   0   x    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -3907,11 +3907,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -3922,7 +3922,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -3933,7 +3933,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -3944,7 +3944,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -3955,52 +3955,52 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90CAN64
 #------------------------------------------------------------
 
 part
-    id               = "c64";
-    desc             = "AT90CAN64";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB3;
+    id                  = "c64";
+    desc                = "AT90CAN64";
+    has_jtag            = yes;
+    stk500_devcode      = 0xB3;
 #    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x96 0x81;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    signature           = 0x1e 0x96 0x81;
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -4038,32 +4038,32 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   0   x      x a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x      x a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -4099,11 +4099,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -4114,7 +4114,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -4125,7 +4125,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -4136,7 +4136,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -4147,52 +4147,52 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90CAN32
 #------------------------------------------------------------
 
 part
-    id               = "c32";
-    desc             = "AT90CAN32";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB3;
+    id                  = "c32";
+    desc                = "AT90CAN32";
+    has_jtag            = yes;
+    stk500_devcode      = 0xB3;
 #    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x95 0x81;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    signature           = 0x1e 0x95 0x81;
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -4230,32 +4230,32 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   0   x      x   x  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x      x   x  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -4291,11 +4291,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -4306,7 +4306,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -4317,7 +4317,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -4328,7 +4328,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -4339,20 +4339,20 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 
 #------------------------------------------------------------
@@ -4360,37 +4360,37 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m16";
-    desc             = "ATmega16";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82;
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x94 0x03;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m16";
+    desc                = "ATmega16";
+    has_jtag            = yes;
+    stk500_devcode      = 0x82;
+    avr910_devcode      = 0x74;
+    signature           = 0x1e 0x94 0x03;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 100;
     latchcycles         = 6;
@@ -4421,31 +4421,31 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x      x   x  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -4481,11 +4481,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lock"
         size            = 1;
@@ -4496,7 +4496,7 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -4507,7 +4507,7 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -4518,59 +4518,59 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
     memory "calibration"
         size            = 4;
 
         read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
                           "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
-        ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega16A
 #------------------------------------------------------------
 
 part parent "m16"
-    id               = "m16a";
-    desc             = "ATmega16A";
-  ;
+    id                  = "m16a";
+    desc                = "ATmega16A";
+;
 
 #------------------------------------------------------------
 # ATmega324P
 #------------------------------------------------------------
 
 part
-    id               = "m324p";
-    desc             = "ATmega324P";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x95 0x08;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 55000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m324p";
+    desc                = "ATmega324P";
+    has_jtag            = yes;
+    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode      = 0x74;
+    signature           = 0x1e 0x95 0x08;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 55000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -4606,31 +4606,31 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x      x a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -4666,11 +4666,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lock"
         size            = 1;
@@ -4681,7 +4681,7 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -4692,7 +4692,7 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -4703,7 +4703,7 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -4715,30 +4715,30 @@ part
                           "x x x x  x x x x  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
 
         read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega164P
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m164p";
-    desc             = "ATmega164P";
-    signature        = 0x1e 0x94 0x0a;
+    id                  = "m164p";
+    desc                = "ATmega164P";
+    signature           = 0x1e 0x94 0x0a;
 
     memory "eeprom"
         paged           = no; /* leave this "no" */
@@ -4748,31 +4748,31 @@ part parent "m324p"
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x      x   0   0  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   0   0  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   0   0 a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   0   0 a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -4808,93 +4808,93 @@ part parent "m324p"
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
-  ;
+;
 
 #------------------------------------------------------------
 # ATmega164PA
 #------------------------------------------------------------
 
 part parent "m164p"
-    id               = "m164pa";
-    desc             = "ATmega164PA";
-  ;
+    id                  = "m164pa";
+    desc                = "ATmega164PA";
+;
 
 #------------------------------------------------------------
 # ATmega164A
 #------------------------------------------------------------
 
 part parent "m164p"
-    id               = "m164a";
-    desc             = "ATmega164A";
-    signature        = 0x1e 0x94 0x0f;
-  ;
+    id                  = "m164a";
+    desc                = "ATmega164A";
+    signature           = 0x1e 0x94 0x0f;
+;
 
 #------------------------------------------------------------
 # ATmega324PB
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m324pb";
-    desc             = "ATmega324PB";
-    signature        = 0x1e 0x95 0x17;
-  ;
+    id                  = "m324pb";
+    desc                = "ATmega324PB";
+    signature           = 0x1e 0x95 0x17;
+;
 
 #------------------------------------------------------------
 # ATmega324PA
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m324pa";
-    desc             = "ATmega324PA";
-    signature        = 0x1e 0x95 0x11;
-  ;
+    id                  = "m324pa";
+    desc                = "ATmega324PA";
+    signature           = 0x1e 0x95 0x11;
+;
 
 #------------------------------------------------------------
 # ATmega324A
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m324a";
-    desc             = "ATmega324A";
-    signature        = 0x1e 0x95 0x15;
-  ;
+    id                  = "m324a";
+    desc                = "ATmega324A";
+    signature           = 0x1e 0x95 0x15;
+;
 
 #------------------------------------------------------------
 # ATmega644
 #------------------------------------------------------------
 
 part
-    id               = "m644";
-    desc             = "ATmega644";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x96 0x09;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 55000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m644";
+    desc                = "ATmega644";
+    has_jtag            = yes;
+    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode      = 0x74;
+    signature           = 0x1e 0x96 0x09;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 55000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -4930,31 +4930,31 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -4990,11 +4990,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lock"
         size            = 1;
@@ -5005,7 +5005,7 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -5016,7 +5016,7 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -5027,7 +5027,7 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -5039,81 +5039,81 @@ part
                           "x x x x  x x x x  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
 
         read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega644A
 #------------------------------------------------------------
 
 part parent "m644"
-    id               = "m644a";
-    desc             = "ATmega644A";
-  ;
+    id                  = "m644a";
+    desc                = "ATmega644A";
+;
 
 #------------------------------------------------------------
 # ATmega644P
 #------------------------------------------------------------
 
 part parent "m644"
-    id               = "m644p";
-    desc             = "ATmega644P";
-    signature        = 0x1e 0x96 0x0a;
-  ;
+    id                  = "m644p";
+    desc                = "ATmega644P";
+    signature           = 0x1e 0x96 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega644PA
 #------------------------------------------------------------
 
 part parent "m644"
-    id               = "m644pa";
-    desc             = "ATmega644PA";
-    signature        = 0x1e 0x96 0x0a;
-  ;
+    id                  = "m644pa";
+    desc                = "ATmega644PA";
+    signature           = 0x1e 0x96 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega1284
 #------------------------------------------------------------
 
 part
-    id               = "m1284";
-    desc             = "ATmega1284";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x97 0x06;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 55000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m1284";
+    desc                = "ATmega1284";
+    has_jtag            = yes;
+    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode      = 0x74;
+    signature           = 0x1e 0x97 0x06;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 55000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -5149,31 +5149,31 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -5209,11 +5209,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lock"
         size            = 1;
@@ -5224,7 +5224,7 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -5235,7 +5235,7 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -5246,7 +5246,7 @@ part
                           "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -5258,55 +5258,55 @@ part
                           "x x x x  x x x x  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
 
         read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega1284P
 #------------------------------------------------------------
 
 part parent "m1284"
-    id               = "m1284p";
-    desc             = "ATmega1284P";
-    signature        = 0x1e 0x97 0x05;
-  ;
+    id                  = "m1284p";
+    desc                = "ATmega1284P";
+    signature           = 0x1e 0x97 0x05;
+;
 
 #------------------------------------------------------------
 # ATmega162
 #------------------------------------------------------------
 
 part
-    id               = "m162";
-    desc             = "ATmega162";
-    has_jtag         = yes;
-    stk500_devcode   = 0x83;
-    avr910_devcode   = 0x63;
-    signature        = 0x1e 0x94 0x04;
-    chip_erase_delay = 9000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
+    id                  = "m162";
+    desc                = "ATmega162";
+    has_jtag            = yes;
+    stk500_devcode      = 0x83;
+    avr910_devcode      = 0x63;
+    signature           = 0x1e 0x94 0x04;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
 
-    idr              = 0x04;
-    spmcr            = 0x57;
+    idr                 = 0x04;
+    spmcr               = 0x57;
     allowfullpagebitstream = yes;
 
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
     ocdrev              = 2;
@@ -5345,23 +5345,23 @@ part
                           "  0   0 a13 a12    a11 a10  a9  a8",
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
-       mode        = 0x41;
-    delay       = 10;
-    blocksize   = 128;
-    readsize    = 256;  
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
 
-        ;
+    ;
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -5392,31 +5392,31 @@ part
         readback_p1     = 0xff;
         readback_p2     = 0xff;
 
-                read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x      x   x  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-                write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   x  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-        ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -5427,7 +5427,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-        ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -5439,7 +5439,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-        ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -5451,7 +5451,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                           "x x x x  x x x x  1 1 1 1  1 i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -5463,21 +5463,21 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-        ;
+    ;
 
     memory "signature"
         size            = 3;
 
         read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-        ;
+    ;
 
     memory "calibration"
         size            = 1;
 
         read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
+    ;
 ;
 
 
@@ -5487,18 +5487,18 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m163";
-    desc             = "ATmega163";
-    stk500_devcode   = 0x81;
-    avr910_devcode   = 0x64;
-    signature        = 0x1e 0x94 0x02;
-    chip_erase_delay = 32000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m163";
+    desc                = "ATmega163";
+    stk500_devcode      = 0x81;
+    avr910_devcode      = 0x64;
+    signature           = 0x1e 0x94 0x02;
+    chip_erase_delay    = 32000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
@@ -5533,18 +5533,18 @@ part
     programlockpolltimeout = 2;
 
 
-   memory "eeprom"
+    memory "eeprom"
         size            = 512;
         min_write_delay = 4000;
         max_write_delay = 4000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  x   x   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
@@ -5552,7 +5552,7 @@ part
         delay           = 20;
         blocksize       = 4;
         readsize        = 256;
-      ;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -5588,11 +5588,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x11;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x11;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -5603,7 +5603,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i 1 1  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -5614,7 +5614,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   1 1 1 1  1 i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -5625,48 +5625,48 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0   x x x x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega169
 #------------------------------------------------------------
 
 part
-    id               = "m169";
-    desc             = "ATmega169";
-    has_jtag         = yes;
-    stk500_devcode   = 0x85;
-    avr910_devcode   = 0x78;
-    signature        = 0x1e 0x94 0x05;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m169";
+    desc                = "ATmega169";
+    has_jtag            = yes;
+    stk500_devcode      = 0x85;
+    avr910_devcode      = 0x78;
+    signature           = 0x1e 0x94 0x05;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -5693,7 +5693,7 @@ part
 
     ocdrev              = 2;
 
-   memory "eeprom"
+    memory "eeprom"
         paged           = no; /* leave this "no" */
         page_size       = 4;  /* for parallel programming */
         size            = 512;
@@ -5701,31 +5701,31 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  x   x   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -5761,11 +5761,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -5776,7 +5776,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -5787,7 +5787,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -5796,7 +5796,7 @@ part
 
         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                           "x x x x  x x x x  o o o o  o o o o";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -5807,79 +5807,79 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega169A
 #------------------------------------------------------------
 
 part parent "m169"
-    id               = "m169a";
-    desc             = "ATmega169A";
-    signature        = 0x1E 0x94 0x11;
-  ;
+    id                  = "m169a";
+    desc                = "ATmega169A";
+    signature           = 0x1E 0x94 0x11;
+;
 
 #------------------------------------------------------------
 # ATmega169P
 #------------------------------------------------------------
 
 part parent "m169"
-    id               = "m169p";
-    desc             = "ATmega169P";
-    signature        = 0x1E 0x94 0x05;
-  ;
+    id                  = "m169p";
+    desc                = "ATmega169P";
+    signature           = 0x1E 0x94 0x05;
+;
 
 #------------------------------------------------------------
 # ATmega169PA
 #------------------------------------------------------------
 
 part parent "m169"
-    id               = "m169pa";
-    desc             = "ATmega169PA";
-    signature        = 0x1E 0x94 0x05;
-  ;
+    id                  = "m169pa";
+    desc                = "ATmega169PA";
+    signature           = 0x1E 0x94 0x05;
+;
 
 #------------------------------------------------------------
 # ATmega329
 #------------------------------------------------------------
 
 part
-    id               = "m329";
-    desc             = "ATmega329";
-    has_jtag         = yes;
+    id                  = "m329";
+    desc                = "ATmega329";
+    has_jtag            = yes;
 #    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
 #    avr910_devcode   = 0x?;  # try the ATmega169 one:
-    avr910_devcode   = 0x75;
-    signature        = 0x1e 0x95 0x03;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    avr910_devcode      = 0x75;
+    signature           = 0x1e 0x95 0x03;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -5906,7 +5906,7 @@ part
 
     ocdrev              = 3;
 
-   memory "eeprom"
+    memory "eeprom"
         paged           = no; /* leave this "no" */
         page_size       = 4;  /* for parallel programming */
         size            = 1024;
@@ -5914,31 +5914,31 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  x   x   x   x      x   x  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x   x  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -5970,13 +5970,13 @@ part
                           "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage = "0 1 0 0 1 1 0 0   x x a13 a12 a11 a10 a9 a8   a7 a6 x x x x x x   x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0   x x a13 a12 a11 a10 a9 a8   a7 a6 x x x x x x   x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -5987,7 +5987,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -5998,7 +5998,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -6009,7 +6009,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
                           "x x x x  x x x x   x x x x  x i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -6020,118 +6020,118 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega329A
 #------------------------------------------------------------
 
 part parent "m329"
-    id               = "m329a";
-    desc             = "ATmega329A";
-  ;
+    id                  = "m329a";
+    desc                = "ATmega329A";
+;
 
 #------------------------------------------------------------
 # ATmega329P
 #------------------------------------------------------------
 
 part parent "m329"
-    id               = "m329p";
-    desc             = "ATmega329P";
-    signature        = 0x1e 0x95 0x0b;
-  ;
+    id                  = "m329p";
+    desc                = "ATmega329P";
+    signature           = 0x1e 0x95 0x0b;
+;
 
 #------------------------------------------------------------
 # ATmega329PA
 #------------------------------------------------------------
 
 part parent "m329"
-    id               = "m329pa";
-    desc             = "ATmega329PA";
-    signature        = 0x1e 0x95 0x0b;
-  ;
+    id                  = "m329pa";
+    desc                = "ATmega329PA";
+    signature           = 0x1e 0x95 0x0b;
+;
 
 #------------------------------------------------------------
 # ATmega3290
 #------------------------------------------------------------
 
 part parent "m329"
-    id               = "m3290";
-    desc             = "ATmega3290";
-    signature        = 0x1e 0x95 0x04;
-  ;
+    id                  = "m3290";
+    desc                = "ATmega3290";
+    signature           = 0x1e 0x95 0x04;
+;
 
 #------------------------------------------------------------
 # ATmega3290A
 #------------------------------------------------------------
 
 part parent "m329"
-    id               = "m3290a";
-    desc             = "ATmega3290A";
-    signature        = 0x1e 0x95 0x04;
-  ;
+    id                  = "m3290a";
+    desc                = "ATmega3290A";
+    signature           = 0x1e 0x95 0x04;
+;
 
 #------------------------------------------------------------
 # ATmega3290P
 #------------------------------------------------------------
 
 part parent "m329"
-    id               = "m3290p";
-    desc             = "ATmega3290P";
-    signature        = 0x1e 0x95 0x0c;
-  ;
+    id                  = "m3290p";
+    desc                = "ATmega3290P";
+    signature           = 0x1e 0x95 0x0c;
+;
 
 #------------------------------------------------------------
 # ATmega3290PA
 #------------------------------------------------------------
 
 part parent "m329"
-    id               = "m3290pa";
-    desc             = "ATmega3290PA";
-    signature        = 0x1e 0x95 0x0c;
-  ;
+    id                  = "m3290pa";
+    desc                = "ATmega3290PA";
+    signature           = 0x1e 0x95 0x0c;
+;
 
 #------------------------------------------------------------
 # ATmega649
 #------------------------------------------------------------
 
 part
-    id               = "m649";
-    desc             = "ATmega649";
-    has_jtag         = yes;
+    id                  = "m649";
+    desc                = "ATmega649";
+    has_jtag            = yes;
 #    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
 #    avr910_devcode   = 0x?;  # try the ATmega169 one:
-    avr910_devcode   = 0x75;
-    signature        = 0x1e 0x96 0x03;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    avr910_devcode      = 0x75;
+    signature           = 0x1e 0x96 0x03;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -6158,7 +6158,7 @@ part
 
     ocdrev              = 3;
 
-   memory "eeprom"
+    memory "eeprom"
         paged           = no; /* leave this "no" */
         page_size       = 8;  /* for parallel programming */
         size            = 2048;
@@ -6166,31 +6166,31 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  x   x   x   x      x a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -6222,13 +6222,13 @@ part
                           "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage = "0 1 0 0 1 1 0 0   x a14 a13 a12 a11 a10 a9 a8   a7 x x x x x x x   x x x x x x x x";
+        writepage       = "0 1 0 0 1 1 0 0   x a14 a13 a12 a11 a10 a9 a8   a7 x x x x x x x   x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -6239,7 +6239,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -6250,7 +6250,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -6261,7 +6261,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
                           "x x x x  x x x x   x x x x  x i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -6272,100 +6272,100 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega649A
 #------------------------------------------------------------
 
 part parent "m649"
-    id               = "m649a";
-    desc             = "ATmega649A";
-  ;
+    id                  = "m649a";
+    desc                = "ATmega649A";
+;
 
 #------------------------------------------------------------
 # ATmega649P
 #------------------------------------------------------------
 
 part parent "m649"
-    id               = "m649p";
-    desc             = "ATmega649P";
-    signature        = 0x1e 0x96 0x0b;
-  ;
+    id                  = "m649p";
+    desc                = "ATmega649P";
+    signature           = 0x1e 0x96 0x0b;
+;
 
 #------------------------------------------------------------
 # ATmega6490
 #------------------------------------------------------------
 
 part parent "m649"
-    id               = "m6490";
-    desc             = "ATmega6490";
-    signature        = 0x1e 0x96 0x04;
-  ;
+    id                  = "m6490";
+    desc                = "ATmega6490";
+    signature           = 0x1e 0x96 0x04;
+;
 
 #------------------------------------------------------------
 # ATmega6490A
 #------------------------------------------------------------
 
 part parent "m649"
-    id               = "m6490a";
-    desc             = "ATmega6490A";
-    signature        = 0x1e 0x96 0x04;
-  ;
+    id                  = "m6490a";
+    desc                = "ATmega6490A";
+    signature           = 0x1e 0x96 0x04;
+;
 
 #------------------------------------------------------------
 # ATmega6490P
 #------------------------------------------------------------
 
 part parent "m649"
-    id               = "m6490p";
-    desc             = "ATmega6490P";
-    signature        = 0x1e 0x96 0x0C;
-  ;
+    id                  = "m6490p";
+    desc                = "ATmega6490P";
+    signature           = 0x1e 0x96 0x0C;
+;
 
 #------------------------------------------------------------
 # ATmega32
 #------------------------------------------------------------
 
 part
-    id               = "m32";
-    desc             = "ATmega32";
-    has_jtag         = yes;
-    stk500_devcode   = 0x91;
-    avr910_devcode   = 0x72;
-    signature        = 0x1e 0x95 0x02;
-    chip_erase_delay = 9000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m32";
+    desc                = "ATmega32";
+    has_jtag            = yes;
+    stk500_devcode      = 0x91;
+    avr910_devcode      = 0x72;
+    signature           = 0x1e 0x95 0x02;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -6393,7 +6393,7 @@ part
 
     ocdrev              = 2;
 
-   memory "eeprom"
+    memory "eeprom"
         paged           = no;   /* leave this "no" */
         page_size       = 4;    /* for parallel programming */
         size            = 1024;
@@ -6411,21 +6411,21 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x  a9  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -6461,11 +6461,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -6476,7 +6476,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -6487,7 +6487,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -6498,49 +6498,49 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o o";
-      ;
+    ;
 
     memory "calibration"
         size            = 4;
         read            = "0 0 1 1  1 0 0 0    0 0 x x  x x x x",
                           "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega161
 #------------------------------------------------------------
 
 part
-    id               = "m161";
-    desc             = "ATmega161";
-    stk500_devcode   = 0x80;
-    avr910_devcode   = 0x60;
-    signature        = 0x1e 0x94 0x01;
-    chip_erase_delay = 28000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m161";
+    desc                = "ATmega161";
+    stk500_devcode      = 0x80;
+    avr910_devcode      = 0x60;
+    signature           = 0x1e 0x94 0x01;
+    chip_erase_delay    = 28000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -6562,27 +6562,27 @@ part
     programlockpulsewidth = 0;
     programlockpolltimeout = 2;
 
-   memory "eeprom"
+    memory "eeprom"
         size            = 512;
         min_write_delay = 3400;
         max_write_delay = 3400;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  x   x   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 5;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 5;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -6618,11 +6618,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 16;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 16;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "fuse"
         size            = 1;
@@ -6633,7 +6633,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 x  x x x x",
                           "x x x x  x x x x   1 i 1 i  i i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -6644,58 +6644,58 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega32A
 #------------------------------------------------------------
 
 part parent "m32"
-    id               = "m32a";
-    desc             = "ATmega32A";
-  ;
+    id                  = "m32a";
+    desc                = "ATmega32A";
+;
 
 #------------------------------------------------------------
 # ATmega8
 #------------------------------------------------------------
 
 part
-    id               = "m8";
-    desc             = "ATmega8";
-    stk500_devcode   = 0x70;
-    avr910_devcode   = 0x76;
-    signature        = 0x1e 0x93 0x07;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 10000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m8";
+    desc                = "ATmega8";
+    stk500_devcode      = 0x70;
+    avr910_devcode      = 0x76;
+    signature           = 0x1e 0x93 0x07;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 10000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 0;
     latchcycles         = 5;
@@ -6719,21 +6719,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -6768,11 +6768,11 @@ part
                           " a7  a6  a5   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -6783,7 +6783,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -6794,7 +6794,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -6805,20 +6805,20 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "calibration"
         size            = 4;
         read            = "0  0  1  1   1  0  0  0   0  0  x  x   x  x  x  x",
                           "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 
 
@@ -6827,8 +6827,8 @@ part
 #------------------------------------------------------------
 
 part parent "m8"
-    id               = "m8a";
-    desc             = "ATmega8A";
+    id                  = "m8a";
+    desc                = "ATmega8A";
     ;
 
 #------------------------------------------------------------
@@ -6836,28 +6836,28 @@ part parent "m8"
 #------------------------------------------------------------
 
 part
-    id               = "m8515";
-    desc             = "ATmega8515";
-    stk500_devcode   = 0x63;
-    avr910_devcode   = 0x3A;
-    signature        = 0x1e 0x93 0x06;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m8515";
+    desc                = "ATmega8515";
+    stk500_devcode      = 0x63;
+    avr910_devcode      = 0x3A;
+    signature           = 0x1e 0x93 0x06;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -6885,21 +6885,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
- read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
- write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -6934,11 +6934,11 @@ part
                           " a7  a6  a5   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -6949,7 +6949,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -6960,7 +6960,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -6971,20 +6971,20 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "calibration"
         size            = 4;
         read            = "0 0 1 1  1 0 0 0     0 0 x x  x x x x",
                           "0 0 0 0  0 0 a1 a0   o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 
 
@@ -6994,30 +6994,30 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m8535";
-    desc             = "ATmega8535";
-    stk500_devcode   = 0x64;
-    avr910_devcode   = 0x69;
-    signature        = 0x1e 0x93 0x08;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m8535";
+    desc                = "ATmega8535";
+    stk500_devcode      = 0x64;
+    avr910_devcode      = 0x69;
+    signature           = 0x1e 0x93 0x08;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -7045,21 +7045,21 @@ part
         max_write_delay = 9000;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   x   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x04;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -7094,11 +7094,11 @@ part
                           " a7  a6  a5   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -7109,7 +7109,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -7120,7 +7120,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -7131,20 +7131,20 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "calibration"
         size            = 4;
         read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
                           "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 
 #------------------------------------------------------------
@@ -7166,16 +7166,16 @@ part
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                           "x x x x  x x x x   x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
@@ -7209,10 +7209,10 @@ part
         write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
+        mode            = 0x04;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
     ;
 
     memory "flash"
@@ -7249,10 +7249,10 @@ part
                           " a7 a6 a5 a4   x  x  x  x",
                           "  x  x  x  x   x  x  x  x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 16;
-	readsize	= 256;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 16;
+        readsize        = 256;
     ;
 
     memory "signature"
@@ -7281,7 +7281,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -7292,7 +7292,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 4;
@@ -7308,11 +7308,11 @@ part
 part
     id                  = "t261";
     desc                = "ATtiny261";
-     has_debugwire = yes;
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x00, 0x10;
      eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+                     0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
 #    stk500_devcode      = 0x21;
 #    avr910_devcode      = 0x5e;
     signature           = 0x1e 0x91 0x0c;
@@ -7326,16 +7326,16 @@ part
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                           "x x x x  x x x x   x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
@@ -7375,20 +7375,20 @@ part
         write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
                           "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 4;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
     ;
 
     memory "flash"
@@ -7426,10 +7426,10 @@ part
                           " a7 a6 a5 a4   x  x  x  x",
                           "  x  x  x  x   x  x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
     ;
 
     memory "signature"
@@ -7458,7 +7458,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -7469,7 +7469,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -7480,7 +7480,7 @@ part
                           "x x x x  x x x x   o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
@@ -7494,9 +7494,9 @@ part
 #------------------------------------------------------------
 
 part parent "t261"
-    id               = "t261a";
-    desc             = "ATtiny261A";
-  ;
+    id                  = "t261a";
+    desc                = "ATtiny261A";
+;
 
 #------------------------------------------------------------
 # ATtiny461
@@ -7505,11 +7505,11 @@ part parent "t261"
 part
     id                  = "t461";
     desc                = "ATtiny461";
-     has_debugwire = yes;
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x00, 0x10;
      eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+                     0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
 #    stk500_devcode      = 0x21;
 #    avr910_devcode      = 0x5e;
     signature           = 0x1e 0x92 0x08;
@@ -7523,16 +7523,16 @@ part
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                           "x x x x  x x x x   x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
@@ -7572,20 +7572,20 @@ part
         write           = " 1  1  0  0   0  0  0  0    x x x x  x x x x",
                           "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 4;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
     ;
 
     memory "flash"
@@ -7623,10 +7623,10 @@ part
                           " a7 a6 a5  x   x   x  x  x",
                           "  x  x  x  x   x   x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
     ;
 
     memory "signature"
@@ -7655,7 +7655,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -7666,7 +7666,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -7677,7 +7677,7 @@ part
                           "x x x x  x x x x   o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
@@ -7691,9 +7691,9 @@ part
 #------------------------------------------------------------
 
 part parent "t461"
-    id               = "t461a";
-    desc             = "ATtiny461A";
-  ;
+    id                  = "t461a";
+    desc                = "ATtiny461A";
+;
 
 #------------------------------------------------------------
 # ATtiny861
@@ -7702,11 +7702,11 @@ part parent "t461"
 part
     id                  = "t861";
     desc                = "ATtiny861";
-     has_debugwire = yes;
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x00, 0x10;
      eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+                     0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
 #    stk500_devcode      = 0x21;
 #    avr910_devcode      = 0x5e;
     signature           = 0x1e 0x93 0x0d;
@@ -7720,16 +7720,16 @@ part
     chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                           "x x x x  x x x x   x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
@@ -7769,20 +7769,20 @@ part
         write           = " 1  1  0  0   0  0  0  0    x x x x  x x x a8",
                           "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i  i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 4;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
     ;
 
     memory "flash"
@@ -7820,10 +7820,10 @@ part
                           " a7 a6 a5  x   x   x  x  x",
                           "  x  x  x  x   x   x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
     ;
 
     memory "signature"
@@ -7852,7 +7852,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -7863,7 +7863,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -7874,7 +7874,7 @@ part
                           "x x x x  x x x x   o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
@@ -7888,9 +7888,9 @@ part
 #------------------------------------------------------------
 
 part parent "t861"
-    id               = "t861a";
-    desc             = "ATtiny861A";
-  ;
+    id                  = "t861a";
+    desc                = "ATtiny861A";
+;
 
 #------------------------------------------------------------
 # ATtiny28
@@ -7957,41 +7957,41 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m48";
-    desc             = "ATmega48";
-     has_debugwire = yes;
+    id                  = "m48";
+    desc                = "ATmega48";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x59;
+                     0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+                     0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode      = 0x59;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x92 0x05;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 45000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    signature           = 0x1e 0x92 0x05;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 45000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 0;
     latchcycles         = 5;
@@ -8018,31 +8018,31 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   0   x      x   x   x   x",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
     memory "flash"
         paged           = yes;
         size            = 4096;
@@ -8077,11 +8077,11 @@ part
                           " a7  a6  a5   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -8092,7 +8092,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -8103,7 +8103,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -8114,7 +8114,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
                           "x x x x  x x x x   x x x x  x x x i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -8125,100 +8125,100 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
                           "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega48A
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48a";
-    desc             = "ATmega48A";
-  ;
+    id                  = "m48a";
+    desc                = "ATmega48A";
+;
 
 #------------------------------------------------------------
 # ATmega48P
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48p";
-    desc             = "ATmega48P";
-    signature        = 0x1e 0x92 0x0a;
-  ;
+    id                  = "m48p";
+    desc                = "ATmega48P";
+    signature           = 0x1e 0x92 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega48PA
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48pa";
-    desc             = "ATmega48PA";
-    signature        = 0x1e 0x92 0x0a;
-  ;
+    id                  = "m48pa";
+    desc                = "ATmega48PA";
+    signature           = 0x1e 0x92 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega48PB
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48pb";
-    desc             = "ATmega48PB";
-    signature        = 0x1e 0x92 0x10;
-  ;
+    id                  = "m48pb";
+    desc                = "ATmega48PB";
+    signature           = 0x1e 0x92 0x10;
+;
 
 #------------------------------------------------------------
 # ATmega88
 #------------------------------------------------------------
 
 part
-    id               = "m88";
-    desc             = "ATmega88";
-     has_debugwire = yes;
+    id                  = "m88";
+    desc                = "ATmega88";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x73;
+                     0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+                     0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode      = 0x73;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x93 0x0a;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    signature           = 0x1e 0x93 0x0a;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 0;
     latchcycles         = 5;
@@ -8245,31 +8245,31 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   0   x      x   x   x  a8",
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -8304,11 +8304,11 @@ part
                           " a7  a6  a5   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -8319,7 +8319,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -8330,7 +8330,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -8341,7 +8341,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
                           "x x x x  x x x x   x x x x  x i i i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -8352,100 +8352,100 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
                           "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega88A
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88a";
-    desc             = "ATmega88A";
-  ;
+    id                  = "m88a";
+    desc                = "ATmega88A";
+;
 
 #------------------------------------------------------------
 # ATmega88P
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88p";
-    desc             = "ATmega88P";
-    signature        = 0x1e 0x93 0x0f;
-  ;
+    id                  = "m88p";
+    desc                = "ATmega88P";
+    signature           = 0x1e 0x93 0x0f;
+;
 
 #------------------------------------------------------------
 # ATmega88PA
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88pa";
-    desc             = "ATmega88PA";
-    signature        = 0x1e 0x93 0x0f;
-  ;
+    id                  = "m88pa";
+    desc                = "ATmega88PA";
+    signature           = 0x1e 0x93 0x0f;
+;
 
 #------------------------------------------------------------
 # ATmega88PB
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88pb";
-    desc             = "ATmega88PB";
-    signature        = 0x1e 0x93 0x16;
-  ;
+    id                  = "m88pb";
+    desc                = "ATmega88PB";
+    signature           = 0x1e 0x93 0x16;
+;
 
 #------------------------------------------------------------
 # ATmega168
 #------------------------------------------------------------
 
 part
-    id              = "m168";
-    desc            = "ATmega168";
-     has_debugwire = yes;
+    id                  = "m168";
+    desc                = "ATmega168";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode  = 0x86;
+                     0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+                     0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode      = 0x86;
     # avr910_devcode = 0x;
-    signature       = 0x1e 0x94 0x06;
-    pagel           = 0xd7;
-    bs2             = 0xc2;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+    signature           = 0x1e 0x94 0x06;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
                        "x x x x x x x x x x x x x x x x";
 
-    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+    chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
                        "x x x x x x x x x x x x x x x x";
 
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 0;
     latchcycles         = 5;
@@ -8476,27 +8476,27 @@ part
                           " 0 0 0 x x x x a8",
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " o o o o o o o o";
-    
+
         write           = " 1 1 0 0 0 0 0 0",
                           " 0 0 0 x x x x a8",
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-        ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -8511,89 +8511,89 @@ part
                           " 0 0 0 a12 a11 a10 a9 a8",
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " o o o o o o o o";
-        
-        read_hi          = " 0 0 1 0 1 0 0 0",
+
+        read_hi         = " 0 0 1 0 1 0 0 0",
                            " 0 0 0 a12 a11 a10 a9 a8",
                            " a7 a6 a5 a4 a3 a2 a1 a0",
                            " o o o o o o o o";
-        
+
         loadpage_lo     = " 0 1 0 0 0 0 0 0",
                           " 0 0 0 x x x x x",
                           " x x a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
-        
+
         loadpage_hi     = " 0 1 0 0 1 0 0 0",
                           " 0 0 0 x x x x x",
                           " x x a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
-        
+
         writepage       = " 0 1 0 0 1 1 0 0",
                           " 0 0 0 a12 a11 a10 a9 a8",
                           " a7 a6 x x x x x x",
                           " x x x x x x x x";
 
-        mode        = 0x41;
-        delay       = 6;
-        blocksize   = 128;
-        readsize    = 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
 
-        ;
-        
+    ;
+
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
                           "x x x x x x x x i i i i i i i i";
-        ;
-    
+    ;
+
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
                           "x x x x x x x x i i i i i i i i";
-        ;
-    
+    ;
+
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
                           "x x x x x x x x x x x x x i i i";
-        ;
-    
+    ;
+
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
                           "x x x x x x x x 1 1 i i i i i i";
-        ;
-    
+    ;
+
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
                           "0 0 0 0 0 0 0 0 o o o o o o o o";
-        ;
-    
+    ;
+
     memory "signature"
         size            = 3;
         read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
                           "x x x x x x a1 a0 o o o o o o o o";
-        ;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -8601,74 +8601,74 @@ part
 #------------------------------------------------------------
 
 part parent "m168"
-    id               = "m168a";
-    desc             = "ATmega168A";
-  ;
+    id                  = "m168a";
+    desc                = "ATmega168A";
+;
 
 #------------------------------------------------------------
 # ATmega168P
 #------------------------------------------------------------
 
 part parent "m168"
-    id              = "m168p";
-    desc            = "ATmega168P";
-    signature       = 0x1e 0x94 0x0b;
-  ;
+    id                  = "m168p";
+    desc                = "ATmega168P";
+    signature           = 0x1e 0x94 0x0b;
+;
 
 #------------------------------------------------------------
 # ATmega168PA
 #------------------------------------------------------------
 
 part parent "m168"
-    id              = "m168pa";
-    desc            = "ATmega168PA";
-    signature       = 0x1e 0x94 0x0b;
-  ;
+    id                  = "m168pa";
+    desc                = "ATmega168PA";
+    signature           = 0x1e 0x94 0x0b;
+;
 
 #------------------------------------------------------------
 # ATmega168PB
 #------------------------------------------------------------
 
 part parent "m168"
-    id              = "m168pb";
-    desc            = "ATmega168PB";
-    signature       = 0x1e 0x94 0x15;
-  ;
+    id                  = "m168pb";
+    desc                = "ATmega168PB";
+    signature           = 0x1e 0x94 0x15;
+;
 
 #------------------------------------------------------------
 # ATtiny828
 #------------------------------------------------------------
 
 part
-    id              = "t828";
-    desc            = "ATtiny828";
-     has_debugwire = yes;
+    id                  = "t828";
+    desc                = "ATtiny828";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
                 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
                 0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode  = 0x86;
+    stk500_devcode      = 0x86;
     # avr910_devcode = 0x;
-    signature       = 0x1e 0x93 0x14;
-    pagel           = 0xd7;
-    bs2             = 0xc2;
-    chip_erase_delay = 15000;
-    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+    signature           = 0x1e 0x93 0x14;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 15000;
+    pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
                        "x x x x x x x x x x x x x x x x";
 
-    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+    chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
                        "x x x x x x x x x x x x x x x x";
 
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
    0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -8709,21 +8709,21 @@ part
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
 
-   loadpage_lo   = "  1   1   0   0      0   0   0   1",
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
                    "  0   0   0   0      0   0   0   0",
                    "  0   0   0   0      0   0  a1  a0",
                    "  i   i   i   i      i   i   i   i";
 
-writepage   = "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
               "  0   0   x   x      x   x   x  a8",
               " a7  a6  a5  a4     a3  a2   0   0",
               "  x   x   x   x      x   x   x   x";
 
-   mode      = 0x41;
-   delay      = 5;
-   blocksize   = 4;
-   readsize   = 256;
-        ;
+        mode            = 0x41;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -8739,7 +8739,7 @@ writepage   = "  1   1   0   0      0   0   1   0",
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " o o o o o o o o";
 
-        read_hi          = " 0 0 1 0 1 0 0 0",
+        read_hi         = " 0 0 1 0 1 0 0 0",
                            " 0 0 0 0 a11 a10 a9 a8",
                            " a7 a6 a5 a4 a3 a2 a1 a0",
                            " o o o o o o o o";
@@ -8759,12 +8759,12 @@ writepage   = "  1   1   0   0      0   0   1   0",
                           " a7 a6 a5 x x x x x",
                           " x x x x x x x x";
 
-        mode        = 0x41;
-        delay       = 6;
-        blocksize   = 128;
-        readsize    = 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
 
-        ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -8775,7 +8775,7 @@ writepage   = "  1   1   0   0      0   0   1   0",
 
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
                           "x x x x x x x x i i i i i i i i";
-        ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -8786,7 +8786,7 @@ writepage   = "  1   1   0   0      0   0   1   0",
 
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
                           "x x x x x x x x i i i i i i i i";
-        ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -8797,7 +8797,7 @@ writepage   = "  1   1   0   0      0   0   1   0",
 
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
                           "x x x x x x x x 1 1 1 i i i i i";
-        ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -8808,19 +8808,19 @@ writepage   = "  1   1   0   0      0   0   1   0",
 
         write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
                           "x x x x x x x x 1 1 i i i i i i";
-        ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
                           "0 0 0 0 0 0 0 0 o o o o o o o o";
-        ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
                           "x x x x x x a1 a0 o o o o o o o o";
-        ;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -8828,46 +8828,46 @@ writepage   = "  1   1   0   0      0   0   1   0",
 #------------------------------------------------------------
 
 part parent "t828"
-    id              = "t828r";
-    desc            = "ATtiny828R";
-  ;
+    id                  = "t828r";
+    desc                = "ATtiny828R";
+;
 
 #------------------------------------------------------------
 # ATtiny87
 #------------------------------------------------------------
 
 part
-     id            = "t87";
-     desc          = "ATtiny87";
-     has_debugwire = yes;
+    id                  = "t87";
+    desc                = "ATtiny87";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4,
                0x00, 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB,
                0xBF, 0x99, 0xF9, 0xBB, 0xAF;
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x93 0x87;
-     reset            = io;
-     chip_erase_delay = 15000;
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x93 0x87;
+    reset               = io;
+    chip_erase_delay    = 15000;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
@@ -8893,166 +8893,166 @@ part
     spmcr               = 0x57;
     allowfullpagebitstream = no;
 
-     memory "eeprom"
-         size            = 512;
+    memory "eeprom"
+        size            = 512;
         paged           = no;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         # semi-automatically corrected: check part/datasheet
-        write = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
 
-  loadpage_lo   = "  1   1   0   0      0   0   0   1",
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
         "  0   0   0   0      0   0   0   0",
         "  0   0   0   0      0   0  a1  a0",
         "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 4;
-  readsize  = 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 128;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 128;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0  a12  a11 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2   a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0  a12  a11 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2   a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x  a5  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x  a5  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         writepage       = "  0  1  0  0   1   1   0  0",
+        writepage       = "  0  1  0  0   1   1   0  0",
                            "  0  0  0  0  a11 a10 a9 a8",
                            " a7 a6 a5  x   x  x  x  x",
                            "  x  x  x  x   x  x  x  x";
 
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 64;
-  readsize  = 256;
-       ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 #   ATtiny87 has Signature Bytes: 0x1E 0x93 0x87.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
+    ;
 
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                            "0 0 0 0  0 0 0 0  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  x x x x  x x x i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny167
 #------------------------------------------------------------
 
 part
-     id            = "t167";
-     desc          = "ATtiny167";
-     has_debugwire = yes;
+    id                  = "t167";
+    desc                = "ATtiny167";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4,
                0x00, 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB,
                0xBF, 0x99, 0xF9, 0xBB, 0xAF;
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x94 0x87;
-     reset            = io;
-     chip_erase_delay = 15000;
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x94 0x87;
+    reset               = io;
+    chip_erase_delay    = 15000;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout     = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 0;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 0;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
@@ -9078,151 +9078,151 @@ part
     spmcr               = 0x57;
     allowfullpagebitstream = no;
 
-     memory "eeprom"
-         size            = 512;
+    memory "eeprom"
+        size            = 512;
         paged           = no;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
         # semi-automatically corrected: check part/datasheet
-        write = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
+        write           = "1 1 0 0 0 0 0 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 a1 a0   i i i i i i i i";
 
-  loadpage_lo   = "  1   1   0   0      0   0   0   1",
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
         "  0   0   0   0      0   0   0   0",
         "  0   0   0   0      0   0  a1  a0",
         "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 4;
-  readsize  = 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 16384;
-         page_size       = 128;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 16384;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0  a12  a11 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2   a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0  a12  a11 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2   a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x  a5  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x  a5  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-          writepage       = "  0  1  0  0   1   1   0  0",
+        writepage       = "  0  1  0  0   1   1   0  0",
                            "  0  0  0  a12  a11 a10 a9 a8",
                            " a7 a6 x  x   x  x  x  x",
                            "  x  x  x  x   x  x  x  x";
 
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 64;
-  readsize  = 256;
-       ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 #   ATtiny167 has Signature Bytes: 0x1E 0x94 0x87.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
+    ;
 
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                            "0 0 0 0  0 0 0 0  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  x x x x  x x x i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny48
 #------------------------------------------------------------
 
 part
-    id               = "t48";
-    desc             = "ATtiny48";
-     has_debugwire = yes;
+    id                  = "t48";
+    desc                = "ATtiny48";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
                      0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
                      0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x73;
+    stk500_devcode      = 0x73;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x92 0x09;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 15000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    signature           = 0x1e 0x92 0x09;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 15000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
     timeout             = 200;
@@ -9291,7 +9291,7 @@ part
         delay           = 20;
         blocksize       = 4;
         readsize        = 64;
-      ;
+    ;
     memory "flash"
         paged           = yes;
         size            = 4096;
@@ -9330,7 +9330,7 @@ part
         delay           = 6;
         blocksize       = 64;
         readsize        = 256;
-      ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -9341,7 +9341,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -9352,7 +9352,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -9363,7 +9363,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
                           "x x x x  x x x x   1 1 1 1  1 1 1 i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -9374,61 +9374,61 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
                           "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny88
 #------------------------------------------------------------
 
 part
-    id               = "t88";
-    desc             = "ATtiny88";
-     has_debugwire = yes;
+    id                  = "t88";
+    desc                = "ATtiny88";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x73;
+                     0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+                     0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode      = 0x73;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x93 0x11;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    signature           = 0x1e 0x93 0x11;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 0;
     latchcycles         = 5;
@@ -9455,31 +9455,31 @@ part
         max_write_delay = 3600;
         readback_p1     = 0xff;
         readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
+        read            = "  1   0   1   0      0   0   0   0",
                           "  0   0   0   x      x   x   x   x",
                           "  x  a6  a5  a4     a3  a2  a1  a0",
                           "  o   o   o   o      o   o   o   o";
 
-	write           = "  1   1   0   0      0   0   0   0",
+        write           = "  1   1   0   0      0   0   0   0",
                           "  0   0   0   x      x   x   x   x",
                           "  x  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 64;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 64;
+    ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -9514,11 +9514,11 @@ part
                           " a7  a6  a5   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -9529,7 +9529,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -9540,7 +9540,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -9551,7 +9551,7 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
                           "x x x x  x x x x   x x x x  x x x i";
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -9562,71 +9562,71 @@ part
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
                           "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega328
 #------------------------------------------------------------
 
 part
-    id			= "m328";
-    desc		= "ATmega328";
-    has_debugwire	= yes;
-    flash_instr		= 0xB6, 0x01, 0x11;
-    eeprom_instr	= 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-			  0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-			  0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode	= 0x86;
-    # avr910_devcode	= 0x;
-    signature		= 0x1e 0x95 0x14;
-    pagel		= 0xd7;
-    bs2			= 0xc2;
-    chip_erase_delay	= 9000;
-    pgm_enable = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-		 "x x x x x x x x x x x x x x x x";
+    id                  = "m328";
+    desc                = "ATmega328";
+    has_debugwire       = yes;
+    flash_instr         = 0xB6, 0x01, 0x11;
+    eeprom_instr        = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
+                          0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+                          0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode      = 0x86;
+    # avr910_devcode    = 0x;
+    signature           = 0x1e 0x95 0x14;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+                 "x x x x x x x x x x x x x x x x";
 
-    chip_erase = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-		 "x x x x x x x x x x x x x x x x";
+    chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+                 "x x x x x x x x x x x x x x x x";
 
-    timeout	= 200;
-    stabdelay	= 100;
-    cmdexedelay	= 25;
-    synchloops	= 32;
-    bytedelay	= 0;
-    pollindex	= 3;
-    pollvalue	= 0x53;
-    predelay	= 1;
-    postdelay	= 1;
-    pollmethod	= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
-    pp_controlstack =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay	= 100;
-    progmodedelay	= 0;
-    latchcycles		= 5;
-    togglevtg		= 1;
-    poweroffdelay	= 15;
-    resetdelayms	= 1;
-    resetdelayus	= 0;
-    hvleavestabdelay	= 15;
-    resetdelay		= 15;
-    chiperasepulsewidth	= 0;
+    pp_controlstack     =
+        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
+        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
     programfusepulsewidth = 0;
     programfusepolltimeout = 5;
@@ -9636,134 +9636,134 @@ part
     ocdrev              = 1;
 
     memory "eeprom"
-	paged		= no;
-	page_size	= 4;
-	size		= 1024;
-	min_write_delay = 3600;
-	max_write_delay = 3600;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read = " 1 0 1 0 0 0 0 0",
-	       " 0 0 0 x x x a9 a8",
-	       " a7 a6 a5 a4 a3 a2 a1 a0",
-	       " o o o o o o o o";
+        paged           = no;
+        page_size       = 4;
+        size            = 1024;
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = " 1 0 1 0 0 0 0 0",
+               " 0 0 0 x x x a9 a8",
+               " a7 a6 a5 a4 a3 a2 a1 a0",
+               " o o o o o o o o";
 
-	write = " 1 1 0 0 0 0 0 0",
-	      	" 0 0 0 x x x a9 a8",
-		" a7 a6 a5 a4 a3 a2 a1 a0",
-		" i i i i i i i i";
+        write           = " 1 1 0 0 0 0 0 0",
+                " 0 0 0 x x x a9 a8",
+                " a7 a6 a5 a4 a3 a2 a1 a0",
+                " i i i i i i i i";
 
-	loadpage_lo = " 1 1 0 0 0 0 0 1",
-		      " 0 0 0 0 0 0 0 0",
-		      " 0 0 0 0 0 0 a1 a0",
-		      " i i i i i i i i";
+        loadpage_lo     = " 1 1 0 0 0 0 0 1",
+                      " 0 0 0 0 0 0 0 0",
+                      " 0 0 0 0 0 0 a1 a0",
+                      " i i i i i i i i";
 
-	writepage = " 1 1 0 0 0 0 1 0",
-		    " 0 0 x x x x a9 a8",
-		    " a7 a6 a5 a4 a3 a2 0 0",
-		    " x x x x x x x x";
+        writepage       = " 1 1 0 0 0 0 1 0",
+                    " 0 0 x x x x a9 a8",
+                    " a7 a6 a5 a4 a3 a2 0 0",
+                    " x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
     ;
 
     memory "flash"
-	paged		= yes;
-	size		= 32768;
-	page_size	= 128;
-	num_pages	= 256;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read_lo = " 0 0 1 0 0 0 0 0",
-		  " 0 0 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
+        paged           = yes;
+        size            = 32768;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = " 0 0 1 0 0 0 0 0",
+                  " 0 0 a13 a12 a11 a10 a9 a8",
+                  " a7 a6 a5 a4 a3 a2 a1 a0",
+                  " o o o o o o o o";
 
-	read_hi = " 0 0 1 0 1 0 0 0",
-		  " 0 0 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
+        read_hi         = " 0 0 1 0 1 0 0 0",
+                  " 0 0 a13 a12 a11 a10 a9 a8",
+                  " a7 a6 a5 a4 a3 a2 a1 a0",
+                  " o o o o o o o o";
 
-	loadpage_lo = " 0 1 0 0 0 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x x a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
+        loadpage_lo     = " 0 1 0 0 0 0 0 0",
+                      " 0 0 0 x x x x x",
+                      " x x a5 a4 a3 a2 a1 a0",
+                      " i i i i i i i i";
 
-	loadpage_hi = " 0 1 0 0 1 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x x a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
+        loadpage_hi     = " 0 1 0 0 1 0 0 0",
+                      " 0 0 0 x x x x x",
+                      " x x a5 a4 a3 a2 a1 a0",
+                      " i i i i i i i i";
 
-	writepage = " 0 1 0 0 1 1 0 0",
-		    " 0 0 a13 a12 a11 a10 a9 a8",
-		    " a7 a6 x x x x x x",
-		    " x x x x x x x x";
+        writepage       = " 0 1 0 0 1 1 0 0",
+                    " 0 0 a13 a12 a11 a10 a9 a8",
+                    " a7 a6 x x x x x x",
+                    " x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
 
     ;
 
     memory "lfuse"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
+               "x x x x x x x x o o o o o o o o";
 
-	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-	      	"x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
+                "x x x x x x x x i i i i i i i i";
     ;
 
     memory "hfuse"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
+               "x x x x x x x x o o o o o o o o";
 
-	write = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-	      	"x x x x x x x x i i i i i i i i";
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
+                "x x x x x x x x i i i i i i i i";
     ;
 
     memory "efuse"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
+               "x x x x x x x x o o o o o o o o";
 
-	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-	      	"x x x x x x x x x x x x x i i i";
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
+                "x x x x x x x x x x x x x i i i";
     ;
 
     memory "lock"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
+               "x x x x x x x x o o o o o o o o";
 
-	write = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-	      	"x x x x x x x x 1 1 i i i i i i";
+        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
+                "x x x x x x x x 1 1 i i i i i i";
     ;
 
     memory "calibration"
-	size = 1;
-	read = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-	       "0 0 0 0 0 0 0 0 o o o o o o o o";
+        size            = 1;
+        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
+               "0 0 0 0 0 0 0 0 o o o o o o o o";
     ;
 
     memory "signature"
-	size = 3;
-	read = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-	       "x x x x x x a1 a0 o o o o o o o o";
+        size            = 3;
+        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
+               "x x x x x x a1 a0 o o o o o o o o";
     ;
 ;
 
@@ -9772,9 +9772,9 @@ part
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m328p";
-    desc            = "ATmega328P";
-    signature       = 0x1e 0x95 0x0f;
+    id                  = "m328p";
+    desc                = "ATmega328P";
+    signature           = 0x1e 0x95 0x0f;
 ;
 
 #------------------------------------------------------------
@@ -9782,18 +9782,18 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m328pb";
-    desc            = "ATmega328PB";
-    signature       = 0x1e 0x95 0x16;
+    id                  = "m328pb";
+    desc                = "ATmega328PB";
+    signature           = 0x1e 0x95 0x16;
 
     memory "efuse"
-        size = 1;
+        size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
+        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
                "x x x x x x x x o o o o o o o o";
 
-        write = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
+        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
                 "x x x x x x x x x x x x i i i i";
     ;
 ;
@@ -9803,15 +9803,15 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m32m1";
-    desc            = "ATmega32M1";
-    # stk500_devcode	= 0x;
-    # avr910_devcode	= 0x;
-    signature       = 0x1e 0x95 0x84;
-    bs2             = 0xe2;
+    id                  = "m32m1";
+    desc                = "ATmega32M1";
+    # stk500_devcode    = 0x;
+    # avr910_devcode    = 0x;
+    signature           = 0x1e 0x95 0x84;
+    bs2                 = 0xe2;
 
     memory "efuse"
-        size = 1;
+        size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
@@ -9826,85 +9826,85 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m64m1";
-    desc            = "ATmega64M1";
-    # stk500_devcode	= 0x;
-    # avr910_devcode	= 0x;
-    signature       = 0x1e 0x96 0x84;
-    bs2             = 0xe2;
+    id                  = "m64m1";
+    desc                = "ATmega64M1";
+    # stk500_devcode    = 0x;
+    # avr910_devcode    = 0x;
+    signature           = 0x1e 0x96 0x84;
+    bs2                 = 0xe2;
 
     memory "eeprom"
-	paged		= no;
+        paged           = no;
         page_size       = 8;
         size            = 2048;
-	min_write_delay = 3600;
-	max_write_delay = 3600;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read = " 1 0 1 0 0 0 0 0",
-	       " 0 0 0 x x a10 a9 a8",
-	       " a7 a6 a5 a4 a3 a2 a1 a0",
-	       " o o o o o o o o";
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = " 1 0 1 0 0 0 0 0",
+               " 0 0 0 x x a10 a9 a8",
+               " a7 a6 a5 a4 a3 a2 a1 a0",
+               " o o o o o o o o";
 
-	write = " 1 1 0 0 0 0 0 0",
-	      	" 0 0 0 x x a10 a9 a8",
-		" a7 a6 a5 a4 a3 a2 a1 a0",
-		" i i i i i i i i";
+        write           = " 1 1 0 0 0 0 0 0",
+                " 0 0 0 x x a10 a9 a8",
+                " a7 a6 a5 a4 a3 a2 a1 a0",
+                " i i i i i i i i";
 
-	loadpage_lo = " 1 1 0 0 0 0 0 1",
-		      " 0 0 0 0 0 0 0 0",
-		      " 0 0 0 0 0 a2 a1 a0",
-		      " i i i i i i i i";
+        loadpage_lo     = " 1 1 0 0 0 0 0 1",
+                      " 0 0 0 0 0 0 0 0",
+                      " 0 0 0 0 0 a2 a1 a0",
+                      " i i i i i i i i";
 
-	writepage = " 1 1 0 0 0 0 1 0",
-		    " 0 0 x x x a10 a9 a8",
-		    " a7 a6 a5 a4 a3 0 0 0",
-		    " x x x x x x x x";
+        writepage       = " 1 1 0 0 0 0 1 0",
+                    " 0 0 x x x a10 a9 a8",
+                    " a7 a6 a5 a4 a3 0 0 0",
+                    " x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
     ;
 
     memory "flash"
-	paged		= yes;
+        paged           = yes;
         size            = 65536;
         page_size       = 256;
         num_pages       = 256;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read_lo = " 0 0 1 0 0 0 0 0",
-		  " 0 a14 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = " 0 0 1 0 0 0 0 0",
+                  " 0 a14 a13 a12 a11 a10 a9 a8",
+                  " a7 a6 a5 a4 a3 a2 a1 a0",
+                  " o o o o o o o o";
 
-	read_hi = " 0 0 1 0 1 0 0 0",
-		  " 0 a14 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
+        read_hi         = " 0 0 1 0 1 0 0 0",
+                  " 0 a14 a13 a12 a11 a10 a9 a8",
+                  " a7 a6 a5 a4 a3 a2 a1 a0",
+                  " o o o o o o o o";
 
-	loadpage_lo = " 0 1 0 0 0 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x a6 a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
+        loadpage_lo     = " 0 1 0 0 0 0 0 0",
+                      " 0 0 0 x x x x x",
+                      " x a6 a5 a4 a3 a2 a1 a0",
+                      " i i i i i i i i";
 
-	loadpage_hi = " 0 1 0 0 1 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x a6 a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
+        loadpage_hi     = " 0 1 0 0 1 0 0 0",
+                      " 0 0 0 x x x x x",
+                      " x a6 a5 a4 a3 a2 a1 a0",
+                      " i i i i i i i i";
 
-	writepage = " 0 1 0 0 1 1 0 0",
-		    " 0 a14 a13 a12 a11 a10 a9 a8",
-		    " a7 x x x x x x x",
-		    " x x x x x x x x";
+        writepage       = " 0 1 0 0 1 1 0 0",
+                    " 0 a14 a13 a12 a11 a10 a9 a8",
+                    " a7 x x x x x x x",
+                    " x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
     ;
 
     memory "efuse"
@@ -9913,7 +9913,7 @@ part parent "m328"
         max_write_delay = 4500;
         read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
                           "x x x x x x x x o o o o o o o o";
-        
+
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
                           "x x x x x x x x x x i i i i i i";
     ;
@@ -9924,38 +9924,38 @@ part parent "m328"
 #------------------------------------------------------------
 
 part
-     id            = "t2313";
-     desc          = "ATtiny2313";
-     has_debugwire = yes;
+    id                  = "t2313";
+    desc                = "ATtiny2313";
+    has_debugwire       = yes;
      flash_instr   = 0xB2, 0x0F, 0x1F;
      eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-     stk500_devcode   = 0x23;
+                     0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
+    stk500_devcode      = 0x23;
 ##   Use the ATtiny26 devcode:
-     avr910_devcode   = 0x5e;
-     signature        = 0x1e 0x91 0x0a;
-     pagel            = 0xD4;
-     bs2              = 0xD6;
-     reset            = io;
-     chip_erase_delay = 9000;
+    avr910_devcode      = 0x5e;
+    signature           = 0x1e 0x91 0x0a;
+    pagel               = 0xD4;
+    bs2                 = 0xD6;
+    reset               = io;
+    chip_erase_delay    = 9000;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
@@ -9979,181 +9979,181 @@ part
 
     ocdrev              = 0;
 
-     memory "eeprom"
-         size            = 128;
+    memory "eeprom"
+        size            = 128;
         paged           = no;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
                            "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
+        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
                            "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 2048;
-         page_size       = 32;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0   0    0   0  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0   0    0   0  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
 # The information in the data sheet of April/2004 is wrong, this works:
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x   x   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
 # The information in the data sheet of April/2004 is wrong, this works:
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x   x   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
 # The information in the data sheet of April/2004 is wrong, this works:
-         writepage       = "  0  1  0  0   1  1  0  0",
+        writepage       = "  0  1  0  0   1  1  0  0",
                            "  0  0  0  0   0  0 a9 a8",
                            " a7 a6 a5 a4   x  x  x  x",
                            "  x  x  x  x   x  x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
 #   ATtiny2313 has Signature Bytes: 0x1E 0x91 0x0A.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  1 1 i i  i i i i";
-         read           = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  x x x x  x x x i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 # The Tiny2313 has calibration data for both 4 MHz and 8 MHz.
 # The information in the data sheet of April/2004 is wrong, this works:
 
-     memory "calibration"
-         size            = 2;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 2;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny2313A
 #------------------------------------------------------------
 
 part parent "t2313"
-    id              = "t2313a";
-    desc            = "ATtiny2313A";
-  ;
+    id                  = "t2313a";
+    desc                = "ATtiny2313A";
+;
 
 #------------------------------------------------------------
 # ATtiny4313
 #------------------------------------------------------------
 
 part
-     id            = "t4313";
-     desc          = "ATtiny4313";
-     has_debugwire = yes;
+    id                  = "t4313";
+    desc                = "ATtiny4313";
+    has_debugwire       = yes;
      flash_instr   = 0xB2, 0x0F, 0x1F;
      eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-     stk500_devcode   = 0x23;
+                     0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
+    stk500_devcode      = 0x23;
 ##   Use the ATtiny26 devcode:
-     avr910_devcode   = 0x5e;
-     signature        = 0x1e 0x92 0x0d;
-     pagel            = 0xD4;
-     bs2              = 0xD6;
-     reset            = io;
-     chip_erase_delay = 9000;
+    avr910_devcode      = 0x5e;
+    signature           = 0x1e 0x92 0x0d;
+    pagel               = 0xD4;
+    bs2                 = 0xD6;
+    reset               = io;
+    chip_erase_delay    = 9000;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
@@ -10177,166 +10177,166 @@ part
 
     ocdrev              = 0;
 
-     memory "eeprom"
-         size            = 256;
+    memory "eeprom"
+        size            = 256;
         paged           = no;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1   0  1  0   0  0  0  0   0 0 0 x  x x x x",
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1   0  1  0   0  0  0  0   0 0 0 x  x x x x",
                            "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
-         write           = "1   1  0  0   0  0  0  0   0 0 0 x  x x x x",
+        write           = "1   1  0  0   0  0  0  0   0 0 0 x  x x x x",
                            "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 64;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0   0    0 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0   0    0 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         writepage       = "  0  1  0  0   1   1  0  0",
+        writepage       = "  0  1  0  0   1   1  0  0",
                            "  0  0  0  0   0 a10 a9 a8",
                            " a7 a6 a5  x   x   x  x  x",
                            "  x  x  x  x   x   x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
 #   ATtiny4313 has Signature Bytes: 0x1E 0x92 0x0D.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  1 1 i i  i i i i";
-         read           = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  x x x x  x x x i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 
-     memory "calibration"
-         size            = 2;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 2;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90PWM2
 #------------------------------------------------------------
 
 part
-     id            = "pwm2";
-     desc          = "AT90PWM2";
-     has_debugwire = yes;
+    id                  = "pwm2";
+    desc                = "AT90PWM2";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-     stk500_devcode   = 0x65;
+                     0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
+                     0x99, 0xF9, 0xBB, 0xAF;
+    stk500_devcode      = 0x65;
 ##  avr910_devcode   = ?;
-     signature        = 0x1e 0x93 0x81;
-     pagel            = 0xD8;
-     bs2              = 0xE2;
-     reset            = io;
-     chip_erase_delay = 9000;
+    signature           = 0x1e 0x93 0x81;
+    pagel               = 0xD8;
+    bs2                 = 0xE2;
+    reset               = io;
+    chip_erase_delay    = 9000;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -10358,128 +10358,128 @@ part
     programlockpulsewidth = 0;
     programlockpolltimeout = 5;
 
-     memory "eeprom"
-         size            = 512;
+    memory "eeprom"
+        size            = 512;
         paged           = no;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x a8",
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0  o o o o  o o o o";
 
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x a8",
+        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0  i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 64;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0   0   a11 a10 a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0   0   a11 a10 a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         writepage       = "  0  1  0  0   1   1   0   0",
+        writepage       = "  0  1  0  0   1   1   0   0",
                            "  0  0  0  0   a11 a10 a9  a8",
                            " a7 a6 a5  x   x   x   x   x",
                            "  x  x  x  x   x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-       ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
 #   AT90PWM2 has Signature Bytes: 0x1E 0x93 0x81.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  1 1 i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  0    o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90PWM3
@@ -10488,9 +10488,9 @@ part
 # Completely identical to AT90PWM2 (including the signature!)
 
 part parent "pwm2"
-     id            = "pwm3";
-     desc          = "AT90PWM3";
-  ;
+    id                  = "pwm3";
+    desc                = "AT90PWM3";
+;
 
 #------------------------------------------------------------
 # AT90PWM2B
@@ -10498,12 +10498,12 @@ part parent "pwm2"
 # Same as AT90PWM2 but different signature.
 
 part parent "pwm2"
-     id            = "pwm2b";
-     desc          = "AT90PWM2B";
-     signature     = 0x1e 0x93 0x83;
+    id                  = "pwm2b";
+    desc                = "AT90PWM2B";
+    signature           = 0x1e 0x93 0x83;
 
     ocdrev              = 1;
-  ;
+;
 
 #------------------------------------------------------------
 # AT90PWM3B
@@ -10512,11 +10512,11 @@ part parent "pwm2"
 # Completely identical to AT90PWM2B (including the signature!)
 
 part parent "pwm2b"
-     id            = "pwm3b";
-     desc          = "AT90PWM3B";
+    id                  = "pwm3b";
+    desc                = "AT90PWM3B";
 
     ocdrev              = 1;
-  ;
+;
 
 #------------------------------------------------------------
 # AT90PWM316
@@ -10525,9 +10525,9 @@ part parent "pwm2b"
 # Similar to AT90PWM3B, but with 16 kiB flash, 512 B EEPROM, and 1024 B SRAM.
 
 part parent "pwm3b"
-     id            = "pwm316";
-     desc          = "AT90PWM316";
-     signature     = 0x1e 0x94 0x83;
+    id                  = "pwm316";
+    desc                = "AT90PWM316";
+    signature           = 0x1e 0x94 0x83;
 
     ocdrev              = 1;
 
@@ -10565,12 +10565,12 @@ part parent "pwm3b"
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-  ;
+        mode            = 0x21;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90PWM216
@@ -10578,47 +10578,47 @@ part parent "pwm3b"
 # Completely identical to AT90PWM316 (including the signature!)
 
 part parent "pwm316"
-     id = "pwm216";
-     desc = "AT90PWM216";
-  ; 
+    id                  = "pwm216";
+    desc                = "AT90PWM216";
+;
 
 #------------------------------------------------------------
 # ATtiny25
 #------------------------------------------------------------
 
 part
-     id            = "t25";
-     desc          = "ATtiny25";
-     has_debugwire = yes;
+    id                  = "t25";
+    desc                = "ATtiny25";
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x02, 0x12;
      eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+                     0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x91 0x08;
-     reset            = io;
-     chip_erase_delay = 4500;
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x91 0x08;
+    reset               = io;
+    chip_erase_delay    = 4500;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     hvsp_controlstack   =
         0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
@@ -10642,169 +10642,169 @@ part
 
     ocdrev              = 1;
 
-     memory "eeprom"
-         size            = 128;
+    memory "eeprom"
+        size            = 128;
         paged           = no;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
                            "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
+        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
                            "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 2048;
-         page_size       = 32;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0   0    0   0  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0   0    0   0  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x   x   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x   x   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         writepage       = "  0  1  0  0   1  1  0  0",
+        writepage       = "  0  1  0  0   1  1  0  0",
                            "  0  0  0  0   0  0 a9 a8",
                            " a7 a6 a5 a4   x  x  x  x",
                            "  x  x  x  x   x  x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
 #   ATtiny25 has Signature Bytes: 0x1E 0x91 0x08.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  1 1 i i  i i i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                            "0 0 0 0  0 0 0 0  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  x x x x  x x x i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny45
 #------------------------------------------------------------
 
 part
-     id            = "t45";
-     desc          = "ATtiny45";
-     has_debugwire = yes;
+    id                  = "t45";
+    desc                = "ATtiny45";
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x02, 0x12;
      eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-     stk500_devcode   = 0x14;
+                     0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x92 0x06;
-     reset            = io;
-     chip_erase_delay = 4500;
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x92 0x06;
+    reset               = io;
+    chip_erase_delay    = 4500;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
-    hvsp_controlstack     =
-	0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
         0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
@@ -10826,166 +10826,166 @@ part
 
     ocdrev              = 1;
 
-     memory "eeprom"
-         size            = 256;
-         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
+    memory "eeprom"
+        size            = 256;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
                            "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
+        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
                            "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 64;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0   0    0  a10 a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0   0    0  a10 a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         writepage       = "  0  1  0  0   1  1  0  0",
+        writepage       = "  0  1  0  0   1  1  0  0",
                            "  0  0  0  0   0 a10 a9 a8",
                            " a7 a6 a5  x   x  x  x  x",
                            "  x  x  x  x   x  x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
 #   ATtiny45 has Signature Bytes: 0x1E 0x92 0x08. (Data sheet 2586C-AVR-06/05 (doc2586.pdf) indicates otherwise!)
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  1 1 i i  i i i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                            "0 0 0 0  0 0 0 0  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  x x x x  x x x i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny85
 #------------------------------------------------------------
 
 part
-     id            = "t85";
-     desc          = "ATtiny85";
-     has_debugwire = yes;
+    id                  = "t85";
+    desc                = "ATtiny85";
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x02, 0x12;
      eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+                     0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x93 0x0b;
-     reset            = io;
-     chip_erase_delay = 4500;
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x93 0x0b;
+    reset               = io;
+    chip_erase_delay    = 4500;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     hvsp_controlstack   =
         0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
@@ -11009,129 +11009,129 @@ part
 
     ocdrev              = 1;
 
-     memory "eeprom"
-         size            = 512;
+    memory "eeprom"
+        size            = 512;
         paged           = no;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
 
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
+        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
                            "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x  a8",
+                          " a7  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 64;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
                            "  0   0   0   0  a11 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
+        read_hi         = "  0   0   1   0    1   0   0   0",
                            "  0   0   0   0  a11 a10  a9  a8",
                            " a7  a6  a5  a4   a3  a2  a1  a0",
                            "  o   o   o   o    o   o   o   o";
 
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
                            "  0   0   0   x    x   x   x   x",
                            "  x   x   x  a4   a3  a2  a1  a0",
                            "  i   i   i   i    i   i   i   i";
 
-         writepage       = "  0  1  0  0   1   1   0  0",
+        writepage       = "  0  1  0  0   1   1   0  0",
                            "  0  0  0  0  a11 a10 a9 a8",
                            " a7 a6 a5  x   x  x  x  x",
                            "  x  x  x  x   x  x  x  x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
 #   ATtiny85 has Signature Bytes: 0x1E 0x93 0x08.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                            "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
                            "x x x x  x x x x  1 1 i i  i i i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
                            "0 0 0 0  0 0 0 0  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
                            "x x x x  x x x x  i i i i  i i i i";
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-       ;
+    ;
 
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                            "x x x x  x x x x  x x x x  x x x i";
 
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                            "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-     ;
+    ;
 
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
                            "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega640
@@ -11139,32 +11139,32 @@ part
 # Almost same as ATmega1280, except for different memory sizes
 
 part
-    id               = "m640";
-    desc             = "ATmega640";
-    signature        = 0x1e 0x96 0x08;
-    has_jtag         = yes;
+    id                  = "m640";
+    desc                = "ATmega640";
+    signature           = 0x1e 0x96 0x08;
+    has_jtag            = yes;
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -11208,24 +11208,24 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -11261,11 +11261,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -11276,7 +11276,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -11287,7 +11287,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -11298,7 +11298,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -11309,52 +11309,52 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega1280
 #------------------------------------------------------------
 
 part
-    id               = "m1280";
-    desc             = "ATmega1280";
-    signature        = 0x1e 0x97 0x03;
-    has_jtag         = yes;
+    id                  = "m1280";
+    desc                = "ATmega1280";
+    signature           = 0x1e 0x97 0x03;
+    has_jtag            = yes;
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -11398,24 +11398,24 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -11451,11 +11451,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -11466,7 +11466,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -11477,7 +11477,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -11488,7 +11488,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -11499,20 +11499,20 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega1281
@@ -11520,44 +11520,44 @@ part
 # Identical to ATmega1280
 
 part parent "m1280"
-    id               = "m1281";
-    desc             = "ATmega1281";
-    signature        = 0x1e 0x97 0x04;
+    id                  = "m1281";
+    desc                = "ATmega1281";
+    signature           = 0x1e 0x97 0x04;
 
     ocdrev              = 3;
-  ;
+;
 
 #------------------------------------------------------------
 # ATmega2560
 #------------------------------------------------------------
 
 part
-    id               = "m2560";
-    desc             = "ATmega2560";
-    signature        = 0x1e 0x98 0x01;
-    has_jtag         = yes;
-    stk500_devcode   = 0xB2;
+    id                  = "m2560";
+    desc                = "ATmega2560";
+    signature           = 0x1e 0x98 0x01;
+    has_jtag            = yes;
+    stk500_devcode      = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -11601,24 +11601,24 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -11659,11 +11659,11 @@ part
                           "  0   0   0   0      0   0   0 a16",
                           "  0   0   0   0      0   0   0   0";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -11674,7 +11674,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -11685,7 +11685,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -11696,7 +11696,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -11707,32 +11707,32 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega2561
 #------------------------------------------------------------
 
 part parent "m2560"
-    id               = "m2561";
-    desc             = "ATmega2561";
-    signature        = 0x1e 0x98 0x02;
+    id                  = "m2561";
+    desc                = "ATmega2561";
+    signature           = 0x1e 0x98 0x02;
 
     ocdrev              = 4;
-  ;
+;
 
 #------------------------------------------------------------
 # ATmega128RFA1
@@ -11740,11 +11740,11 @@ part parent "m2560"
 # Identical to ATmega2561 but half the ROM
 
 part parent "m2561"
-    id               = "m128rfa1";
-    desc             = "ATmega128RFA1";
-    signature        = 0x1e 0xa7 0x01;
-    chip_erase_delay = 55000;
-    bs2              = 0xE2;
+    id                  = "m128rfa1";
+    desc                = "ATmega128RFA1";
+    signature           = 0x1e 0xa7 0x01;
+    chip_erase_delay    = 55000;
+    bs2                 = 0xE2;
 
     ocdrev              = 3;
 
@@ -11782,23 +11782,23 @@ part parent "m2561"
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-  ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega256RFR2
 #------------------------------------------------------------
 
 part parent "m2561"
-    id               = "m256rfr2";
-    desc             = "ATmega256RFR2";
-    signature        = 0x1e 0xa8 0x02;
-    chip_erase_delay = 18500;
-    bs2              = 0xE2;
+    id                  = "m256rfr2";
+    desc                = "ATmega256RFR2";
+    signature           = 0x1e 0xa8 0x02;
+    chip_erase_delay    = 18500;
+    bs2                 = 0xE2;
 
     memory "eeprom"
         paged           = no; /* leave this "no" */
@@ -11818,47 +11818,47 @@ part parent "m2561"
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x a12    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x a12    a11 a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
 
     ocdrev              = 4;
-  ;
+;
 
 #------------------------------------------------------------
 # ATmega128RFR2
 #------------------------------------------------------------
 
 part parent "m128rfa1"
-    id               = "m128rfr2";
-    desc             = "ATmega128RFR2";
-    signature        = 0x1e 0xa7 0x02;
+    id                  = "m128rfr2";
+    desc                = "ATmega128RFR2";
+    signature           = 0x1e 0xa7 0x02;
 
 
     ocdrev              = 3;
-  ;
+;
 
 #------------------------------------------------------------
 # ATmega64RFR2
 #------------------------------------------------------------
 
 part parent "m128rfa1"
-    id               = "m64rfr2";
-    desc             = "ATmega64RFR2";
-    signature        = 0x1e 0xa6 0x02;
+    id                  = "m64rfr2";
+    desc                = "ATmega64RFR2";
+    signature           = 0x1e 0xa6 0x02;
 
 
     ocdrev              = 3;
@@ -11897,11 +11897,11 @@ part parent "m128rfa1"
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "eeprom"
         paged           = no; /* leave this "no" */
@@ -11921,780 +11921,83 @@ part parent "m128rfa1"
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
 
-  ;
+;
 
 #------------------------------------------------------------
 # ATmega2564RFR2
 #------------------------------------------------------------
 
 part parent "m256rfr2"
-    id               = "m2564rfr2";
-    desc             = "ATmega2564RFR2";
-    signature        = 0x1e 0xa8 0x03;
-  ;
+    id                  = "m2564rfr2";
+    desc                = "ATmega2564RFR2";
+    signature           = 0x1e 0xa8 0x03;
+;
 
 #------------------------------------------------------------
 # ATmega1284RFR2
 #------------------------------------------------------------
 
 part parent "m128rfr2"
-    id               = "m1284rfr2";
-    desc             = "ATmega1284RFR2";
-    signature        = 0x1e 0xa7 0x03;
-  ;
+    id                  = "m1284rfr2";
+    desc                = "ATmega1284RFR2";
+    signature           = 0x1e 0xa7 0x03;
+;
 
 #------------------------------------------------------------
 # ATmega644RFR2
 #------------------------------------------------------------
 
 part parent "m64rfr2"
-    id               = "m644rfr2";
-    desc             = "ATmega644RFR2";
-    signature        = 0x1e 0xa6 0x03;
-  ;
+    id                  = "m644rfr2";
+    desc                = "ATmega644RFR2";
+    signature           = 0x1e 0xa6 0x03;
+;
 
 #------------------------------------------------------------
 # ATtiny24
 #------------------------------------------------------------
 
 part
-     id            = "t24";
-     desc          = "ATtiny24";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x07, 0x17;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x91 0x0b;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
-    hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 0;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 128;
-        paged           = no;
-        page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 2048;
-         page_size       = 32;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0  0 a9 a8",
-                           " a7 a6 a5 a4   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATtiny24A
-#------------------------------------------------------------
-
-part parent "t24"
-    id               = "t24a";
-    desc             = "ATtiny24A";
-  ;
-
-#------------------------------------------------------------
-# ATtiny44
-#------------------------------------------------------------
-
-part
-     id            = "t44";
-     desc          = "ATtiny44";
-     has_debugwire = yes;
+    id                  = "t24";
+    desc                = "ATtiny24";
+    has_debugwire       = yes;
      flash_instr   = 0xB4, 0x07, 0x17;
      eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
                      0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
                      0x99, 0xE1, 0xBB, 0xAC;
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x92 0x07;
-     reset            = io;
-     chip_erase_delay = 4500;
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x91 0x0b;
+    reset               = io;
+    chip_erase_delay    = 4500;
 
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                         "x x x x  x x x x    x x x x  x x x x";
 
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                         "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
-    hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 0;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 256;
-        paged           = no;
-        page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-        # semi-automatically corrected: check part/datasheet
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x x   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 64;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATtiny44A
-#------------------------------------------------------------
-
-part parent "t44"
-    id               = "t44a";
-    desc             = "ATtiny44A";
-  ;
-
-#------------------------------------------------------------
-# ATtiny84
-#------------------------------------------------------------
-
-part
-     id            = "t84";
-     desc          = "ATtiny84";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x07, 0x17;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x93 0x0c;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
-    hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 0;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 512;
-        paged           = no;
-        page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-        # semi-automatically corrected: check part/datasheet
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 64;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATtiny84A
-#------------------------------------------------------------
-
-part parent "t84"
-    id               = "t84a";
-    desc             = "ATtiny84A";
-  ;
-
-#------------------------------------------------------------
-# ATtiny441
-#------------------------------------------------------------
-
-part parent "t44"
-     id            = "t441";
-     desc          = "ATtiny441";
-     signature     = 0x1e 0x92 0x15;
-
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 16;
-         num_pages       = 256;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5 a4  a3  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 16;
-	readsize	= 256;
-     ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-;
-
-#------------------------------------------------------------
-# ATtiny841
-#------------------------------------------------------------
-
-part parent "t84"
-     id            = "t841";
-     desc          = "ATtiny841";
-     signature     = 0x1e 0x93 0x15;
-
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 16;
-         num_pages       = 512;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5 a4  a3  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 16;
-	readsize	= 256;
-     ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-;
-
-#------------------------------------------------------------
-# ATtiny43U
-#------------------------------------------------------------
-
-part
-    id            = "t43u";
-    desc          = "ATtiny43U";
-    has_debugwire = yes;
-    flash_instr   = 0xB4, 0x07, 0x17;
-    eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-                         0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
-                         0x99, 0xE1, 0xBB, 0xAC;
-    stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode   = 0x20;
-    signature        = 0x1e 0x92 0x0C;
-    reset            = io;
-    chip_erase_delay = 1000;
-
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout                     = 200;
+    timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
     synchloops          = 32;
@@ -12704,7 +12007,704 @@ part
     predelay            = 1;
     postdelay           = 1;
     pollmethod          = 1;
-        pp_controlstack = 0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E, 0x4E, 0x5E,
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        size            = 128;
+        paged           = no;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
+                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x   x   x   x",
+                          "  x  a6  a5  a4     a3  a2   0   0",
+                          "  x   x   x   x      x   x   x   x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0   0  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        writepage       = "  0  1  0  0   1  1  0  0",
+                           "  0  0  0  0   0  0 a9 a8",
+                           " a7 a6 a5 a4   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
+#   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny24A
+#------------------------------------------------------------
+
+part parent "t24"
+    id                  = "t24a";
+    desc                = "ATtiny24A";
+;
+
+#------------------------------------------------------------
+# ATtiny44
+#------------------------------------------------------------
+
+part
+    id                  = "t44";
+    desc                = "ATtiny44";
+    has_debugwire       = yes;
+     flash_instr   = 0xB4, 0x07, 0x17;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+                     0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
+## no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x92 0x07;
+    reset               = io;
+    chip_erase_delay    = 4500;
+
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        size            = 256;
+        paged           = no;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        # semi-automatically corrected: check part/datasheet
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x x   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0  a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0  a10 a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        writepage       = "  0  1  0  0   1  1  0  0",
+                           "  0  0  0  0   0 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
+#   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+    ;
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny44A
+#------------------------------------------------------------
+
+part parent "t44"
+    id                  = "t44a";
+    desc                = "ATtiny44A";
+;
+
+#------------------------------------------------------------
+# ATtiny84
+#------------------------------------------------------------
+
+part
+    id                  = "t84";
+    desc                = "ATtiny84";
+    has_debugwire       = yes;
+     flash_instr   = 0xB4, 0x07, 0x17;
+     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+                     0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
+                     0x99, 0xE1, 0xBB, 0xAC;
+## no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x93 0x0c;
+    reset               = io;
+    chip_erase_delay    = 4500;
+
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+
+    hvsp_controlstack   =
+        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
+        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
+    hventerstabdelay    = 100;
+    hvspcmdexedelay     = 0;
+    synchcycles         = 6;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 0;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    chiperasetime       = 0;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+
+    ocdrev              = 1;
+
+    memory "eeprom"
+        size            = 512;
+        paged           = no;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+
+        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
+                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
+
+        # semi-automatically corrected: check part/datasheet
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x x x a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x  a4   a3  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        writepage       = "  0  1  0  0   1   1   0  0",
+                           "  0  0  0  0  a11 a10 a9 a8",
+                           " a7 a6 a5  x   x  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+    ;
+#   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
+    memory "signature"
+        size            = 3;
+        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
+                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
+    ;
+
+    memory "lock"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
+                           "x x x x  x x x x  x x x x  x x i i";
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
+                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  x x x x  x x x i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
+                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny84A
+#------------------------------------------------------------
+
+part parent "t84"
+    id                  = "t84a";
+    desc                = "ATtiny84A";
+;
+
+#------------------------------------------------------------
+# ATtiny441
+#------------------------------------------------------------
+
+part parent "t44"
+    id                  = "t441";
+    desc                = "ATtiny441";
+    signature           = 0x1e 0x92 0x15;
+
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 16;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0    0 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0    0 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x    x  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x    x  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        writepage       = "  0  1  0  0   1   1   0  0",
+                           "  0  0  0  0   0 a10 a9 a8",
+                           " a7 a6 a5 a4  a3  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 16;
+        readsize        = 256;
+    ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny841
+#------------------------------------------------------------
+
+part parent "t84"
+    id                  = "t841";
+    desc                = "ATtiny841";
+    signature           = 0x1e 0x93 0x15;
+
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 16;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read_lo         = "  0   0   1   0    0   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        read_hi         = "  0   0   1   0    1   0   0   0",
+                           "  0   0   0   0  a11 a10  a9  a8",
+                           " a7  a6  a5  a4   a3  a2  a1  a0",
+                           "  o   o   o   o    o   o   o   o";
+
+        loadpage_lo     = "  0   1   0   0    0   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x    x  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        loadpage_hi     = "  0   1   0   0    1   0   0   0",
+                           "  0   0   0   x    x   x   x   x",
+                           "  x   x   x   x    x  a2  a1  a0",
+                           "  i   i   i   i    i   i   i   i";
+
+        writepage       = "  0  1  0  0   1   1   0  0",
+                           "  0  0  0  0  a11 a10 a9 a8",
+                           " a7 a6 a5 a4  a3  x  x  x",
+                           "  x  x  x  x   x  x  x  x";
+
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 16;
+        readsize        = 256;
+    ;
+
+    memory "efuse"
+        size            = 1;
+        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
+                           "x x x x  x x x x  i i i i  i i i i";
+
+        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
+                           "x x x x  x x x x  o o o o  o o o o";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny43U
+#------------------------------------------------------------
+
+part
+    id                  = "t43u";
+    desc                = "ATtiny43U";
+    has_debugwire       = yes;
+    flash_instr   = 0xB4, 0x07, 0x17;
+    eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
+                         0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
+                         0x99, 0xE1, 0xBB, 0xAC;
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    signature           = 0x1e 0x92 0x0C;
+    reset               = io;
+    chip_erase_delay    = 1000;
+
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+                        "x x x x  x x x x    x x x x  x x x x";
+
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     = 0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E, 0x4E, 0x5E,
                                          0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E, 0x06, 0x16, 0x46, 0x56,
                                          0x0A, 0x1A, 0x4A, 0x5A, 0x1E, 0x7C, 0x00, 0x01, 0x00, 0x00,
                                          0x00, 0x00;
@@ -12725,35 +12725,35 @@ part
     programlockpulsewidth = 0;
     programlockpolltimeout = 5;
     memory "eeprom"
-                size            = 64;
-                paged                   = yes;
-                page_size       = 4;
-                num_pages               = 16;
-                min_write_delay = 4000;
-                max_write_delay = 4500;
-                readback_p1     = 0xff;
-                readback_p2     = 0xff;
-                read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
+        size            = 64;
+        paged           = yes;
+        page_size       = 4;
+        num_pages       = 16;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback_p1     = 0xff;
+        readback_p2     = 0xff;
+        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
                                   "0  0 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
 
-                write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
+        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
                                   "0  0 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
 
-                loadpage_lo     = "  1   1   0   0      0   0   0   1",
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
                                   "  0   0   0   0      0   0   0   0",
                                   "  0   0   0   0      0   0  a1  a0",
                                   "  i   i   i   i      i   i   i   i";
 
-                writepage       = "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
                                   "  0   0   x   x      x   x   x   x",
                                   "  0   0  a5  a4     a3  a2   0   0",
                                   "  x   x   x   x      x   x   x   x";
 
-                mode            = 0x41;
-                delay           = 5;
-                blocksize       = 4;
-                readsize        = 256;
-        ;
+        mode            = 0x41;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
     memory "flash"
         paged           = yes;
         size            = 4096;
@@ -12789,11 +12789,11 @@ part
                           " a7 a6 a5  x   x  x  x  x",
                           "  x  x  x  x   x  x  x  x";
 
-                mode            = 0x41;
-                delay           = 10;
-                blocksize       = 64;
-                readsize        = 256;
-       ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
@@ -12819,7 +12819,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-        ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -12830,7 +12830,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-        ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -12855,33 +12855,33 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m16u4";
-    desc             = "ATmega16U4";
-    signature        = 0x1e 0x94 0x88;
-    usbpid           = 0x2ff4;
-    has_jtag         = yes;
+    id                  = "m16u4";
+    desc                = "ATmega16U4";
+    signature           = 0x1e 0x94 0x88;
+    usbpid              = 0x2ff4;
+    has_jtag            = yes;
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -12928,19 +12928,19 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x x 0 0 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x 0 0 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -12976,11 +12976,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -12991,7 +12991,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -13002,7 +13002,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -13013,7 +13013,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -13024,53 +13024,53 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega32u4
 #------------------------------------------------------------
 
 part
-    id               = "m32u4";
-    desc             = "ATmega32U4";
-    signature        = 0x1e 0x95 0x87;
-    usbpid           = 0x2ff4;
-    has_jtag         = yes;
+    id                  = "m32u4";
+    desc                = "ATmega32U4";
+    signature           = 0x1e 0x95 0x87;
+    usbpid              = 0x2ff4;
+    has_jtag            = yes;
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -13114,22 +13114,22 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
         # semi-automatically corrected: check part/datasheet
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x x 0 a9 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x x 0 a9 a8   a7 a6 a5 a4 a3 a2 0 0   x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -13165,11 +13165,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -13180,7 +13180,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -13191,7 +13191,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -13202,7 +13202,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -13213,53 +13213,53 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB646
 #------------------------------------------------------------
 
 part
-    id               = "usb646";
-    desc             = "AT90USB646";
-    signature        = 0x1e 0x96 0x82;
-    usbpid           = 0x2ff9;
-    has_jtag         = yes;
+    id                  = "usb646";
+    desc                = "AT90USB646";
+    signature           = 0x1e 0x96 0x82;
+    usbpid              = 0x2ff9;
+    has_jtag            = yes;
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -13303,24 +13303,24 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
+        writepage       = "  1   1   0   0      0   0   1   0",
+                          "  0   0   x   x      x a10  a9  a8",
+                          " a7  a6  a5  a4     a3   0   0   0",
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -13356,11 +13356,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -13371,7 +13371,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -13382,7 +13382,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -13393,7 +13393,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -13404,20 +13404,20 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB647
@@ -13425,45 +13425,45 @@ part
 # identical to AT90USB646
 
 part parent "usb646"
-    id               = "usb647";
-    desc             = "AT90USB647";
-    signature        = 0x1e 0x96 0x82;
+    id                  = "usb647";
+    desc                = "AT90USB647";
+    signature           = 0x1e 0x96 0x82;
 
     ocdrev              = 3;
-  ;
+;
 
 #------------------------------------------------------------
 # AT90USB1286
 #------------------------------------------------------------
 
 part
-    id               = "usb1286";
-    desc             = "AT90USB1286";
-    signature        = 0x1e 0x97 0x82;
-    usbpid           = 0x2ffb;
-    has_jtag         = yes;
+    id                  = "usb1286";
+    desc                = "AT90USB1286";
+    signature           = 0x1e 0x97 0x82;
+    usbpid              = 0x2ffb;
+    has_jtag            = yes;
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    pagel               = 0xD7;
+    bs2                 = 0xA0;
+    reset               = dedicated;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "x x x x  x x x x    x x x x  x x x x";
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -13507,22 +13507,22 @@ part
 
         write           = "  1   1   0   0      0   0   0   0",
                           "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
+                          " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0  a2  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-        # semi-automatically corrected: check part/datasheet 
-        writepage = "1 1 0 0 0 0 1 0   0 0 x x a11 a10 a9 a8   a7 a6 a5 a4 a3 0 0 0   x x x x x x x x";
+        # semi-automatically corrected: check part/datasheet
+        writepage       = "1 1 0 0 0 0 1 0   0 0 x x a11 a10 a9 a8   a7 a6 a5 a4 a3 0 0 0   x x x x x x x x";
 
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -13558,11 +13558,11 @@ part
                           " a7   x   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -13573,7 +13573,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -13584,7 +13584,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -13595,7 +13595,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -13606,20 +13606,20 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB1287
@@ -13627,43 +13627,43 @@ part
 # identical to AT90USB1286
 
 part parent "usb1286"
-    id               = "usb1287";
-    desc             = "AT90USB1287";
-    signature        = 0x1e 0x97 0x82;
+    id                  = "usb1287";
+    desc                = "AT90USB1287";
+    signature           = 0x1e 0x97 0x82;
 
     ocdrev              = 3;
-  ;
+;
 
 #------------------------------------------------------------
 # AT90USB162
 #------------------------------------------------------------
 
 part
-    id               = "usb162";
-    desc             = "AT90USB162";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x94 0x82;
-    usbpid           = 0x2ffa;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "usb162";
+    desc                = "AT90USB162";
+    has_jtag            = no;
+    has_debugwire       = yes;
+    signature           = 0x1e 0x94 0x82;
+    usbpid              = 0x2ffa;
+    chip_erase_delay    = 9000;
+    reset               = io;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
+    pagel               = 0xD7;
+    bs2                 = 0xC6;
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
         0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
@@ -13705,21 +13705,21 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -13755,11 +13755,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -13770,7 +13770,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -13781,7 +13781,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -13792,7 +13792,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -13803,19 +13803,19 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB82
@@ -13826,31 +13826,31 @@ part
 #        num_pages       = 64;
 
 part
-    id               = "usb82";
-    desc             = "AT90USB82";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x93 0x82;
-    usbpid           = 0x2ff7;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "usb82";
+    desc                = "AT90USB82";
+    has_jtag            = no;
+    has_debugwire       = yes;
+    signature           = 0x1e 0x93 0x82;
+    usbpid              = 0x2ff7;
+    chip_erase_delay    = 9000;
+    reset               = io;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
+    pagel               = 0xD7;
+    bs2                 = 0xC6;
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
         0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
@@ -13892,21 +13892,21 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -13942,11 +13942,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -13957,7 +13957,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -13968,7 +13968,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -13979,7 +13979,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -13990,19 +13990,19 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega32U2
@@ -14015,31 +14015,31 @@ part
 #        size            = 1024;
 #        num_pages       = 256;
 part
-    id               = "m32u2";
-    desc             = "ATmega32U2";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x95 0x8a;
-    usbpid           = 0x2ff0;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m32u2";
+    desc                = "ATmega32U2";
+    has_jtag            = no;
+    has_debugwire       = yes;
+    signature           = 0x1e 0x95 0x8a;
+    usbpid              = 0x2ff0;
+    chip_erase_delay    = 9000;
+    reset               = io;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
+    pagel               = 0xD7;
+    bs2                 = 0xC6;
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
         0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
@@ -14081,21 +14081,21 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -14131,11 +14131,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -14146,7 +14146,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -14157,7 +14157,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -14168,7 +14168,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -14179,19 +14179,19 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 #------------------------------------------------------------
 # ATmega16U2
 #------------------------------------------------------------
@@ -14203,31 +14203,31 @@ part
 #        size            = 512;
 #        num_pages       = 128;
 part
-    id               = "m16u2";
-    desc             = "ATmega16U2";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x94 0x89;
-    usbpid           = 0x2fef;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m16u2";
+    desc                = "ATmega16U2";
+    has_jtag            = no;
+    has_debugwire       = yes;
+    signature           = 0x1e 0x94 0x89;
+    usbpid              = 0x2fef;
+    chip_erase_delay    = 9000;
+    reset               = io;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
+    pagel               = 0xD7;
+    bs2                 = 0xC6;
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
         0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
@@ -14269,21 +14269,21 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -14319,11 +14319,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -14334,7 +14334,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -14345,7 +14345,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -14356,7 +14356,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -14367,19 +14367,19 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega8U2
@@ -14391,31 +14391,31 @@ part
 #        blocksize       = 64;
 
 part
-    id               = "m8u2";
-    desc             = "ATmega8U2";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x93 0x89;
-    usbpid           = 0x2fee;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    id                  = "m8u2";
+    desc                = "ATmega8U2";
+    has_jtag            = no;
+    has_debugwire       = yes;
+    signature           = 0x1e 0x93 0x89;
+    usbpid              = 0x2fee;
+    chip_erase_delay    = 9000;
+    reset               = io;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
                        "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
+    pagel               = 0xD7;
+    bs2                 = 0xC6;
 
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
         0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
@@ -14457,21 +14457,21 @@ part
                           " a7  a6  a5  a4     a3  a2  a1  a0",
                           "  i   i   i   i      i   i   i   i";
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
+                          "  0   0   0   0      0   0   0   0",
+                          "  0   0   0   0      0   0  a1  a0",
+                          "  i   i   i   i      i   i   i   i";
 
-	writepage	= "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
                           "  0   0   0   0    a11 a10  a9  a8",
                           " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+                          "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -14507,11 +14507,11 @@ part
                           " a7  a6   x   x      x   x   x   x",
                           "  x   x   x   x      x   x   x   x";
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -14522,7 +14522,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -14533,7 +14533,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -14544,7 +14544,7 @@ part
                           "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -14555,76 +14555,76 @@ part
                           "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
                           "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+    ;
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega165
 #------------------------------------------------------------
 
 part
-    id               = "m165";
-    desc             = "ATmega165";
-    signature        = 0x1e 0x94 0x10;
-    has_jtag         = yes;
+    id                  = "m165";
+    desc                = "ATmega165";
+    signature           = 0x1e 0x94 0x10;
+    has_jtag            = yes;
 #   stk500_devcode   = 0x??;
 #   avr910_devcode   = 0x??;
-    chip_erase_delay = 9000;
-    reset            =  io;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    pgm_enable       = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
+    chip_erase_delay    = 9000;
+    reset               =  io;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
                        "x x x x  x x x x   x x x x  x x x x";
 
-    chip_erase       = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
+    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
                        "x x x x  x x x x   x x x x  x x x x";
 
-    timeout                = 200;
-    stabdelay              = 100;
-    cmdexedelay            = 25;
-    synchloops             = 32;
-    bytedelay              = 0;
-    pollindex              = 3;
-    pollvalue              = 0x53;
-    predelay               = 1;
-    postdelay              = 1;
-    pollmethod             = 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
-    pp_controlstack        =
+    pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	      0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	      0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	      0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay       = 100;
-    progmodedelay          = 0;
-    latchcycles            = 6;
-    togglevtg              = 0;
-    poweroffdelay          = 0;
-    resetdelayms           = 0;
-    resetdelayus           = 0;
-    hvleavestabdelay       = 15;
-    chiperasepulsewidth    = 0;
-    resetdelay             = 15;
-    chiperasepolltimeout   = 10;
-    programfusepulsewidth  = 0;
+              0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
+              0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
+              0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    progmodedelay       = 0;
+    latchcycles         = 6;
+    togglevtg           = 0;
+    poweroffdelay       = 0;
+    resetdelayms        = 0;
+    resetdelayus        = 0;
+    hvleavestabdelay    = 15;
+    chiperasepulsewidth = 0;
+    resetdelay          = 15;
+    chiperasepolltimeout = 10;
+    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth  = 0;
+    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
 
-    idr                    = 0x31;
-    spmcr                  = 0x57;
-    eecr                   = 0x3f;
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    eecr                = 0x3f;
     allowfullpagebitstream = no;
 
     ocdrev                 = 3;
@@ -14662,7 +14662,7 @@ part
         delay           = 20;
         blocksize       = 4;
         readsize        = 256;
-      ;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -14702,114 +14702,114 @@ part
         delay           = 10;
         blocksize       = 128;
         readsize        = 256;
-      ;
+    ;
 
     memory "lfuse"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
         read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
                           "x x x x  x x x x   o o o o  o o o o";
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "hfuse"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
         read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
                           "x x x x  x x x x   o o o o  o o o o";
 
         write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
                           "x x x x  x x x x   i i i i  i i i i";
-      ;
+    ;
 
     memory "efuse"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
                           "x x x x  x x x x  o o o o  o o o o";
 
         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
                           "x x x x  x x x x  x x x x  i i i i";
-     ;
+    ;
 
     memory "lock"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
         read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
                           "x x x x  x x x x   o o o o  o o o o";
 
         write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
                           "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
                           "x x x x  x x x x   o o o o  o o o o";
-      ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega165A
 #------------------------------------------------------------
 
 part parent "m165"
-    id               = "m165a";
-    desc             = "ATmega165A";
-    signature        = 0x1e 0x94 0x10;
-  ;
+    id                  = "m165a";
+    desc                = "ATmega165A";
+    signature           = 0x1e 0x94 0x10;
+;
 
 #------------------------------------------------------------
 # ATmega165P
 #------------------------------------------------------------
 
 part parent "m165"
-    id               = "m165p";
-    desc             = "ATmega165P";
-    signature        = 0x1e 0x94 0x07;
-  ;
+    id                  = "m165p";
+    desc                = "ATmega165P";
+    signature           = 0x1e 0x94 0x07;
+;
 
 #------------------------------------------------------------
 # ATmega165PA
 #------------------------------------------------------------
 
 part parent "m165"
-    id               = "m165pa";
-    desc             = "ATmega165PA";
-    signature        = 0x1e 0x94 0x07;
-  ;
+    id                  = "m165pa";
+    desc                = "ATmega165PA";
+    signature           = 0x1e 0x94 0x07;
+;
 
 #------------------------------------------------------------
 # ATmega325
 #------------------------------------------------------------
 
 part
-    id               = "m325";
-    desc             = "ATmega325";
-    signature        = 0x1e 0x95 0x05;
-    has_jtag         = yes;
+    id                  = "m325";
+    desc                = "ATmega325";
+    signature           = 0x1e 0x95 0x05;
+    has_jtag            = yes;
 #   stk500_devcode   = 0x??; # No STK500v1 support?
 #   avr910_devcode   = 0x??; # Try the ATmega16 one
-    avr910_devcode   = 0x74;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    avr910_devcode      = 0x74;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
     timeout             = 200;
@@ -14881,7 +14881,7 @@ part
         delay           = 10;
         blocksize       = 4;
         readsize        = 256;
-      ;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -14921,7 +14921,7 @@ part
         delay           = 10;
         blocksize       = 128;
         readsize        = 256;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -14932,7 +14932,7 @@ part
                           "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -14943,7 +14943,7 @@ part
                           "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -14954,7 +14954,7 @@ part
                           "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -14966,70 +14966,70 @@ part
                           "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
                           "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
 
         read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega325A
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m325a";
-    desc             = "ATmega325A";
-  ;
+    id                  = "m325a";
+    desc                = "ATmega325A";
+;
 
 #------------------------------------------------------------
 # ATmega325P
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m325p";
-    desc             = "ATmega325P";
-    signature        = 0x1e 0x95 0x0d;
-  ;
+    id                  = "m325p";
+    desc                = "ATmega325P";
+    signature           = 0x1e 0x95 0x0d;
+;
 
 #------------------------------------------------------------
 # ATmega325PA
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m325pa";
-    desc             = "ATmega325PA";
-    signature        = 0x1e 0x95 0x0d;
-  ;
+    id                  = "m325pa";
+    desc                = "ATmega325PA";
+    signature           = 0x1e 0x95 0x0d;
+;
 
 #------------------------------------------------------------
 # ATmega645
 #------------------------------------------------------------
 
 part
-    id               = "m645";
-    desc             = "ATmega645";
-    signature        = 0x1E 0x96 0x05;
-    has_jtag         = yes;
+    id                  = "m645";
+    desc                = "ATmega645";
+    signature           = 0x1E 0x96 0x05;
+    has_jtag            = yes;
 #   stk500_devcode   = 0x??; # No STK500v1 support?
 #   avr910_devcode   = 0x??; # Try the ATmega16 one
-    avr910_devcode   = 0x74;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+    avr910_devcode      = 0x74;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
                        "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
+    chip_erase          = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
                        "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
 
     timeout             = 200;
@@ -15101,7 +15101,7 @@ part
         delay           = 10;
         blocksize       = 8;
         readsize        = 256;
-      ;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -15141,7 +15141,7 @@ part
         delay           = 10;
         blocksize       = 128;
         readsize        = 256;
-      ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -15152,7 +15152,7 @@ part
                           "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -15163,7 +15163,7 @@ part
                           "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -15174,7 +15174,7 @@ part
                           "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -15186,162 +15186,162 @@ part
                           "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
                           "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
-      ;
+    ;
 
     memory "calibration"
         size            = 1;
 
         read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
                           "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega645A
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m645a";
-    desc             = "ATmega645A";
-  ;
+    id                  = "m645a";
+    desc                = "ATmega645A";
+;
 
 #------------------------------------------------------------
 # ATmega645P
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m645p";
-    desc             = "ATmega645P";
-    signature        = 0x1e 0x96 0x0d;
-  ;
+    id                  = "m645p";
+    desc                = "ATmega645P";
+    signature           = 0x1e 0x96 0x0d;
+;
 
 #------------------------------------------------------------
 # ATmega3250
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250";
-    desc             = "ATmega3250";
-    signature        = 0x1E 0x95 0x06;
-  ;
+    id                  = "m3250";
+    desc                = "ATmega3250";
+    signature           = 0x1E 0x95 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega3250A
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250a";
-    desc             = "ATmega3250A";
-    signature        = 0x1E 0x95 0x06;
-  ;
+    id                  = "m3250a";
+    desc                = "ATmega3250A";
+    signature           = 0x1E 0x95 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega3250P
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250p";
-    desc             = "ATmega3250P";
-    signature        = 0x1E 0x95 0x0e;
-  ;
+    id                  = "m3250p";
+    desc                = "ATmega3250P";
+    signature           = 0x1E 0x95 0x0e;
+;
 
 #------------------------------------------------------------
 # ATmega3250PA
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250pa";
-    desc             = "ATmega3250PA";
-    signature        = 0x1E 0x95 0x0e;
-  ;
+    id                  = "m3250pa";
+    desc                = "ATmega3250PA";
+    signature           = 0x1E 0x95 0x0e;
+;
 
 #------------------------------------------------------------
 # ATmega6450
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m6450";
-    desc             = "ATmega6450";
-    signature        = 0x1E 0x96 0x06;
-  ;
+    id                  = "m6450";
+    desc                = "ATmega6450";
+    signature           = 0x1E 0x96 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega6450A
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m6450a";
-    desc             = "ATmega6450A";
-    signature        = 0x1E 0x96 0x06;
-  ;
+    id                  = "m6450a";
+    desc                = "ATmega6450A";
+    signature           = 0x1E 0x96 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega6450P
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m6450p";
-    desc             = "ATmega6450P";
-    signature        = 0x1E 0x96 0x0e;
-  ;
+    id                  = "m6450p";
+    desc                = "ATmega6450P";
+    signature           = 0x1E 0x96 0x0e;
+;
 
 #------------------------------------------------------------
 # AVR XMEGA family common values
 #------------------------------------------------------------
 
 part
-    id		= ".xmega";
-    desc	= "AVR XMEGA family common values";
-    has_pdi	= yes;
-    nvm_base	= 0x01c0;
-    mcu_base	= 0x0090;
+    id                  = ".xmega";
+    desc                = "AVR XMEGA family common values";
+    has_pdi             = yes;
+    nvm_base    = 0x01c0;
+    mcu_base    = 0x0090;
 
     memory "signature"
-        size		= 3;
-        offset		= 0x1000090;
+        size            = 3;
+        offset          = 0x1000090;
     ;
 
     memory "prodsig"
-        size		= 0x32;
-        offset		= 0x8e0200;
-        page_size	= 0x32;
-        readsize	= 0x32;
+        size            = 0x32;
+        offset          = 0x8e0200;
+        page_size       = 0x32;
+        readsize        = 0x32;
     ;
 
     memory "fuse1"
-        size		= 1;
-        offset		= 0x8f0021;
+        size            = 1;
+        offset          = 0x8f0021;
     ;
 
     memory "fuse2"
-        size		= 1;
-        offset		= 0x8f0022;
+        size            = 1;
+        offset          = 0x8f0022;
     ;
 
     memory "fuse4"
-        size		= 1;
-        offset		= 0x8f0024;
+        size            = 1;
+        offset          = 0x8f0024;
     ;
 
     memory "fuse5"
-        size		= 1;
-        offset		= 0x8f0025;
+        size            = 1;
+        offset          = 0x8f0025;
     ;
 
     memory "lock"
-        size		= 1;
-        offset		= 0x8f0027;
+        size            = 1;
+        offset          = 0x8f0027;
     ;
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset		= 0x1000000;
+        offset          = 0x1000000;
     ;
 ;
 
@@ -15350,51 +15350,51 @@ part
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x16a4u";
-    desc	= "ATxmega16A4U";
-    signature	= 0x1e 0x94 0x41;
-    usbpid	= 0x2fe3;
+    id                  = "x16a4u";
+    desc                = "ATxmega16A4U";
+    signature           = 0x1e 0x94 0x41;
+    usbpid              = 0x2fe3;
 
     memory "eeprom"
-        size		= 0x400;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x400;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x4000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x1000;
-        offset		= 0x803000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x803000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x1000;
-        offset		= 0x804000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x804000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x5000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x5000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x100;
+        offset          = 0x8e0400;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -15403,9 +15403,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    id		= "x16c4";
-    desc	= "ATxmega16C4";
-    signature	= 0x1e 0x94 0x43;
+    id                  = "x16c4";
+    desc                = "ATxmega16C4";
+    signature           = 0x1e 0x94 0x43;
 ;
 
 #------------------------------------------------------------
@@ -15413,9 +15413,9 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    id		= "x16d4";
-    desc	= "ATxmega16D4";
-    signature	= 0x1e 0x94 0x42;
+    id                  = "x16d4";
+    desc                = "ATxmega16D4";
+    signature           = 0x1e 0x94 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15423,14 +15423,14 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    id		= "x16a4";
-    desc	= "ATxmega16A4";
-    signature	= 0x1e 0x94 0x41;
-    has_jtag	= yes;
+    id                  = "x16a4";
+    desc                = "ATxmega16A4";
+    signature           = 0x1e 0x94 0x41;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15439,51 +15439,51 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x32a4u";
-    desc	= "ATxmega32A4U";
-    signature	= 0x1e 0x95 0x41;
-    usbpid	= 0x2fe4;
+    id                  = "x32a4u";
+    desc                = "ATxmega32A4U";
+    signature           = 0x1e 0x95 0x41;
+    usbpid              = 0x2fe4;
 
     memory "eeprom"
-        size		= 0x400;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x400;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x8000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x1000;
-        offset		= 0x807000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x807000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x1000;
-        offset		= 0x808000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x808000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x9000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x9000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x100;
+        offset          = 0x8e0400;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -15492,9 +15492,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    id		= "x32c4";
-    desc	= "ATxmega32C4";
-    signature	= 0x1e 0x95 0x44;
+    id                  = "x32c4";
+    desc                = "ATxmega32C4";
+    signature           = 0x1e 0x95 0x44;
 ;
 
 #------------------------------------------------------------
@@ -15502,9 +15502,9 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    id		= "x32d4";
-    desc	= "ATxmega32D4";
-    signature	= 0x1e 0x95 0x42;
+    id                  = "x32d4";
+    desc                = "ATxmega32D4";
+    signature           = 0x1e 0x95 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15512,14 +15512,14 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    id		= "x32a4";
-    desc	= "ATxmega32A4";
-    signature	= 0x1e 0x95 0x41;
-    has_jtag	= yes;
+    id                  = "x32a4";
+    desc                = "ATxmega32A4";
+    signature           = 0x1e 0x95 0x41;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15528,51 +15528,51 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x64a4u";
-    desc	= "ATxmega64A4U";
-    signature	= 0x1e 0x96 0x46;
-    usbpid	= 0x2fe5;
+    id                  = "x64a4u";
+    desc                = "ATxmega64A4U";
+    signature           = 0x1e 0x96 0x46;
+    usbpid              = 0x2fe5;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x10000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x1000;
-        offset		= 0x80f000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x80f000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x1000;
-        offset		= 0x810000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x810000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x11000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x11000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x100;
+        offset          = 0x8e0400;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -15581,10 +15581,10 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64c3";
-    desc	= "ATxmega64C3";
-    signature	= 0x1e 0x96 0x49;
-    usbpid	= 0x2fd6;
+    id                  = "x64c3";
+    desc                = "ATxmega64C3";
+    signature           = 0x1e 0x96 0x49;
+    usbpid              = 0x2fd6;
 ;
 
 #------------------------------------------------------------
@@ -15592,9 +15592,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64d3";
-    desc	= "ATxmega64D3";
-    signature	= 0x1e 0x96 0x4a;
+    id                  = "x64d3";
+    desc                = "ATxmega64D3";
+    signature           = 0x1e 0x96 0x4a;
 ;
 
 #------------------------------------------------------------
@@ -15602,9 +15602,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64d4";
-    desc	= "ATxmega64D4";
-    signature	= 0x1e 0x96 0x47;
+    id                  = "x64d4";
+    desc                = "ATxmega64D4";
+    signature           = 0x1e 0x96 0x47;
 ;
 
 #------------------------------------------------------------
@@ -15612,14 +15612,14 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64a1";
-    desc	= "ATxmega64A1";
-    signature	= 0x1e 0x96 0x4e;
-    has_jtag	= yes;
+    id                  = "x64a1";
+    desc                = "ATxmega64A1";
+    signature           = 0x1e 0x96 0x4e;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15628,10 +15628,10 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a1u";
-    desc	= "ATxmega64A1U";
-    signature	= 0x1e 0x96 0x4e;
-    usbpid	= 0x2fe8;
+    id                  = "x64a1u";
+    desc                = "ATxmega64A1U";
+    signature           = 0x1e 0x96 0x4e;
+    usbpid              = 0x2fe8;
 ;
 
 #------------------------------------------------------------
@@ -15639,9 +15639,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a3";
-    desc	= "ATxmega64A3";
-    signature	= 0x1e 0x96 0x42;
+    id                  = "x64a3";
+    desc                = "ATxmega64A3";
+    signature           = 0x1e 0x96 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15649,10 +15649,10 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a3u";
-    desc	= "ATxmega64A3U";
-    signature	= 0x1e 0x96 0x42;
-    usbpid	= 0x2fe5;
+    id                  = "x64a3u";
+    desc                = "ATxmega64A3U";
+    signature           = 0x1e 0x96 0x42;
+    usbpid              = 0x2fe5;
 ;
 
 #------------------------------------------------------------
@@ -15660,9 +15660,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a4";
-    desc	= "ATxmega64A4";
-    signature	= 0x1e 0x96 0x46;
+    id                  = "x64a4";
+    desc                = "ATxmega64A4";
+    signature           = 0x1e 0x96 0x46;
 ;
 
 #------------------------------------------------------------
@@ -15670,10 +15670,10 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64b1";
-    desc	= "ATxmega64B1";
-    signature	= 0x1e 0x96 0x52;
-    usbpid	= 0x2fe1;
+    id                  = "x64b1";
+    desc                = "ATxmega64B1";
+    signature           = 0x1e 0x96 0x52;
+    usbpid              = 0x2fe1;
 ;
 
 #------------------------------------------------------------
@@ -15681,10 +15681,10 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64b3";
-    desc	= "ATxmega64B3";
-    signature	= 0x1e 0x96 0x51;
-    usbpid	= 0x2fdf;
+    id                  = "x64b3";
+    desc                = "ATxmega64B3";
+    signature           = 0x1e 0x96 0x51;
+    usbpid              = 0x2fdf;
 ;
 
 #------------------------------------------------------------
@@ -15692,51 +15692,51 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128c3";
-    desc	= "ATxmega128C3";
-    signature	= 0x1e 0x97 0x52;
-    usbpid	= 0x2fd7;
+    id                  = "x128c3";
+    desc                = "ATxmega128C3";
+    signature           = 0x1e 0x97 0x52;
+    usbpid              = 0x2fd7;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x2000;
-        offset		= 0x81e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x81e000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x820000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x22000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x200;
+        offset          = 0x8e0400;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 ;
 
@@ -15745,9 +15745,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    id		= "x128d3";
-    desc	= "ATxmega128D3";
-    signature	= 0x1e 0x97 0x48;
+    id                  = "x128d3";
+    desc                = "ATxmega128D3";
+    signature           = 0x1e 0x97 0x48;
 ;
 
 #------------------------------------------------------------
@@ -15755,15 +15755,15 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    id		= "x128d4";
-    desc	= "ATxmega128D4";
-    signature	= 0x1e 0x97 0x47;
+    id                  = "x128d4";
+    desc                = "ATxmega128D4";
+    signature           = 0x1e 0x97 0x47;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x22000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -15772,14 +15772,14 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    id		= "x128a1";
-    desc	= "ATxmega128A1";
-    signature	= 0x1e 0x97 0x4c;
-    has_jtag	= yes;
+    id                  = "x128a1";
+    desc                = "ATxmega128A1";
+    signature           = 0x1e 0x97 0x4c;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15788,9 +15788,9 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a1d";
-    desc	= "ATxmega128A1revD";
-    signature	= 0x1e 0x97 0x41;
+    id                  = "x128a1d";
+    desc                = "ATxmega128A1revD";
+    signature           = 0x1e 0x97 0x41;
 ;
 
 #------------------------------------------------------------
@@ -15798,10 +15798,10 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a1u";
-    desc	= "ATxmega128A1U";
-    signature	= 0x1e 0x97 0x4c;
-    usbpid	= 0x2fed;
+    id                  = "x128a1u";
+    desc                = "ATxmega128A1U";
+    signature           = 0x1e 0x97 0x4c;
+    usbpid              = 0x2fed;
 ;
 
 #------------------------------------------------------------
@@ -15809,9 +15809,9 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a3";
-    desc	= "ATxmega128A3";
-    signature	= 0x1e 0x97 0x42;
+    id                  = "x128a3";
+    desc                = "ATxmega128A3";
+    signature           = 0x1e 0x97 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15819,10 +15819,10 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a3u";
-    desc	= "ATxmega128A3U";
-    signature	= 0x1e 0x97 0x42;
-    usbpid	= 0x2fe6;
+    id                  = "x128a3u";
+    desc                = "ATxmega128A3U";
+    signature           = 0x1e 0x97 0x42;
+    usbpid              = 0x2fe6;
 ;
 
 #------------------------------------------------------------
@@ -15830,56 +15830,56 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128a4";
-    desc	= "ATxmega128A4";
-    signature	= 0x1e 0x97 0x46;
-    has_jtag	= yes;
+    id                  = "x128a4";
+    desc                = "ATxmega128A4";
+    signature           = 0x1e 0x97 0x46;
+    has_jtag            = yes;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x1000;
-        offset		= 0x81f000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x81f000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x820000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x22000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x200;
+        offset          = 0x8e0400;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15888,51 +15888,51 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128a4u";
-    desc	= "ATxmega128A4U";
-    signature	= 0x1e 0x97 0x46;
-    usbpid	= 0x2fde;
+    id                  = "x128a4u";
+    desc                = "ATxmega128A4U";
+    signature           = 0x1e 0x97 0x46;
+    usbpid              = 0x2fde;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x1000;
-        offset		= 0x81f000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x81f000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x820000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x22000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x100;
+        offset          = 0x8e0400;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -15941,57 +15941,57 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128b1";
-    desc	= "ATxmega128B1";
-    signature	= 0x1e 0x97 0x4d;
-    usbpid	= 0x2fea;
-    has_jtag	= yes;
+    id                  = "x128b1";
+    desc                = "ATxmega128B1";
+    signature           = 0x1e 0x97 0x4d;
+    usbpid              = 0x2fea;
+    has_jtag            = yes;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x2000;
-        offset		= 0x81e000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x81e000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x820000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x22000;
+        offset          = 0x800000;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x100;
+        offset          = 0x8e0400;
+        page_size       = 0x100;
+        readsize        = 0x100;
     ;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -16000,10 +16000,10 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x128b1"
-    id		= "x128b3";
-    desc	= "ATxmega128B3";
-    signature	= 0x1e 0x97 0x4b;
-    usbpid	= 0x2fe0;
+    id                  = "x128b3";
+    desc                = "ATxmega128B3";
+    signature           = 0x1e 0x97 0x4b;
+    usbpid              = 0x2fe0;
 ;
 
 #------------------------------------------------------------
@@ -16011,51 +16011,51 @@ part parent "x128b1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x192c3";
-    desc	= "ATxmega192C3";
-    signature	= 0x1e 0x97 0x51;
-    # usbpid	= 0x2f??;
+    id                  = "x192c3";
+    desc                = "ATxmega192C3";
+    signature           = 0x1e 0x97 0x51;
+    # usbpid    = 0x2f??;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x30000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x30000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x2000;
-        offset		= 0x82e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x82e000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x2000;
-        offset		= 0x830000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x830000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x32000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x32000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x200;
+        offset          = 0x8e0400;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 ;
 
@@ -16064,9 +16064,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x192c3"
-    id		= "x192d3";
-    desc	= "ATxmega192D3";
-    signature	= 0x1e 0x97 0x49;
+    id                  = "x192d3";
+    desc                = "ATxmega192D3";
+    signature           = 0x1e 0x97 0x49;
 ;
 
 #------------------------------------------------------------
@@ -16074,14 +16074,14 @@ part parent "x192c3"
 #------------------------------------------------------------
 
 part parent "x192c3"
-    id		= "x192a1";
-    desc	= "ATxmega192A1";
-    signature	= 0x1e 0x97 0x4e;
-    has_jtag	= yes;
+    id                  = "x192a1";
+    desc                = "ATxmega192A1";
+    signature           = 0x1e 0x97 0x4e;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -16090,9 +16090,9 @@ part parent "x192c3"
 #------------------------------------------------------------
 
 part parent "x192a1"
-    id		= "x192a3";
-    desc	= "ATxmega192A3";
-    signature	= 0x1e 0x97 0x44;
+    id                  = "x192a3";
+    desc                = "ATxmega192A3";
+    signature           = 0x1e 0x97 0x44;
 ;
 
 #------------------------------------------------------------
@@ -16100,10 +16100,10 @@ part parent "x192a1"
 #------------------------------------------------------------
 
 part parent "x192a1"
-    id		= "x192a3u";
-    desc	= "ATxmega192A3U";
-    signature	= 0x1e 0x97 0x44;
-    usbpid	= 0x2fe7;
+    id                  = "x192a3u";
+    desc                = "ATxmega192A3U";
+    signature           = 0x1e 0x97 0x44;
+    usbpid              = 0x2fe7;
 ;
 
 #------------------------------------------------------------
@@ -16111,51 +16111,51 @@ part parent "x192a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x256c3";
-    desc	= "ATxmega256C3";
-    signature	= 0x1e 0x98 0x46;
-    usbpid	= 0x2fda;
+    id                  = "x256c3";
+    desc                = "ATxmega256C3";
+    signature           = 0x1e 0x98 0x46;
+    usbpid              = 0x2fda;
 
     memory "eeprom"
-        size		= 0x1000;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x40000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x40000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x2000;
-        offset		= 0x83e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x83e000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x2000;
-        offset		= 0x840000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x840000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x42000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x42000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x200;
+        offset          = 0x8e0400;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 ;
 
@@ -16164,9 +16164,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x256c3"
-    id		= "x256d3";
-    desc	= "ATxmega256D3";
-    signature	= 0x1e 0x98 0x44;
+    id                  = "x256d3";
+    desc                = "ATxmega256D3";
+    signature           = 0x1e 0x98 0x44;
 ;
 
 #------------------------------------------------------------
@@ -16174,14 +16174,14 @@ part parent "x256c3"
 #------------------------------------------------------------
 
 part parent "x256c3"
-    id		= "x256a1";
-    desc	= "ATxmega256A1";
-    signature	= 0x1e 0x98 0x46;
-    has_jtag	= yes;
+    id                  = "x256a1";
+    desc                = "ATxmega256A1";
+    signature           = 0x1e 0x98 0x46;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -16190,9 +16190,9 @@ part parent "x256c3"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3";
-    desc	= "ATxmega256A3";
-    signature	= 0x1e 0x98 0x42;
+    id                  = "x256a3";
+    desc                = "ATxmega256A3";
+    signature           = 0x1e 0x98 0x42;
 ;
 
 #------------------------------------------------------------
@@ -16200,10 +16200,10 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3u";
-    desc	= "ATxmega256A3U";
-    signature	= 0x1e 0x98 0x42;
-    usbpid	= 0x2fec;
+    id                  = "x256a3u";
+    desc                = "ATxmega256A3U";
+    signature           = 0x1e 0x98 0x42;
+    usbpid              = 0x2fec;
 ;
 
 #------------------------------------------------------------
@@ -16211,9 +16211,9 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3b";
-    desc	= "ATxmega256A3B";
-    signature	= 0x1e 0x98 0x43;
+    id                  = "x256a3b";
+    desc                = "ATxmega256A3B";
+    signature           = 0x1e 0x98 0x43;
 ;
 
 #------------------------------------------------------------
@@ -16221,10 +16221,10 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3bu";
-    desc	= "ATxmega256A3BU";
-    signature	= 0x1e 0x98 0x43;
-    usbpid	= 0x2fe2;
+    id                  = "x256a3bu";
+    desc                = "ATxmega256A3BU";
+    signature           = 0x1e 0x98 0x43;
+    usbpid              = 0x2fe2;
 ;
 
 #------------------------------------------------------------
@@ -16232,51 +16232,51 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x384c3";
-    desc	= "ATxmega384C3";
-    signature	= 0x1e 0x98 0x45;
-    usbpid	= 0x2fdb;
+    id                  = "x384c3";
+    desc                = "ATxmega384C3";
+    signature           = 0x1e 0x98 0x45;
+    usbpid              = 0x2fdb;
 
     memory "eeprom"
-        size		= 0x1000;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x8c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x60000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x60000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x2000;
-        offset		= 0x85e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x85e000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x2000;
-        offset		= 0x860000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x860000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x62000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x62000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x200;
+        offset          = 0x8e0400;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 ;
 
@@ -16285,9 +16285,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x384c3"
-    id		= "x384d3";
-    desc	= "ATxmega384D3";
-    signature	= 0x1e 0x98 0x47;
+    id                  = "x384d3";
+    desc                = "ATxmega384D3";
+    signature           = 0x1e 0x98 0x47;
 ;
 
 #------------------------------------------------------------
@@ -16295,50 +16295,50 @@ part parent "x384c3"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x8e5";
-    desc	= "ATxmega8E5";
-    signature	= 0x1e 0x93 0x41;
+    id                  = "x8e5";
+    desc                = "ATxmega8E5";
+    signature           = 0x1e 0x93 0x41;
 
     memory "eeprom"
-        size		= 0x0200;
-        offset		= 0x08c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x0200;
+        offset          = 0x08c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x2000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x2000;
+        offset          = 0x0800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x800;
-        offset		= 0x00801800;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x00801800;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x800;
-        offset		= 0x00802000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x800;
+        offset          = 0x00802000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x2800;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x2800;
+        offset          = 0x0800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
         size            = 0x80;
         offset          = 0x8e0400;
         page_size       = 0x80;
-        readsize	= 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -16347,50 +16347,50 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x16e5";
-    desc	= "ATxmega16E5";
-    signature	= 0x1e 0x94 0x45;
+    id                  = "x16e5";
+    desc                = "ATxmega16E5";
+    signature           = 0x1e 0x94 0x45;
 
     memory "eeprom"
-        size		= 0x0200;
-        offset		= 0x08c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x0200;
+        offset          = 0x08c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x4000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x4000;
+        offset          = 0x0800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x1000;
-        offset		= 0x00803000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x00803000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x1000;
-        offset		= 0x00804000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x00804000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x5000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x5000;
+        offset          = 0x0800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
         size            = 0x80;
         offset          = 0x8e0400;
         page_size       = 0x80;
-        readsize	= 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -16399,50 +16399,50 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x32e5";
-    desc	= "ATxmega32E5";
-    signature	= 0x1e 0x95 0x4c;
+    id                  = "x32e5";
+    desc                = "ATxmega32E5";
+    signature           = 0x1e 0x95 0x4c;
 
     memory "eeprom"
-        size		= 0x0400;
-        offset		= 0x08c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x0400;
+        offset          = 0x08c0000;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "application"
-        size		= 0x8000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x8000;
+        offset          = 0x0800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "apptable"
-        size		= 0x1000;
-        offset		= 0x00807000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x00807000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "boot"
-        size		= 0x1000;
-        offset		= 0x00808000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x1000;
+        offset          = 0x00808000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "flash"
-        size		= 0x9000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x9000;
+        offset          = 0x0800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
         size            = 0x80;
         offset          = 0x8e0400;
         page_size       = 0x80;
-        readsize	= 0x100;
+        readsize        = 0x100;
     ;
 ;
 
@@ -16451,11 +16451,11 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part
-    id		= "uc3a0512";
-    desc	= "AT32UC3A0512";
-    signature	= 0xED 0xC0 0x3F;
-    has_jtag	= yes;
-    is_avr32	= yes;
+    id                  = "uc3a0512";
+    desc                = "AT32UC3A0512";
+    signature           = 0xED 0xC0 0x3F;
+    has_jtag            = yes;
+    is_avr32            = yes;
 
     memory "flash"
         paged           = yes;
@@ -16468,8 +16468,8 @@ part
 ;
 
 part parent "uc3a0512"
-    id		= "ucr2";
-    desc	= "deprecated, use 'uc3a0512'";
+    id                  = "ucr2";
+    desc                = "deprecated, use 'uc3a0512'";
 ;
 
 #------------------------------------------------------------
@@ -16477,36 +16477,36 @@ part parent "uc3a0512"
 #------------------------------------------------------------
 
 part
-    id              = "t1634";
-    desc            = "ATtiny1634";
-     has_debugwire = yes;
+    id                  = "t1634";
+    desc                = "ATtiny1634";
+    has_debugwire       = yes;
      flash_instr   = 0xB6, 0x01, 0x11;
      eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
                 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
                 0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode  = 0x86;
+    stk500_devcode      = 0x86;
     # avr910_devcode = 0x;
-    signature       = 0x1e 0x94 0x12;
-    pagel           = 0xB3;
-    bs2             = 0xB1;
-    reset	    = io;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
+    signature           = 0x1e 0x94 0x12;
+    pagel               = 0xB3;
+    bs2                 = 0xB1;
+    reset               = io;
+    chip_erase_delay    = 9000;
+    pgm_enable          = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
                        "x x x x x x x x x x x x x x x x";
 
-    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
+    chip_erase          = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
                        "x x x x x x x x x x x x x x x x";
 
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 1;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    bytedelay           = 0;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
@@ -16547,21 +16547,21 @@ part
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
 
-   loadpage_lo   = "  1   1   0   0      0   0   0   1",
+        loadpage_lo     = "  1   1   0   0      0   0   0   1",
            "  0   0   0   0      0   0   0   0",
            "  0   0   0   0      0   0  a1  a0",
            "  i   i   i   i      i   i   i   i";
 
-   writepage   = "  1   1   0   0      0   0   1   0",
+        writepage       = "  1   1   0   0      0   0   1   0",
            "  0   0   x   x      x   x   x  a8",
            " a7  a6  a5  a4     a3  a2   0   0",
            "  x   x   x   x      x   x   x   x";
 
-   mode      = 0x41;
-   delay      = 5;
-   blocksize   = 4;
-   readsize   = 256;
-        ;
+        mode            = 0x41;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
+    ;
 
     memory "flash"
         paged           = yes;
@@ -16577,7 +16577,7 @@ part
                           " a7 a6 a5 a4 a3 a2 a1 a0",
                           " o o o o o o o o";
 
-        read_hi          = " 0 0 1 0 1 0 0 0",
+        read_hi         = " 0 0 1 0 1 0 0 0",
                            " 0 0 0 a12 a11 a10 a9 a8",
                            " a7 a6 a5 a4 a3 a2 a1 a0",
                            " o o o o o o o o";
@@ -16592,15 +16592,15 @@ part
                           " x x a5 a4 a3 a2 a1 a0",
                           " i i i i i i i i";
 
-        # semi-automatically corrected: check part/datasheet 
-        writepage = "0 1 0 0 1 1 0 0   0 0 0 a12 a11 a10 a9 a8   a7 a6 a5 a4 x x x x   x x x x x x x x";
+        # semi-automatically corrected: check part/datasheet
+        writepage       = "0 1 0 0 1 1 0 0   0 0 0 a12 a11 a10 a9 a8   a7 a6 a5 a4 x x x x   x x x x x x x x";
 
-        mode        = 0x41;
-        delay       = 6;
-        blocksize   = 128;
-        readsize    = 256;
+        mode            = 0x41;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
 
-        ;
+    ;
 
     memory "lfuse"
         size            = 1;
@@ -16611,7 +16611,7 @@ part
 
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
                           "x x x x x x x x i i i i i i i i";
-        ;
+    ;
 
     memory "hfuse"
         size            = 1;
@@ -16622,7 +16622,7 @@ part
 
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
                           "x x x x x x x x i i i i i i i i";
-        ;
+    ;
 
     memory "efuse"
         size            = 1;
@@ -16633,7 +16633,7 @@ part
 
         write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
                           "x x x x x x x x x x x i i i i i";
-        ;
+    ;
 
     memory "lock"
         size            = 1;
@@ -16644,19 +16644,19 @@ part
 
         write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
                           "x x x x x x x x 1 1 1 1 1 1 i i";
-        ;
+    ;
 
     memory "calibration"
         size            = 1;
         read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
                           "0 0 0 0 0 0 0 0 o o o o o o o o";
-        ;
+    ;
 
     memory "signature"
         size            = 3;
         read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
                           "x x x x x x a1 a0 o o o o o o o o";
-        ;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16664,42 +16664,42 @@ part
 #------------------------------------------------------------
 
 part parent "t1634"
-    id              = "t1634r";
-    desc            = "ATtiny1634R";
-  ;
+    id                  = "t1634r";
+    desc                = "ATtiny1634R";
+;
 
 #------------------------------------------------------------
 # Common values for reduced core tinys (4/5/9/10/20/40)
 #------------------------------------------------------------
 
 part
-    id		= ".reduced_core_tiny";
-    desc	= "Common values for reduced core tinys";
-    has_tpi	= yes;
+    id                  = ".reduced_core_tiny";
+    desc                = "Common values for reduced core tinys";
+    has_tpi             = yes;
 
     memory "signature"
-        size		= 3;
-        offset		= 0x3fc0;
-        page_size	= 16;
+        size            = 3;
+        offset          = 0x3fc0;
+        page_size       = 16;
     ;
 
     memory "fuse"
-        size		= 1;
-        offset		= 0x3f40;
-        page_size	= 16;
-	blocksize	= 4;
+        size            = 1;
+        offset          = 0x3f40;
+        page_size       = 16;
+        blocksize       = 4;
     ;
 
     memory "calibration"
-        size		= 1;
-        offset		= 0x3f80;
-        page_size	= 16;
+        size            = 1;
+        offset          = 0x3f80;
+        page_size       = 16;
     ;
 
     memory "lockbits"
-        size		= 1;
-        offset		= 0x3f00;
-        page_size	= 16;
+        size            = 1;
+        offset          = 0x3f00;
+        page_size       = 16;
     ;
 ;
 
@@ -16708,15 +16708,15 @@ part
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id		= "t4";
-    desc	= "ATtiny4";
-    signature	= 0x1e 0x8f 0x0a;
+    id                  = "t4";
+    desc                = "ATtiny4";
+    signature           = 0x1e 0x8f 0x0a;
 
     memory "flash"
-        size		= 512;
-        offset		= 0x4000;
-        page_size	= 16;
-        blocksize	= 128;
+        size            = 512;
+        offset          = 0x4000;
+        page_size       = 16;
+        blocksize       = 128;
     ;
 ;
 
@@ -16725,9 +16725,9 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent "t4"
-    id		= "t5";
-    desc	= "ATtiny5";
-    signature	= 0x1e 0x8f 0x09;
+    id                  = "t5";
+    desc                = "ATtiny5";
+    signature           = 0x1e 0x8f 0x09;
 ;
 
 #------------------------------------------------------------
@@ -16735,15 +16735,15 @@ part parent "t4"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id		= "t9";
-    desc	= "ATtiny9";
-    signature	= 0x1e 0x90 0x08;
+    id                  = "t9";
+    desc                = "ATtiny9";
+    signature           = 0x1e 0x90 0x08;
 
     memory "flash"
-        size		= 1024;
-        offset		= 0x4000;
-        page_size	= 16;
-        blocksize	= 128;
+        size            = 1024;
+        offset          = 0x4000;
+        page_size       = 16;
+        blocksize       = 128;
     ;
 ;
 
@@ -16752,9 +16752,9 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent "t9"
-    id		= "t10";
-    desc	= "ATtiny10";
-    signature	= 0x1e 0x90 0x03;
+    id                  = "t10";
+    desc                = "ATtiny10";
+    signature           = 0x1e 0x90 0x03;
 ;
 
 #------------------------------------------------------------
@@ -16762,9 +16762,9 @@ part parent "t9"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id          = "t20";
-    desc        = "ATtiny20";
-    signature   = 0x1e 0x91 0x0F;
+    id                  = "t20";
+    desc                = "ATtiny20";
+    signature           = 0x1e 0x91 0x0F;
 
     memory "flash"
         size            = 2048;
@@ -16779,15 +16779,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id		= "t40";
-    desc	= "ATtiny40";
-    signature	= 0x1e 0x92 0x0E;
+    id                  = "t40";
+    desc                = "ATtiny40";
+    signature           = 0x1e 0x92 0x0E;
 
     memory "flash"
-        size		= 4096;
-        offset		= 0x4000;
-        page_size	= 64;
-        blocksize	= 128;
+        size            = 4096;
+        offset          = 0x4000;
+        page_size       = 64;
+        blocksize       = 128;
     ;
 ;
 
@@ -16796,15 +16796,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id    = "t102";
-    desc  = "ATtiny102";
-    signature = 0x1e 0x90 0x0C;
+    id                  = "t102";
+    desc                = "ATtiny102";
+    signature           = 0x1e 0x90 0x0C;
 
     memory "flash"
-        size    = 1024;
-        offset    = 0x4000;
-        page_size = 16;
-        blocksize = 128;
+        size            = 1024;
+        offset          = 0x4000;
+        page_size       = 16;
+        blocksize       = 128;
     ;
 ;
 
@@ -16813,15 +16813,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id    = "t104";
-    desc  = "ATtiny104";
-    signature = 0x1e 0x90 0x0B;
+    id                  = "t104";
+    desc                = "ATtiny104";
+    signature           = 0x1e 0x90 0x0B;
 
     memory "flash"
-        size    = 1024;
-        offset    = 0x4000;
-        page_size = 16;
-        blocksize = 128;
+        size            = 1024;
+        offset          = 0x4000;
+        page_size       = 16;
+        blocksize       = 128;
     ;
 ;
 
@@ -16830,47 +16830,47 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part
-    id				= "m406";
-    desc			= "ATmega406";
-    has_jtag			= yes;
-    signature			= 0x1e 0x95 0x07;
+    id                  = "m406";
+    desc                = "ATmega406";
+    has_jtag            = yes;
+    signature           = 0x1e 0x95 0x07;
 
     # STK500 parameters (parallel programming IO lines)
-    pagel			= 0xa7;
-    bs2				= 0xa0;
-    serial			= no;
-    parallel			= yes;
+    pagel               = 0xa7;
+    bs2                 = 0xa0;
+    serial              = no;
+    parallel            = yes;
 
     # STK500v2 HV programming parameters, from XML
-    pp_controlstack		= 0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
-				  0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
-				  0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
-				  0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    pp_controlstack     = 0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+                                  0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+                                  0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+                                  0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
 
     # JTAG ICE mkII parameters, also from XML files
-    allowfullpagebitstream	= no;
-    enablepageprogramming	= yes;
-    idr				= 0x51;
-    rampz			= 0x00;
-    spmcr			= 0x57;
-    eecr			= 0x3f;
+    allowfullpagebitstream = no;
+    enablepageprogramming = yes;
+    idr                 = 0x51;
+    rampz               = 0x00;
+    spmcr               = 0x57;
+    eecr                = 0x3f;
 
     memory "eeprom"
-        paged		= no;
-        size		= 512;
-        page_size	= 4;
-        blocksize	= 4;
-	readsize	= 4;
-        num_pages	= 128;
+        paged           = no;
+        size            = 512;
+        page_size       = 4;
+        blocksize       = 4;
+        readsize        = 4;
+        num_pages       = 128;
     ;
 
     memory "flash"
-        paged		= yes;
-        size		= 40960;
-        page_size	= 128;
-        blocksize	= 128;
-	readsize	= 128;
-        num_pages	= 320;
+        paged           = yes;
+        size            = 40960;
+        page_size       = 128;
+        blocksize       = 128;
+        readsize        = 128;
+        num_pages       = 320;
     ;
 
     memory "hfuse"
@@ -16882,7 +16882,7 @@ part
     ;
 
     memory "lockbits"
-        size		= 1;
+        size            = 1;
     ;
 
     memory "signature"
@@ -16895,72 +16895,72 @@ part
 #------------------------------------------------------------
 
 part
-    id		= ".avr8x";
-    desc	= "AVR8X family common values";
-    has_updi	= yes;
-    nvm_base	= 0x1000;
-    ocd_base	= 0x0F80;
+    id                  = ".avr8x";
+    desc                = "AVR8X family common values";
+    has_updi            = yes;
+    nvm_base    = 0x1000;
+    ocd_base    = 0x0F80;
 
     memory "signature"
-        size		= 3;
-        offset		= 0x1100;
-        readsize	= 0x3;
+        size            = 3;
+        offset          = 0x1100;
+        readsize        = 0x3;
     ;
 
     memory "prodsig"
-        size		= 0x3D;
-        offset		= 0x1103;
-        page_size	= 0x3D;
-        readsize	= 0x3D;
+        size            = 0x3D;
+        offset          = 0x1103;
+        page_size       = 0x3D;
+        readsize        = 0x3D;
     ;
 
     memory "sernum"
-        size		= 10;
-        offset		= 0x1104;
-        readsize	= 1;
+        size            = 10;
+        offset          = 0x1104;
+        readsize        = 1;
     ;
 
     memory "osccal16"
-        size		= 2;
-        offset		= 0x1118;
-        readsize	= 1;
+        size            = 2;
+        offset          = 0x1118;
+        readsize        = 1;
     ;
 
     memory "osccal20"
-        size		= 2;
-        offset		= 0x111A;
-        readsize	= 1;
+        size            = 2;
+        offset          = 0x111A;
+        readsize        = 1;
     ;
 
     memory "tempsense"
-        size		= 2;
-        offset		= 0x1120;
-        readsize	= 1;
+        size            = 2;
+        offset          = 0x1120;
+        readsize        = 1;
     ;
 
     memory "osc16err"
-        size		= 2;
-        offset		= 0x1122;
-        readsize	= 1;
+        size            = 2;
+        offset          = 0x1122;
+        readsize        = 1;
     ;
 
     memory "osc20err"
-        size		= 2;
-        offset		= 0x1124;
-        readsize	= 1;
+        size            = 2;
+        offset          = 0x1124;
+        readsize        = 1;
     ;
 
     memory "fuses"
-        size		= 9;
-        offset		= 0x1280;
-        page_size = 0x0A;
-        readsize  = 0x0A;
+        size            = 9;
+        offset          = 0x1280;
+        page_size       = 0x0A;
+        readsize        = 0x0A;
     ;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x1280;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1280;
+        readsize        = 1;
     ;
 
     memory "wdtcfg"
@@ -16968,9 +16968,9 @@ part
     ;
 
     memory "fuse1"
-        size		= 1;
-        offset		= 0x1281;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1281;
+        readsize        = 1;
     ;
 
     memory "bodcfg"
@@ -16978,9 +16978,9 @@ part
     ;
 
     memory "fuse2"
-        size		= 1;
-        offset		= 0x1282;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1282;
+        readsize        = 1;
     ;
 
     memory "osccfg"
@@ -16988,9 +16988,9 @@ part
     ;
 
     memory "fuse4"
-        size		= 1;
-        offset		= 0x1284;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1284;
+        readsize        = 1;
     ;
 
     memory "tcd0cfg"
@@ -16998,9 +16998,9 @@ part
     ;
 
     memory "fuse5"
-        size		= 1;
-        offset		= 0x1285;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1285;
+        readsize        = 1;
     ;
 
     memory "syscfg0"
@@ -17008,9 +17008,9 @@ part
     ;
 
     memory "fuse6"
-        size		= 1;
-        offset		= 0x1286;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1286;
+        readsize        = 1;
     ;
 
     memory "syscfg1"
@@ -17018,9 +17018,9 @@ part
     ;
 
     memory "fuse7"
-        size		= 1;
-        offset		= 0x1287;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1287;
+        readsize        = 1;
     ;
 
     memory "append"
@@ -17032,9 +17032,9 @@ part
     ;
 
     memory "fuse8"
-        size		= 1;
-        offset		= 0x1288;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1288;
+        readsize        = 1;
     ;
 
     memory "bootend"
@@ -17046,14 +17046,14 @@ part
     ;
 
     memory "lock"
-        size		= 1;
-        offset		= 0x128a;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x128a;
+        readsize        = 1;
     ;
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset		= 0x1000000;
+        offset          = 0x1000000;
     ;
 ;
 
@@ -17062,15 +17062,15 @@ part
 #------------------------------------------------------------
 
 part parent    ".avr8x"
-    id			= ".avr8x_tiny";
-    desc		= "AVR8X tiny family common values";
-    family_id	= "tinyAVR";
+    id                  = ".avr8x_tiny";
+    desc                = "AVR8X tiny family common values";
+    family_id   = "tinyAVR";
 
     memory "userrow"
-        size		= 0x20;
-        offset		= 0x1300;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 0x20;
+        offset          = 0x1300;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
@@ -17083,15 +17083,15 @@ part parent    ".avr8x"
 #------------------------------------------------------------
 
 part parent    ".avr8x"
-    id			= ".avr8x_mega";
-    desc		= "AVR8X mega family common values";
-    family_id	= "megaAVR";
+    id                  = ".avr8x_mega";
+    desc                = "AVR8X mega family common values";
+    family_id   = "megaAVR";
 
     memory "userrow"
-        size		= 0x40;
-        offset		= 0x1300;
-        page_size	= 0x40;
-        readsize	= 0x100;
+        size            = 0x40;
+        offset          = 0x1300;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "usersig"
@@ -17104,22 +17104,22 @@ part parent    ".avr8x"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t202";
-    desc      = "ATtiny202";
-    signature = 0x1E 0x91 0x23;
+    id                  = "t202";
+    desc                = "ATtiny202";
+    signature           = 0x1E 0x91 0x23;
 
     memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x800;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x40;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17128,22 +17128,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t204";
-    desc      = "ATtiny204";
-    signature = 0x1E 0x91 0x22;
+    id                  = "t204";
+    desc                = "ATtiny204";
+    signature           = 0x1E 0x91 0x22;
 
     memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x800;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x40;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17152,22 +17152,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t402";
-    desc      = "ATtiny402";
-    signature = 0x1E 0x92 0x27;
+    id                  = "t402";
+    desc                = "ATtiny402";
+    signature           = 0x1E 0x92 0x27;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17176,22 +17176,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t404";
-    desc      = "ATtiny404";
-    signature = 0x1E 0x92 0x26;
+    id                  = "t404";
+    desc                = "ATtiny404";
+    signature           = 0x1E 0x92 0x26;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17200,22 +17200,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t406";
-    desc      = "ATtiny406";
-    signature = 0x1E 0x92 0x25;
+    id                  = "t406";
+    desc                = "ATtiny406";
+    signature           = 0x1E 0x92 0x25;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17224,22 +17224,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t804";
-    desc      = "ATtiny804";
-    signature = 0x1E 0x93 0x25;
+    id                  = "t804";
+    desc                = "ATtiny804";
+    signature           = 0x1E 0x93 0x25;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17248,22 +17248,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t806";
-    desc      = "ATtiny806";
-    signature = 0x1E 0x93 0x24;
+    id                  = "t806";
+    desc                = "ATtiny806";
+    signature           = 0x1E 0x93 0x24;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17272,22 +17272,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t807";
-    desc      = "ATtiny807";
-    signature = 0x1E 0x93 0x23;
+    id                  = "t807";
+    desc                = "ATtiny807";
+    signature           = 0x1E 0x93 0x23;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17296,22 +17296,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1604";
-    desc      = "ATtiny1604";
-    signature = 0x1E 0x94 0x25;
+    id                  = "t1604";
+    desc                = "ATtiny1604";
+    signature           = 0x1E 0x94 0x25;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17320,22 +17320,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1606";
-    desc      = "ATtiny1606";
-    signature = 0x1E 0x94 0x24;
+    id                  = "t1606";
+    desc                = "ATtiny1606";
+    signature           = 0x1E 0x94 0x24;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17344,22 +17344,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1607";
-    desc      = "ATtiny1607";
-    signature = 0x1E 0x94 0x23;
+    id                  = "t1607";
+    desc                = "ATtiny1607";
+    signature           = 0x1E 0x94 0x23;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17368,22 +17368,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t212";
-    desc      = "ATtiny212";
-    signature = 0x1E 0x91 0x21;
+    id                  = "t212";
+    desc                = "ATtiny212";
+    signature           = 0x1E 0x91 0x21;
 
     memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x800;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x40;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17392,22 +17392,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t214";
-    desc      = "ATtiny214";
-    signature = 0x1E 0x91 0x20;
+    id                  = "t214";
+    desc                = "ATtiny214";
+    signature           = 0x1E 0x91 0x20;
 
     memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x800;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x40;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17416,22 +17416,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t412";
-    desc      = "ATtiny412";
-    signature = 0x1E 0x92 0x23;
+    id                  = "t412";
+    desc                = "ATtiny412";
+    signature           = 0x1E 0x92 0x23;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17441,22 +17441,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t414";
-    desc      = "ATtiny414";
-    signature = 0x1E 0x92 0x22;
+    id                  = "t414";
+    desc                = "ATtiny414";
+    signature           = 0x1E 0x92 0x22;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17465,22 +17465,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t416";
-    desc      = "ATtiny416";
-    signature = 0x1E 0x92 0x21;
+    id                  = "t416";
+    desc                = "ATtiny416";
+    signature           = 0x1E 0x92 0x21;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17490,22 +17490,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t417";
-    desc      = "ATtiny417";
-    signature = 0x1E 0x92 0x20;
+    id                  = "t417";
+    desc                = "ATtiny417";
+    signature           = 0x1E 0x92 0x20;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17515,22 +17515,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t814";
-    desc      = "ATtiny814";
-    signature = 0x1E 0x93 0x22;
+    id                  = "t814";
+    desc                = "ATtiny814";
+    signature           = 0x1E 0x93 0x22;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17540,22 +17540,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t816";
-    desc      = "ATtiny816";
-    signature = 0x1E 0x93 0x21;
+    id                  = "t816";
+    desc                = "ATtiny816";
+    signature           = 0x1E 0x93 0x21;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17564,22 +17564,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t817";
-    desc      = "ATtiny817";
-    signature = 0x1E 0x93 0x20;
+    id                  = "t817";
+    desc                = "ATtiny817";
+    signature           = 0x1E 0x93 0x20;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17588,22 +17588,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1614";
-    desc      = "ATtiny1614";
-    signature = 0x1E 0x94 0x22;
+    id                  = "t1614";
+    desc                = "ATtiny1614";
+    signature           = 0x1E 0x94 0x22;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17612,22 +17612,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1616";
-    desc      = "ATtiny1616";
-    signature = 0x1E 0x94 0x21;
+    id                  = "t1616";
+    desc                = "ATtiny1616";
+    signature           = 0x1E 0x94 0x21;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17636,22 +17636,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1617";
-    desc      = "ATtiny1617";
-    signature = 0x1E 0x94 0x20;
+    id                  = "t1617";
+    desc                = "ATtiny1617";
+    signature           = 0x1E 0x94 0x20;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17660,22 +17660,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t3216";
-    desc      = "ATtiny3216";
-    signature = 0x1E 0x95 0x21;
+    id                  = "t3216";
+    desc                = "ATtiny3216";
+    signature           = 0x1E 0x95 0x21;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x8000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17684,22 +17684,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t3217";
-    desc      = "ATtiny3217";
-    signature = 0x1E 0x95 0x22;
+    id                  = "t3217";
+    desc                = "ATtiny3217";
+    signature           = 0x1E 0x95 0x22;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x8000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17708,22 +17708,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t424";
-    desc      = "ATtiny424";
-    signature = 0x1E 0x92 0x2C;
+    id                  = "t424";
+    desc                = "ATtiny424";
+    signature           = 0x1E 0x92 0x2C;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17732,22 +17732,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t426";
-    desc      = "ATtiny426";
-    signature = 0x1E 0x92 0x2B;
+    id                  = "t426";
+    desc                = "ATtiny426";
+    signature           = 0x1E 0x92 0x2B;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17756,22 +17756,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t427";
-    desc      = "ATtiny427";
-    signature = 0x1E 0x92 0x2A;
+    id                  = "t427";
+    desc                = "ATtiny427";
+    signature           = 0x1E 0x92 0x2A;
 
     memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x1000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17780,22 +17780,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t824";
-    desc      = "ATtiny824";
-    signature = 0x1E 0x93 0x29;
+    id                  = "t824";
+    desc                = "ATtiny824";
+    signature           = 0x1E 0x93 0x29;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17804,22 +17804,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t826";
-    desc      = "ATtiny826";
-    signature = 0x1E 0x93 0x28;
+    id                  = "t826";
+    desc                = "ATtiny826";
+    signature           = 0x1E 0x93 0x28;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17828,22 +17828,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t827";
-    desc      = "ATtiny827";
-    signature = 0x1E 0x93 0x27;
+    id                  = "t827";
+    desc                = "ATtiny827";
+    signature           = 0x1E 0x93 0x27;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x80;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17852,22 +17852,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1624";
-    desc      = "ATtiny1624";
-    signature = 0x1E 0x94 0x2A;
+    id                  = "t1624";
+    desc                = "ATtiny1624";
+    signature           = 0x1E 0x94 0x2A;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 #------------------------------------------------------------
@@ -17875,22 +17875,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1626";
-    desc      = "ATtiny1626";
-    signature = 0x1E 0x94 0x29;
+    id                  = "t1626";
+    desc                = "ATtiny1626";
+    signature           = 0x1E 0x94 0x29;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17899,22 +17899,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t1627";
-    desc      = "ATtiny1627";
-    signature = 0x1E 0x94 0x28;
+    id                  = "t1627";
+    desc                = "ATtiny1627";
+    signature           = 0x1E 0x94 0x28;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x8000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17923,22 +17923,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t3224";
-    desc      = "ATtiny3224";
-    signature = 0x1E 0x95 0x28;
+    id                  = "t3224";
+    desc                = "ATtiny3224";
+    signature           = 0x1E 0x95 0x28;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x8000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17947,22 +17947,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t3226";
-    desc      = "ATtiny3226";
-    signature = 0x1E 0x95 0x27;
+    id                  = "t3226";
+    desc                = "ATtiny3226";
+    signature           = 0x1E 0x95 0x27;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x8000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17971,22 +17971,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "t3227";
-    desc      = "ATtiny3227";
-    signature = 0x1E 0x95 0x26;
+    id                  = "t3227";
+    desc                = "ATtiny3227";
+    signature           = 0x1E 0x95 0x26;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x8000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -17995,22 +17995,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "m808";
-    desc      = "ATmega808";
-    signature = 0x1E 0x93 0x26;
+    id                  = "m808";
+    desc                = "ATmega808";
+    signature           = 0x1E 0x93 0x26;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x4000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18019,22 +18019,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "m809";
-    desc      = "ATmega809";
-    signature = 0x1E 0x93 0x2A;
+    id                  = "m809";
+    desc                = "ATmega809";
+    signature           = 0x1E 0x93 0x2A;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x4000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18043,22 +18043,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "m1608";
-    desc      = "ATmega1608";
-    signature = 0x1E 0x94 0x27;
+    id                  = "m1608";
+    desc                = "ATmega1608";
+    signature           = 0x1E 0x94 0x27;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x4000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18067,22 +18067,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_tiny"
-    id        = "m1609";
-    desc      = "ATmega1609";
-    signature = 0x1E 0x94 0x26;
+    id                  = "m1609";
+    desc                = "ATmega1609";
+    signature           = 0x1E 0x94 0x26;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x4000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x20;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18091,22 +18091,22 @@ part parent    ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent    ".avr8x_mega"
-    id        = "m3208";
-    desc      = "ATmega3208";
-    signature = 0x1E 0x95 0x30;
+    id                  = "m3208";
+    desc                = "ATmega3208";
+    signature           = 0x1E 0x95 0x30;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x4000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18115,22 +18115,22 @@ part parent    ".avr8x_mega"
 #------------------------------------------------------------
 
 part parent    ".avr8x_mega"
-    id        = "m3209";
-    desc      = "ATmega3209";
-    signature = 0x1E 0x95 0x31;
+    id                  = "m3209";
+    desc                = "ATmega3209";
+    signature           = 0x1E 0x95 0x31;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x4000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18139,22 +18139,22 @@ part parent    ".avr8x_mega"
 #------------------------------------------------------------
 
 part parent    ".avr8x_mega"
-    id        = "m4808";
-    desc      = "ATmega4808";
-    signature = 0x1E 0x96 0x50;
+    id                  = "m4808";
+    desc                = "ATmega4808";
+    signature           = 0x1E 0x96 0x50;
 
     memory "flash"
-        size      = 0xC000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0xC000;
+        offset          = 0x4000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18163,22 +18163,22 @@ part parent    ".avr8x_mega"
 #------------------------------------------------------------
 
 part parent    ".avr8x_mega"
-    id        = "m4809";
-    desc      = "ATmega4809";
-    signature = 0x1E 0x96 0x51;
+    id                  = "m4809";
+    desc                = "ATmega4809";
+    signature           = 0x1E 0x96 0x51;
 
     memory "flash"
-        size      = 0xC000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0xC000;
+        offset          = 0x4000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18187,48 +18187,48 @@ part parent    ".avr8x_mega"
 #------------------------------------------------------------
 
 part
-    id		= ".avrdx";
-    desc	= "AVR-Dx family common values";
-    has_updi	= yes;
-    nvm_base	= 0x1000;
-    ocd_base	= 0x0F80;
+    id                  = ".avrdx";
+    desc                = "AVR-Dx family common values";
+    has_updi            = yes;
+    nvm_base    = 0x1000;
+    ocd_base    = 0x0F80;
 
     memory "signature"
-        size		= 3;
-        offset		= 0x1100;
-        readsize	= 0x3;
+        size            = 3;
+        offset          = 0x1100;
+        readsize        = 0x3;
     ;
 
     memory "prodsig"
-        size		= 0x7D;
-        offset		= 0x1103;
-        page_size	= 0x7D;
-        readsize	= 0x7D;
+        size            = 0x7D;
+        offset          = 0x1103;
+        page_size       = 0x7D;
+        readsize        = 0x7D;
     ;
 
     memory "tempsense"
-        size		= 2;
-        offset		= 0x1104;
-        readsize	= 1;
+        size            = 2;
+        offset          = 0x1104;
+        readsize        = 1;
     ;
 
     memory "sernum"
-        size		= 16;
-        offset		= 0x1110;
-        readsize	= 1;
+        size            = 16;
+        offset          = 0x1110;
+        readsize        = 1;
     ;
 
     memory "fuses"
-        size		= 9;
-        offset		= 0x1050;
-        page_size = 0x10;
-        readsize  = 0x10;
+        size            = 9;
+        offset          = 0x1050;
+        page_size       = 0x10;
+        readsize        = 0x10;
     ;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x1050;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1050;
+        readsize        = 1;
     ;
 
     memory "wdtcfg"
@@ -18236,9 +18236,9 @@ part
     ;
 
     memory "fuse1"
-        size		= 1;
-        offset		= 0x1051;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1051;
+        readsize        = 1;
     ;
 
     memory "bodcfg"
@@ -18246,9 +18246,9 @@ part
     ;
 
     memory "fuse2"
-        size		= 1;
-        offset		= 0x1052;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1052;
+        readsize        = 1;
     ;
 
     memory "osccfg"
@@ -18256,9 +18256,9 @@ part
     ;
 
     memory "fuse4"
-        size		= 1;
-        offset		= 0x1054;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1054;
+        readsize        = 1;
     ;
 
     memory "tcd0cfg"
@@ -18266,9 +18266,9 @@ part
     ;
 
     memory "fuse5"
-        size		= 1;
-        offset		= 0x1055;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1055;
+        readsize        = 1;
     ;
 
     memory "syscfg0"
@@ -18276,9 +18276,9 @@ part
     ;
 
     memory "fuse6"
-        size		= 1;
-        offset		= 0x1056;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1056;
+        readsize        = 1;
     ;
 
     memory "syscfg1"
@@ -18286,9 +18286,9 @@ part
     ;
 
     memory "fuse7"
-        size		= 1;
-        offset		= 0x1057;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1057;
+        readsize        = 1;
     ;
 
     memory "codesize"
@@ -18300,9 +18300,9 @@ part
     ;
 
     memory "fuse8"
-        size		= 1;
-        offset		= 0x1058;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1058;
+        readsize        = 1;
     ;
 
     memory "bootsize"
@@ -18314,17 +18314,17 @@ part
     ;
 
     memory "lock"
-        size		= 4;
-        offset		= 0x1040;
-        page_size = 0x1;
-        readsize  = 0x4;
+        size            = 4;
+        offset          = 0x1040;
+        page_size       = 0x1;
+        readsize        = 0x4;
     ;
 
     memory "userrow"
-        size      = 0x20;
-        offset    = 0x1080;
-        page_size = 0x20;
-        readsize  = 0x20;
+        size            = 0x20;
+        offset          = 0x1080;
+        page_size       = 0x20;
+        readsize        = 0x20;
     ;
 
     memory "usersig"
@@ -18333,7 +18333,7 @@ part
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset		= 0x1000000;
+        offset          = 0x1000000;
     ;
 ;
 
@@ -18342,22 +18342,22 @@ part
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32da28";
-    desc      = "AVR32DA28";
-    signature = 0x1E 0x95 0x34;
+    id                  = "avr32da28";
+    desc                = "AVR32DA28";
+    signature           = 0x1E 0x95 0x34;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18366,22 +18366,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32da32";
-    desc      = "AVR32DA32";
-    signature = 0x1E 0x95 0x33;
+    id                  = "avr32da32";
+    desc                = "AVR32DA32";
+    signature           = 0x1E 0x95 0x33;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18390,22 +18390,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32da48";
-    desc      = "AVR32DA48";
-    signature = 0x1E 0x95 0x32;
+    id                  = "avr32da48";
+    desc                = "AVR32DA48";
+    signature           = 0x1E 0x95 0x32;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18414,22 +18414,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64da28";
-    desc      = "AVR64DA28";
-    signature = 0x1E 0x96 0x15;
+    id                  = "avr64da28";
+    desc                = "AVR64DA28";
+    signature           = 0x1E 0x96 0x15;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18438,22 +18438,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64da32";
-    desc      = "AVR64DA32";
-    signature = 0x1E 0x96 0x14;
+    id                  = "avr64da32";
+    desc                = "AVR64DA32";
+    signature           = 0x1E 0x96 0x14;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18462,22 +18462,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64da48";
-    desc      = "AVR64DA48";
-    signature = 0x1E 0x96 0x13;
+    id                  = "avr64da48";
+    desc                = "AVR64DA48";
+    signature           = 0x1E 0x96 0x13;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18486,22 +18486,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64da64";
-    desc      = "AVR64DA64";
-    signature = 0x1E 0x96 0x12;
+    id                  = "avr64da64";
+    desc                = "AVR64DA64";
+    signature           = 0x1E 0x96 0x12;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18510,22 +18510,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128da28";
-    desc      = "AVR128DA28";
-    signature = 0x1E 0x97 0x0A;
+    id                  = "avr128da28";
+    desc                = "AVR128DA28";
+    signature           = 0x1E 0x97 0x0A;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18534,22 +18534,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128da32";
-    desc      = "AVR128DA32";
-    signature = 0x1E 0x97 0x09;
+    id                  = "avr128da32";
+    desc                = "AVR128DA32";
+    signature           = 0x1E 0x97 0x09;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18558,22 +18558,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128da48";
-    desc      = "AVR128DA48";
-    signature = 0x1E 0x97 0x08;
+    id                  = "avr128da48";
+    desc                = "AVR128DA48";
+    signature           = 0x1E 0x97 0x08;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18582,22 +18582,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128da64";
-    desc      = "AVR128DA64";
-    signature = 0x1E 0x97 0x07;
+    id                  = "avr128da64";
+    desc                = "AVR128DA64";
+    signature           = 0x1E 0x97 0x07;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18606,22 +18606,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32db28";
-    desc      = "AVR32DB28";
-    signature = 0x1E 0x95 0x37;
+    id                  = "avr32db28";
+    desc                = "AVR32DB28";
+    signature           = 0x1E 0x95 0x37;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18630,22 +18630,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32db32";
-    desc      = "AVR32DB32";
-    signature = 0x1E 0x95 0x36;
+    id                  = "avr32db32";
+    desc                = "AVR32DB32";
+    signature           = 0x1E 0x95 0x36;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18654,22 +18654,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32db48";
-    desc      = "AVR32DB48";
-    signature = 0x1E 0x95 0x35;
+    id                  = "avr32db48";
+    desc                = "AVR32DB48";
+    signature           = 0x1E 0x95 0x35;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18678,22 +18678,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64db28";
-    desc      = "AVR64DB28";
-    signature = 0x1E 0x96 0x19;
+    id                  = "avr64db28";
+    desc                = "AVR64DB28";
+    signature           = 0x1E 0x96 0x19;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18702,22 +18702,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64db32";
-    desc      = "AVR64DB32";
-    signature = 0x1E 0x96 0x18;
+    id                  = "avr64db32";
+    desc                = "AVR64DB32";
+    signature           = 0x1E 0x96 0x18;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18726,22 +18726,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64db48";
-    desc      = "AVR64DB48";
-    signature = 0x1E 0x96 0x17;
+    id                  = "avr64db48";
+    desc                = "AVR64DB48";
+    signature           = 0x1E 0x96 0x17;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18750,22 +18750,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64db64";
-    desc      = "AVR64DB64";
-    signature = 0x1E 0x96 0x16;
+    id                  = "avr64db64";
+    desc                = "AVR64DB64";
+    signature           = 0x1E 0x96 0x16;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18774,22 +18774,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128db28";
-    desc      = "AVR128DB28";
-    signature = 0x1E 0x97 0x0E;
+    id                  = "avr128db28";
+    desc                = "AVR128DB28";
+    signature           = 0x1E 0x97 0x0E;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18798,22 +18798,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128db32";
-    desc      = "AVR128DB32";
-    signature = 0x1E 0x97 0x0D;
+    id                  = "avr128db32";
+    desc                = "AVR128DB32";
+    signature           = 0x1E 0x97 0x0D;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18822,22 +18822,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128db48";
-    desc      = "AVR128DB48";
-    signature = 0x1E 0x97 0x0C;
+    id                  = "avr128db48";
+    desc                = "AVR128DB48";
+    signature           = 0x1E 0x97 0x0C;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18846,22 +18846,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr128db64";
-    desc      = "AVR128DB64";
-    signature = 0x1E 0x97 0x0B;
+    id                  = "avr128db64";
+    desc                = "AVR128DB64";
+    signature           = 0x1E 0x97 0x0B;
 
     memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x20000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18870,22 +18870,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr16dd14";
-    desc      = "AVR16DD14";
-    signature = 0x1E 0x94 0x34;
+    id                  = "avr16dd14";
+    desc                = "AVR16DD14";
+    signature           = 0x1E 0x94 0x34;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18894,22 +18894,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr16dd20";
-    desc      = "AVR16DD20";
-    signature = 0x1E 0x94 0x33;
+    id                  = "avr16dd20";
+    desc                = "AVR16DD20";
+    signature           = 0x1E 0x94 0x33;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18918,22 +18918,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr16dd28";
-    desc      = "AVR16DD28";
-    signature = 0x1E 0x94 0x32;
+    id                  = "avr16dd28";
+    desc                = "AVR16DD28";
+    signature           = 0x1E 0x94 0x32;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18942,22 +18942,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr16dd32";
-    desc      = "AVR16DD32";
-    signature = 0x1E 0x94 0x31;
+    id                  = "avr16dd32";
+    desc                = "AVR16DD32";
+    signature           = 0x1E 0x94 0x31;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18966,22 +18966,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32dd14";
-    desc      = "AVR32DD14";
-    signature = 0x1E 0x95 0x3B;
+    id                  = "avr32dd14";
+    desc                = "AVR32DD14";
+    signature           = 0x1E 0x95 0x3B;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -18990,22 +18990,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32dd20";
-    desc      = "AVR32DD20";
-    signature = 0x1E 0x95 0x3A;
+    id                  = "avr32dd20";
+    desc                = "AVR32DD20";
+    signature           = 0x1E 0x95 0x3A;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19014,22 +19014,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32dd28";
-    desc      = "AVR32DD28";
-    signature = 0x1E 0x95 0x39;
+    id                  = "avr32dd28";
+    desc                = "AVR32DD28";
+    signature           = 0x1E 0x95 0x39;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19038,22 +19038,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr32dd32";
-    desc      = "AVR32DD32";
-    signature = 0x1E 0x95 0x38;
+    id                  = "avr32dd32";
+    desc                = "AVR32DD32";
+    signature           = 0x1E 0x95 0x38;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19062,22 +19062,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64dd14";
-    desc      = "AVR64DD14";
-    signature = 0x1E 0x96 0x1D;
+    id                  = "avr64dd14";
+    desc                = "AVR64DD14";
+    signature           = 0x1E 0x96 0x1D;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19086,22 +19086,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64dd20";
-    desc      = "AVR64DD20";
-    signature = 0x1E 0x96 0x1C;
+    id                  = "avr64dd20";
+    desc                = "AVR64DD20";
+    signature           = 0x1E 0x96 0x1C;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19110,22 +19110,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64dd28";
-    desc      = "AVR64DD28";
-    signature = 0x1E 0x96 0x1B;
+    id                  = "avr64dd28";
+    desc                = "AVR64DD28";
+    signature           = 0x1E 0x96 0x1B;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19134,22 +19134,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id        = "avr64dd32";
-    desc      = "AVR64DD32";
-    signature = 0x1E 0x96 0x1A;
+    id                  = "avr64dd32";
+    desc                = "AVR64DD32";
+    signature           = 0x1E 0x96 0x1A;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x200;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 0x100;
+        offset          = 0x1400;
+        page_size       = 0x1;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19158,14 +19158,14 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrdx"
-    id			= ".avrex";
-    desc		= "AVR-Ex family common values";
+    id                  = ".avrex";
+    desc                = "AVR-Ex family common values";
 
     memory "userrow"
-        size      = 0x40;
-        offset    = 0x1080;
-        page_size = 0x40;
-        readsize  = 0x40;
+        size            = 0x40;
+        offset          = 0x1080;
+        page_size       = 0x40;
+        readsize        = 0x40;
     ;
 
     memory "usersig"
@@ -19178,22 +19178,22 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr8ea28";
-    desc      = "AVR8EA28";
-    signature = 0x1E 0x93 0x2C;
+    id                  = "avr8ea28";
+    desc                = "AVR8EA28";
+    signature           = 0x1E 0x93 0x2C;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19202,22 +19202,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr8ea32";
-    desc      = "AVR8EA32";
-    signature = 0x1E 0x93 0x2B;
+    id                  = "avr8ea32";
+    desc                = "AVR8EA32";
+    signature           = 0x1E 0x93 0x2B;
 
     memory "flash"
-        size      = 0x2000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x2000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19226,22 +19226,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr16ea28";
-    desc      = "AVR16EA28";
-    signature = 0x1E 0x94 0x37;
+    id                  = "avr16ea28";
+    desc                = "AVR16EA28";
+    signature           = 0x1E 0x94 0x37;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19250,22 +19250,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr16ea32";
-    desc      = "AVR16EA32";
-    signature = 0x1E 0x94 0x36;
+    id                  = "avr16ea32";
+    desc                = "AVR16EA32";
+    signature           = 0x1E 0x94 0x36;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19274,22 +19274,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr16ea48";
-    desc      = "AVR16EA48";
-    signature = 0x1E 0x94 0x35;
+    id                  = "avr16ea48";
+    desc                = "AVR16EA48";
+    signature           = 0x1E 0x94 0x35;
 
     memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x4000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19298,22 +19298,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr32ea28";
-    desc      = "AVR32EA28";
-    signature = 0x1E 0x95 0x3E;
+    id                  = "avr32ea28";
+    desc                = "AVR32EA28";
+    signature           = 0x1E 0x95 0x3E;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19322,22 +19322,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr32ea32";
-    desc      = "AVR32EA32";
-    signature = 0x1E 0x95 0x3D;
+    id                  = "avr32ea32";
+    desc                = "AVR32EA32";
+    signature           = 0x1E 0x95 0x3D;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19346,22 +19346,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr32ea48";
-    desc      = "AVR32EA48";
-    signature = 0x1E 0x95 0x3C;
+    id                  = "avr32ea48";
+    desc                = "AVR32EA48";
+    signature           = 0x1E 0x95 0x3C;
 
     memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 0x8000;
+        offset          = 0x800000;
+        page_size       = 0x40;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19370,22 +19370,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr64ea28";
-    desc      = "AVR64EA28";
-    signature = 0x1E 0x96 0x20;
+    id                  = "avr64ea28";
+    desc                = "AVR64EA28";
+    signature           = 0x1E 0x96 0x20;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19394,22 +19394,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr64ea32";
-    desc      = "AVR64EA32";
-    signature = 0x1E 0x96 0x1F;
+    id                  = "avr64ea32";
+    desc                = "AVR64EA32";
+    signature           = 0x1E 0x96 0x1F;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19418,22 +19418,22 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent    ".avrex"
-    id        = "avr64ea48";
-    desc      = "AVR64EA48";
-    signature = 0x1E 0x96 0x1E;
+    id                  = "avr64ea48";
+    desc                = "AVR64EA48";
+    signature           = 0x1E 0x96 0x1E;
 
     memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x80;
-        readsize  = 0x100;
+        size            = 0x10000;
+        offset          = 0x800000;
+        page_size       = 0x80;
+        readsize        = 0x100;
     ;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 0x200;
+        offset          = 0x1400;
+        page_size       = 0x8;
+        readsize        = 0x100;
     ;
 ;
 
@@ -19442,25 +19442,25 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "lgt8f88p";
-    desc             = "LGT8F88P";
-    signature        = 0x1e 0x93 0x0f;
+    id                  = "lgt8f88p";
+    desc                = "LGT8F88P";
+    signature           = 0x1e 0x93 0x0f;
 
     ocdrev              = 1;
-  ;
+;
 
 part parent "m168"
-    id              = "lgt8f168p";
-    desc            = "LGT8F168P";
-    signature       = 0x1e 0x94 0x0b;
+    id                  = "lgt8f168p";
+    desc                = "LGT8F168P";
+    signature           = 0x1e 0x94 0x0b;
 
     ocdrev              = 1;
 ;
 
 part parent "m328"
-    id      = "lgt8f328p";
-    desc    = "LGT8F328P";
-    signature   = 0x1e 0x95 0x0F;
+    id                  = "lgt8f328p";
+    desc                = "LGT8F328P";
+    signature           = 0x1e 0x95 0x0F;
 
     ocdrev              = 1;
 ;

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1819,7 +1819,7 @@ static OPCODE *op_addr_suggest(char *desc, OPCODE *op, int opnum, int mem_nbytes
 
   ret = malloc(sizeof *ret);
   if(!ret) {
-    avrdude_message(MSG_INFO, "op_addr_check(): out of memory\n");
+    avrdude_message(MSG_INFO, "op_addr_suggest(): out of memory\n");
     exit(1);
   }
   memcpy(ret, op, sizeof *ret);
@@ -1859,7 +1859,7 @@ static int op_diff_forgivable(OPCODE *opshould, OPCODE *opis) {
     if(memcmp(&opshould->bit[i], &opis->bit[i], sizeof opshould->bit[i])) { /* command bit i different? */
       errors++;
       if(i >= 8 && i < 24)
-        if(opshould->bit[i].type == AVR_CMDBIT_VALUE && opis->bit[i].type == AVR_CMDBIT_ADDRESS)
+        if((opshould->bit[i].type == AVR_CMDBIT_VALUE || opshould->bit[i].type == AVR_CMDBIT_IGNORE) && opis->bit[i].type == AVR_CMDBIT_ADDRESS)
           forgivable++;
     }
   }

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -45,7 +45,7 @@ int yywarning(char * errmsg, ...);
 static int assign_pin(int pinno, TOKEN * v, int invert);
 static int assign_pin_list(int invert);
 static int which_opcode(TOKEN * opcode);
-static int parse_cmdbits(OPCODE * op);
+static int parse_cmdbits(OPCODE * op, int opnum);
 
 static int pin_name;
 %}
@@ -1267,7 +1267,8 @@ part_parm :
         free_token($1);
         YYABORT;
       }
-      if(0 != parse_cmdbits(op)) YYABORT;
+      if(0 != parse_cmdbits(op, opnum))
+        YYABORT;
       if (current_part->op[opnum] != NULL) {
         /*yywarning("operation redefined");*/
         avr_free_opcode(current_part->op[opnum]);
@@ -1405,7 +1406,8 @@ mem_spec :
         free_token($1);
         YYABORT;
       }
-      if(0 != parse_cmdbits(op)) YYABORT;
+      if(0 != parse_cmdbits(op, opnum))
+        YYABORT;
       if (current_mem->op[opnum] != NULL) {
         /*yywarning("operation redefined");*/
         avr_free_opcode(current_mem->op[opnum]);
@@ -1529,7 +1531,7 @@ static int which_opcode(TOKEN * opcode)
 }
 
 
-static int parse_cmdbits(OPCODE * op)
+static int parse_cmdbits(OPCODE * op, int opnum)
 {
   TOKEN * t;
   int bitno;
@@ -1585,7 +1587,10 @@ static int parse_cmdbits(OPCODE * op)
           case 'a':
             op->bit[bitno].type  = AVR_CMDBIT_ADDRESS;
             op->bit[bitno].value = 0;
-            op->bit[bitno].bitno = 8*(bitno/8) + bitno % 8;
+            op->bit[bitno].bitno = bitno < 8 || bitno > 23? 0:
+              opnum == AVR_OP_LOAD_EXT_ADDR? bitno+8: bitno-8; /* correct bit number for lone 'a' */
+            if(bitno < 8 || bitno > 23)
+              yywarning("address bits don't normally appear in Byte 0 or Byte 3 of SPI programming commands");
             break;
           case 'i':
             op->bit[bitno].type  = AVR_CMDBIT_INPUT;

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1629,5 +1629,8 @@ static int parse_cmdbits(OPCODE * op)
 
   }  /* while */
 
+  if(bitno > 0)
+    yywarning("too few opcode bits in instruction");
+
   return rv;
 }


### PR DESCRIPTION
Makes avrdude warn about SPI programming command definitions in `.conf` with too few bits or with incorrect address bits; two levels of warning exist:
 - Standard (no -v needed) if address bits miss or are wrong, and thus would make the SPI command fail
 - When -v is given also warns about superfluous address bits in the command that are unlikely to affect functionality

Ensures that a lone `a` in SPI programming commands uses the correct address bit number (depending on its position in the command). This includes `load_ext_addr` and considers the use of word addresses in flash memories and byte addresses everywhere else. The previous initialisation for lone `a` was not helpful, which may be the reason why it never could have been, and indeed never was, used in `.conf` files.

Also repairs the `avrdude.conf.in` file for the serious errors mentioned in Issue #915, most of which avrdude now warns about. 

This PR addresses two types of *human error* that have kept appearing in the `.conf` files:
  1. Wrong assignment of address lines in `a` bits or missing address bits
  2. Opening a memory section to modify parameters in a `parent` inherited part description (in fact it zaps all parameters first)

The reason why `avrdude -v` warns about superfluous address bit errors in SPI commands is that these indicate copy/paste errors that warrant a further look at the description.

Limitations of the PR:  The first type of human error is now thoroughly handled in that avrdude warns when it sees this behaviour, and that the current `.conf` file has been scrubbed of these errors. The second problem is only partially handled by this PR in that only some obvious errors affecting some 5 parts have been corrected in `.conf`.
