### PR TITLE
Implement -c <wildcard>/dev_options for printing programmer entries of avrdude.conf

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1243,7 +1243,7 @@ void avr_add_mem_order(const char *str) {
     if(avr_mem_order[i] && !strcmp(avr_mem_order[i], str))
       return;
     if(!avr_mem_order[i]) {
-      avr_mem_order[i] = strdup(str);
+      avr_mem_order[i] = cfg_strdup("avr_mem_order()", str);
       return;
     }
   }

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -651,7 +651,7 @@ static int avrftdi_pin_setup(PROGRAMMER * pgm)
 static int avrftdi_open(PROGRAMMER * pgm, char *port)
 {
 	int vid, pid, interface, index, err;
-	char * serial, *desc;
+	const char *serial, *desc;
 	
 	avrftdi_t* pdata = to_pdata(pgm);
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -672,6 +672,7 @@ void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, AVRPART * p,
 AVRPART * avr_new_part(void)
 {
   AVRPART * p;
+  char *nulp = cache_string("");
 
   p = (AVRPART *)malloc(sizeof(AVRPART));
   if (p == NULL) {
@@ -686,8 +687,8 @@ AVRPART * avr_new_part(void)
   p->reset_disposition = RESET_DEDICATED;
   p->retry_pulse = PIN_AVR_SCK;
   p->flags = AVRPART_SERIALOK | AVRPART_PARALLELOK | AVRPART_ENABLEPAGEPROGRAMMING;
-  p->parent_id = NULL;
-  p->config_file = NULL;
+  p->parent_id = nulp;
+  p->config_file = nulp;
   p->lineno = 0;
   memset(p->signature, 0xFF, 3);
   p->ctl_stack_type = CTL_STACK_NONE;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -672,7 +672,7 @@ void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, AVRPART * p,
 AVRPART * avr_new_part(void)
 {
   AVRPART * p;
-  char *nulp = cache_string("");
+  const char *nulp = cache_string("");
 
   p = (AVRPART *)malloc(sizeof(AVRPART));
   if (p == NULL) {

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -956,7 +956,7 @@ char *cmdbitstr(CMDBIT cb) {
   else
     space[1] = 0;
 
-  return strdup(space);
+  return cfg_strdup("cmdbitstr()", space);
 }
 
 
@@ -998,7 +998,7 @@ char *opcode2str(OPCODE *op, int opnum, int detailed) {
   int compact = 1;
 
   if(!op)
-    return strdup("NULL");
+    return cfg_strdup("opcode2str()", "NULL");
 
   // Can the opcode be printed in a compact way? Only if address bits are systematic.
   for(int i=31; i >= 0; i--)
@@ -1033,7 +1033,7 @@ char *opcode2str(OPCODE *op, int opnum, int detailed) {
     *sp++ = '"';
   *sp = 0;
 
-  return strdup(space);
+  return cfg_strdup("opcode2str()", space);
 }
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -33,10 +33,10 @@
 
 #include "config_gram.h"
 
-char default_programmer[MAX_STR_CONST];
-char default_parallel[PATH_MAX];
-char default_serial[PATH_MAX];
-char default_spi[PATH_MAX];
+const char *default_programmer;
+const char *default_parallel;
+const char *default_serial;
+const char *default_spi;
 double default_bitclock;
 
 LISTID       string_list;

--- a/src/config.c
+++ b/src/config.c
@@ -366,7 +366,7 @@ int read_config(const char * file)
 
 
 // Linear-search cache for a few often-referenced strings
-char *cache_string(const char *file) {
+const char *cache_string(const char *file) {
   static char **fnames;
   static int n=0;
 
@@ -393,4 +393,9 @@ char *cache_string(const char *file) {
   }
 
   return fnames[n++];
+}
+
+// Captures comments during parsing
+int capture_comment_char(int c) {
+  return c;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,13 @@
 #endif
 
 
+typedef struct {
+  char *kw;                     // Keyword near the comments
+  LISTID comms;                 // Chained list of comments
+  int rhs;                      // Comments to print rhs of keyword line
+} COMMENT;
+
+
 enum { V_NONE, V_NUM, V_NUM_REAL, V_STR };
 typedef struct value_t {
   int      type;
@@ -94,7 +101,19 @@ void print_token(TOKEN *tkn);
 
 void pyytext(void);
 
-void capture_comment_str(const char *str);
+COMMENT *locate_comment(const LISTID comments, const char *where, int rhs);
+
+void cfg_capture_prologue(void);
+
+LISTID cfg_get_prologue(void);
+
+void capture_comment_str(const char *com, int lineno);
+
+void capture_lvalue_kw(const char *kw, int lineno);
+
+LISTID cfg_move_comments(void);
+
+void cfg_pop_comms(void);
 
 #ifdef __cplusplus
 }

--- a/src/config.h
+++ b/src/config.h
@@ -94,7 +94,7 @@ void print_token(TOKEN *tkn);
 
 void pyytext(void);
 
-int capture_comment_char(int c);
+void capture_comment_str(const char *str);
 
 #ifdef __cplusplus
 }

--- a/src/config.h
+++ b/src/config.h
@@ -30,8 +30,6 @@
 #endif
 
 
-#define MAX_STR_CONST 1024
-
 enum { V_NONE, V_NUM, V_NUM_REAL, V_STR };
 typedef struct value_t {
   int      type;

--- a/src/config.h
+++ b/src/config.h
@@ -35,11 +35,11 @@
 enum { V_NONE, V_NUM, V_NUM_REAL, V_STR };
 typedef struct value_t {
   int      type;
-  /*union { TODO: use an anonymous union here ? */
+  union {
     int      number;
     double   number_real;
     char   * string;
-  /*};*/
+  };
 } VALUE;
 
 
@@ -66,40 +66,35 @@ extern bool         is_alias; // current entry is alias
 #endif
 extern YYSTYPE yylval;
 
-extern char string_buf[MAX_STR_CONST];
-extern char *string_buf_ptr;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int yyparse(void);
 
-int yyerror(char * errmsg, ...);
+int yyerror(char *errmsg, ...);
 
-int yywarning(char * errmsg, ...);
+int yywarning(char *errmsg, ...);
 
-TOKEN * new_token(int primary);
+TOKEN *new_token(int primary);
 
-void free_token(TOKEN * tkn);
+void free_token(TOKEN *tkn);
 
 void free_tokens(int n, ...);
 
-TOKEN * number(char * text);
+TOKEN *number(const char *text);
 
-TOKEN * number_real(char * text);
+TOKEN *number_real(const char *text);
 
-TOKEN * hexnumber(char * text);
+TOKEN *hexnumber(const char *text);
 
-TOKEN * string(char * text);
+TOKEN *string(const char *text);
 
-TOKEN * keyword(int primary);
+TOKEN *keyword(int primary);
 
-void print_token(TOKEN * tkn);
+void print_token(TOKEN *tkn);
 
 void pyytext(void);
-
-char * dup_string(const char * str);
 
 int capture_comment_char(int c);
 

--- a/src/config.h
+++ b/src/config.h
@@ -101,8 +101,6 @@ void pyytext(void);
 
 char * dup_string(const char * str);
 
-char * cache_string(const char * file);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -101,6 +101,8 @@ void pyytext(void);
 
 char * dup_string(const char * str);
 
+int capture_comment_char(int c);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1356,8 +1356,7 @@ yesno :
 mem_specs :
   mem_spec TKN_SEMI |
   mem_alias TKN_SEMI |
-  mem_specs mem_spec TKN_SEMI |
-  /* empty */
+  mem_specs mem_spec TKN_SEMI
 ;
 
 

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -453,24 +453,10 @@ prog_parms :
 prog_parm :
   K_ID TKN_EQUAL string_list {
     {
-      TOKEN * t;
-      char *s;
-      int do_yyabort = 0;
       while (lsize(string_list)) {
-        t = lrmv_n(string_list, 1);
-        if (!do_yyabort) {
-          s = dup_string(t->value.string);
-          if (s == NULL) {
-            do_yyabort = 1;
-          } else {
-            ladd(current_prog->id, s);
-          }
-        }
-        /* if do_yyabort == 1 just make the list empty */
+        TOKEN *t = lrmv_n(string_list, 1);
+        ladd(current_prog->id, cfg_strdup("config_gram.y", t->value.string));
         free_token(t);
-      }
-      if (do_yyabort) {
-        YYABORT;
       }
     }
   } |

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -532,8 +532,7 @@ prog_parm_conntype_id:
 prog_parm_usb:
   K_USBDEV TKN_EQUAL TKN_STRING {
     {
-      strncpy(current_prog->usbdev, $3->value.string, PGM_USBSTRINGLEN);
-      current_prog->usbdev[PGM_USBSTRINGLEN-1] = 0;
+      current_prog->usbdev = cache_string($3->value.string);
       free_token($3);
     }
   } |
@@ -546,22 +545,19 @@ prog_parm_usb:
   K_USBPID TKN_EQUAL usb_pid_list |
   K_USBSN TKN_EQUAL TKN_STRING {
     {
-      strncpy(current_prog->usbsn, $3->value.string, PGM_USBSTRINGLEN);
-      current_prog->usbsn[PGM_USBSTRINGLEN-1] = 0;
+      current_prog->usbsn = cache_string($3->value.string);
       free_token($3);
     }
   } |
   K_USBVENDOR TKN_EQUAL TKN_STRING {
     {
-      strncpy(current_prog->usbvendor, $3->value.string, PGM_USBSTRINGLEN);
-      current_prog->usbvendor[PGM_USBSTRINGLEN-1] = 0;
+      current_prog->usbvendor = cache_string($3->value.string);
       free_token($3);
     }
   } |
   K_USBPRODUCT TKN_EQUAL TKN_STRING {
     {
-      strncpy(current_prog->usbproduct, $3->value.string, PGM_USBSTRINGLEN);
-      current_prog->usbproduct[PGM_USBSTRINGLEN-1] = 0;
+      current_prog->usbproduct = cache_string($3->value.string);
       free_token($3);
     }
   }

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -246,26 +246,22 @@ def :
   part_def TKN_SEMI |
 
   K_DEFAULT_PROGRAMMER TKN_EQUAL TKN_STRING TKN_SEMI {
-    strncpy(default_programmer, $3->value.string, MAX_STR_CONST);
-    default_programmer[MAX_STR_CONST-1] = 0;
+    default_programmer = cache_string($3->value.string);
     free_token($3);
   } |
 
   K_DEFAULT_PARALLEL TKN_EQUAL TKN_STRING TKN_SEMI {
-    strncpy(default_parallel, $3->value.string, PATH_MAX);
-    default_parallel[PATH_MAX-1] = 0;
+    default_parallel = cache_string($3->value.string);
     free_token($3);
   } |
 
   K_DEFAULT_SERIAL TKN_EQUAL TKN_STRING TKN_SEMI {
-    strncpy(default_serial, $3->value.string, PATH_MAX);
-    default_serial[PATH_MAX-1] = 0;
+    default_serial = cache_string($3->value.string);
     free_token($3);
   } |
 
   K_DEFAULT_SPI TKN_EQUAL TKN_STRING TKN_SEMI {
-    strncpy(default_spi, $3->value.string, PATH_MAX);
-    default_spi[PATH_MAX-1] = 0;
+    default_spi = cache_string($3->value.string);
     free_token($3);
   } |
 

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1397,7 +1397,8 @@ yesno :
 mem_specs :
   mem_spec TKN_SEMI |
   mem_alias TKN_SEMI |
-  mem_specs mem_spec TKN_SEMI
+  mem_specs mem_spec TKN_SEMI |
+  /* empty */
 ;
 
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <whereami.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -51,7 +52,7 @@
 #include "developer_opts.h"
 #include "developer_opts_private.h"
 
-// return 0 if op code would encode (essentially) the same SPI command
+// Return 0 if op code would encode (essentially) the same SPI command
 static int opcodecmp(OPCODE *op1, OPCODE *op2, int opnum) {
   char *opstr1, *opstr2, *p;
   int cmp;
@@ -68,7 +69,7 @@ static int opcodecmp(OPCODE *op1, OPCODE *op2, int opnum) {
     exit(1);
   }
 
-  // don't care x and 0 are functionally equivalent
+  // Don't care x and 0 are functionally equivalent
   for(p=opstr1; *p; p++)
     if(*p == 'x')
       *p = '0';
@@ -108,7 +109,7 @@ static void printallopcodes(AVRPART *p, const char *d, OPCODE **opa) {
 
 
 
-// mnemonic characterisation of flags
+// Mnemonic characterisation of flags
 static char *parttype(AVRPART *p) {
   static char type[1024];
 
@@ -144,7 +145,7 @@ static char *parttype(AVRPART *p) {
 }
 
 
-// check whether address bits are where they should be in ISP commands
+// Check whether address bits are where they should be in ISP commands
 static void checkaddr(int memsize, int pagesize, int opnum, OPCODE *op, AVRPART *p, AVRMEM *m) {
   int i, lo, hi;
   const char *opstr = opcodename(opnum);
@@ -152,7 +153,7 @@ static void checkaddr(int memsize, int pagesize, int opnum, OPCODE *op, AVRPART 
   lo = intlog2(pagesize);
   hi = intlog2(memsize-1);
 
-  // address bits should be between positions lo and hi (and fall in line), outside should be 0 or don't care
+  // Address bits should be between positions lo and hi (and fall in line), outside should be 0 or don't care
   for(i=0; i<16; i++) {         // ISP programming only deals with 16-bit addresses (words for flash, bytes for eeprom)
     if(i < lo || i > hi) {
       if(op->bit[i+8].type != AVR_CMDBIT_IGNORE && !(op->bit[i+8].type == AVR_CMDBIT_VALUE && op->bit[i+8].value == 0)) {
@@ -168,7 +169,7 @@ static void checkaddr(int memsize, int pagesize, int opnum, OPCODE *op, AVRPART 
         dev_info(".cmderr\t%s\t%s-%s\tbit %d inconsistent: a%d specified as a%d\n", p->desc, m->desc, opstr, i+8, i, op->bit[i+8].bitno);
     }
   }
-  for(i=0; i<32; i++)           // command bits 8..23 should not contain address bits
+  for(i=0; i<32; i++)           // Command bits 8..23 should not contain address bits
     if((i<8 || i>23) && op->bit[i].type == AVR_CMDBIT_ADDRESS)
       dev_info(".cmderr\t%s\t%s-%s\tbit %d contains a%d which it shouldn't\n", p->desc, m->desc, opstr, i, op->bit[i].bitno);
 }
@@ -180,7 +181,7 @@ static char *dev_sprintf(const char *fmt, ...) {
   char *p = NULL;
   va_list ap;
 
-  // compute size
+  // Compute size
   va_start(ap, fmt);
   size = vsnprintf(p, size, fmt, ap);
   va_end(ap);
@@ -188,7 +189,7 @@ static char *dev_sprintf(const char *fmt, ...) {
   if(size < 0)
     return NULL;
 
-  size++;                       // for temrinating '\0'
+  size++;                       // For temrinating '\0'
   if(!(p = malloc(size)))
    return NULL;
 
@@ -228,7 +229,7 @@ static int dev_part_strct_entry(bool tsv, char *col0, char *col1, char *col2, co
   const char *n = name? name: "name_error";
   const char *c = cont? cont: "cont_error";
 
-  if(tsv) {                     // tab separated values
+  if(tsv) {                     // Tab separated values
     if(col0) {
       dev_info("%s\t", col0);
       if(col1) {
@@ -239,7 +240,7 @@ static int dev_part_strct_entry(bool tsv, char *col0, char *col1, char *col2, co
       }
     }
     dev_info("%s\t%s\n", n, c);
-  } else {                      // grammar conform
+  } else {                      // Grammar conform
     int indent = col2 && strcmp(col2, "part");
 
     printf("%*s%-*s = %s;\n", indent? 8: 4, "", indent? 15: 19, n, c);
@@ -285,7 +286,7 @@ static int intcmp(int a, int b) {
 }
 
 
-// deep copies for comparison and raw output
+// Deep copies for comparison and raw output
 
 typedef struct {
   AVRMEM base;
@@ -297,19 +298,19 @@ static int avrmem_deep_copy(AVRMEMdeep *d, AVRMEM *m) {
 
   d->base = *m;
 
-  // zap all bytes beyond terminating nul of desc array
+  // Zap all bytes beyond terminating nul of desc array
   len = strlen(m->desc)+1;
   if(len < sizeof m->desc)
     memset(d->base.desc + len, 0, sizeof m->desc - len);
 
-  // zap address values
+  // Zap address values
   d->base.buf = NULL;
   d->base.tags = NULL;
   for(int i=0; i<AVR_OP_MAX; i++)
     d->base.op[i] = NULL;
 
 
-  // copy over the SPI operations themselves
+  // Copy over the SPI operations themselves
   memset(d->base.op, 0, sizeof d->base.op);
   memset(d->ops, 0, sizeof d->ops);
   for(size_t i=0; i<sizeof d->ops/sizeof *d->ops; i++)
@@ -353,7 +354,7 @@ static int avrpart_deep_copy(AVRPARTdeep *d, AVRPART *p) {
   d->base.config_file = NULL;
   d->base.lineno = 0;
 
-  // zap all bytes beyond terminating nul of desc, id and family_id array
+  // Zap all bytes beyond terminating nul of desc, id and family_id array
   len = strlen(p->desc);
   if(len < sizeof p->desc)
     memset(d->base.desc + len, 0, sizeof p->desc - len);
@@ -366,20 +367,20 @@ static int avrpart_deep_copy(AVRPARTdeep *d, AVRPART *p) {
   if(len < sizeof p->id)
     memset(d->base.id + len, 0, sizeof p->id - len);
 
-  // zap address values
+  // Zap address values
   d->base.mem = NULL;
   d->base.mem_alias = NULL;
   for(int i=0; i<AVR_OP_MAX; i++)
     d->base.op[i] = NULL;
 
-  // copy over the SPI operations
+  // Copy over the SPI operations
   memset(d->base.op, 0, sizeof d->base.op);
   memset(d->ops, 0, sizeof d->ops);
   for(int i=0; i<AVR_OP_MAX; i++)
     if(p->op[i])
       d->ops[i] = *p->op[i];
 
-  // fill in all memories we got in defined order
+  // Fill in all memories we got in defined order
   di = 0;
   for(size_t mi=0; mi < sizeof avr_mem_order/sizeof *avr_mem_order && avr_mem_order[mi]; mi++) {
     m = p->mem? avr_locate_mem(p, avr_mem_order[mi]): NULL;
@@ -396,23 +397,28 @@ static int avrpart_deep_copy(AVRPARTdeep *d, AVRPART *p) {
   return di;
 }
 
+
 static char txtchar(unsigned char in) {
   in &= 0x7f;
   return in == ' '? '_': in > ' ' && in < 0x7f? in: '.';
 }
 
+static void dev_raw_dump(const char *p, int nbytes, const char *name, const char *sub, int idx) {
+  int n = (nbytes + 31)/32;
 
-static void dev_raw_dump(unsigned char *p, int nbytes, const char *name, const char *sub, int idx) {
-  unsigned char *end = p+nbytes;
-  int n = ((end - p) + 15)/16;
-
-  for(int i=0; i<n; i++, p += 16) {
-    dev_info("%s\t%s\t%02x%04x: ", name, sub, idx, i*16);
-    for(int j=0; j<16; j++)
-      dev_info("%02x", p+i*16+j<end? p[i*16+j]: 0);
+  for(int i=0; i<n; i++, p += 32, nbytes -= 32) {
+    dev_info("%s\t%s\t%02x%03x0: ", name, sub, idx, 2*i);
+    for(int j=0; j<32; j++) {
+      if(j && j%8 == 0)
+        dev_info(" ");
+      if(j < nbytes)
+        dev_info("%02x", (unsigned char) p[j]);
+      else
+        dev_info("  ");
+    }
     dev_info(" ");
-    for(int j=0; j<16; j++)
-      dev_info("%c", txtchar(p+i*16+j<end? p[i*16+j]: 0));
+    for(int j=0; j<32 && j < nbytes; j++)
+      dev_info("%c", txtchar((unsigned char) p[j]));
     dev_info("\n");
   }
 }
@@ -422,11 +428,11 @@ static void dev_part_raw(AVRPART *part) {
   AVRPARTdeep dp;
   int di = avrpart_deep_copy(&dp, part);
 
-  dev_raw_dump((unsigned char *) &dp.base, sizeof dp.base, part->desc, "part", 0);
-  dev_raw_dump((unsigned char *) &dp.ops, sizeof dp.ops, part->desc, "ops", 1);
+  dev_raw_dump((char *) &dp.base, sizeof dp.base, part->desc, "part", 0);
+  dev_raw_dump((char *) &dp.ops, sizeof dp.ops, part->desc, "ops", 1);
 
   for(int i=0; i<di; i++)
-    dev_raw_dump((unsigned char *) (dp.mems+i), sizeof dp.mems[i], part->desc, dp.mems[i].base.desc, i+2);
+    dev_raw_dump((char *) (dp.mems+i), sizeof dp.mems[i], part->desc, dp.mems[i].base.desc, i+2);
 }
 
 
@@ -527,7 +533,7 @@ static void dev_part_strct(AVRPART *p, bool tsv, AVRPART *base) {
   _if_partout(intcmp, "0x%02x", idr);
   _if_partout(intcmp, "0x%02x", rampz);
   _if_partout(intcmp, "0x%02x", spmcr);
-  _if_partout(intcmp, "0x%02x", eecr);  // why is eecr an unsigned short?
+  _if_partout(intcmp, "0x%02x", eecr);  // Why is eecr an unsigned short?
   _if_partout(intcmp, "0x%04x", mcu_base);
   _if_partout(intcmp, "0x%04x", nvm_base);
   _if_partout(intcmp, "0x%04x", ocd_base);
@@ -553,7 +559,7 @@ static void dev_part_strct(AVRPART *p, bool tsv, AVRPART *base) {
       bm = avr_new_memtype();
 
     if(!tsv) {
-      if(!memorycmp(bm, m))     // same memory bit for bit, no need to instantiate
+      if(!memorycmp(bm, m))     // Same memory bit for bit, no need to instantiate
         continue;
 
       dev_info("\n    memory \"%s\"\n", m->desc);
@@ -562,7 +568,7 @@ static void dev_part_strct(AVRPART *p, bool tsv, AVRPART *base) {
     _if_memout_yn(paged);
     _if_memout(intcmp, m->size > 8192? "0x%x": "%d", size);
     _if_memout(intcmp, "%d", page_size);
-    _if_memout(intcmp, "%d", num_pages); // why can AVRDUDE not compute this?
+    _if_memout(intcmp, "%d", num_pages);
     _if_memout(intcmp, "0x%x", offset);
     _if_memout(intcmp, "%d", min_write_delay);
     _if_memout(intcmp, "%d", max_write_delay);
@@ -607,7 +613,7 @@ void dev_output_part_defs(char *partdesc) {
   if((flags = strchr(partdesc, '/')))
     *flags++ = 0;
 
-  if(!flags && !strcmp(partdesc, "*")) // treat -p * as if it was -p */*
+  if(!flags && !strcmp(partdesc, "*")) // Treat -p * as if it was -p */*
     flags = "*";
 
   if(!*flags || !strchr("cdoASsrw*t", *flags)) {
@@ -645,7 +651,7 @@ void dev_output_part_defs(char *partdesc) {
     return;
   }
 
-  // redirect stderr to stdout
+  // Redirect stderr to stdout
   fflush(stderr); fflush(stdout); dup2(1, 2);
 
   all = *flags == '*';
@@ -660,14 +666,14 @@ void dev_output_part_defs(char *partdesc) {
   tsv   = !!strchr(flags, 't');
 
 
-  // go through all memories and add them to the memory order list
+  // Go through all memories and add them to the memory order list
   for(LNODEID ln1 = lfirst(part_list); ln1; ln1 = lnext(ln1)) {
     AVRPART *p = ldata(ln1);
     if(p->mem)
       for(LNODEID lnm=lfirst(p->mem); lnm; lnm=lnext(lnm))
         avr_add_mem_order(((AVRMEM *) ldata(lnm))->desc);
 
-    // same for aliased memories (though probably not needed)
+    // Same for aliased memories (though probably not needed)
     if(p->mem_alias)
       for(LNODEID lnm=lfirst(p->mem_alias); lnm; lnm=lnext(lnm))
         avr_add_mem_order(((AVRMEM_ALIAS *) ldata(lnm))->desc);
@@ -696,7 +702,7 @@ void dev_output_part_defs(char *partdesc) {
     if(raw)
       dev_part_raw(p);
 
-    // identify core flash and eeprom parameters
+    // Identify core flash and eeprom parameters
 
     flashsize = flashoffset = flashpagesize = eepromsize = eepromoffset = eeprompagesize = 0;
     if(p->mem) {
@@ -715,7 +721,7 @@ void dev_output_part_defs(char *partdesc) {
       }
     }
 
-    // "real" entries don't seem to have a space in their desc (a bit hackey)
+    // "Real" entries don't seem to have a space in their desc (a bit hackey)
     if(flashsize && !strchr(p->desc, ' ')) {
       int ok, nfuses;
       AVRMEM *m;
@@ -819,7 +825,7 @@ void dev_output_part_defs(char *partdesc) {
       } else
         ok &= ~DEV_SPI_CALIBRATION;
 
-      // actually, some AT90S... parts cannot read, only write lock bits :-0
+      // Actually, some AT90S... parts cannot read, only write lock bits :-0
       if( ! ((m = avr_locate_mem(p, "lock")) && m->op[AVR_OP_WRITE]))
         ok &= ~DEV_SPI_LOCK;
 
@@ -866,14 +872,14 @@ void dev_output_part_defs(char *partdesc) {
       }
     }
 
-    // print wait delays for AVR family parts
+    // Print wait delays for AVR family parts
     if(waits) {
       if(!(p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI | AVRPART_HAS_TPI | AVRPART_AVR32)))
         dev_info(".wd_chip_erase %.3f ms %s\n", p->chip_erase_delay/1000.0, p->desc);
       if(p->mem) {
         for(LNODEID lnm=lfirst(p->mem); lnm; lnm=lnext(lnm)) {
           AVRMEM *m = ldata(lnm);
-          // write delays not needed for read-only calibration and signature memories
+          // Write delays not needed for read-only calibration and signature memories
           if(strcmp(m->desc, "calibration") && strcmp(m->desc, "signature")) {
             if(!(p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI | AVRPART_HAS_TPI | AVRPART_AVR32))) {
               if(m->min_write_delay == m->max_write_delay)
@@ -893,9 +899,45 @@ void dev_output_part_defs(char *partdesc) {
 
 static void dev_pgm_raw(PROGRAMMER *pgm) {
   PROGRAMMER dp;
+  int len, idx;
+  char *id = ldata(lfirst(pgm->id));
+  LNODEID ln;
 
   memcpy(&dp, pgm, sizeof dp);
-  dev_raw_dump((unsigned char *) &dp, sizeof dp, pgm->desc, "pgm", 0);
+
+  // Dump id, usbpid and hvupdi_support lists
+  for(idx=0, ln=lfirst(dp.id); ln; ln=lnext(ln))
+    dev_raw_dump(ldata(ln), strlen(ldata(ln))+1, id, "id", idx++);
+  for(idx=0, ln=lfirst(dp.usbpid); ln; ln=lnext(ln))
+    dev_raw_dump(ldata(ln), sizeof(int), id, "usbpid", idx++);
+  for(idx=0, ln=lfirst(dp.hvupdi_support); ln; ln=lnext(ln))
+    dev_raw_dump(ldata(ln), sizeof(int), id, "hvupdi_", idx++);
+
+  // Dump cache_string values
+  if(dp.usbdev && *dp.usbdev)
+    dev_raw_dump(dp.usbdev, strlen(dp.usbdev)+1, id, "usbdev", 0);
+  if(dp.usbsn && *dp.usbsn)
+    dev_raw_dump(dp.usbsn, strlen(dp.usbsn)+1, id, "usbsn", 0);
+  if(dp.usbvendor && *dp.usbvendor)
+    dev_raw_dump(dp.usbvendor, strlen(dp.usbvendor)+1, id, "usbvend", 0);
+  if(dp.usbproduct && *dp.usbproduct)
+    dev_raw_dump(dp.usbproduct, strlen(dp.usbproduct)+1, id, "usbprod", 0);
+
+  // Zap all bytes beyond terminating nul of desc, type and port array
+  if((len = strlen(dp.desc)+1) < sizeof dp.desc)
+    memset(dp.desc + len, 0, sizeof dp.desc - len);
+  if((len = strlen(dp.type)+1) < sizeof dp.type)
+    memset(dp.type + len, 0, sizeof dp.type - len);
+  if((len = strlen(dp.port)+1) < sizeof dp.port)
+    memset(dp.port + len, 0, sizeof dp.port - len);
+
+  // Zap address values
+  dp.id = NULL;
+  dp.parent_id = NULL;
+  dp.initpgm = NULL;
+
+  // Only dump contents of PROGRAMMER struct up to and excluding the fd component
+  dev_raw_dump((char *) &dp, offsetof(PROGRAMMER, fd), id, "pgm", 0);
 }
 
 
@@ -934,7 +976,7 @@ void dev_output_pgm_defs(char *pgmid) {
   if((flags = strchr(pgmid, '/')))
     *flags++ = 0;
 
-  if(!flags && !strcmp(pgmid, "*")) // treat -c * as if it was -c */A
+  if(!flags && !strcmp(pgmid, "*")) // Treat -c * as if it was -c */A
     flags = "A";
 
   if(!*flags || !strchr("ASsrt", *flags)) {
@@ -966,7 +1008,7 @@ void dev_output_pgm_defs(char *pgmid) {
     return;
   }
 
-  // redirect stderr to stdout
+  // Redirect stderr to stdout
   fflush(stderr); fflush(stdout); dup2(1, 2);
 
   astrc = !!strchr(flags, 'A');

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -402,14 +402,11 @@ static int avrpart_deep_copy(AVRPARTdeep *d, const AVRPART *p) {
 
   // Copy over desc, id, and family_id
   memset(d->descbuf, 0, sizeof d->descbuf);
-  if(d->descbuf)
-    strncpy(d->descbuf, p->desc, sizeof d->descbuf-1);
+  strncpy(d->descbuf, p->desc, sizeof d->descbuf-1);
   memset(d->idbuf, 0, sizeof d->idbuf);
-  if(d->idbuf)
-    strncpy(d->idbuf, p->id, sizeof d->idbuf-1);
+  strncpy(d->idbuf, p->id, sizeof d->idbuf-1);
   memset(d->family_idbuf, 0, sizeof d->family_idbuf);
-  if(d->family_idbuf)
-    strncpy(d->family_idbuf, p->family_id, sizeof d->family_idbuf-1);
+  strncpy(d->family_idbuf, p->family_id, sizeof d->family_idbuf-1);
 
   // Zap address values
   d->base.desc = NULL;

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -214,7 +214,7 @@ int dev_message(int msglvl, const char *fmt, ...) {
 
   if(verbose >= msglvl) {
     va_start(ap, fmt);
-    rc = vfprintf(stderr, fmt, ap);
+    rc = vfprintf(stdout, fmt, ap);
     va_end(ap);
     if(rc > 0)
       dev_nprinted += rc;
@@ -651,9 +651,6 @@ void dev_output_part_defs(char *partdesc) {
     return;
   }
 
-  // Redirect stderr to stdout
-  fflush(stderr); fflush(stdout); dup2(1, 2);
-
   all = *flags == '*';
   cmdok = all || !!strchr(flags, 'c');
   descs = all || !!strchr(flags, 'd');
@@ -1086,9 +1083,6 @@ void dev_output_pgm_defs(char *pgmid) {
     );
     return;
   }
-
-  // Redirect stderr to stdout
-  fflush(stderr); fflush(stdout); dup2(1, 2);
 
   astrc = !!strchr(flags, 'A');
   strct = !!strchr(flags, 'S');

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -383,7 +383,7 @@ static int avrpart_deep_copy(AVRPARTdeep *d, AVRPART *p) {
   // Fill in all memories we got in defined order
   di = 0;
   for(size_t mi=0; mi < sizeof avr_mem_order/sizeof *avr_mem_order && avr_mem_order[mi]; mi++) {
-    m = p->mem? avr_locate_mem(p, avr_mem_order[mi]): NULL;
+    m = p->mem? avr_locate_mem_noalias(p, avr_mem_order[mi]): NULL;
     if(m) {
       if(di >= sizeof d->mems/sizeof *d->mems) {
         avrdude_message(MSG_INFO, "%s: ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n", progname);
@@ -553,8 +553,8 @@ static void dev_part_strct(AVRPART *p, bool tsv, AVRPART *base) {
   for(size_t mi=0; mi < sizeof avr_mem_order/sizeof *avr_mem_order && avr_mem_order[mi]; mi++) {
     AVRMEM *m, *bm;
 
-    m = p->mem? avr_locate_mem(p, avr_mem_order[mi]): NULL;
-    bm = base && base->mem? avr_locate_mem(base, avr_mem_order[mi]): NULL;
+    m = p->mem? avr_locate_mem_noalias(p, avr_mem_order[mi]): NULL;
+    bm = base && base->mem? avr_locate_mem_noalias(base, avr_mem_order[mi]): NULL;
 
     if(!m && bm && !tsv)
       dev_info("\n    memory \"%s\" = NULL;\n", bm->desc);

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1055,8 +1055,8 @@ void dev_output_pgm_defs(char *pgmid) {
   if((flags = strchr(pgmid, '/')))
     *flags++ = 0;
 
-  if(!flags && !strcmp(pgmid, "*")) // Treat -c * as if it was -c */A
-    flags = "A";
+  if(!flags && !strcmp(pgmid, "*")) // Treat -c * as if it was -c */s
+    flags = "s";
 
   if(!*flags || !strchr("ASsrt", *flags)) {
     dev_info("%s: flags for developer option -c <wildcard>/<flags> not recognised\n", progname);
@@ -1077,7 +1077,7 @@ void dev_output_pgm_defs(char *pgmid) {
       "  $ avrdude -c */st | grep baudrate\n"
       "  $ avrdude -c */r | sort\n"
       "Notes:\n"
-      "  -c * is the same as -c */A\n"
+      "  -c * is the same as -c */s\n"
       "  This help message is printed using any unrecognised flag, eg, -c/h\n"
       "  Leaving no space after -c can be an OK substitute for quoting in shells\n"
       "  /s, /S and /A outputs are designed to be used as input in avrdude.conf\n"

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -533,7 +533,7 @@ static void dev_part_strct(AVRPART *p, bool tsv, AVRPART *base) {
   _if_partout(intcmp, "0x%02x", idr);
   _if_partout(intcmp, "0x%02x", rampz);
   _if_partout(intcmp, "0x%02x", spmcr);
-  _if_partout(intcmp, "0x%02x", eecr);  // Why is eecr an unsigned short?
+  _if_partout(intcmp, "0x%02x", eecr);
   _if_partout(intcmp, "0x%04x", mcu_base);
   _if_partout(intcmp, "0x%04x", nvm_base);
   _if_partout(intcmp, "0x%04x", ocd_base);

--- a/src/developer_opts.h
+++ b/src/developer_opts.h
@@ -19,6 +19,7 @@
 #ifndef developer_opts_h
 #define developer_opts_h
 
+void dev_output_pgm_part(int dev_opt_c, char *programmer, int dev_opt_p, char *partdesc);
 void dev_output_part_defs(char *partdesc);
 void dev_output_pgm_defs(char *programmer);
 

--- a/src/developer_opts.h
+++ b/src/developer_opts.h
@@ -20,5 +20,6 @@
 #define developer_opts_h
 
 void dev_output_part_defs(char *partdesc);
+void dev_output_pgm_defs(char *programmer);
 
 #endif

--- a/src/developer_opts_private.h
+++ b/src/developer_opts_private.h
@@ -62,6 +62,7 @@ static int dev_message(int msglvl, const char *fmt, ...);
     dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf(fmt, pgm->component)); \
 } while(0)
 
+// Result must be a malloc()ed string
 #define _if_pgmout_str(cmp, result, component) do { \
   if(!base || cmp(base->component, pgm->component)) \
     dev_part_strct_entry(tsv, ".prog", id, NULL, #component, result); \
@@ -80,14 +81,17 @@ static int dev_message(int msglvl, const char *fmt, ...);
     dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component)); \
 } while(0)
 
+// Result must be a malloc()ed string
 #define _partout_str(result, component) \
   dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result)
 
+// Result must be a malloc()ed string
 #define _if_partout_str(cmp, result, component) do { \
   if(!base || cmp(base->component, p->component)) \
     dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result); \
 } while(0)
 
+// Result must be a malloc()ed string
 #define _if_n_partout_str(cmp, n, result, component) do { \
   if(!base || cmp(base->component, p->component, n)) \
     dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result); \
@@ -102,30 +106,33 @@ static int dev_message(int msglvl, const char *fmt, ...);
     dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, dev_sprintf(fmt, m->component)); \
 } while(0)
 
+// Result must be a malloc()ed string
 #define _memout_str(result, component) \
   dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result)
 
+// Result must be a malloc()ed string
 #define _if_n_memout_str(cmp, n, result, component) do { \
   if(!bm || cmp(bm->component, m->component, n)) \
     dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result); \
 } while(0)
 
 #define _memout_yn(component) \
-  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, strdup(m->component? "yes": "no"))
+  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_memout_yn()", m->component? "yes": "no"))
 
 #define _if_memout_yn(component) do { \
   if(!bm || bm->component != m->component) \
-    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, strdup(m->component? "yes": "no")); \
+    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_if_memout_yn()", m->component? "yes": "no")); \
 } while(0)
 
 #define _flagout(mask, name) \
-  _partout_str(strdup(p->flags & (mask)? "yes": "no"), name)
+  _partout_str(cfg_strdup("_flagout()", p->flags & (mask)? "yes": "no"), name)
 
 #define _if_flagout(mask, name) do { \
   if(!base || (base->flags & (mask)) != (p->flags & (mask))) \
-    _partout_str(strdup(p->flags & (mask)? "yes": "no"), name); \
+    _partout_str(cfg_strdup("_if_flagout()", p->flags & (mask)? "yes": "no"), name); \
 } while(0)
 
+// Result must be a malloc()ed string
 #define _cmderr(result, component) \
   dev_part_strct_entry(tsv, ".cmderr", p->desc, m->desc, #component, result)
 

--- a/src/developer_opts_private.h
+++ b/src/developer_opts_private.h
@@ -52,76 +52,77 @@ static int dev_message(int msglvl, const char *fmt, ...);
 #define dev_notice2(...) dev_message(DEV_NOTICE2, __VA_ARGS__)
 
 #define _pgmout(fmt, component) \
-  dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf(fmt, pgm->component))
+  dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf(fmt, pgm->component), pgm->comments)
 
 #define _pgmout_fmt(name, fmt, what) \
-  dev_part_strct_entry(tsv, ".prog", id, NULL, name, dev_sprintf(fmt, what))
+  dev_part_strct_entry(tsv, ".prog", id, NULL, name, dev_sprintf(fmt, what), pgm->comments)
 
 #define _if_pgmout(cmp, fmt, component) do { \
   if(!base || cmp(base->component, pgm->component)) \
-    dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf(fmt, pgm->component)); \
+    dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf(fmt, pgm->component), pgm->comments); \
 } while(0)
 
-// Result must be a malloc()ed string
+// Result must be a malloc'd string
 #define _if_pgmout_str(cmp, result, component) do { \
   if(!base || cmp(base->component, pgm->component)) \
-    dev_part_strct_entry(tsv, ".prog", id, NULL, #component, result); \
+    dev_part_strct_entry(tsv, ".prog", id, NULL, #component, result, pgm->comments); \
 } while(0)
 
+
 #define _partout(fmt, component) \
-  dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component))
+  dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component), p->comments)
 
 #define _if_partout(cmp, fmt, component) do { \
   if(!base || cmp(base->component, p->component)) \
-    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component)); \
+    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component), p->comments); \
 } while(0)
 
 #define _if_n_partout(cmp, n, fmt, component) do { \
   if(!base || cmp(base->component, p->component, n)) \
-    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component)); \
+    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component), p->comments); \
 } while(0)
 
-// Result must be a malloc()ed string
+// Result must be a malloc'd string
 #define _partout_str(result, component) \
-  dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result)
+  dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result, p->comments)
 
-// Result must be a malloc()ed string
+// Result must be a malloc'd string
 #define _if_partout_str(cmp, result, component) do { \
   if(!base || cmp(base->component, p->component)) \
-    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result); \
+    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result, p->comments); \
 } while(0)
 
-// Result must be a malloc()ed string
+// Result must be a malloc'd string
 #define _if_n_partout_str(cmp, n, result, component) do { \
   if(!base || cmp(base->component, p->component, n)) \
-    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result); \
+    dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result, p->comments); \
 } while(0)
 
 
 #define _memout(fmt, component) \
-  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, dev_sprintf(fmt, m->component))
+  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, dev_sprintf(fmt, m->component), m->comments)
 
 #define _if_memout(cmp, fmt, component) do { \
   if(!bm || cmp(bm->component, m->component)) \
-    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, dev_sprintf(fmt, m->component)); \
+    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, dev_sprintf(fmt, m->component), m->comments); \
 } while(0)
 
-// Result must be a malloc()ed string
+// Result must be a malloc'd string
 #define _memout_str(result, component) \
-  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result)
+  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result, m->comments)
 
-// Result must be a malloc()ed string
+// Result must be a malloc'd string
 #define _if_n_memout_str(cmp, n, result, component) do { \
   if(!bm || cmp(bm->component, m->component, n)) \
-    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result); \
+    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result, m->comments); \
 } while(0)
 
 #define _memout_yn(component) \
-  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_memout_yn()", m->component? "yes": "no"))
+  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_memout_yn()", m->component? "yes": "no"), m->comments)
 
 #define _if_memout_yn(component) do { \
   if(!bm || bm->component != m->component) \
-    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_if_memout_yn()", m->component? "yes": "no")); \
+    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_if_memout_yn()", m->component? "yes": "no"), m->comments); \
 } while(0)
 
 #define _flagout(mask, name) \
