### PR TITLE
Try to run ChipErase on UPDI even if return code is -67

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1118,7 +1118,7 @@ int main(int argc, char * argv [])
       rc = avr_signature(pgm, p);
       if (rc != 0) {
         // -68 == -(0x44) == -(RSP3_FAIL_OCD_LOCKED)
-        if ((rc == -68) && (p->flags & AVRPART_HAS_UPDI) && (attempt < 1)) {
+        if ((rc == -68 || rc == -67) && (p->flags & AVRPART_HAS_UPDI) && (attempt < 1)) {
           attempt++;
           if (pgm->read_sib) {
              // Read SIB and compare FamilyID


### PR DESCRIPTION
More details in https://github.com/arduino/ArduinoCore-megaavr/issues/33#issuecomment-495613256

Co-authored-by: Martino Facchin <m.facchin@arduino.cc>

Related conversation with @MCUdude https://github.com/umbynos/avrdude/commit/b6d21d1c5eef8b9d2f74f37c7c484d066100bf0f#commitcomment-73387352