### PR TITLE
Implement a dry run for -U updates before opening the programmer

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -346,7 +346,7 @@ static int ihex2b(char * infile, FILE * inf,
           return -1;
         }
         nextaddr = ihex.loadofs + baseaddr - fileoffset;
-        if (nextaddr + ihex.reclen > bufsize) {
+        if (nextaddr + ihex.reclen > (unsigned) bufsize) {
           avrdude_message(MSG_INFO, "%s: ERROR: address 0x%04x out of range at line %d of %s\n",
                           progname, nextaddr+ihex.reclen, lineno, infile);
           return -1;
@@ -412,7 +412,6 @@ static int b2srec(unsigned char * inbuf, int bufsize,
   unsigned char * buf;
   unsigned int nextaddr;
   int n, nbytes, addr_width;
-  int i;
   unsigned char cksum;
 
   char * tmpl=0;
@@ -460,10 +459,10 @@ static int b2srec(unsigned char * inbuf, int bufsize,
 
       cksum += n + addr_width + 1;
 
-      for (i=addr_width; i>0; i--) 
+      for (int i=addr_width; i>0; i--)
         cksum += (nextaddr >> (i-1) * 8) & 0xff;
 
-      for (i=nextaddr; i<nextaddr + n; i++) {
+      for (unsigned i=nextaddr; i<nextaddr + n; i++) {
         fprintf(outf, "%02X", buf[i]);
         cksum += buf[i];
       }
@@ -494,7 +493,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
     addr_width = 3;
     tmpl="S9%02X%06X";
   }
-  else if (startaddr <= 0xffffffff) {
+  else if ((unsigned) startaddr <= 0xffffffff) {
     addr_width = 4;
     tmpl="S9%02X%08X";
   }
@@ -502,7 +501,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
   fprintf(outf, tmpl, n + addr_width + 1, nextaddr);
 
   cksum += n + addr_width +1;
-  for (i=addr_width; i>0; i--) 
+  for (int i=addr_width; i>0; i--)
     cksum += (nextaddr >> (i - 1) * 8) & 0xff;
   cksum = 0xff - cksum;
   fprintf(outf, "%02X\n", cksum);
@@ -597,7 +596,7 @@ static int srec2b(char * infile, FILE * inf,
   int len;
   struct ihexrec srec;
   int rc;
-  int reccount;
+  unsigned int reccount;
   unsigned char datarec;
 
   char * msg = 0;
@@ -687,7 +686,7 @@ static int srec2b(char * infile, FILE * inf,
         return -1;
       }
       nextaddr -= fileoffset;
-      if (nextaddr + srec.reclen > bufsize) {
+      if (nextaddr + srec.reclen > (unsigned) bufsize) {
         avrdude_message(MSG_INFO, msg, progname, nextaddr+srec.reclen, "",
                 lineno, infile);
         return -1;
@@ -1006,8 +1005,7 @@ static int elf2b(char * infile, FILE * inf,
        * ELF file region for these, and extract the actual byte to write
        * from it, using the "foff" offset obtained above.
        */
-      if (mem->size != 1 &&
-          sh->sh_size > mem->size) {
+      if (mem->size != 1 && sh->sh_size > (unsigned) mem->size) {
         avrdude_message(MSG_INFO, "%s: ERROR: section \"%s\" does not fit into \"%s\" memory:\n"
                         "    0x%x + %u > %u\n",
                         progname, sname, mem->desc,
@@ -1507,7 +1505,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
   if (rc < 0)
     return -1;
 
-  if (fio.op == FIO_READ)
+  if (size < 0 || fio.op == FIO_READ)
     size = mem->size;
 
   if (fio.op == FIO_READ) {

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -100,11 +100,8 @@ static int fileio_num(struct fioparms * fio,
 		char * filename, FILE * f, AVRMEM * mem, int size,
 		FILEFMT fmt);
 
-static int fmt_autodetect(char * fname);
 
-
-
-char * fmtstr(FILEFMT format)
+char * fileio_fmtstr(FILEFMT format)
 {
   switch (format) {
     case FMT_AUTO : return "auto-detect"; break;
@@ -1402,7 +1399,7 @@ int fileio_setparms(int op, struct fioparms * fp,
 
 
 
-static int fmt_autodetect(char * fname)
+int fileio_fmt_autodetect(const char * fname)
 {
   FILE * f;
   unsigned char buf[MAX_LINE_LEN];
@@ -1547,7 +1544,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
       return -1;
     }
 
-    format_detect = fmt_autodetect(fname);
+    format_detect = fileio_fmt_autodetect(fname);
     if (format_detect < 0) {
       avrdude_message(MSG_INFO, "%s: can't determine file format for %s, specify explicitly\n",
                       progname, fname);
@@ -1556,8 +1553,8 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     format = format_detect;
 
     if (quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: %s file %s auto detected as %s\n",
-              progname, fio.iodesc, fname, fmtstr(format));
+      avrdude_message(MSG_NOTICE, "%s: %s file %s auto detected as %s\n",
+              progname, fio.iodesc, fname, fileio_fmtstr(format));
     }
   }
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -872,7 +872,9 @@ enum {
 extern "C" {
 #endif
 
-char * fmtstr(FILEFMT format);
+char * fileio_fmtstr(FILEFMT format);
+
+int fileio_fmt_autodetect(const char * fname);
 
 int fileio(int oprwv, char * filename, FILEFMT format,
            struct avrpart * p, char * memtype, int size);
@@ -935,6 +937,14 @@ const char *update_plural(int x);
 const char *update_inname(const char *fn);
 const char *update_outname(const char *fn);
 const char *update_interval(int a, int b);
+
+// Helper functions for dry run to determine file access
+int update_is_okfile(const char *fn);
+int update_is_writeable(const char *fn);
+int update_is_readable(const char *fn);
+
+int update_dryrun(struct avrpart *p, UPDATE *upd);
+
 
 #ifdef __cplusplus
 }

--- a/src/msvc/msvc_compat.h
+++ b/src/msvc/msvc_compat.h
@@ -28,6 +28,11 @@
 #pragma comment(lib, "ws2_32.lib")
 #pragma comment(lib, "setupapi.lib")
 
+#define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
+
+#define R_OK 4
+#define W_OK 2
+#define X_OK 1
 #define F_OK 0
 
 #define PATH_MAX _MAX_PATH

--- a/src/update.c
+++ b/src/update.c
@@ -368,13 +368,11 @@ int update_is_readable(const char *fn) {
 static void ioerror(const char *iotype, UPDATE *upd) {
   avrdude_message(MSG_INFO, "%s: file %s is not %s",
     progname, update_outname(upd->filename), iotype);
-  if(errno) {
-    char buf[1024];
-    strerror_r(errno, buf, sizeof buf);
-    avrdude_message(MSG_INFO, ". %s", buf);
-  } else if(upd->filename && *upd->filename)
+  if(errno)
+    avrdude_message(MSG_INFO, ". %s", strerror(errno));
+  else if(upd->filename && *upd->filename)
     avrdude_message(MSG_INFO, " (not a regular or character file?)");
-   avrdude_message(MSG_INFO, "\n");
+  avrdude_message(MSG_INFO, "\n");
 }
 
 // Basic checks to reveal serious failure before programming


### PR DESCRIPTION
This PR checks -U update requests for 
  - Typos in memory names
  - Whether the files can be written or read
  - Automatic format detection if necessary

before opening the programmer. This to reduce the chances of the programming failing midway through.

Whilst the `update_dryrun()` goes through some of the checks of `do_op()`, the functionality of `do_op()` has not been changed, so applications that use `do_op()` from libavrdude will work the same.

Needs thorough testing for cases where the dry run exits when, without it, the command would legitimately work. It is possible to construct cases where the dry run misses opportunities to check, but this is not an issue as this will be done during the *real* work.

Minor additional changes:
  - Give strerror() system info when files are not read/writeable
  - Lift the auto detection message from MSG_INFO to MSG_NOTICE
  - Provide fileio_fmt_autodetect() in the AVRDUDE library
  - Rename fmtstr() in the AVRDUDE library to fileio_fmtstr() to
    avoid name clashes when an application links with it


Examples:

```
$ avrdude -U - -p m328p -c usb-bub-ii
avrdude: can't auto detect file format for stdin/out, specify explicitly

$ rm -f testin; touch testin
$ avrdude -U testin -p m328p -c usb-bub-ii
avrdude: can't determine file format for testin, specify explicitly

$ avrdude -qqU efuse:r:testin:i -U eeprom:w:testin:a -p m328p -c usb-bub-ii && echo OK
OK

$ avrdude -qqU efuse:r:testin:i -U eeprom:w:festin:a -p m328p -c usb-bub-ii && echo OK
avrdude: file festin is not readable. No such file or directory

$ chmod -r testin 
$ avrdude -U testin -p m328p -c usb-bub-ii
avrdude: file testin is not readable. Permission denied

$ avrdude -U flash:r:testin:r -U another -p m328p -c usb-bub-ii
avrdude: file another is not readable. No such file or directory

$ avrdude -U - -U typo:r:.:h -U eeprom:w:testin:r -p m328p -c usb-bub-ii
avrdude: can't auto detect file format for stdin/out, specify explicitly
avrdude: unknown memory type typo
avrdude: file . is not writeable (not a regular or character file?)
avrdude: file testin is not readable. Permission denied

$ rm -f testin

$ avrdude -U efuse:w:0xff:m -qqp ATmega8 -c usb-bub-ii && echo OK
avrdude: skipping -U efuse:... as memory not defined for part ATmega8
OK

$ avrdude -U efuse:r:0xff:m -qqp ATmega8 -c usb-bub-ii && echo OK
avrdude: invalid file format 'immediate' for output

$ avrdude -U eeprom:w:/dev/urandom:r -qqp m328p -c usb-bub-ii && echo OK
OK
```
