### PR TITLE
adding support for all Linux baud rates v.2

### DIFF
--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -77,6 +77,45 @@ static struct baud_mapping baud_lookup_table [] = {
 #ifdef B230400
   { 230400, B230400 },
 #endif
+#ifdef B250000
+  { 250000, B250000 },
+#endif
+#ifdef B460800
+  { 460800, B460800 },
+#endif
+#ifdef B500000
+  { 500000, B500000 },
+#endif
+#ifdef B576000
+  { 576000, B576000 },
+#endif
+#ifdef B921600
+  { 921600, B921600 },
+#endif
+#ifdef B1000000
+  { 1000000, B1000000 },
+#endif
+#ifdef B1152000
+  { 1152000, B1152000 },
+#endif
+#ifdef B1500000
+  { 1500000, B1500000 },
+#endif
+#ifdef B2000000
+  { 2000000, B2000000 },
+#endif
+#ifdef B2500000
+  { 2500000, B2500000 },
+#endif
+#ifdef B3000000
+  { 3000000, B3000000 },
+#endif
+#ifdef B3500000
+  { 3500000, B3500000 },
+#endif
+#ifdef B4000000
+  { 4000000, B4000000 },
+#endif
   { 0,      0 }                 /* Terminator. */
 };
 


### PR DESCRIPTION
If optiboot can work at higher bauds, why not avrdude.
Versoin 2 of #985.
Linux uses the old-style bitmapped version of the Bxxxx macros. Most other OSes can pass the baud rate without Bxxx values.