@@ -132,8 +133,8 @@ static int dev_message(int msglvl, const char *fmt, ...);
     _partout_str(cfg_strdup("_if_flagout()", p->flags & (mask)? "yes": "no"), name); \
 } while(0)
 
-// Result must be a malloc()ed string
+// Result must be a malloc'd string
 #define _cmderr(result, component) \
-  dev_part_strct_entry(tsv, ".cmderr", p->desc, m->desc, #component, result)
+  dev_part_strct_entry(tsv, ".cmderr", p->desc, m->desc, #component, result, NULL)
 
 #endif

--- a/src/developer_opts_private.h
+++ b/src/developer_opts_private.h
@@ -51,6 +51,22 @@ static int dev_message(int msglvl, const char *fmt, ...);
 #define dev_notice(...)  dev_message(DEV_NOTICE,  __VA_ARGS__)
 #define dev_notice2(...) dev_message(DEV_NOTICE2, __VA_ARGS__)
 
+#define _pgmout(fmt, component) \
+  dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf(fmt, pgm->component))
+
+#define _pgmout_fmt(name, fmt, what) \
+  dev_part_strct_entry(tsv, ".prog", id, NULL, name, dev_sprintf(fmt, what))
+
+#define _if_pgmout(cmp, fmt, component) do { \
+  if(!base || cmp(base->component, pgm->component)) \
+    dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf(fmt, pgm->component)); \
+} while(0)
+
+#define _if_pgmout_str(cmp, result, component) do { \
+  if(!base || cmp(base->component, pgm->component)) \
+    dev_part_strct_entry(tsv, ".prog", id, NULL, #component, result); \
+} while(0)
+
 #define _partout(fmt, component) \
   dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component))
 

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -851,7 +851,7 @@ static int ft245r_open(PROGRAMMER * pgm, char * port) {
       avrdude_message(MSG_NOTICE,
           "%s: ft245r_open(): no device identifier in portname, using default\n",
           progname);
-      pgm->usbsn[0] = 0;
+      pgm->usbsn = cache_string("");
       devnum = 0;
     } else {
       if (strlen(device) == 8 ){ // serial number
@@ -863,7 +863,7 @@ static int ft245r_open(PROGRAMMER * pgm, char * port) {
               device);
         }
         // copy serial number to pgm struct
-        strcpy(pgm->usbsn, device);
+        pgm->usbsn = cache_string(device);
         // and use first device with matching serial (should be unique)
         devnum = 0;
       }

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -609,7 +609,7 @@ static int jtagmkI_initialize(PROGRAMMER * pgm, AVRPART * p)
   if (jtagmkI_reset(pgm) < 0)
     return -1;
 
