### PR TITLE
Dragon JTAG fix

### DIFF
--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1840,8 +1840,8 @@ void jtagmkII_close(PROGRAMMER * pgm)
 
   avrdude_message(MSG_NOTICE2, "%s: jtagmkII_close()\n", progname);
 
-  if (pgm->flag & PGM_FL_IS_PDI) {
-    /* When in PDI mode, restart target. */
+  if (pgm->flag & (PGM_FL_IS_PDI | PGM_FL_IS_JTAG)) {
+    /* When in PDI or JTAG mode, restart target. */
     buf[0] = CMND_GO;
     avrdude_message(MSG_NOTICE2, "%s: jtagmkII_close(): Sending GO command: ",
 	      progname);


### PR DESCRIPTION
This simple fix resolves the issue where a connected AVR JTAG target doesn't start its program after programming has occurred. Fix has been tested on real hardware.

Closes #366 and #377