### PR TITLE
Fix Issue #918

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -282,6 +282,16 @@ int avr_read_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
 int avr_mem_hiaddr(AVRMEM * mem)
 {
   int i, n;
+  static int disableffopt;
+
+  /* calling once with NULL disables any future trailing-0xff optimisation */
+  if(!mem) {
+    disableffopt = 1;
+    return 0;
+  }
+
+  if(disableffopt)
+    return mem->size;
 
   /* return the highest non-0xff address regardless of how much
      memory was read */

--- a/src/avr.c
+++ b/src/avr.c
@@ -278,6 +278,7 @@ int avr_read_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
  * value. This is useful for determining where to stop when dealing
  * with "flash" memory, since writing 0xff to flash is typically a
  * no-op. Always return an even number since flash is word addressed.
+ * Only apply this optimisation on flash-type memory.
  */
 int avr_mem_hiaddr(AVRMEM * mem)
 {
@@ -291,6 +292,13 @@ int avr_mem_hiaddr(AVRMEM * mem)
   }
 
   if(disableffopt)
+    return mem->size;
+
+  /* if the memory is not a flash-type memory do not remove trailing 0xff */
+  if(strcasecmp(mem->desc, "flash") &&
+     strcasecmp(mem->desc, "application") &&
+     strcasecmp(mem->desc, "apptable") &&
+     strcasecmp(mem->desc, "boot"))
     return mem->size;
 
   /* return the highest non-0xff address regardless of how much
@@ -426,15 +434,8 @@ int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype,
       nread++;
       report_progress(nread, npages, NULL);
     }
-    if (!failure) {
-      if (strcasecmp(mem->desc, "flash") == 0 ||
-          strcasecmp(mem->desc, "application") == 0 ||
-          strcasecmp(mem->desc, "apptable") == 0 ||
-          strcasecmp(mem->desc, "boot") == 0)
-        return avr_mem_hiaddr(mem);
-      else
-        return mem->size;
-    }
+    if (!failure)
+      return avr_mem_hiaddr(mem);
     /* else: fall back to byte-at-a-time write, for historical reasons */
   }
 
@@ -464,13 +465,7 @@ int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype,
     report_progress(i, mem->size, NULL);
   }
 
-  if (strcasecmp(mem->desc, "flash") == 0 ||
-      strcasecmp(mem->desc, "application") == 0 ||
-      strcasecmp(mem->desc, "apptable") == 0 ||
-      strcasecmp(mem->desc, "boot") == 0)
-    return avr_mem_hiaddr(mem);
-  else
-    return i;
+  return avr_mem_hiaddr(mem);
 }
 
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1585,21 +1585,14 @@ int fileio(int op, char * filename, FILEFMT format,
       return -1;
   }
 
-  if (rc > 0) {
-    if ((op == FIO_READ) && (strcasecmp(mem->desc, "flash") == 0 ||
-                             strcasecmp(mem->desc, "application") == 0 ||
-                             strcasecmp(mem->desc, "apptable") == 0 ||
-                             strcasecmp(mem->desc, "boot") == 0)) {
-      /*
-       * if we are reading flash, just mark the size as being the
-       * highest non-0xff byte
-       */
-      int hiaddr = avr_mem_hiaddr(mem);
+  /* on reading flash set the size to location of highest non-0xff byte */
+  if (rc > 0 && op == FIO_READ) {
+    int hiaddr = avr_mem_hiaddr(mem);
 
-      if(hiaddr < rc)           /* if trailing-0xff not disabled */
-        rc = hiaddr;
-    }
+    if(hiaddr < rc)             /* if trailing-0xff not disabled */
+      rc = hiaddr;
   }
+
   if (format != FMT_IMM && !using_stdio) {
     fclose(f);
   }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1594,7 +1594,10 @@ int fileio(int op, char * filename, FILEFMT format,
        * if we are reading flash, just mark the size as being the
        * highest non-0xff byte
        */
-      rc = avr_mem_hiaddr(mem);
+      int hiaddr = avr_mem_hiaddr(mem);
+
+      if(hiaddr < rc)           /* if trailing-0xff not disabled */
+        rc = hiaddr;
     }
   }
   if (format != FMT_IMM && !using_stdio) {

--- a/src/main.c
+++ b/src/main.c
@@ -528,6 +528,7 @@ int main(int argc, char * argv [])
 
       case 'D': /* disable auto erase */
         uflags &= ~UF_AUTO_ERASE;
+        avr_mem_hiaddr(NULL); /* disable trailing 0xff optimisation */
         break;
 
       case 'e': /* perform a chip erase */


### PR DESCRIPTION
Piggy-backs "Do not remove trailing 0xff sequences from avr reads or file input" onto option `-D`.

The rationale is that some SPM programmers (bootloaders) are unable to carry out chip erase, but perfectly able to carry out paged writes clearing the memory to 0xff using SPM page erase internally. These SPM programmers need to see the full input file including any trailing 0xff.

This PR provides this functionality under `-D`.

Testing with this [sketch-ending-in-ff.hex](https://github.com/avrdudes/avrdude/files/8421967/sketch-ending-in-ff.txt) now works as it should:

```
$ avrdude -Dqp atmega328p -c arduino -b 115200 -P /dev/ttyUSB0 -U flash:w:sketch-ending-in-ff.hex:i

avrdude: AVR device initialized and ready to accept instructions
avrdude: Device signature = 0x1e950f (probably m328p)
avrdude: reading input file "sketch-ending-in-ff.hex"
avrdude: writing flash (2185 bytes):
avrdude: 2185 bytes of flash written
avrdude: verifying flash memory against sketch-ending-in-ff.hex:
avrdude: 2185 bytes of flash verified

avrdude done.  Thank you.
```

Documentation will be changed when/if this PR is accepted