-  strcpy(hfuse.desc, "hfuse");
+  hfuse.desc = cache_string("hfuse");
   if (jtagmkI_read_byte(pgm, p, &hfuse, 1, &b) < 0)
     return -1;
   if ((b & OCDEN) != 0)

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1439,7 +1439,7 @@ static int jtagmkII_initialize(PROGRAMMER * pgm, AVRPART * p)
   }
 
   if ((pgm->flag & PGM_FL_IS_JTAG) && !(p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI))) {
-    strcpy(hfuse.desc, "hfuse");
+    hfuse.desc = cache_string("hfuse");
     if (jtagmkII_read_byte(pgm, p, &hfuse, 1, &b) < 0)
       return -1;
     if ((b & OCDEN) != 0)

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -488,7 +488,6 @@ static int jtagmkII_recv_frame(PROGRAMMER * pgm, unsigned char **msg,
   int rv;
   unsigned char c, *buf = NULL, header[8];
   unsigned short r_seqno = 0;
-  unsigned short checksum = 0;
 
   struct timeval tv;
   double timeoutval = 100;	/* seconds */
@@ -521,7 +520,6 @@ static int jtagmkII_recv_frame(PROGRAMMER * pgm, unsigned char **msg,
       if (serial_recv(&pgm->fd, &c, 1) != 0)
 	goto timedout;
     }
-    checksum ^= c;
 
     if (state < sDATA)
       header[headeridx++] = c;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -67,13 +67,20 @@ SIGN     [+-]
 
 
 
-#   { /* The following eats '#' style comments to end of line */
+#   { /* The following captures all '#' style comments to end of line */
        BEGIN(comment); }
-<comment>[^\n] { /* eat comments */ }
-<comment>\n { cfg_lineno++; BEGIN(INITIAL); }
+<comment>[^\n]*\n+ { /* eat comments */
+  capture_comment_char('#');
+  for(int i=0; yytext[i]; i++) {
+    capture_comment_char(yytext[i]);
+    if(yytext[i] == '\n')
+      cfg_lineno++;
+  }
+  BEGIN(INITIAL);
+}
 
 
-"/*" {  /* The following eats multiline C style comments */
+"/*" {  /* The following eats multiline C style comments, they are not captured */
         int c;
         int comment_start;
         

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -45,8 +45,6 @@ DIGIT    [0-9]
 HEXDIGIT [0-9a-fA-F]
 SIGN     [+-]
 
-%x incl
-%x comment
 %option nounput
 
 /* Bump resources for classic lex. */
@@ -73,16 +71,12 @@ SIGN     [+-]
 
 0x{HEXDIGIT}+ { yylval = hexnumber(yytext); return TKN_NUMBER; }
 
-#   { /* The following captures all '#' style comments to end of line */
-       BEGIN(comment); }
-<comment>[^\n]*\n+ { /* eat comments */
-  capture_comment_char('#');
+#[^\n]*\n+ { /* record and skip # comments */
+  capture_comment_str(yytext);
   for(int i=0; yytext[i]; i++) {
-    capture_comment_char(yytext[i]);
     if(yytext[i] == '\n')
       cfg_lineno++;
   }
-  BEGIN(INITIAL);
 }
 
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -39,6 +39,15 @@
 #define YYERRCODE 256
 #endif
 
+/* capture lvalue keywords to associate comments with that assignment */
+#define ccap() capture_lvalue_kw(yytext, cfg_lineno)
+
+static void adjust_cfg_lineno(const char *p) {
+  while(*p)
+    if(*p++ == '\n')
+      cfg_lineno++;
+}
+
 %}
 
 DIGIT    [0-9]
@@ -71,14 +80,19 @@ SIGN     [+-]
 
 0x{HEXDIGIT}+ { yylval = hexnumber(yytext); return TKN_NUMBER; }
 
-#[^\n]*\n+ { /* record and skip # comments */
-  capture_comment_str(yytext);
-  for(int i=0; yytext[i]; i++) {
-    if(yytext[i] == '\n')
-      cfg_lineno++;
-  }
+#\n#\ PROGRAMMER\ DEFINITIONS\n#\n+ { /* Record comments so far as prologue and skip */
+  cfg_capture_prologue();
+  adjust_cfg_lineno(yytext);
 }
 
