### PR TITLE
Revert "Ensure page_size is always at least 1"

### DIFF
--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -255,7 +255,6 @@ AVRMEM * avr_new_memtype(void)
   }
 
   memset(m, 0, sizeof(*m));
-  m->page_size = 1; // ensure not 0
 
   return m;
 }

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1308,13 +1308,7 @@ mem_spec :
 
   K_PAGE_SIZE       TKN_EQUAL TKN_NUMBER
     {
-      int ps = $3->value.number;
-      if (ps <= 0)
-        avrdude_message(MSG_INFO,
-                        "%s, line %d: invalid page size %d, ignored\n",
-                        infile, lineno, ps);
-      else
-        current_mem->page_size = ps;
+      current_mem->page_size = $3->value.number;
       free_token($3);
     } |
 


### PR DESCRIPTION
This reverts commit da0e437eaa6fab3a3cc27a1425b06ed7c6f3eb97.

Reason for this revert https://github.com/ElTangas/jtag2updi/issues/16#issuecomment-781645764
We use the jtag2udpi fw on the SAMD11 to be able to program the ATMega4809. That commit was breaking the upload with AVRdude

Related conversation with @MCUdude https://github.com/umbynos/avrdude/commit/9ae854d2ae2b7046f31266b41211bf5e0a5e9bc9#commitcomment-73386063


Co-authored-by: Martino Facchin <m.facchin@arduino.cc>