### PR TITLE
Ignore target memories not present in avrdude.conf

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1242,8 +1242,12 @@ int main(int argc, char * argv [])
 
 
   for (ln=lfirst(updates); ln; ln=lnext(ln)) {
+    UPDATE * prev = upd;
     upd = ldata(ln);
-    rc = do_op(pgm, p, upd, uflags);
+
+    if (strcmp(prev->memtype, upd->memtype) != 0 || avr_locate_mem(p, upd->memtype) != NULL)
+      rc = do_op(pgm, p, upd, uflags);
+
     if (rc) {
       exitrc = 1;
       break;

--- a/src/update.c
+++ b/src/update.c
@@ -222,9 +222,9 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
 
   mem = avr_locate_mem(p, upd->memtype);
   if (mem == NULL) {
-    avrdude_message(MSG_INFO, "\"%s\" memory type not defined for part \"%s\"\n",
-            upd->memtype, p->desc);
-    return -1;
+    avrdude_message(MSG_INFO, "%s: warning: \"%s\" memory type not defined for part \"%s\"\n\n",
+            progname, upd->memtype, p->desc);
+    return 0;
   }
 
   AVRMEM_ALIAS * alias_mem = avr_find_memalias(p, mem);


### PR DESCRIPTION
I'm just throwing this one in to check if there's any interest. Please close if permissive "features" like this are out of the question.

This is basically a more generic approach to #981.
Instead of terminating, it will now ignore a memory passed to Avrdude using `-U`, but not present in avrdude.conf.
The changes in main.c is there to prevent Avrdude from both trying to write *and* then verify a memory not present, which would lead to duplicated warning messages

Without this PR:

```
$ ./avrdude -cusbtiny -patmega2560 -Unotpresent:w:0x00:m -Uefuse:w:0xfd:m

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e9801 (probably m2560)
"notpresent" memory type not defined for part "ATmega2560"

avrdude done.  Thank you.
```

With this PR:
```
$ ./avrdude -cusbtiny -patmega2560 -Unotpresent:w:0x00:m -Uefuse:w:0xfd:m

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e9801 (probably m2560)
avrdude: warning: "notpresent" memory type not defined for part "ATmega2560"

avrdude: reading input file "0xfd"
avrdude: writing efuse (1 bytes):

Writing | ################################################## | 100% 0.00s

avrdude: 1 bytes of efuse written
avrdude: verifying efuse memory against 0xfd:

Reading | ################################################## | 100% 0.00s

avrdude: 1 bytes of efuse verified

avrdude done.  Thank you.
```