+#\n#\ PART\ DEFINITIONS\n#\n+ { /* Ignore part definions header */
+  adjust_cfg_lineno(yytext);
+}
+
+[ \t]*#[^\n]*\n+ { /* Record and skip # comments including preceding white space */
+  capture_comment_str(yytext, cfg_lineno);
+  adjust_cfg_lineno(yytext);
+}
 
 "/*" {  /* The following eats multiline C style comments, they are not captured */
         int c;
@@ -108,137 +122,137 @@ SIGN     [+-]
 
 
 alias            { yylval=NULL; return K_ALIAS; }
-allowfullpagebitstream { yylval=NULL; return K_ALLOWFULLPAGEBITSTREAM; }
-avr910_devcode   { yylval=NULL; return K_AVR910_DEVCODE; }
+allowfullpagebitstream { yylval=NULL; ccap(); return K_ALLOWFULLPAGEBITSTREAM; }
+avr910_devcode   { yylval=NULL; ccap(); return K_AVR910_DEVCODE; }
 bank_size        { yylval=NULL; return K_PAGE_SIZE; }
 banked           { yylval=NULL; return K_PAGED; }
-baudrate         { yylval=NULL; return K_BAUDRATE; }
-blocksize        { yylval=NULL; return K_BLOCKSIZE; }
-bs2              { yylval=NULL; return K_BS2; }
-buff             { yylval=NULL; return K_BUFF; }
-bytedelay        { yylval=NULL; return K_BYTEDELAY; }
-chip_erase       { yylval=new_token(K_CHIP_ERASE); return K_CHIP_ERASE; }
-chip_erase_delay { yylval=NULL; return K_CHIP_ERASE_DELAY; }
-chiperasepolltimeout { yylval=NULL; return K_CHIPERASEPOLLTIMEOUT; }
-chiperasepulsewidth { yylval=NULL; return K_CHIPERASEPULSEWIDTH; }
-chiperasetime    { yylval=NULL; return K_CHIPERASETIME; }
-cmdexedelay      { yylval=NULL; return K_CMDEXEDELAY; }
-connection_type  { yylval=NULL; return K_CONNTYPE; }
+baudrate         { yylval=NULL; ccap(); return K_BAUDRATE; }
+blocksize        { yylval=NULL; ccap(); return K_BLOCKSIZE; }
+bs2              { yylval=NULL; ccap(); return K_BS2; }
+buff             { yylval=NULL; ccap(); return K_BUFF; }
+bytedelay        { yylval=NULL; ccap(); return K_BYTEDELAY; }
+chip_erase       { yylval=new_token(K_CHIP_ERASE); ccap(); return K_CHIP_ERASE; }
+chip_erase_delay { yylval=NULL; ccap(); return K_CHIP_ERASE_DELAY; }
+chiperasepolltimeout { yylval=NULL; ccap(); return K_CHIPERASEPOLLTIMEOUT; }
+chiperasepulsewidth { yylval=NULL; ccap(); return K_CHIPERASEPULSEWIDTH; }
+chiperasetime    { yylval=NULL; ccap(); return K_CHIPERASETIME; }
+cmdexedelay      { yylval=NULL; ccap(); return K_CMDEXEDELAY; }
+connection_type  { yylval=NULL; ccap(); return K_CONNTYPE; }
 dedicated        { yylval=new_token(K_DEDICATED); return K_DEDICATED; }
 default_bitclock { yylval=NULL; return K_DEFAULT_BITCLOCK; }
 default_parallel { yylval=NULL; return K_DEFAULT_PARALLEL; }
 default_programmer { yylval=NULL; return K_DEFAULT_PROGRAMMER; }
 default_serial   { yylval=NULL; return K_DEFAULT_SERIAL; }
 default_spi      { yylval=NULL; return K_DEFAULT_SPI; }
-delay            { yylval=NULL; return K_DELAY; }
-desc             { yylval=NULL; return K_DESC; }
-family_id        { yylval=NULL; return K_FAMILY_ID; }
-devicecode       { yylval=NULL; return K_DEVICECODE; }
-eecr             { yylval=NULL; return K_EECR; }
+delay            { yylval=NULL; ccap(); return K_DELAY; }
+desc             { yylval=NULL; ccap(); return K_DESC; }
+devicecode       { yylval=NULL; ccap(); return K_DEVICECODE; }
+eecr             { yylval=NULL; ccap(); return K_EECR; }
 eeprom           { yylval=NULL; return K_EEPROM; }
-eeprom_instr     { yylval=NULL; return K_EEPROM_INSTR; }
-enablepageprogramming { yylval=NULL; return K_ENABLEPAGEPROGRAMMING; }
-errled           { yylval=NULL; return K_ERRLED; }
+eeprom_instr     { yylval=NULL; ccap(); return K_EEPROM_INSTR; }
+enablepageprogramming { yylval=NULL; ccap(); return K_ENABLEPAGEPROGRAMMING; }
+errled           { yylval=NULL; ccap(); return K_ERRLED; }
+family_id        { yylval=NULL; ccap(); return K_FAMILY_ID; }
 flash            { yylval=NULL; return K_FLASH; }
-flash_instr      { yylval=NULL; return K_FLASH_INSTR; }
-has_debugwire    { yylval=NULL; return K_HAS_DW; }
-has_jtag         { yylval=NULL; return K_HAS_JTAG; }
-has_pdi          { yylval=NULL; return K_HAS_PDI; }
-has_tpi          { yylval=NULL; return K_HAS_TPI; }
-has_updi         { yylval=NULL; return K_HAS_UPDI; }
-hventerstabdelay { yylval=NULL; return K_HVENTERSTABDELAY; }
-hvleavestabdelay { yylval=NULL; return K_HVLEAVESTABDELAY; }
-hvsp_controlstack  { yylval=NULL; return K_HVSP_CONTROLSTACK; }
-hvspcmdexedelay  { yylval=NULL; return K_HVSPCMDEXEDELAY; }
-hvupdi_support   { yylval=NULL; return K_HVUPDI_SUPPORT; }
-hvupdi_variant   { yylval=NULL; return K_HVUPDI_VARIANT; }
-id               { yylval=NULL; return K_ID; }
-idr              { yylval=NULL; return K_IDR; }
+flash_instr      { yylval=NULL; ccap(); return K_FLASH_INSTR; }
+has_debugwire    { yylval=NULL; ccap(); return K_HAS_DW; }
+has_jtag         { yylval=NULL; ccap(); return K_HAS_JTAG; }
+has_pdi          { yylval=NULL; ccap(); return K_HAS_PDI; }
+has_tpi          { yylval=NULL; ccap(); return K_HAS_TPI; }
+has_updi         { yylval=NULL; ccap(); return K_HAS_UPDI; }
+hventerstabdelay { yylval=NULL; ccap(); return K_HVENTERSTABDELAY; }
+hvleavestabdelay { yylval=NULL; ccap(); return K_HVLEAVESTABDELAY; }
+hvsp_controlstack  { yylval=NULL; ccap(); return K_HVSP_CONTROLSTACK; }
+hvspcmdexedelay  { yylval=NULL; ccap(); return K_HVSPCMDEXEDELAY; }
+hvupdi_support   { yylval=NULL; ccap(); return K_HVUPDI_SUPPORT; }
+hvupdi_variant   { yylval=NULL; ccap(); return K_HVUPDI_VARIANT; }
+id               { yylval=NULL; ccap(); return K_ID; }
+idr              { yylval=NULL; ccap(); return K_IDR; }
 io               { yylval=new_token(K_IO); return K_IO; }
-is_at90s1200     { yylval=NULL; return K_IS_AT90S1200; }
-is_avr32         { yylval=NULL; return K_IS_AVR32; }
-latchcycles      { yylval=NULL; return K_LATCHCYCLES; }
-load_ext_addr    { yylval=new_token(K_LOAD_EXT_ADDR); return K_LOAD_EXT_ADDR; }
-loadpage_hi      { yylval=new_token(K_LOADPAGE_HI); return K_LOADPAGE_HI; }
-loadpage_lo      { yylval=new_token(K_LOADPAGE_LO); return K_LOADPAGE_LO; }
-max_write_delay  { yylval=NULL; return K_MAX_WRITE_DELAY; }
-mcu_base         { yylval=NULL; return K_MCU_BASE; }
-memory           { yylval=NULL; return K_MEMORY; }
-min_write_delay  { yylval=NULL; return K_MIN_WRITE_DELAY; }
-miso             { yylval=NULL; return K_MISO; }
-mode             { yylval=NULL; return K_MODE; }
-mosi             { yylval=NULL; return K_MOSI; }
+is_at90s1200     { yylval=NULL; ccap(); return K_IS_AT90S1200; }
+is_avr32         { yylval=NULL; ccap(); return K_IS_AVR32; }
+latchcycles      { yylval=NULL; ccap(); return K_LATCHCYCLES; }
+load_ext_addr    { yylval=new_token(K_LOAD_EXT_ADDR); ccap(); return K_LOAD_EXT_ADDR; }
+loadpage_hi      { yylval=new_token(K_LOADPAGE_HI); ccap(); return K_LOADPAGE_HI; }
+loadpage_lo      { yylval=new_token(K_LOADPAGE_LO); ccap(); return K_LOADPAGE_LO; }
+max_write_delay  { yylval=NULL; ccap(); return K_MAX_WRITE_DELAY; }
+mcu_base         { yylval=NULL; ccap(); return K_MCU_BASE; }
+memory           { yylval=NULL; ccap(); return K_MEMORY; }
+min_write_delay  { yylval=NULL; ccap(); return K_MIN_WRITE_DELAY; }
+miso             { yylval=NULL; ccap(); return K_MISO; }
+mode             { yylval=NULL; ccap(); return K_MODE; }
+mosi             { yylval=NULL; ccap(); return K_MOSI; }
 no               { yylval=new_token(K_NO); return K_NO; }
 NULL             { yylval=NULL; return K_NULL; }
 num_banks        { yylval=NULL; return K_NUM_PAGES; }
-num_pages        { yylval=NULL; return K_NUM_PAGES; }
-nvm_base         { yylval=NULL; return K_NVM_BASE; }
-ocd_base         { yylval=NULL; return K_OCD_BASE; }
-ocdrev           { yylval=NULL; return K_OCDREV; }
-offset           { yylval=NULL; return K_OFFSET; }
-page_size        { yylval=NULL; return K_PAGE_SIZE; }
-paged            { yylval=NULL; return K_PAGED; }
-pagel            { yylval=NULL; return K_PAGEL; }
-parallel         { yylval=NULL; return K_PARALLEL; }
+num_pages        { yylval=NULL; ccap(); return K_NUM_PAGES; }
+nvm_base         { yylval=NULL; ccap(); return K_NVM_BASE; }
+ocd_base         { yylval=NULL; ccap(); return K_OCD_BASE; }
+ocdrev           { yylval=NULL; ccap(); return K_OCDREV; }
+offset           { yylval=NULL; ccap(); return K_OFFSET; }
+paged            { yylval=NULL; ccap(); return K_PAGED; }
+pagel            { yylval=NULL; ccap(); return K_PAGEL; }
+page_size        { yylval=NULL; ccap(); return K_PAGE_SIZE; }
+parallel         { yylval=NULL; ccap(); return K_PARALLEL; }
 parent           { yylval=NULL; return K_PARENT; }
-part             { yylval=NULL; return K_PART; }
-pgm_enable       { yylval=new_token(K_PGM_ENABLE); return K_PGM_ENABLE; }
-pgmled           { yylval=NULL; return K_PGMLED; }
-pollindex        { yylval=NULL; return K_POLLINDEX; }
-pollmethod       { yylval=NULL; return K_POLLMETHOD; }
-pollvalue        { yylval=NULL; return K_POLLVALUE; }
-postdelay        { yylval=NULL; return K_POSTDELAY; }
-poweroffdelay    { yylval=NULL; return K_POWEROFFDELAY; }
-pp_controlstack  { yylval=NULL; return K_PP_CONTROLSTACK; }
-predelay         { yylval=NULL; return K_PREDELAY; }
-progmodedelay    { yylval=NULL; return K_PROGMODEDELAY; }
-programfusepolltimeout { yylval=NULL; return K_PROGRAMFUSEPOLLTIMEOUT; }
-programfusepulsewidth { yylval=NULL; return K_PROGRAMFUSEPULSEWIDTH; }
-programlockpolltimeout { yylval=NULL; return K_PROGRAMLOCKPOLLTIMEOUT; }
-programlockpulsewidth { yylval=NULL; return K_PROGRAMLOCKPULSEWIDTH; }
-programmer       { yylval=NULL; return K_PROGRAMMER; }
+part             { yylval=NULL; ccap(); return K_PART; }
+pgm_enable       { yylval=new_token(K_PGM_ENABLE); ccap(); return K_PGM_ENABLE; }
+pgmled           { yylval=NULL; ccap(); return K_PGMLED; }
+pollindex        { yylval=NULL; ccap(); return K_POLLINDEX; }
+pollmethod       { yylval=NULL; ccap(); return K_POLLMETHOD; }
+pollvalue        { yylval=NULL; ccap(); return K_POLLVALUE; }
+postdelay        { yylval=NULL; ccap(); return K_POSTDELAY; }
+poweroffdelay    { yylval=NULL; ccap(); return K_POWEROFFDELAY; }
+pp_controlstack  { yylval=NULL; ccap(); return K_PP_CONTROLSTACK; }
+predelay         { yylval=NULL; ccap(); return K_PREDELAY; }
+progmodedelay    { yylval=NULL; ccap(); return K_PROGMODEDELAY; }
+programfusepolltimeout { yylval=NULL; ccap(); return K_PROGRAMFUSEPOLLTIMEOUT; }
+programfusepulsewidth { yylval=NULL; ccap(); return K_PROGRAMFUSEPULSEWIDTH; }
+programlockpolltimeout { yylval=NULL; ccap(); return K_PROGRAMLOCKPOLLTIMEOUT; }
+programlockpulsewidth { yylval=NULL; ccap(); return K_PROGRAMLOCKPULSEWIDTH; }
+programmer       { yylval=NULL; ccap(); return K_PROGRAMMER; }
 pseudo           { yylval=new_token(K_PSEUDO); return K_PSEUDO; }
-pwroff_after_write { yylval=NULL; return K_PWROFF_AFTER_WRITE; }
-rampz            { yylval=NULL; return K_RAMPZ; }
-rdyled           { yylval=NULL; return K_RDYLED; }
-read             { yylval=new_token(K_READ); return K_READ; }
-read_hi          { yylval=new_token(K_READ_HI); return K_READ_HI; }
-read_lo          { yylval=new_token(K_READ_LO); return K_READ_LO; }
-readback         { yylval=NULL; return K_READBACK; }
-readback_p1      { yylval=NULL; return K_READBACK_P1; }
-readback_p2      { yylval=NULL; return K_READBACK_P2; }
-readsize        { yylval=NULL; return K_READSIZE; }
-reset            { yylval=new_token(K_RESET); return K_RESET; }
-resetdelay       { yylval=NULL; return K_RESETDELAY; }
-resetdelayms     { yylval=NULL; return K_RESETDELAYMS; }
-resetdelayus     { yylval=NULL; return K_RESETDELAYUS; }
-retry_pulse      { yylval=NULL; return K_RETRY_PULSE; }
-sck              { yylval=new_token(K_SCK); return K_SCK; }
-serial           { yylval=NULL; return K_SERIAL; }
-signature        { yylval=NULL; return K_SIGNATURE; }
-size             { yylval=NULL; return K_SIZE; }
+pwroff_after_write { yylval=NULL; ccap(); return K_PWROFF_AFTER_WRITE; }
+rampz            { yylval=NULL; ccap(); return K_RAMPZ; }
+rdyled           { yylval=NULL; ccap(); return K_RDYLED; }
+read             { yylval=new_token(K_READ); ccap(); return K_READ; }
+read_hi          { yylval=new_token(K_READ_HI); ccap(); return K_READ_HI; }
+read_lo          { yylval=new_token(K_READ_LO); ccap(); return K_READ_LO; }
+readback         { yylval=NULL; ccap(); return K_READBACK; }
+readback_p1      { yylval=NULL; ccap(); return K_READBACK_P1; }
+readback_p2      { yylval=NULL; ccap(); return K_READBACK_P2; }
+readsize        { yylval=NULL; ccap(); return K_READSIZE; }
+reset            { yylval=new_token(K_RESET); ccap(); return K_RESET; }
+resetdelay       { yylval=NULL; ccap(); return K_RESETDELAY; }
+resetdelayms     { yylval=NULL; ccap(); return K_RESETDELAYMS; }
+resetdelayus     { yylval=NULL; ccap(); return K_RESETDELAYUS; }
+retry_pulse      { yylval=NULL; ccap(); return K_RETRY_PULSE; }
+sck              { yylval=new_token(K_SCK); ccap(); return K_SCK; }
+serial           { yylval=NULL; ccap(); return K_SERIAL; }
+signature        { yylval=NULL; ccap(); return K_SIGNATURE; }
+size             { yylval=NULL; ccap(); return K_SIZE; }
 spi              { yylval=NULL; return K_SPI; }
-spmcr            { yylval=NULL; return K_SPMCR; }
-stabdelay        { yylval=NULL; return K_STABDELAY; }
-stk500_devcode   { yylval=NULL; return K_STK500_DEVCODE; }
-synchcycles      { yylval=NULL; return K_SYNCHCYCLES; }
-synchloops       { yylval=NULL; return K_SYNCHLOOPS; }
-timeout          { yylval=NULL; return K_TIMEOUT; }
-togglevtg        { yylval=NULL; return K_TOGGLEVTG; }
-type             { yylval=NULL; return K_TYPE; }
+spmcr            { yylval=NULL; ccap(); return K_SPMCR; }
+stabdelay        { yylval=NULL; ccap(); return K_STABDELAY; }
+stk500_devcode   { yylval=NULL; ccap(); return K_STK500_DEVCODE; }
+synchcycles      { yylval=NULL; ccap(); return K_SYNCHCYCLES; }
+synchloops       { yylval=NULL; ccap(); return K_SYNCHLOOPS; }
+timeout          { yylval=NULL; ccap(); return K_TIMEOUT; }
+togglevtg        { yylval=NULL; ccap(); return K_TOGGLEVTG; }
+type             { yylval=NULL; ccap(); return K_TYPE; }
 usb              { yylval=NULL; return K_USB; }
-usbdev           { yylval=NULL; return K_USBDEV; }
-usbpid           { yylval=NULL; return K_USBPID; }
-usbproduct       { yylval=NULL; return K_USBPRODUCT; }
-usbsn            { yylval=NULL; return K_USBSN; }
-usbvendor        { yylval=NULL; return K_USBVENDOR; }
-usbvid           { yylval=NULL; return K_USBVID; }
-vcc              { yylval=NULL; return K_VCC; }
-vfyled           { yylval=NULL; return K_VFYLED; }
-write            { yylval=new_token(K_WRITE); return K_WRITE; }
-write_hi         { yylval=new_token(K_WRITE_HI); return K_WRITE_HI; }
-write_lo         { yylval=new_token(K_WRITE_LO); return K_WRITE_LO; }
-writepage        { yylval=new_token(K_WRITEPAGE); return K_WRITEPAGE; }
+usbdev           { yylval=NULL; ccap(); return K_USBDEV; }
+usbpid           { yylval=NULL; ccap(); return K_USBPID; }
+usbproduct       { yylval=NULL; ccap(); return K_USBPRODUCT; }
+usbsn            { yylval=NULL; ccap(); return K_USBSN; }
+usbvendor        { yylval=NULL; ccap(); return K_USBVENDOR; }
+usbvid           { yylval=NULL; ccap(); return K_USBVID; }
+vcc              { yylval=NULL; ccap(); return K_VCC; }
+vfyled           { yylval=NULL; ccap(); return K_VFYLED; }
+write            { yylval=new_token(K_WRITE); ccap(); return K_WRITE; }
+write_hi         { yylval=new_token(K_WRITE_HI); ccap(); return K_WRITE_HI; }
+write_lo         { yylval=new_token(K_WRITE_LO); ccap(); return K_WRITE_LO; }
+writepage        { yylval=new_token(K_WRITEPAGE); ccap(); return K_WRITEPAGE; }
 yes              { yylval=new_token(K_YES); return K_YES; }
 
 ","       { yylval = NULL; pyytext(); return TKN_COMMA; }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -45,7 +45,6 @@ DIGIT    [0-9]
 HEXDIGIT [0-9a-fA-F]
 SIGN     [+-]
 
-%x strng
 %x incl
 %x comment
 %option nounput
@@ -61,11 +60,18 @@ SIGN     [+-]
 {SIGN}?{DIGIT}+"."{DIGIT}* { yylval = number_real(yytext); return TKN_NUMBER_REAL; }
 {SIGN}?"."{DIGIT}+         { yylval = number_real(yytext); return TKN_NUMBER_REAL; }
 
-"\""      { string_buf_ptr = string_buf; BEGIN(strng); }
+["]([^"\\\n]|\\.|\\\n)*["] {
+  char *str= cfg_strdup("lexer.l", yytext);
+  cfg_unescape(str, str+1);
+  size_t len = strlen(str);
+  if(len)
+    str[len-1] = 0;
+  yylval = string(str);
+  free(str);
+  return TKN_STRING;
+}
 
 0x{HEXDIGIT}+ { yylval = hexnumber(yytext); return TKN_NUMBER; }
