### PR TITLE
Fix Issue #942: Treat x bits in .conf SPI commands as 0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,7 @@ Changes since version 7.0:
     - adding support for all Linux baud rates v.2 #993
     - Replace internal knowledge in jtag3.c by a public API #996
     - JTAG3 UPDI EEPROM fix #1013
+    - Treat x bits in .conf SPI commands as 0 #943
 
   * Internals:
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -82,11 +82,11 @@ int avr_set_bits(OPCODE * op, unsigned char * cmd)
   unsigned char mask;
 
   for (i=0; i<32; i++) {
-    if (op->bit[i].type == AVR_CMDBIT_VALUE) {
+    if (op->bit[i].type == AVR_CMDBIT_VALUE || op->bit[i].type == AVR_CMDBIT_IGNORE) {
       j = 3 - i / 8;
       bit = i % 8;
       mask = 1 << bit;
-      if (op->bit[i].value)
+      if (op->bit[i].value && op->bit[i].type == AVR_CMDBIT_VALUE)
         cmd[j] = cmd[j] | mask;
       else
         cmd[j] = cmd[j] & ~mask;


### PR DESCRIPTION
Treats don't care bits in SPI programming commands as if they were 0. Avoids uninitialised bits if SPI command had wrongly used an x bit, and makes AVRDUDE behaviour deterministic in this case.