### PR TITLE
man-page: Fix logfile short option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -273,4 +273,6 @@ install(TARGETS libavrdude
     PUBLIC_HEADER DESTINATION include COMPONENT dev
     )
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.conf" TYPE SYSCONF)
-install(FILES avrdude.1 TYPE MAN)
+install(FILES "avrdude.1"
+	DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
+	)

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -39,7 +39,7 @@
 .Oc
 .Op Fl F
 .Op Fl i Ar delay
-.Op Fl n logfile
+.Op Fl l Ar logfile
 .Op Fl n
 .Op Fl O
 .Op Fl P Ar port


### PR DESCRIPTION
man synopsis states [-n -logfile] option. Later on in avrdude.1 as well as in
main.c -l is used.
Also '-logfile' is no option alternative but a parameter.
This is a minor issue but still confusing when one uses / to search
through man pages.

Fixing this issue brought another one into light. As it is closely related put this fix on top of this one as agreed upon.

-- Always leave the code cleaner than you found it --

Signed-off-by: brutzzl3r <s3b.gr0ss@gmail.com>