### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 #     cmake --build build
 
 cmake_minimum_required(VERSION 3.12)
-project(avrdude VERSION 7.0)
+project(avrdude VERSION 7.0 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,8 @@ if(WIN32)
 endif()
 
 if(MSVC)
+    enable_language(CXX)
+
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS=1)
     add_compile_definitions(_CRT_NONSTDC_NO_WARNINGS=1)
     add_compile_definitions(_WINSOCK_DEPRECATED_NO_WARNINGS=1)


### PR DESCRIPTION
Fix the following build failure without a C++ compiler:

```
CMake Error at CMakeLists.txt:24 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>