### PR TITLE
Replace internal knowledge in jtag3.c by a public API

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -439,16 +439,16 @@ int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype,
 	(vmem->tags[i] & TAG_ALLOCATED) != 0)
     {
       rc = pgm->read_byte(pgm, p, mem, i, mem->buf + i);
-      if (rc != 0) {
+      if (rc != LIBAVRDUDE_SUCCESS) {
         avrdude_message(MSG_INFO, "avr_read(): error reading address 0x%04lx\n", i);
-        if (rc == -1) {
+        if (rc == LIBAVRDUDE_GENERAL_FAILURE) {
           avrdude_message(MSG_INFO, "    read operation not supported for memory \"%s\"\n",
                           memtype);
-          return -2;
+          return LIBAVRDUDE_NOTSUPPORTED;
         }
         avrdude_message(MSG_INFO, "    read operation failed for memory \"%s\"\n",
                         memtype);
-        return rc;
+        return LIBAVRDUDE_SOFTFAIL;
       }
     }
     report_progress(i, mem->size, NULL);
@@ -1035,14 +1035,14 @@ int avr_signature(PROGRAMMER * pgm, AVRPART * p)
 
   report_progress (0,1,"Reading");
   rc = avr_read(pgm, p, "signature", 0);
-  if (rc < 0) {
+  if (rc < LIBAVRDUDE_SUCCESS) {
     avrdude_message(MSG_INFO, "%s: error reading signature data for part \"%s\", rc=%d\n",
                     progname, p->desc, rc);
     return rc;
   }
   report_progress (1,1,NULL);
 
-  return 0;
+  return LIBAVRDUDE_SUCCESS;
 }
 
 static uint8_t get_fuse_bitmask(AVRMEM * m) {

--- a/src/jtag3_private.h
+++ b/src/jtag3_private.h
@@ -145,6 +145,7 @@
 #  define RSP3_FAIL_UNSUPP_MEMORY       0x34 /* unsupported memory type */
 #  define RSP3_FAIL_WRONG_LENGTH        0x35 /* wrong lenth for mem access */
 #  define RSP3_FAIL_OCD_LOCKED          0x44 /* device is locked */
+#  define RSP3_FAIL_CRC_FAILURE         0x47 /* CRC failure in device */
 #  define RSP3_FAIL_NOT_UNDERSTOOD      0x91
 
 /* ICE events */

--- a/src/jtag3_private.h
+++ b/src/jtag3_private.h
@@ -144,8 +144,8 @@
 #  define RSP3_FAIL_WRONG_MODE          0x32 /* progmode vs. non-prog */
 #  define RSP3_FAIL_UNSUPP_MEMORY       0x34 /* unsupported memory type */
 #  define RSP3_FAIL_WRONG_LENGTH        0x35 /* wrong lenth for mem access */
+#  define RSP3_FAIL_CRC_FAILURE         0x43 /* CRC failure in device */
 #  define RSP3_FAIL_OCD_LOCKED          0x44 /* device is locked */
-#  define RSP3_FAIL_CRC_FAILURE         0x47 /* CRC failure in device */
 #  define RSP3_FAIL_NOT_UNDERSTOOD      0x91
 
 /* ICE events */

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -27,6 +27,16 @@
 #include <stdint.h>
 
 typedef uint32_t pinmask_t;
+/*
+ * Values returned by library functions.
+ * Some library functions also return a count, i.e. a positive
+ * number greater than 0.
+ */
+#define LIBAVRDUDE_SUCCESS 0
+#define LIBAVRDUDE_GENERAL_FAILURE (-1)
+#define LIBAVRDUDE_NOTSUPPORTED (-2) // operation not supported
+#define LIBAVRDUDE_SOFTFAIL (-3) // returned by avr_signature() if caller
+                                 // might proceed with chip erase
 
 /* formerly lists.h */
 

--- a/src/main.c
+++ b/src/main.c
@@ -1116,9 +1116,8 @@ int main(int argc, char * argv [])
     usleep(waittime);
     if (init_ok) {
       rc = avr_signature(pgm, p);
-      if (rc != 0) {
-        // -68 == -(0x44) == -(RSP3_FAIL_OCD_LOCKED)
-        if ((rc == -68) && (p->flags & AVRPART_HAS_UPDI) && (attempt < 1)) {
+      if (rc != LIBAVRDUDE_SUCCESS) {
+        if ((rc == LIBAVRDUDE_SOFTFAIL) && (p->flags & AVRPART_HAS_UPDI) && (attempt < 1)) {
           attempt++;
           if (pgm->read_sib) {
              // Read SIB and compare FamilyID


### PR DESCRIPTION
In certain situations (CRC failure, device locked), that JTAG3
read functions need to return an indication to the caller that
it is OK to proceed, and allow erasing the device anyway.

Historically, the JTAG3 code passed the respective protocol
errors directly (and unexplained) up to the caller, leaving
the decision to the caller how to handle the situation.

Replace that by a more common return value API. New code should
prefer this API instead of any hardcoded return values.

This is an alternative implementation proposal meant to supersede
PR #982