### PR TITLE
Provide file format I: Intel HEX with comments that ignores checksum errors

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -709,6 +709,8 @@ can be one of:
 .Bl -tag -width sss
 .It Ar i
 Intel Hex
+.It Ar I
+Intel Hex with comments on download and tolerance of checksum errors on upload
 .It Ar s
 Motorola S-record
 .It Ar r

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -768,6 +768,9 @@ the file to read or write.  Possible values are:
 @item i
 Intel Hex
 
+@item I
+Intel Hex with comments on download and tolerance of checksum errors on upload
+
 @item s
 Motorola S-record
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -822,7 +822,8 @@ typedef enum {
   FMT_DEC,
   FMT_OCT,
   FMT_BIN,
-  FMT_ELF
+  FMT_ELF,
+  FMT_IHXC,
 } FILEFMT;
 
 struct fioparms {

--- a/src/update.c
+++ b/src/update.c
@@ -130,6 +130,7 @@ UPDATE * parse_op(char * s)
       case 'a': upd->format = FMT_AUTO; break;
       case 's': upd->format = FMT_SREC; break;
       case 'i': upd->format = FMT_IHEX; break;
+      case 'I': upd->format = FMT_IHXC; break;
       case 'r': upd->format = FMT_RBIN; break;
       case 'e': upd->format = FMT_ELF; break;
       case 'm': upd->format = FMT_IMM; break;


### PR DESCRIPTION
The new file type `I` is essentially Intel HEX that, on download, inserts comments next to data records with the resolved effective address and an ASCII dump of that same record. On upload the `I` format is permissive with respect to check sum errors, which is useful, eg, after manipulating an Intel HEX file for debugging.

```
$ avrdude -c usbtiny -qqp m328p -U flash:w:blink.hex:I
$ avrdude -c usbtiny -qqp m328p -U flash:r:-:I | tee b.hex
:2000000033C0000041C000003FC000003DC000003BC0000039C0000037C0000035C0000010 // 00000> 3@..A@..?@..=@..;@..9@..7@..5@..
:2000200033C0000031C000002FC000002DC000002BC0000043C0000027C0000025C0000046 // 00020> 3@..1@../@..-@..+@..C@..'@..%@..
:2000400023C0000021C000001FC000001DC000001BC0000019C0000017C0000015C00000C0 // 00040> #@..!@...@...@...@...@...@...@..
:2000600013C0000011C0000011241FBECFEFD8E0DEBFCDBF21E0A0E0B1E001C01D92A230D7 // 00060> .@...@...$.>OoX`^?M?!`_`1`.@.."0
:20008000B207E1F755D068C0BBCF1092800082E080938100259AE0E6F1E0E49147D06C1979 // 00080> 2.awUPh@;O.....`....%.`fq`d.GPl.
:2000A0007D098E099F09653F714081059105B0F33DD06B017C011D9AF1CF08950F930FB7F5 // 000a0> }.....e?q@....0s=Pk.|...qO.....7
:2000C0000F930AB50F5F0ABD70F00BB50F4F0BBD50F0009100010F4F0093000100910101ED // 000c0> ...5._.=pp.5.O.=Pp.....O........
:2000E0000F4F009301010F910FBF0F9118952FB7F894609184006091850036B37AB58BB59D // 000e0> .O.......?..../7x.`...`...63z5.5
:20010000909100012FBF2091010130FF06C06F3F21F07F5F8F4F9F4F2F4F33E02695979546 // 00100> ..../?_...0..@o?!p._.O.O/O3`&...
:200120008795779567953A95C9F70895E0CF0895789483E084BD85BD81E080936F0094E0DA // 00120> ..w.g.:.Iw..`O..x..`.=.=.`..o..`
:200140009093B1008093B00087E880937A001092C1009BDFB2DFFECFF89400C0F894FFCF2B // 00140> ..1...0..h..z...A.._2_~Ox..@x..O
:1801600048656C6C6F2C20776F726C640A626C696E6B2E68657800FF93                 // 00160> Hello,_world.blink.hex..
:00000001FF
$ avrdude -c usbtiny -qqp m328p -U flash:w:b.hex:I
```