-
-
 
 #   { /* The following captures all '#' style comments to end of line */
        BEGIN(comment); }
@@ -106,20 +112,6 @@ SIGN     [+-]
         }
      }
 
-
-<strng>\" { *string_buf_ptr = 0; string_buf_ptr = string_buf;
-             yylval = string(string_buf_ptr); BEGIN(INITIAL); return TKN_STRING; }
-<strng>\\n  *string_buf_ptr++ = '\n';
-<strng>\\t  *string_buf_ptr++ = '\t';
-<strng>\\r  *string_buf_ptr++ = '\r';
-<strng>\\b  *string_buf_ptr++ = '\b';
-<strng>\\f  *string_buf_ptr++ = '\f';
-<strng>\\(.|\n)  *(string_buf_ptr++) = yytext[1];
-<strng>[^\\\n\"]+ { char *yptr = yytext; while (*yptr) 
-                                         *(string_buf_ptr++) = *(yptr++); }
-
-<strng>\n { yyerror("unterminated character constant");
-            return YYERRCODE; }
 
 alias            { yylval=NULL; return K_ALIAS; }
 allowfullpagebitstream { yylval=NULL; return K_ALLOWFULLPAGEBITSTREAM; }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -978,7 +978,7 @@ extern "C" {
 
 const PROGRAMMER_TYPE *locate_programmer_type(const char *id);
 
-const char *locate_programmer_type_id(const void (*initpgm)(struct programmer_t *pgm));
+const char *locate_programmer_type_id(void (*initpgm)(struct programmer_t *pgm));
 
 typedef void (*walk_programmer_types_cb)(const char *id, const char *desc,
                                     void *cookie);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -217,7 +217,7 @@ typedef struct opcode {
 typedef struct avrpart {
   char          desc[AVR_DESCLEN];  /* long part name */
   char          id[AVR_IDLEN];      /* short part name */
-  char        * parent_id;          /* parent id if set, for -p.../s */
+  const char  * parent_id;          /* parent id if set, for -p.../s */
   char          family_id[AVR_FAMILYIDLEN+1]; /* family id in the SIB (avr8x) */
   int           hvupdi_variant;     /* HV pulse on UPDI pin, no pin or RESET pin */
   int           stk500_devcode;     /* stk500 device code */
@@ -280,7 +280,7 @@ typedef struct avrpart {
 
   LISTID        mem;                /* avr memory definitions */
   LISTID        mem_alias;          /* memory alias definitions */
-  char          *config_file;       /* config file where defined */
+  const char  * config_file;        /* config file where defined */
   int           lineno;             /* config file line number */
 } AVRPART;
 
@@ -640,7 +640,6 @@ extern struct serial_device usbhid_serdev;
 #define PGM_DESCLEN 80
 #define PGM_PORTLEN PATH_MAX
 #define PGM_TYPELEN 32
-#define PGM_USBSTRINGLEN 256
 
 typedef enum {
   EXIT_VCC_UNSPEC,
@@ -672,7 +671,7 @@ typedef struct programmer_t {
   char desc[PGM_DESCLEN];
   char type[PGM_TYPELEN];
   char port[PGM_PORTLEN];
-  char *parent_id;
+  const char *parent_id;
   void (*initpgm)(struct programmer_t * pgm);
   unsigned int pinno[N_PINS];
   struct pindef_t pin[N_PINS];
@@ -685,8 +684,7 @@ typedef struct programmer_t {
   int baudrate;
   int usbvid;
   LISTID usbpid;
-  char usbdev[PGM_USBSTRINGLEN], usbsn[PGM_USBSTRINGLEN];
-  char usbvendor[PGM_USBSTRINGLEN], usbproduct[PGM_USBSTRINGLEN];
+  const char *usbdev, *usbsn, *usbvendor, *usbproduct;
   double bitclock;    /* JTAG ICE clock period in microseconds */
   int ispdelay;    /* ISP clock delay */
   union filedescriptor fd;
@@ -740,7 +738,7 @@ typedef struct programmer_t {
   int  (*parseextparams) (struct programmer_t * pgm, LISTID xparams);
   void (*setup)          (struct programmer_t * pgm);
   void (*teardown)       (struct programmer_t * pgm);
-  char *config_file;          /* config file where defined */
+  const char *config_file;    /* config file where defined */
   int  lineno;                /* config file line number */
   void *cookie;		      /* for private use by the programmer */
   char flag;		      /* for private use of the programmer */
@@ -988,6 +986,8 @@ int init_config(void);
 void cleanup_config(void);
 
 int read_config(const char * file);
+
+char *cache_string(const char *file);
 
 #ifdef __cplusplus
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -992,10 +992,10 @@ void walk_programmer_types(/*LISTID programmer_types,*/ walk_programmer_types_cb
 
 extern LISTID       part_list;
 extern LISTID       programmers;
-extern char         default_programmer[];
-extern char         default_parallel[];
-extern char         default_serial[];
-extern char         default_spi[];
+extern const char *default_programmer;
+extern const char *default_parallel;
+extern const char *default_serial;
+extern const char *default_spi;
 extern double       default_bitclock;
 
 /* This name is fixed, it's only here for symmetry with

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -270,7 +270,7 @@ typedef struct avrpart {
   unsigned char idr;                /* JTAG ICE mkII XML file parameter */
   unsigned char rampz;              /* JTAG ICE mkII XML file parameter */
   unsigned char spmcr;              /* JTAG ICE mkII XML file parameter */
-  unsigned short eecr;              /* JTAC ICE mkII XML file parameter */
+  unsigned char eecr;               /* JTAC ICE mkII XML file parameter */
   unsigned int mcu_base;            /* Base address of MCU control block in ATxmega devices */
   unsigned int nvm_base;            /* Base address of NVM controller in ATxmega devices */
   unsigned int ocd_base;            /* Base address of OCD module in AVR8X/UPDI devices */

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -666,13 +666,13 @@ typedef enum {
   CONNTYPE_SPI
 } conntype_t;
 
+/* Any changes here, please also reflect in dev_pgm_strct() of developer_opts.c */
 typedef struct programmer_t {
   LISTID id;
   char desc[PGM_DESCLEN];
   char type[PGM_TYPELEN];
   char port[PGM_PORTLEN];
   const char *parent_id;
-  void (*initpgm)(struct programmer_t * pgm);
   unsigned int pinno[N_PINS];
   struct pindef_t pin[N_PINS];
   exit_vcc_t exit_vcc;
@@ -684,11 +684,16 @@ typedef struct programmer_t {
   int baudrate;
   int usbvid;
   LISTID usbpid;
+  LISTID hvupdi_support;         // List of UPDI HV variants the tool supports, see HV_UPDI_VARIANT_x
   const char *usbdev, *usbsn, *usbvendor, *usbproduct;
-  double bitclock;    /* JTAG ICE clock period in microseconds */
-  int ispdelay;    /* ISP clock delay */
+  double bitclock;              // JTAG ICE clock period in microseconds
+  int ispdelay;                 // ISP clock delay
+  int  page_size;               // Page size if the programmer supports paged write/load
+
+  // Values below are not set by config_gram.y; first one must be fd for dev_pgm_raw()
   union filedescriptor fd;
-  int  page_size;  /* page size if the programmer supports paged write/load */
+  void (*initpgm)(struct programmer_t * pgm);
+
   int  (*rdy_led)        (struct programmer_t * pgm, int value);
   int  (*err_led)        (struct programmer_t * pgm, int value);
   int  (*pgm_led)        (struct programmer_t * pgm, int value);
@@ -738,11 +743,10 @@ typedef struct programmer_t {
   int  (*parseextparams) (struct programmer_t * pgm, LISTID xparams);
   void (*setup)          (struct programmer_t * pgm);
   void (*teardown)       (struct programmer_t * pgm);
-  const char *config_file;    /* config file where defined */
-  int  lineno;                /* config file line number */
-  void *cookie;		      /* for private use by the programmer */
-  char flag;		      /* for private use of the programmer */
-  LISTID hvupdi_support;  /* List of UPDI HV variants the tool supports. See HV_UPDI_VARIANT_ */
+  const char *config_file;      // Config file where defined
+  int  lineno;                  // Config file line number
+  void *cookie;                 // For private use by the programmer
+  char flag;                    // For private use of the programmer
 } PROGRAMMER;
 
 #ifdef __cplusplus

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -203,8 +203,6 @@ typedef struct opcode {
 #define HV_UPDI_VARIANT_1      1 /* Dedicated UPDI pin, no HV (megaAVR0/AVR-Dx) */
 #define HV_UPDI_VARIANT_2      2 /* Shared UPDI pin, HV on _RESET (AVR-Ex) */
 
-#define AVR_DESCLEN 64
-#define AVR_IDLEN   32
 #define AVR_FAMILYIDLEN 7
 #define AVR_SIBLEN 16
 #define CTL_STACK_SIZE 32
@@ -215,10 +213,10 @@ typedef struct opcode {
 
 /* Any changes here, please also reflect in dev_part_strct() of developer_opts.c */
 typedef struct avrpart {
-  char          desc[AVR_DESCLEN];  /* long part name */
-  char          id[AVR_IDLEN];      /* short part name */
+  const char  * desc;               /* long part name */
+  const char  * id;                 /* short part name */
   const char  * parent_id;          /* parent id if set, for -p.../s */
-  char          family_id[AVR_FAMILYIDLEN+1]; /* family id in the SIB (avr8x) */
+  const char  * family_id;          /* family id in the SIB (avr8x) */
   int           hvupdi_variant;     /* HV pulse on UPDI pin, no pin or RESET pin */
   int           stk500_devcode;     /* stk500 device code */
   int           avr910_devcode;     /* avr910 device code */
@@ -286,7 +284,7 @@ typedef struct avrpart {
 
 #define AVR_MEMDESCLEN 64
 typedef struct avrmem {
-  char desc[AVR_MEMDESCLEN];  /* memory description ("flash", "eeprom", etc) */
+  const char *desc;           /* memory description ("flash", "eeprom", etc) */
   int paged;                  /* page addressed (e.g. ATmega flash) */
   int size;                   /* total memory size in bytes */
   int page_size;              /* size of memory page (if page addressed) */
@@ -312,7 +310,7 @@ typedef struct avrmem {
 } AVRMEM;
 
 typedef struct avrmem_alias {
-  char desc[AVR_MEMDESCLEN];  /* alias name ("syscfg0" etc.) */
+  const char *desc;           /* alias name ("syscfg0" etc.) */
   AVRMEM *aliased_mem;
 } AVRMEM_ALIAS;
 
@@ -330,8 +328,8 @@ int avr_set_bits(OPCODE * op, unsigned char * cmd);
 int avr_set_addr(OPCODE * op, unsigned char * cmd, unsigned long addr);
 int avr_set_addr_mem(AVRMEM *mem, int opnum, unsigned char *cmd, unsigned long addr);
 int avr_set_input(OPCODE * op, unsigned char * cmd, unsigned char data);
-int avr_get_output(OPCODE * op, unsigned char * res, unsigned char * data);
-int avr_get_output_index(OPCODE * op);
+int avr_get_output(const OPCODE *op, const unsigned char *res, unsigned char *data);
+int avr_get_output_index(const OPCODE *op);
 char cmdbitchar(CMDBIT cb);
 char *cmdbitstr(CMDBIT cb);
 const char *opcodename(int opnum);
@@ -340,26 +338,26 @@ char *opcode2str(OPCODE *op, int opnum, int detailed);
 /* Functions for AVRMEM structures */
 AVRMEM * avr_new_memtype(void);
 AVRMEM_ALIAS * avr_new_memalias(void);
-int avr_initmem(AVRPART * p);
-AVRMEM * avr_dup_mem(AVRMEM * m);
+int avr_initmem(const AVRPART *p);
+AVRMEM * avr_dup_mem(const AVRMEM *m);
 void     avr_free_mem(AVRMEM * m);
 void     avr_free_memalias(AVRMEM_ALIAS * m);
-AVRMEM * avr_locate_mem(AVRPART * p, const char * desc);
-AVRMEM * avr_locate_mem_noalias(AVRPART * p, const char * desc);
-AVRMEM_ALIAS * avr_locate_memalias(AVRPART * p, const char * desc);
-AVRMEM_ALIAS * avr_find_memalias(AVRPART * p, AVRMEM * m_orig);
-void avr_mem_display(const char * prefix, FILE * f, AVRMEM * m, AVRPART * p,
-                     int type, int verbose);
+AVRMEM * avr_locate_mem(const AVRPART *p, const char *desc);
+AVRMEM * avr_locate_mem_noalias(const AVRPART *p, const char *desc);
+AVRMEM_ALIAS * avr_locate_memalias(const AVRPART *p, const char *desc);
+AVRMEM_ALIAS * avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig);
+void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
+                     const AVRPART *p, int verbose);
 
 /* Functions for AVRPART structures */
 AVRPART * avr_new_part(void);
-AVRPART * avr_dup_part(AVRPART * d);
+AVRPART * avr_dup_part(const AVRPART *d);
 void      avr_free_part(AVRPART * d);
-AVRPART * locate_part(LISTID parts, const char * partdesc);
-AVRPART * locate_part_by_avr910_devcode(LISTID parts, int devcode);
-AVRPART * locate_part_by_signature(LISTID parts, unsigned char * sig,
+AVRPART * locate_part(const LISTID parts, const char *partdesc);
+AVRPART * locate_part_by_avr910_devcode(const LISTID parts, int devcode);
+AVRPART * locate_part_by_signature(const LISTID parts, unsigned char *sig,
                                    int sigsize);
-void avr_display(FILE * f, AVRPART * p, const char * prefix, int verbose);
+void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose);
 
 typedef void (*walk_avrparts_cb)(const char *name, const char *desc,
                                  const char *cfgname, int cfglineno,
@@ -653,7 +651,6 @@ extern struct serial_device usbhid_serdev;
 #define ON  1
 #define OFF 0
 
-#define PGM_DESCLEN 80
 #define PGM_PORTLEN PATH_MAX
 #define PGM_TYPELEN 32
 
@@ -685,7 +682,7 @@ typedef enum {
 /* Any changes here, please also reflect in dev_pgm_strct() of developer_opts.c */
 typedef struct programmer_t {
   LISTID id;
-  char desc[PGM_DESCLEN];
+  const char *desc;
   void (*initpgm)(struct programmer_t *pgm);
   const char *parent_id;        // Used by developer options -c*/[sr...]
   struct pindef_t pin[N_PINS];
@@ -762,6 +759,7 @@ typedef struct programmer_t {
   int  (*parseextparams) (struct programmer_t * pgm, LISTID xparams);
   void (*setup)          (struct programmer_t * pgm);
   void (*teardown)       (struct programmer_t * pgm);
+
   const char *config_file;      // Config file where defined
   int  lineno;                  // Config file line number
   void *cookie;                 // For private use by the programmer
@@ -773,8 +771,8 @@ extern "C" {
 #endif
 
 PROGRAMMER * pgm_new(void);
-PROGRAMMER * pgm_dup(const PROGRAMMER * const src);
-void         pgm_free(PROGRAMMER * const p);
+PROGRAMMER * pgm_dup(const PROGRAMMER *src);
+void         pgm_free(PROGRAMMER *p);
 
 void programmer_display(PROGRAMMER * pgm, const char * p);
 
@@ -783,10 +781,10 @@ void programmer_display(PROGRAMMER * pgm, const char * p);
 #define SHOW_PPI_PINS ((1<<PPI_AVR_VCC)|(1<<PPI_AVR_BUFF))
 #define SHOW_AVR_PINS ((1<<PIN_AVR_RESET)|(1<<PIN_AVR_SCK)|(1<<PIN_AVR_MOSI)|(1<<PIN_AVR_MISO))
 #define SHOW_LED_PINS ((1<<PIN_LED_ERR)|(1<<PIN_LED_RDY)|(1<<PIN_LED_PGM)|(1<<PIN_LED_VFY))
-void pgm_display_generic_mask(PROGRAMMER * pgm, const char * p, unsigned int show);
-void pgm_display_generic(PROGRAMMER * pgm, const char * p);
+void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int show);
+void pgm_display_generic(const PROGRAMMER *pgm, const char *p);
 
-PROGRAMMER * locate_programmer(LISTID programmers, const char * configid);
+PROGRAMMER *locate_programmer(const LISTID programmers, const char *configid);
 
 typedef void (*walk_programmers_cb)(const char *name, const char *desc,
                                     const char *cfgname, int cfglineno,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -536,7 +536,7 @@ const char * pins_to_str(const struct pindef_t * const pindef);
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation
- * @returns a pointer to a string, which was created by strdup (NULL if out of memory)
+ * @returns a pointer to a string, which was created by strdup
  */
 char *pins_to_strdup(const struct pindef_t * const pindef);
 
@@ -1006,6 +1006,10 @@ extern double       default_bitclock;
 extern "C" {
 #endif
 
+void *cfg_malloc(const char *funcname, size_t n);
+
+char *cfg_strdup(const char *funcname, const char *s);
+
 int init_config(void);
 
 void cleanup_config(void);
@@ -1013,6 +1017,12 @@ void cleanup_config(void);
 int read_config(const char * file);
 
 const char *cache_string(const char *file);
+
+unsigned char *cfg_unescapeu(unsigned char *d, const unsigned char *s);
+
+char *cfg_unescape(char *d, const char *s);
+
+char *cfg_escape(const char *s);
 
 #ifdef __cplusplus
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -215,7 +215,8 @@ typedef struct opcode {
 typedef struct avrpart {
   const char  * desc;               /* long part name */
   const char  * id;                 /* short part name */
-  const char  * parent_id;          /* parent id if set, for -p.../s */
+  LISTID        comments;           // Used by developer options -p*/[ASsr...]
+  const char  * parent_id;          /* Used by developer options */
   const char  * family_id;          /* family id in the SIB (avr8x) */
   int           hvupdi_variant;     /* HV pulse on UPDI pin, no pin or RESET pin */
   int           stk500_devcode;     /* stk500 device code */
@@ -285,6 +286,7 @@ typedef struct avrpart {
 #define AVR_MEMDESCLEN 64
 typedef struct avrmem {
   const char *desc;           /* memory description ("flash", "eeprom", etc) */
+  LISTID comments;            // Used by developer options -p*/[ASsr...]
   int paged;                  /* page addressed (e.g. ATmega flash) */
   int size;                   /* total memory size in bytes */
   int page_size;              /* size of memory page (if page addressed) */
@@ -684,7 +686,8 @@ typedef struct programmer_t {
   LISTID id;
   const char *desc;
   void (*initpgm)(struct programmer_t *pgm);
-  const char *parent_id;        // Used by developer options -c*/[sr...]
+  LISTID        comments;       // Used by developer options -c*/[ASsr...]
+  const char *parent_id;        // Used by developer options
   struct pindef_t pin[N_PINS];
   conntype_t conntype;
   int baudrate;

--- a/src/main.c
+++ b/src/main.c
@@ -314,10 +314,11 @@ int main(int argc, char * argv [])
   else
     progname = argv[0];
 
-  default_parallel[0] = 0;
-  default_serial[0]   = 0;
-  default_spi[0]      = 0;
-  default_bitclock    = 0.0;
+  default_programmer = "";
+  default_parallel   = "";
+  default_serial     = "";
+  default_spi        = "";
+  default_bitclock   = 0.0;
 
   init_config();
 
@@ -351,7 +352,7 @@ int main(int argc, char * argv [])
   quell_progress = 0;
   exitspecs     = NULL;
   pgm           = NULL;
-  programmer    = default_programmer;
+  programmer    = cfg_strdup("main()", default_programmer);
   verbose       = 0;
   baudrate      = 0;
   bitclock      = 0.0;
@@ -755,7 +756,7 @@ int main(int argc, char * argv [])
   int dev_opts = 0;
   // Developer option -c <wildcard>/[ASsrt] prints programmer description(s) and exits
   if(programmer && (strcmp(programmer, "*") == 0 || strchr(programmer, '/'))) {
-    dev_output_pgm_defs(programmer);
+    dev_output_pgm_defs(cfg_strdup("main()", programmer));
     dev_opts = 1;
   }
   // Developer option -p <wildcard>/[dASsrcow*t] prints part description(s) and exits
@@ -849,11 +850,11 @@ int main(int argc, char * argv [])
     switch (pgm->conntype)
     {
       case CONNTYPE_PARALLEL:
-        port = default_parallel;
+        port = cfg_strdup("main()", default_parallel);
         break;
 
       case CONNTYPE_SERIAL:
-        port = default_serial;
+        port = cfg_strdup("main()", default_serial);
         break;
 
       case CONNTYPE_USB:

--- a/src/main.c
+++ b/src/main.c
@@ -140,6 +140,10 @@ static void list_programmers_callback(const char *name, const char *desc,
                                       void *cookie)
 {
     struct list_walk_cookie *c = (struct list_walk_cookie *)cookie;
+
+    if (*name == 0 || *name == '.')
+       return;
+
     if (verbose){
         fprintf(c->f, "%s%-16s = %-30s [%s:%d]\n",
                 c->prefix, name, desc, cfgname, cfglineno);

--- a/src/main.c
+++ b/src/main.c
@@ -754,7 +754,7 @@ int main(int argc, char * argv [])
 
   avrdude_message(MSG_NOTICE, "\n");
 
-  // developer option -p <wildcard>/[*codws] prints various aspects of part descriptions and exits
+  // Developer option -p <wildcard>/[dASsrcow*t] prints part description(s) and exits
   if(partdesc && (strcmp(partdesc, "*") == 0 || strchr(partdesc, '/'))) {
     dev_output_part_defs(partdesc);
     exit(1);
@@ -768,6 +768,12 @@ int main(int argc, char * argv [])
       avrdude_message(MSG_INFO, "\n");
       exit(1);
     }
+  }
+
+  // Developer option -c <wildcard>/[ASsrt] prints programmer description(s) and exits
+  if(programmer && (strcmp(programmer, "*") == 0 || strchr(programmer, '/'))) {
+    dev_output_pgm_defs(programmer);
+    exit(1);
   }
 
   if (programmer) {

--- a/src/main.c
+++ b/src/main.c
@@ -752,13 +752,21 @@ int main(int argc, char * argv [])
   }
 
 
-  avrdude_message(MSG_NOTICE, "\n");
-
+  int dev_opts = 0;
+  // Developer option -c <wildcard>/[ASsrt] prints programmer description(s) and exits
+  if(programmer && (strcmp(programmer, "*") == 0 || strchr(programmer, '/'))) {
+    dev_output_pgm_defs(programmer);
+    dev_opts = 1;
+  }
   // Developer option -p <wildcard>/[dASsrcow*t] prints part description(s) and exits
   if(partdesc && (strcmp(partdesc, "*") == 0 || strchr(partdesc, '/'))) {
     dev_output_part_defs(partdesc);
-    exit(1);
+    dev_opts = 1;
   }
+  if(dev_opts)
+    exit(0);
+
+  avrdude_message(MSG_NOTICE, "\n");
 
   if (partdesc) {
     if (strcmp(partdesc, "?") == 0) {
@@ -768,12 +776,6 @@ int main(int argc, char * argv [])
       avrdude_message(MSG_INFO, "\n");
       exit(1);
     }
-  }
-
-  // Developer option -c <wildcard>/[ASsrt] prints programmer description(s) and exits
-  if(programmer && (strcmp(programmer, "*") == 0 || strchr(programmer, '/'))) {
-    dev_output_pgm_defs(programmer);
-    exit(1);
   }
 
   if (programmer) {

--- a/src/main.c
+++ b/src/main.c
@@ -922,10 +922,7 @@ int main(int argc, char * argv [])
                       progname,
                       (upd->op == DEVICE_READ)? 'r': (upd->op == DEVICE_WRITE)? 'w': 'v',
                       upd->filename, mtype);
-      if ((upd->memtype = strdup(mtype)) == NULL) {
-        avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
-        exit(1);
-      }
+      upd->memtype = cfg_strdup("main()", mtype);
     }
 
     if (!avr_mem_might_be_known(upd->memtype)) {

--- a/src/main.c
+++ b/src/main.c
@@ -1073,9 +1073,9 @@ int main(int argc, char * argv [])
              pgm->read_sib(pgm, p, sib);
              avrdude_message(MSG_NOTICE, "%s: System Information Block: \"%s\"\n",
                              progname, sib);
-            if (quell_progress < 2) {
+            if (quell_progress < 2)
               avrdude_message(MSG_INFO, "%s: Received FamilyID: \"%.*s\"\n", progname, AVR_FAMILYIDLEN, sib);
-            }
+
             if (strncmp(p->family_id, sib, AVR_FAMILYIDLEN)) {
               avrdude_message(MSG_INFO, "%s: Expected FamilyID: \"%s\"\n", progname, p->family_id);
               if (!ovsigck) {
@@ -1093,9 +1093,8 @@ int main(int argc, char * argv [])
               avrdude_message(MSG_INFO, "%s: conflicting -e and -n options specified, NOT erasing chip\n",
                               progname);
             } else {
-              if (quell_progress < 2) {
+              if (quell_progress < 2)
                 avrdude_message(MSG_INFO, "%s: erasing chip\n", progname);
-              }
               exitrc = avr_unlock(pgm, p);
               if(exitrc) goto main_exit;
               goto sig_again;
@@ -1229,9 +1228,8 @@ int main(int argc, char * argv [])
       avrdude_message(MSG_INFO, "%s: conflicting -e and -n options specified, NOT erasing chip\n",
                       progname);
     } else {
-      if (quell_progress < 2) {
+      if (quell_progress < 2)
       	avrdude_message(MSG_INFO, "%s: erasing chip\n", progname);
-      }
       exitrc = avr_chip_erase(pgm, p);
       if(exitrc) goto main_exit;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -244,6 +244,14 @@ static void replace_backslashes(char *s)
   }
 }
 
+// Return 2 if string is * or starts with */, 1 if string contains /, 0 otherwise
+static int dev_opt(char *str) {
+  return
+    !str? 0:
+    !strcmp(str, "*") || !strncmp(str, "*/", 2)? 2:
+    !!strchr(str, '/');
+}
+
 
 /*
  * main routine
@@ -752,20 +760,14 @@ int main(int argc, char * argv [])
     bitclock = default_bitclock;
   }
 
+  // Developer options to print parts and/or programmer entries of avrdude.conf
+  int dev_opt_c = dev_opt(programmer); // -c <wildcard>/[sSArt]
+  int dev_opt_p = dev_opt(partdesc);   // -p <wildcard>/[dsSArcow*t]
 
-  int dev_opts = 0;
-  // Developer option -c <wildcard>/[ASsrt] prints programmer description(s) and exits
-  if(programmer && (strcmp(programmer, "*") == 0 || strchr(programmer, '/'))) {
-    dev_output_pgm_defs(cfg_strdup("main()", programmer));
-    dev_opts = 1;
-  }
-  // Developer option -p <wildcard>/[dASsrcow*t] prints part description(s) and exits
-  if(partdesc && (strcmp(partdesc, "*") == 0 || strchr(partdesc, '/'))) {
-    dev_output_part_defs(partdesc);
-    dev_opts = 1;
-  }
-  if(dev_opts)
+  if(dev_opt_c || dev_opt_p) {  // See -c/h and or -p/h
+    dev_output_pgm_part(dev_opt_c, programmer, dev_opt_p, partdesc);
     exit(0);
+  }
 
   avrdude_message(MSG_NOTICE, "\n");
 

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -67,14 +67,7 @@ PROGRAMMER * pgm_new(void)
   PROGRAMMER * pgm;
   const char *nulp = cache_string("");
 
-  pgm = (PROGRAMMER *)malloc(sizeof(*pgm));
-  if (pgm == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory allocating programmer structure\n",
-            progname);
-    return NULL;
-  }
-
-  memset(pgm, 0, sizeof(*pgm));
+  pgm = (PROGRAMMER *) cfg_malloc("pgm_new()", sizeof(*pgm));
 
   pgm->id = lcreat(NULL, 0);
   pgm->usbpid = lcreat(NULL, 0);
@@ -162,24 +155,13 @@ PROGRAMMER * pgm_dup(const PROGRAMMER * const src)
   PROGRAMMER * pgm;
   LNODEID ln;
 
-  pgm = (PROGRAMMER *)malloc(sizeof(*pgm));
-  if (pgm == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory allocating programmer structure\n",
-            progname);
-    return NULL;
-  }
-
+  pgm = (PROGRAMMER *) cfg_malloc("pgm_dup()", sizeof(*pgm));
   memcpy(pgm, src, sizeof(*pgm));
 
   pgm->id = lcreat(NULL, 0);
   pgm->usbpid = lcreat(NULL, 0);
   for (ln = lfirst(src->usbpid); ln; ln = lnext(ln)) {
-    int *ip = malloc(sizeof(int));
-    if (ip == NULL) {
-      avrdude_message(MSG_INFO, "%s: out of memory allocating programmer structure\n",
-              progname);
-      exit(1);
-    }
+    int *ip = cfg_malloc("pgm_dup()", sizeof(int));
     *ip = *(int *) ldata(ln);
     ladd(pgm->usbpid, ip);
   }

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -65,6 +65,7 @@ PROGRAMMER * pgm_new(void)
 {
   int i;
   PROGRAMMER * pgm;
+  char *nulp = cache_string("");
 
   pgm = (PROGRAMMER *)malloc(sizeof(*pgm));
   if (pgm == NULL) {
@@ -79,12 +80,17 @@ PROGRAMMER * pgm_new(void)
   pgm->usbpid = lcreat(NULL, 0);
   pgm->desc[0] = 0;
   pgm->type[0] = 0;
-  pgm->parent_id = NULL;
-  pgm->config_file = NULL;
+  pgm->parent_id = nulp;
+  pgm->config_file = nulp;
   pgm->lineno = 0;
   pgm->baudrate = 0;
   pgm->initpgm = NULL;
   pgm->hvupdi_support = lcreat(NULL, 0);
+
+  pgm->usbdev = nulp;
+  pgm->usbsn = nulp;
+  pgm->usbvendor = nulp;
+  pgm->usbproduct = nulp;
 
   for (i=0; i<N_PINS; i++) {
     pgm->pinno[i] = 0;
@@ -146,7 +152,7 @@ void pgm_free(PROGRAMMER * const p)
   ldestroy_cb(p->usbpid, free);
   p->id = NULL;
   p->usbpid = NULL;
-  /* do not free p->parent_id nor p->config_file */
+  /* do not free p->parent_id, p->config_file, p->usbdev, p->usbsn, p->usbvendor or p-> usbproduct */
   /* p->cookie is freed by pgm_teardown */
   free(p);
 }

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -65,7 +65,7 @@ PROGRAMMER * pgm_new(void)
 {
   int i;
   PROGRAMMER * pgm;
-  char *nulp = cache_string("");
+  const char *nulp = cache_string("");
 
   pgm = (PROGRAMMER *)malloc(sizeof(*pgm));
   if (pgm == NULL) {

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -61,31 +61,29 @@ static void pgm_default_powerup_powerdown (struct programmer_t * pgm)
 }
 
 
-PROGRAMMER * pgm_new(void)
-{
-  int i;
-  PROGRAMMER * pgm;
+PROGRAMMER *pgm_new(void) {
+  PROGRAMMER *pgm = (PROGRAMMER *) cfg_malloc("pgm_new()", sizeof(*pgm));
   const char *nulp = cache_string("");
 
-  pgm = (PROGRAMMER *) cfg_malloc("pgm_new()", sizeof(*pgm));
-
+  // Initialise const char * and LISTID entities
   pgm->id = lcreat(NULL, 0);
   pgm->usbpid = lcreat(NULL, 0);
-  pgm->desc[0] = 0;
-  pgm->type[0] = 0;
-  pgm->parent_id = nulp;
-  pgm->config_file = nulp;
-  pgm->lineno = 0;
-  pgm->baudrate = 0;
-  pgm->initpgm = NULL;
   pgm->hvupdi_support = lcreat(NULL, 0);
-
+  pgm->desc = nulp;
+  pgm->parent_id = nulp;
   pgm->usbdev = nulp;
   pgm->usbsn = nulp;
   pgm->usbvendor = nulp;
   pgm->usbproduct = nulp;
+  pgm->config_file = nulp;
 
-  for (i=0; i<N_PINS; i++) {
+  // Default values
+  pgm->initpgm = NULL;
+  pgm->lineno = 0;
+  pgm->baudrate = 0;
+
+  // Clear pin array
+  for(int i=0; i<N_PINS; i++) {
     pgm->pinno[i] = 0;
     pin_clear_all(&(pgm->pin[i]));
   }
@@ -121,49 +119,70 @@ PROGRAMMER * pgm_new(void)
    * optional functions - these are checked to make sure they are
    * assigned before they are called
    */
+  pgm->unlock         = NULL;
   pgm->cmd            = NULL;
   pgm->cmd_tpi        = NULL;
   pgm->spi            = NULL;
   pgm->paged_write    = NULL;
   pgm->paged_load     = NULL;
+  pgm->page_erase     = NULL;
   pgm->write_setup    = NULL;
   pgm->read_sig_bytes = NULL;
+  pgm->read_sib       = NULL;
+  pgm->print_parms    = NULL;
   pgm->set_vtarget    = NULL;
   pgm->set_varef      = NULL;
   pgm->set_fosc       = NULL;
+  pgm->set_sck_period = NULL;
+  pgm->setpin         = NULL;
+  pgm->getpin         = NULL;
+  pgm->highpulsepin   = NULL;
+  pgm->parseexitspecs = NULL;
   pgm->perform_osccal = NULL;
   pgm->parseextparams = NULL;
   pgm->setup          = NULL;
   pgm->teardown       = NULL;
 
+  // For allocating "global" memory by the programmer
+  pgm->cookie          = NULL;
+
   return pgm;
 }
 
-void pgm_free(PROGRAMMER * const p)
-{
-  ldestroy_cb(p->id, free);
-  ldestroy_cb(p->usbpid, free);
-  p->id = NULL;
-  p->usbpid = NULL;
-  /* do not free p->parent_id, p->config_file, p->usbdev, p->usbsn, p->usbvendor or p-> usbproduct */
-  /* p->cookie is freed by pgm_teardown */
-  free(p);
+void pgm_free(PROGRAMMER *p) {
+  if(p) {
+    ldestroy_cb(p->id, free);
+    ldestroy_cb(p->usbpid, free);
+    ldestroy_cb(p->hvupdi_support, free);
+    p->id = NULL;
+    p->usbpid = NULL;
+    p->hvupdi_support = NULL;
+    // Never free const char *, eg, p->desc, which are set by cache_string()
+    // p->cookie is freed by pgm_teardown
+    free(p);
+  }
 }
 
-PROGRAMMER * pgm_dup(const PROGRAMMER * const src)
-{
-  PROGRAMMER * pgm;
-  LNODEID ln;
+PROGRAMMER *pgm_dup(const PROGRAMMER *src) {
+  PROGRAMMER *pgm = pgm_new();
 
-  pgm = (PROGRAMMER *) cfg_malloc("pgm_dup()", sizeof(*pgm));
-  memcpy(pgm, src, sizeof(*pgm));
+  if(src) {
+    memcpy(pgm, src, sizeof(*pgm));
+    pgm->id = lcreat(NULL, 0);
+    pgm->usbpid = lcreat(NULL, 0);
+    pgm->hvupdi_support = lcreat(NULL, 0);
 
-  pgm->id = lcreat(NULL, 0);
-  pgm->usbpid = lcreat(NULL, 0);
-  for (ln = lfirst(src->usbpid); ln; ln = lnext(ln)) {
-    int *ip = cfg_malloc("pgm_dup()", sizeof(int));
-    *ip = *(int *) ldata(ln);
-    ladd(pgm->usbpid, ip);
+    // Leave id list empty but copy usbpid and hvupdi_support over
+    for(LNODEID ln = lfirst(src->hvupdi_support); ln; ln = lnext(ln)) {
+      int *ip = cfg_malloc("pgm_dup()", sizeof(int));
+      *ip = *(int *) ldata(ln);
+      ladd(pgm->hvupdi_support, ip);
+    }
+    for(LNODEID ln = lfirst(src->usbpid); ln; ln = lnext(ln)) {
+      int *ip = cfg_malloc("pgm_dup()", sizeof(int));
+      *ip = *(int *) ldata(ln);
+      ladd(pgm->usbpid, ip);
+    }
   }
 
   return pgm;
@@ -207,8 +226,7 @@ static void pgm_default_6 (struct programmer_t * pgm, const char * p)
 }
 
 
-void programmer_display(PROGRAMMER * pgm, const char * p)
-{
+void programmer_display(PROGRAMMER *pgm, const char * p) {
   avrdude_message(MSG_INFO, "%sProgrammer Type : %s\n", p, pgm->type);
   avrdude_message(MSG_INFO, "%sDescription     : %s\n", p, pgm->desc);
 
@@ -216,8 +234,7 @@ void programmer_display(PROGRAMMER * pgm, const char * p)
 }
 
 
-void pgm_display_generic_mask(PROGRAMMER * pgm, const char * p, unsigned int show)
-{
+void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int show) {
   if(show & (1<<PPI_AVR_VCC)) 
     avrdude_message(MSG_INFO, "%s  VCC     = %s\n", p, pins_to_str(&pgm->pin[PPI_AVR_VCC]));
   if(show & (1<<PPI_AVR_BUFF))
@@ -240,33 +257,22 @@ void pgm_display_generic_mask(PROGRAMMER * pgm, const char * p, unsigned int sho
     avrdude_message(MSG_INFO, "%s  VFY LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_VFY]));
 }
 
-void pgm_display_generic(PROGRAMMER * pgm, const char * p)
-{
+void pgm_display_generic(const PROGRAMMER *pgm, const char *p) {
   pgm_display_generic_mask(pgm, p, SHOW_ALL_PINS);
 }
 
-PROGRAMMER * locate_programmer(LISTID programmers, const char * configid)
-{
-  LNODEID ln1, ln2;
-  PROGRAMMER * p = NULL;
-  const char * id;
-  int found;
+PROGRAMMER *locate_programmer(const LISTID programmers, const char *configid) {
+  PROGRAMMER *p = NULL;
+  int found = 0;
 
-  found = 0;
-
-  for (ln1=lfirst(programmers); ln1 && !found; ln1=lnext(ln1)) {
+  for(LNODEID ln1=lfirst(programmers); ln1 && !found; ln1=lnext(ln1)) {
     p = ldata(ln1);
-    for (ln2=lfirst(p->id); ln2 && !found; ln2=lnext(ln2)) {
-      id = ldata(ln2);
-      if (strcasecmp(configid, id) == 0)
+    for(LNODEID ln2=lfirst(p->id); ln2 && !found; ln2=lnext(ln2))
+      if(strcasecmp(configid, (const char *) ldata(ln2)) == 0)
         found = 1;
-    }
   }
 
-  if (found)
-    return p;
-
-  return NULL;
+  return found? p: NULL;
 }
 
 /*
@@ -296,16 +302,11 @@ void walk_programmers(LISTID programmers, walk_programmers_cb cb, void *cookie)
 /*
  * Compare function to sort the list of programmers
  */
-static int sort_programmer_compare(PROGRAMMER * p1,PROGRAMMER * p2)
-{
-  char* id1;
-  char* id2;
-  if(p1 == NULL || p2 == NULL) {
+static int sort_programmer_compare(const PROGRAMMER *p1, const PROGRAMMER *p2) {
+  if(p1 == NULL || p1->id == NULL || p2 == NULL || p2->id == NULL)
     return 0;
-  }
-  id1 = ldata(lfirst(p1->id));
-  id2 = ldata(lfirst(p2->id));
-  return strncasecmp(id1,id2,AVR_IDLEN);
+
+  return strcasecmp(ldata(lfirst(p1->id)), ldata(lfirst(p2->id)));
 }
 
 /*

--- a/src/pgm_type.c
+++ b/src/pgm_type.c
@@ -57,55 +57,55 @@
 #include "xbee.h"
 
 
-const PROGRAMMER_TYPE programmers_types[] = {
-        {"arduino", arduino_initpgm, arduino_desc},
-        {"avr910", avr910_initpgm, avr910_desc},
-        {"avrftdi", avrftdi_initpgm, avrftdi_desc},
-        {"buspirate", buspirate_initpgm, buspirate_desc},
-        {"buspirate_bb", buspirate_bb_initpgm, buspirate_bb_desc},
-        {"butterfly", butterfly_initpgm, butterfly_desc},
-        {"butterfly_mk", butterfly_mk_initpgm, butterfly_mk_desc},
-        {"dragon_dw", jtagmkII_dragon_dw_initpgm, jtagmkII_dragon_dw_desc},
-        {"dragon_hvsp", stk500v2_dragon_hvsp_initpgm, stk500v2_dragon_hvsp_desc},
-        {"dragon_isp", stk500v2_dragon_isp_initpgm, stk500v2_dragon_isp_desc},
-        {"dragon_jtag", jtagmkII_dragon_initpgm, jtagmkII_dragon_desc},
-        {"dragon_pdi", jtagmkII_dragon_pdi_initpgm, jtagmkII_dragon_pdi_desc},
-        {"dragon_pp", stk500v2_dragon_pp_initpgm, stk500v2_dragon_pp_desc},
-        {"flip1", flip1_initpgm, flip1_desc},
-        {"flip2", flip2_initpgm, flip2_desc},
-        {"ftdi_syncbb", ft245r_initpgm, ft245r_desc},
-        {"jtagmki", jtagmkI_initpgm, jtagmkI_desc},
-        {"jtagmkii", jtagmkII_initpgm, jtagmkII_desc},
-        {"jtagmkii_avr32", jtagmkII_avr32_initpgm, jtagmkII_avr32_desc},
-        {"jtagmkii_dw", jtagmkII_dw_initpgm, jtagmkII_dw_desc},
-        {"jtagmkii_isp", stk500v2_jtagmkII_initpgm, stk500v2_jtagmkII_desc},
-        {"jtagmkii_pdi", jtagmkII_pdi_initpgm, jtagmkII_pdi_desc},
-        {"jtagmkii_updi", jtagmkII_updi_initpgm, jtagmkII_updi_desc},
-        {"jtagice3", jtag3_initpgm, jtag3_desc},
-        {"jtagice3_pdi", jtag3_pdi_initpgm, jtag3_pdi_desc},
-        {"jtagice3_updi", jtag3_updi_initpgm, jtag3_updi_desc},
-        {"jtagice3_dw", jtag3_dw_initpgm, jtag3_dw_desc},
-        {"jtagice3_isp", stk500v2_jtag3_initpgm, stk500v2_jtag3_desc},
-        {"linuxgpio", linuxgpio_initpgm, linuxgpio_desc},
-        {"linuxspi", linuxspi_initpgm, linuxspi_desc},
-        {"micronucleus", micronucleus_initpgm, micronucleus_desc},
-        {"par", par_initpgm, par_desc},
-        {"pickit2", pickit2_initpgm, pickit2_desc},
-        {"serbb", serbb_initpgm, serbb_desc},
-        {"serialupdi", serialupdi_initpgm, serialupdi_desc},
-        {"stk500", stk500_initpgm, stk500_desc},
-        {"stk500generic", stk500generic_initpgm, stk500generic_desc},
-        {"stk500v2", stk500v2_initpgm, stk500v2_desc},
-        {"stk500hvsp", stk500hvsp_initpgm, stk500hvsp_desc},
-        {"stk500pp", stk500pp_initpgm, stk500pp_desc},
-        {"stk600", stk600_initpgm, stk600_desc},
-        {"stk600hvsp", stk600hvsp_initpgm, stk600hvsp_desc},
-        {"stk600pp", stk600pp_initpgm, stk600pp_desc},
-        {"teensy", teensy_initpgm, teensy_desc},
-        {"usbasp", usbasp_initpgm, usbasp_desc},
-        {"usbtiny", usbtiny_initpgm, usbtiny_desc},
-        {"wiring", wiring_initpgm, wiring_desc},
-        {"xbee", xbee_initpgm, xbee_desc},
+const PROGRAMMER_TYPE programmers_types[] = { // Name(s) the programmers call themselves
+  {"arduino", arduino_initpgm, arduino_desc}, // "Arduino"
+  {"avr910", avr910_initpgm, avr910_desc}, // "avr910"
+  {"avrftdi", avrftdi_initpgm, avrftdi_desc}, // "avrftdi"
+  {"buspirate", buspirate_initpgm, buspirate_desc}, // "BusPirate"
+  {"buspirate_bb", buspirate_bb_initpgm, buspirate_bb_desc}, // "BusPirate_BB"
+  {"butterfly", butterfly_initpgm, butterfly_desc}, // "butterfly"
+  {"butterfly_mk", butterfly_mk_initpgm, butterfly_mk_desc}, // "butterfly_mk"
+  {"dragon_dw", jtagmkII_dragon_dw_initpgm, jtagmkII_dragon_dw_desc}, // "DRAGON_DW"
+  {"dragon_hvsp", stk500v2_dragon_hvsp_initpgm, stk500v2_dragon_hvsp_desc}, // "DRAGON_HVSP"
+  {"dragon_isp", stk500v2_dragon_isp_initpgm, stk500v2_dragon_isp_desc}, // "DRAGON_ISP"
+  {"dragon_jtag", jtagmkII_dragon_initpgm, jtagmkII_dragon_desc}, // "DRAGON_JTAG"
+  {"dragon_pdi", jtagmkII_dragon_pdi_initpgm, jtagmkII_dragon_pdi_desc}, // "DRAGON_PDI"
+  {"dragon_pp", stk500v2_dragon_pp_initpgm, stk500v2_dragon_pp_desc}, // "DRAGON_PP"
+  {"flip1", flip1_initpgm, flip1_desc}, // "flip1"
+  {"flip2", flip2_initpgm, flip2_desc}, // "flip2"
+  {"ftdi_syncbb", ft245r_initpgm, ft245r_desc}, // "ftdi_syncbb"
+  {"jtagmki", jtagmkI_initpgm, jtagmkI_desc}, // "JTAGMKI"
+  {"jtagmkii", jtagmkII_initpgm, jtagmkII_desc}, // "JTAGMKII"
+  {"jtagmkii_avr32", jtagmkII_avr32_initpgm, jtagmkII_avr32_desc}, // "JTAGMKII_AVR32"
+  {"jtagmkii_dw", jtagmkII_dw_initpgm, jtagmkII_dw_desc}, // "JTAGMKII_DW"
+  {"jtagmkii_isp", stk500v2_jtagmkII_initpgm, stk500v2_jtagmkII_desc}, // "JTAGMKII_ISP"
+  {"jtagmkii_pdi", jtagmkII_pdi_initpgm, jtagmkII_pdi_desc}, // "JTAGMKII_PDI"
+  {"jtagmkii_updi", jtagmkII_updi_initpgm, jtagmkII_updi_desc}, // "JTAGMKII_UPDI"
+  {"jtagice3", jtag3_initpgm, jtag3_desc}, // "JTAGICE3"
+  {"jtagice3_pdi", jtag3_pdi_initpgm, jtag3_pdi_desc}, // "JTAGICE3_PDI"
+  {"jtagice3_updi", jtag3_updi_initpgm, jtag3_updi_desc}, // "JTAGICE3_UPDI"
+  {"jtagice3_dw", jtag3_dw_initpgm, jtag3_dw_desc}, // "JTAGICE3_DW"
+  {"jtagice3_isp", stk500v2_jtag3_initpgm, stk500v2_jtag3_desc}, // "JTAG3_ISP"
+  {"linuxgpio", linuxgpio_initpgm, linuxgpio_desc}, // "linuxgpio"
+  {"linuxspi", linuxspi_initpgm, linuxspi_desc}, // LINUXSPI
+  {"micronucleus", micronucleus_initpgm, micronucleus_desc}, // "micronucleus" or "Micronucleus V2.0"
+  {"par", par_initpgm, par_desc}, // "PPI"
+  {"pickit2", pickit2_initpgm, pickit2_desc}, // "pickit2"
+  {"serbb", serbb_initpgm, serbb_desc}, // "SERBB"
+  {"serialupdi", serialupdi_initpgm, serialupdi_desc}, // "serialupdi"
+  {"stk500", stk500_initpgm, stk500_desc}, // "STK500"
+  {"stk500generic", stk500generic_initpgm, stk500generic_desc}, // "STK500GENERIC"
+  {"stk500v2", stk500v2_initpgm, stk500v2_desc}, // "STK500V2"
+  {"stk500hvsp", stk500hvsp_initpgm, stk500hvsp_desc}, // "STK500HVSP"
+  {"stk500pp", stk500pp_initpgm, stk500pp_desc}, // "STK500PP"
+  {"stk600", stk600_initpgm, stk600_desc}, // "STK600"
+  {"stk600hvsp", stk600hvsp_initpgm, stk600hvsp_desc}, // "STK600HVSP"
+  {"stk600pp", stk600pp_initpgm, stk600pp_desc}, // "STK600PP"
+  {"teensy", teensy_initpgm, teensy_desc}, // "teensy"
+  {"usbasp", usbasp_initpgm, usbasp_desc}, // "usbasp"
+  {"usbtiny", usbtiny_initpgm, usbtiny_desc}, // "USBtiny" or "usbtiny"
+  {"wiring", wiring_initpgm, wiring_desc}, // "Wiring"
+  {"xbee", xbee_initpgm, xbee_desc}, // "XBee"
 };
 
 const PROGRAMMER_TYPE * locate_programmer_type(const char * id)
@@ -127,6 +127,16 @@ const PROGRAMMER_TYPE * locate_programmer_type(const char * id)
 
   return NULL;
 }
+
+// Return type id given the init function or "" if not found
+const char *locate_programmer_type_id(void (*initpgm)(struct programmer_t *pgm)) {
+  for (int i=0; i < sizeof programmers_types/sizeof*programmers_types; i++)
+    if(programmers_types[i].initpgm == initpgm)
+      return programmers_types[i].id;
+
+  return "";
+}
+
 
 /*
  * Iterate over the list of programmers given as "programmers", and

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -312,7 +312,7 @@ int pins_check(const struct programmer_t * const pgm, const struct pin_checklist
 }
 
 /**
- * This function returns a string representation of defined pins eg. ~1,2,~4,~5,7
+ * This function returns a string of defined pins, eg, ~1,2,~4,~5,7 or " (not used)"
  * Another execution of this function will overwrite the previous result in the static buffer.
  *
  * @param[in] pindef the pin definition for which we want the string representation
@@ -347,6 +347,28 @@ const char * pins_to_str(const struct pindef_t * const pindef) {
 }
 
 /**
+ * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
+ *
+ * @param[in] pindef the pin definition for which we want the string representation
+ * @returns a pointer to a string, which was created by strdup (NULL if out of memory)
+ */
+char *pins_to_strdup(const struct pindef_t * const pindef) {
+  char buf[6*(PIN_MAX+1)], *p = buf;
+
+  *buf = 0;
+  for(int pin = PIN_MIN; pin <= PIN_MAX; pin++) {
+    int index = pin / PIN_FIELD_ELEMENT_SIZE, bit = pin % PIN_FIELD_ELEMENT_SIZE;
+    if(pindef->mask[index] & (1 << bit)) {
+      if(*buf)
+         *p++ = ',', *p++=' ';
+      p += sprintf(p, "~%d" + !(pindef->inverse[index] & (1 << bit)), pin);
+    }
+  }
+
+  return strdup(buf);
+}
+
+/**
  * Returns the name of the pin as string.
  *
  * @param pinname the pinname which we want as string.
@@ -369,3 +391,24 @@ const char * avr_pin_name(int pinname) {
 }
 
 
+/**
+ * Returns the name of the pin as string.
+ *
+ * @param pinname the pinname which we want as string.
+ * @returns a lowercase string with the pinname, or <unknown> if pinname is invalid.
+ */
+const char * avr_pin_lcname(int pinname) {
+  switch(pinname) {
+  case PPI_AVR_VCC   : return "vcc";
+  case PPI_AVR_BUFF  : return "buff";
+  case PIN_AVR_RESET : return "reset";
+  case PIN_AVR_SCK   : return "sck";
+  case PIN_AVR_MOSI  : return "mosi";
+  case PIN_AVR_MISO  : return "miso";
+  case PIN_LED_ERR   : return "errled";
+  case PIN_LED_RDY   : return "rdyled";
+  case PIN_LED_PGM   : return "pgmled";
+  case PIN_LED_VFY   : return "vfyled";
+  default : return "<unknown>";
+  }
+}

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -350,7 +350,7 @@ const char * pins_to_str(const struct pindef_t * const pindef) {
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation
- * @returns a pointer to a string, which was created by strdup (NULL if out of memory)
+ * @returns a pointer to a string, which was created by strdup
  */
 char *pins_to_strdup(const struct pindef_t * const pindef) {
   char buf[6*(PIN_MAX+1)], *p = buf;
@@ -365,7 +365,7 @@ char *pins_to_strdup(const struct pindef_t * const pindef) {
     }
   }
 
-  return strdup(buf);
+  return cfg_strdup("pins_to_strdup()", buf);
 }
 
 /**

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -361,7 +361,7 @@ char *pins_to_strdup(const struct pindef_t * const pindef) {
     if(pindef->mask[index] & (1 << bit)) {
       if(*buf)
          *p++ = ',', *p++=' ';
-      p += sprintf(p, "~%d" + !(pindef->inverse[index] & (1 << bit)), pin);
+      p += sprintf(p, pindef->inverse[index] & (1 << bit)? "~%d": "%d", pin);
     }
   }
 

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -65,8 +65,8 @@ static int              avrdoperRxPosition = 0; /* amount of bytes already consu
 /* ------------------------------------------------------------------------ */
 /* ------------------------------------------------------------------------ */
 
-static int usbOpenDevice(union filedescriptor *fdp, int vendor, char *vendorName,
-			 int product, char *productName, int doReportIDs)
+static int usbOpenDevice(union filedescriptor *fdp, int vendor, const char *vendorName,
+			 int product, const char *productName, int doReportIDs)
 {
     hid_device *dev;
 

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -393,7 +393,7 @@ static int net_send(union filedescriptor *fd, const unsigned char * buf, size_t 
 	}
 
 	while (len) {
-		rc = send(fd->ifd, p, (len > 1024) ? 1024 : len, 0);
+		rc = send(fd->ifd, (const char *) p, (len > 1024)? 1024: len, 0);
 		if (rc < 0) {
 			FormatMessage(
 				FORMAT_MESSAGE_ALLOCATE_BUFFER |
@@ -527,7 +527,7 @@ reselect:
 			}
 		}
 
-		rc = recv(fd->ifd, p, (buflen - len > 1024) ? 1024 : buflen - len, 0);
+		rc = recv(fd->ifd, (char *) p, (buflen - len > 1024)? 1024: buflen - len, 0);
 		if (rc < 0) {
 			FormatMessage(
 				FORMAT_MESSAGE_ALLOCATE_BUFFER |
@@ -693,7 +693,7 @@ static int net_drain(union filedescriptor *fd, int display)
 			}
 		}
 
-		rc = recv(fd->ifd, &buf, 1, 0);
+		rc = recv(fd->ifd, (char *) &buf, 1, 0);
 		if (rc < 0) {
 			FormatMessage(
 				FORMAT_MESSAGE_ALLOCATE_BUFFER |

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3093,12 +3093,14 @@ static int stk500v2_setparm_real(PROGRAMMER * pgm, unsigned char parm, unsigned 
 
 static int stk500v2_setparm(PROGRAMMER * pgm, unsigned char parm, unsigned char value)
 {
-  unsigned char current_value;
+  unsigned char current_value = value;
   int res;
 
   res = stk500v2_getparm(pgm, parm, &current_value);
-  if (res < 0)
+  if (res < 0) {
     avrdude_message(MSG_INFO, "%s: Unable to get parameter 0x%02x\n", progname, parm);
+    return -1;
+  }
 
   // don't issue a write if the correct value is already set.
   if (value == current_value) {
@@ -3245,13 +3247,15 @@ f_to_kHz_MHz(double f, const char **unit)
 
 static void stk500v2_print_parms1(PROGRAMMER * pgm, const char * p)
 {
-  unsigned char vtarget, vadjust, osc_pscale, osc_cmatch, sck_duration =0; //XXX 0 is not correct, check caller
+  unsigned char vtarget = 0, vadjust = 0, osc_pscale = 0, osc_cmatch = 0, sck_duration =0; //XXX 0 is not correct, check caller
   unsigned int sck_stk600, clock_conf, dac, oct, varef;
   unsigned char vtarget_jtag[4];
   int prescale;
   double f;
   const char *unit;
   void *mycookie;
+
+  memset(vtarget_jtag, 0, sizeof vtarget_jtag);
 
   if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE_MKII) {
     mycookie = pgm->cookie;

--- a/src/term.c
+++ b/src/term.c
@@ -20,7 +20,6 @@
 
 #include "ac_cfg.h"
 
-#include <ctype.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -346,178 +345,6 @@ static int cmd_dump(PROGRAMMER * pgm, struct avrpart * p,
 }
 
 
-// Convert the next n hex digits of s to a hex number
-static unsigned int tohex(const unsigned char *s, unsigned int n) {
-  int ret, c;
-
-  ret = 0;
-  while(n--) {
-    ret *= 16;
-    c = *s++;
-    ret += c >= '0' && c <= '9'? c - '0': c >= 'a' && c <= 'f'? c - 'a' + 10: c - 'A' + 10;
-  }
-
-  return ret;
-}
-
-/*
- * Create a utf-8 character sequence from a single unicode character.
- * Permissive for some invalid unicode sequences but not for those with
- * high bit set). Returns numbers of characters written (0-6).
- */
-static int wc_to_utf8str(unsigned int wc, unsigned char *str) {
-  if(!(wc & ~0x7fu)) {
-    *str = (char) wc;
-    return 1;
-  }
-  if(!(wc & ~0x7ffu)) {
-    *str++ = (char) ((wc >> 6) | 0xc0);
-    *str++ = (char) ((wc & 0x3f) | 0x80);
-    return 2;
-  }
-  if(!(wc & ~0xffffu)) {
-    *str++ = (char) ((wc >> 12) | 0xe0);
-    *str++ = (char) (((wc >> 6) & 0x3f) | 0x80);
-    *str++ = (char) ((wc & 0x3f) | 0x80);
-    return 3;
-  }
-  if(!(wc & ~0x1fffffu)) {
-    *str++ = (char) ((wc >> 18) | 0xf0);
-    *str++ = (char) (((wc >> 12) & 0x3f) | 0x80);
-    *str++ = (char) (((wc >> 6) & 0x3f) | 0x80);
-    *str++ = (char) ((wc & 0x3f) | 0x80);
-    return 4;
-  }
-  if(!(wc & ~0x3ffffffu)) {
-    *str++ = (char) ((wc >> 24) | 0xf8);
-    *str++ = (char) (((wc >> 18) & 0x3f) | 0x80);
-    *str++ = (char) (((wc >> 12) & 0x3f) | 0x80);
-    *str++ = (char) (((wc >> 6) & 0x3f) | 0x80);
-    *str++ = (char) ((wc & 0x3f) | 0x80);
-    return 5;
-  }
-  if(!(wc & ~0x7fffffffu)) {
-    *str++ = (char) ((wc >> 30) | 0xfc);
-    *str++ = (char) (((wc >> 24) & 0x3f) | 0x80);
-    *str++ = (char) (((wc >> 18) & 0x3f) | 0x80);
-    *str++ = (char) (((wc >> 12) & 0x3f) | 0x80);
-    *str++ = (char) (((wc >> 6) & 0x3f) | 0x80);
-    *str++ = (char) ((wc & 0x3f) | 0x80);
-    return 6;
-  }
-  return 0;
-}
-
-// Unescape C-style strings, destination d must hold enough space (and can be source s)
-static unsigned char *unescape(unsigned char *d, const unsigned char *s) {
-  unsigned char *ret = d;
-  int n, k;
-
-  while(*s) {
-    switch (*s) {
-    case '\\':
-      switch (*++s) {
-      case 'n':
-        *d = '\n';
-        break;
-      case 't':
-        *d = '\t';
-        break;
-      case 'a':
-        *d = '\a';
-        break;
-      case 'b':
-        *d = '\b';
-        break;
-      case 'e':                 // Non-standard ESC
-        *d = 27;
-        break;
-      case 'f':
-        *d = '\f';
-        break;
-      case 'r':
-        *d = '\r';
-        break;
-      case 'v':
-        *d = '\v';
-        break;
-      case '?':
-        *d = '?';
-        break;
-      case '`':
-        *d = '`';
-        break;
-      case '"':
-        *d = '"';
-        break;
-      case '\'':
-        *d = '\'';
-        break;
-      case '\\':
-        *d = '\\';
-        break;
-      case '0':
-      case '1':
-      case '2':
-      case '3':
-      case '4':
-      case '5':
-      case '6':
-      case '7':                 // 1-3 octal digits
-        n = *s - '0';
-        for(k = 0; k < 2 && s[1] >= '0' && s[1] <= '7'; k++)  // Max 2 more octal characters
-          n *= 8, n += s[1] - '0', s++;
-        *d = n;
-        break;
-      case 'x':                 // Unlimited hex digits
-        for(k = 0; isxdigit(s[k + 1]); k++)
-          continue;
-        if(k > 0) {
-          *d = tohex(s + 1, k);
-          s += k;
-        } else {                // No hex digits after \x? copy \x
-          *d++ = '\\';
-          *d = 'x';
-        }
-        break;
-      case 'u':                 // Exactly 4 hex digits and valid unicode
-        if(isxdigit(s[1]) && isxdigit(s[2]) && isxdigit(s[3]) && isxdigit(s[4]) &&
-          (n = wc_to_utf8str(tohex(s+1, 4), d))) {
-          d += n - 1;
-          s += 4;
-        } else {                // Invalid \u sequence? copy \u
-          *d++ = '\\';
-          *d = 'u';
-        }
-        break;
-      case 'U':                 // Exactly 6 hex digits and valid unicode
-        if(isxdigit(s[1]) && isxdigit(s[2]) && isxdigit(s[3]) && isxdigit(s[4]) && isxdigit(s[5]) && isxdigit(s[6]) &&
-          (n = wc_to_utf8str(tohex(s+1, 6), d))) {
-          d += n - 1;
-          s += 6;
-        } else {                // Invalid \U sequence? copy \U
-          *d++ = '\\';
-          *d = 'U';
-        }
-        break;
-      default:                  // Keep the escape sequence (C would warn and remove \)
-        *d++ = '\\';
-        *d = *s;
-      }
-      break;
-
-    default:                    // Not an escape sequence: just copy the character
-      *d = *s;
-    }
-    d++;
-    s++;
-  }
-  *d = *s;                      // Terminate
-
-  return ret;
-}
-
-
 static size_t maxstrlen(int argc, char **argv) {
   size_t max = 0;
 
@@ -800,7 +627,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
           }
           // Strip start and end quotes, and unescape C string
           strncpy(s, argi+1, arglen-2);
-          unescape((unsigned char *) s, (unsigned char *) s);
+          cfg_unescape(s, s);
           if (*argi == '\'') { // Single C-style character
             if(*s && s[1])
               terminal_message(MSG_INFO, "%s (write): only using first character of %s\n",

--- a/src/term.c
+++ b/src/term.c
@@ -20,6 +20,7 @@
 
 #include "ac_cfg.h"
 
+#include <ctype.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/update.c
+++ b/src/update.c
@@ -37,11 +37,7 @@ UPDATE * parse_op(char * s)
   int i;
   size_t fnlen;
 
-  upd = (UPDATE *)malloc(sizeof(UPDATE));
-  if (upd == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
-    exit(1);
-  }
+  upd = (UPDATE *) cfg_malloc("parse_op()", sizeof(UPDATE));
 
   i = 0;
   p = s;
@@ -52,22 +48,12 @@ UPDATE * parse_op(char * s)
   if (*p != ':') {
     upd->memtype = NULL;        /* default memtype, "flash", or "application" */
     upd->op = DEVICE_WRITE;
-    upd->filename = (char *)malloc(strlen(buf) + 1);
-    if (upd->filename == NULL) {
-        avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
-        exit(1);
-    }
-    strcpy(upd->filename, buf);
+    upd->filename = cfg_strdup("parse_op()", buf);
     upd->format = FMT_AUTO;
     return upd;
   }
 
-  upd->memtype = (char *)malloc(strlen(buf)+1);
-  if (upd->memtype == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
-    exit(1);
-  }
-  strcpy(upd->memtype, buf);
+  upd->memtype = cfg_strdup("parse_op()", buf);
 
   p++;
   if (*p == 'r') {
@@ -118,10 +104,10 @@ UPDATE * parse_op(char * s)
     // and to binary for read operations:
     upd->format = upd->op == DEVICE_READ? FMT_RBIN: FMT_AUTO;
     fnlen = strlen(cp);
-    upd->filename = (char *)malloc(fnlen + 1);
+    upd->filename = (char *) cfg_malloc("parse_op()", fnlen + 1);
   } else {
     fnlen = p - cp;
-    upd->filename = (char *)malloc(fnlen +1);
+    upd->filename = (char *) cfg_malloc("parse_op()", fnlen +1);
     c = *++p;
     if (c && p[1])
       /* More than one char - force failure below. */
@@ -147,12 +133,6 @@ UPDATE * parse_op(char * s)
     }
   }
 
-  if (upd->filename == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
-    free(upd->memtype);
-    free(upd);
-    return NULL;
-  }
   memcpy(upd->filename, cp, fnlen);
   upd->filename[fnlen] = 0;
 
@@ -163,19 +143,15 @@ UPDATE * dup_update(UPDATE * upd)
 {
   UPDATE * u;
 
-  u = (UPDATE *)malloc(sizeof(UPDATE));
-  if (u == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
-    exit(1);
-  }
+  u = (UPDATE *) cfg_malloc("dup_update()", sizeof(UPDATE));
 
   memcpy(u, upd, sizeof(UPDATE));
 
   if (upd->memtype != NULL)
-    u->memtype = strdup(upd->memtype);
+    u->memtype = cfg_strdup("dup_update()", upd->memtype);
   else
     u->memtype = NULL;
-  u->filename = strdup(upd->filename);
+  u->filename = cfg_strdup("dup_update()", upd->filename);
 
   return u;
 }
@@ -184,14 +160,10 @@ UPDATE * new_update(int op, char * memtype, int filefmt, char * filename)
 {
   UPDATE * u;
 
-  u = (UPDATE *)malloc(sizeof(UPDATE));
-  if (u == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
-    exit(1);
-  }
+  u = (UPDATE *) cfg_malloc("new_update()", sizeof(UPDATE));
 
-  u->memtype = strdup(memtype);
-  u->filename = strdup(filename);
+  u->memtype = cfg_strdup("new_update()", memtype);
+  u->filename = cfg_strdup("new_update()", filename);
   u->op = op;
   u->format = filefmt;
 

--- a/src/update.c
+++ b/src/update.c
@@ -306,11 +306,11 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     return LIBAVRDUDE_SOFTFAIL;
   }
 
-  AVRMEM_ALIAS * alias_mem = avr_find_memalias(p, mem);
-  char alias_mem_desc[AVR_DESCLEN + 1] = "";
-  if(alias_mem) {
-    strcat(alias_mem_desc, "/");
-    strcat(alias_mem_desc, alias_mem->desc);
+  AVRMEM_ALIAS *alias_mem = avr_find_memalias(p, mem);
+  char *alias_mem_desc = cfg_malloc("do_op()", 2 + (alias_mem && alias_mem->desc? strlen(alias_mem->desc): 0));
+  if(alias_mem && alias_mem->desc && *alias_mem->desc) {
+    *alias_mem_desc = '/';
+    strcpy(alias_mem_desc+1, alias_mem->desc);
   }
   
   switch (upd->op) {

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -160,9 +160,9 @@ static int usbasp_transmit(PROGRAMMER * pgm, unsigned char receive,
 			   unsigned char functionid, const unsigned char *send,
 			   unsigned char *buffer, int buffersize);
 #ifdef USE_LIBUSB_1_0
-static int usbOpenDevice(libusb_device_handle **device, int vendor, char *vendorName, int product, char *productName);
+static int usbOpenDevice(libusb_device_handle **device, int vendor, const char *vendorName, int product, const char *productName);
 #else
-static int usbOpenDevice(usb_dev_handle **device, int vendor, char *vendorName, int product, char *productName);
+static int usbOpenDevice(usb_dev_handle **device, int vendor, const char *vendorName, int product, const char *productName);
 #endif
 // interface - prog.
 static int usbasp_open(PROGRAMMER * pgm, char * port);
@@ -337,7 +337,7 @@ static int usbasp_transmit(PROGRAMMER * pgm,
  */
 #ifdef USE_LIBUSB_1_0
 static int usbOpenDevice(libusb_device_handle **device, int vendor,
-			 char *vendorName, int product, char *productName)
+			 const char *vendorName, int product, const char *productName)
 {
     libusb_device_handle *handle = NULL;
     int                  errorCode = USB_ERROR_NOTFOUND;
@@ -412,7 +412,7 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
 }
 #else
 static int usbOpenDevice(usb_dev_handle **device, int vendor,
-			 char *vendorName, int product, char *productName)
+			 const char *vendorName, int product, const char *productName)
 {
 struct usb_bus       *bus;
 struct usb_device    *dev;


### PR DESCRIPTION
Try `avrdude -c*/h` and play with it.

Now `avrdude -c* -p*` should output a file that could be used to replace `avrdude.conf` for the part and programmer definitions.

Am aware that currently `avrdude.conf` has a *lot of very useful comments*, particularly the programmers (less so the parts). Am thinking about how to record comments during the lex/yacc parsing phase so that they can be printed at the right location during `avrdude -c* -p*`. But that's for another day.