### PR TITLE
Fix `.Dd` macro in manpage

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -18,7 +18,7 @@
 .\"
 .\" $Id$
 .\"
-.Dd DATE November 22, 2021
+.Dd November 22, 2021
 .Os
 .Dt AVRDUDE 1
 .Sh NAME


### PR DESCRIPTION
The correct format for `.Dd` according to **mdoc(7)** is -
```man
.Dd month day, year
```