### PR TITLE
Use const for programmer functions where useful

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -38,8 +38,7 @@
 #include "arduino.h"
 
 /* read signature bytes - arduino version */
-static int arduino_read_sig_bytes(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m)
-{
+static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m) {
   unsigned char buf[32];
 
   /* Signature byte reads are always 3 bytes. */
@@ -80,8 +79,7 @@ static int arduino_read_sig_bytes(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m)
   return 3;
 }
 
-static int arduino_open(PROGRAMMER * pgm, char * port)
-{
+static int arduino_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   strcpy(pgm->port, port);
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
@@ -118,8 +116,7 @@ static void arduino_close(PROGRAMMER * pgm)
 
 const char arduino_desc[] = "Arduino programmer";
 
-void arduino_initpgm(PROGRAMMER * pgm)
-{
+void arduino_initpgm(PROGRAMMER *pgm) {
   /* This is mostly a STK500; just the signature is read
      differently than on real STK500v1 
      and the DTR signal is set when opening the serial port

--- a/src/arduino.h
+++ b/src/arduino.h
@@ -22,7 +22,7 @@
 #define arduino_h__
 
 extern const char arduino_desc[];
-void arduino_initpgm (PROGRAMMER * pgm);
+void arduino_initpgm(PROGRAMMER *pgm);
 
 #endif
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -295,10 +295,7 @@ int avr_mem_hiaddr(AVRMEM * mem)
     return mem->size;
 
   /* if the memory is not a flash-type memory do not remove trailing 0xff */
-  if(strcasecmp(mem->desc, "flash") &&
-     strcasecmp(mem->desc, "application") &&
-     strcasecmp(mem->desc, "apptable") &&
-     strcasecmp(mem->desc, "boot"))
+  if(!avr_mem_is_flash_type(mem))
     return mem->size;
 
   /* return the highest non-0xff address regardless of how much
@@ -1251,6 +1248,18 @@ void avr_add_mem_order(const char *str) {
     "%s: avr_mem_order[] under-dimensioned in avr.c; increase and recompile\n",
     progname);
   exit(1);
+}
+
+int avr_mem_is_flash_type(AVRMEM *mem) {
+  return
+     strcmp(mem->desc, "flash") == 0 ||
+     strcmp(mem->desc, "application") == 0 ||
+     strcmp(mem->desc, "apptable") == 0 ||
+     strcmp(mem->desc, "boot") == 0;
+}
+
+int avr_mem_is_eeprom_type(AVRMEM *mem) {
+  return strcmp(mem->desc, "eeprom") == 0;
 }
 
 int avr_mem_is_known(const char *str) {

--- a/src/avr.c
+++ b/src/avr.c
@@ -38,8 +38,7 @@ FP_UpdateProgress update_progress;
 #define DEBUG 0
 
 /* TPI: returns 1 if NVM controller busy, 0 if free */
-int avr_tpi_poll_nvmbsy(PROGRAMMER *pgm)
-{
+int avr_tpi_poll_nvmbsy(const PROGRAMMER *pgm) {
   unsigned char cmd;
   unsigned char res;
 
@@ -49,8 +48,7 @@ int avr_tpi_poll_nvmbsy(PROGRAMMER *pgm)
 }
 
 /* TPI chip erase sequence */
-int avr_tpi_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 	int err;
   AVRMEM *mem;
 
@@ -99,8 +97,7 @@ int avr_tpi_chip_erase(PROGRAMMER * pgm, AVRPART * p)
 }
 
 /* TPI program enable sequence */
-int avr_tpi_program_enable(PROGRAMMER * pgm, AVRPART * p, unsigned char guard_time)
-{
+int avr_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p, unsigned char guard_time) {
 	int err, retry;
 	unsigned char cmd[2];
 	unsigned char response;
@@ -149,7 +146,7 @@ int avr_tpi_program_enable(PROGRAMMER * pgm, AVRPART * p, unsigned char guard_ti
 }
 
 /* TPI: setup NVMCMD register and pointer register (PR) for read/write/erase */
-static int avr_tpi_setup_rw(PROGRAMMER * pgm, AVRMEM * mem,
+static int avr_tpi_setup_rw(const PROGRAMMER *pgm, const AVRMEM *mem,
 			    unsigned long addr, unsigned char nvmcmd)
 {
   unsigned char cmd[4];
@@ -178,7 +175,7 @@ static int avr_tpi_setup_rw(PROGRAMMER * pgm, AVRMEM * mem,
   return 0;
 }
 
-int avr_read_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem, 
+int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                           unsigned long addr, unsigned char * value)
 {
   unsigned char cmd[4];
@@ -280,7 +277,7 @@ int avr_read_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
  * no-op. Always return an even number since flash is word addressed.
  * Only apply this optimisation on flash-type memory.
  */
-int avr_mem_hiaddr(AVRMEM * mem)
+int avr_mem_hiaddr(const AVRMEM * mem)
 {
   int i, n;
   static int disableffopt;
@@ -322,7 +319,7 @@ int avr_mem_hiaddr(AVRMEM * mem)
  *
  * Return the number of bytes read, or < 0 if an error occurs.  
  */
-int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype,
+int avr_read(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype,
              AVRPART * v)
 {
   unsigned long    i, lastaddr;
@@ -469,7 +466,7 @@ int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype,
 /*
  * write a page data at the specified address
  */
-int avr_write_page(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem, 
+int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr)
 {
   unsigned char cmd[4];
@@ -529,7 +526,7 @@ int avr_write_page(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
 }
 
 
-int avr_write_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr, unsigned char data)
 {
   unsigned char cmd[4];
@@ -790,7 +787,7 @@ int avr_write_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
 /*
  * write a byte of data at the specified address
  */
-int avr_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+int avr_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr, unsigned char data)
 {
   return pgm->write_byte(pgm, p, mem, addr, data);
@@ -806,8 +803,8 @@ int avr_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
  *
  * Return the number of bytes written, or -1 if an error occurs.
  */
-int avr_write(PROGRAMMER * pgm, AVRPART * p, char * memtype, int size, 
-              int auto_erase)
+int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype,
+              int size, int auto_erase)
 {
   int              rc;
   int              newpage, page_tainted, flush_page, do_write;
@@ -1031,8 +1028,7 @@ int avr_write(PROGRAMMER * pgm, AVRPART * p, char * memtype, int size,
 /*
  * read the AVR device's signature bytes
  */
-int avr_signature(PROGRAMMER * pgm, AVRPART * p)
-{
+int avr_signature(const PROGRAMMER *pgm, const AVRPART *p) {
   int rc;
 
   report_progress (0,1,"Reading");
@@ -1084,7 +1080,7 @@ int compare_memory_masked(AVRMEM * m, uint8_t b1, uint8_t b2) {
  *
  * Return the number of bytes verified, or -1 if they don't match.
  */
-int avr_verify(AVRPART * p, AVRPART * v, char * memtype, int size)
+int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int size)
 {
   int i;
   unsigned char * buf1, * buf2;
@@ -1153,8 +1149,7 @@ int avr_verify(AVRPART * p, AVRPART * v, char * memtype, int size)
 }
 
 
-int avr_get_cycle_count(PROGRAMMER * pgm, AVRPART * p, int * cycles)
-{
+int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles) {
   AVRMEM * a;
   unsigned int cycle_count = 0;
   unsigned char v1;
@@ -1192,8 +1187,7 @@ int avr_get_cycle_count(PROGRAMMER * pgm, AVRPART * p, int * cycles)
 }
 
 
-int avr_put_cycle_count(PROGRAMMER * pgm, AVRPART * p, int cycles)
-{
+int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles) {
   AVRMEM * a;
   unsigned char v1;
   int rc;
@@ -1250,7 +1244,7 @@ void avr_add_mem_order(const char *str) {
   exit(1);
 }
 
-int avr_mem_is_flash_type(AVRMEM *mem) {
+int avr_mem_is_flash_type(const AVRMEM *mem) {
   return
      strcmp(mem->desc, "flash") == 0 ||
      strcmp(mem->desc, "application") == 0 ||
@@ -1258,7 +1252,7 @@ int avr_mem_is_flash_type(AVRMEM *mem) {
      strcmp(mem->desc, "boot") == 0;
 }
 
-int avr_mem_is_eeprom_type(AVRMEM *mem) {
+int avr_mem_is_eeprom_type(const AVRMEM *mem) {
   return strcmp(mem->desc, "eeprom") == 0;
 }
 
@@ -1279,8 +1273,7 @@ int avr_mem_might_be_known(const char *str) {
 }
 
 
-int avr_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+int avr_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   int rc;
 
   rc = pgm->chip_erase(pgm, p);
@@ -1288,8 +1281,7 @@ int avr_chip_erase(PROGRAMMER * pgm, AVRPART * p)
   return rc;
 }
 
-int avr_unlock(PROGRAMMER * pgm, AVRPART * p)
-{
+int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p) {
   int rc = -1;
 
   if (pgm->unlock)

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -71,14 +71,12 @@ static void avr910_teardown(PROGRAMMER * pgm)
 }
 
 
-static int avr910_send(PROGRAMMER * pgm, char * buf, size_t len)
-{
+static int avr910_send(const PROGRAMMER *pgm, char *buf, size_t len) {
   return serial_send(&pgm->fd, (unsigned char *)buf, len);
 }
 
 
-static int avr910_recv(PROGRAMMER * pgm, char * buf, size_t len)
-{
+static int avr910_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
   int rv;
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
@@ -91,14 +89,12 @@ static int avr910_recv(PROGRAMMER * pgm, char * buf, size_t len)
 }
 
 
-static int avr910_drain(PROGRAMMER * pgm, int display)
-{
+static int avr910_drain(const PROGRAMMER *pgm, int display) {
   return serial_drain(&pgm->fd, display);
 }
 
 
-static int avr910_vfy_cmd_sent(PROGRAMMER * pgm, char * errmsg)
-{
+static int avr910_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
   char c;
 
   avr910_recv(pgm, &c, 1);
@@ -114,8 +110,7 @@ static int avr910_vfy_cmd_sent(PROGRAMMER * pgm, char * errmsg)
 /*
  * issue the 'chip erase' command to the AVR device
  */
-static int avr910_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+static int avr910_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   avr910_send(pgm, "e", 1);
   if (avr910_vfy_cmd_sent(pgm, "chip erase") < 0)
     return -1;
@@ -129,15 +124,13 @@ static int avr910_chip_erase(PROGRAMMER * pgm, AVRPART * p)
 }
 
 
-static int avr910_enter_prog_mode(PROGRAMMER * pgm)
-{
+static int avr910_enter_prog_mode(const PROGRAMMER *pgm) {
   avr910_send(pgm, "P", 1);
   return avr910_vfy_cmd_sent(pgm, "enter prog mode");
 }
 
 
-static int avr910_leave_prog_mode(PROGRAMMER * pgm)
-{
+static int avr910_leave_prog_mode(const PROGRAMMER *pgm) {
   avr910_send(pgm, "L", 1);
   return avr910_vfy_cmd_sent(pgm, "leave prog mode");
 }
@@ -146,8 +139,7 @@ static int avr910_leave_prog_mode(PROGRAMMER * pgm)
 /*
  * issue the 'program enable' command to the AVR device
  */
-static int avr910_program_enable(PROGRAMMER * pgm, AVRPART * p)
-{
+static int avr910_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   return -1;
 }
 
@@ -155,8 +147,7 @@ static int avr910_program_enable(PROGRAMMER * pgm, AVRPART * p)
 /*
  * initialize the AVR device and prepare it to accept commands
  */
-static int avr910_initialize(PROGRAMMER * pgm, AVRPART * p)
-{
+static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   char id[8];
   char sw[2];
   char hw[2];
@@ -273,16 +264,14 @@ static int avr910_initialize(PROGRAMMER * pgm, AVRPART * p)
 }
 
 
-static void avr910_disable(PROGRAMMER * pgm)
-{
+static void avr910_disable(const PROGRAMMER *pgm) {
   /* Do nothing. */
 
   return;
 }
 
 
-static void avr910_enable(PROGRAMMER * pgm)
-{
+static void avr910_enable(PROGRAMMER *pgm, const AVRPART *p) {
   /* Do nothing. */
 
   return;
@@ -293,7 +282,7 @@ static void avr910_enable(PROGRAMMER * pgm)
  * transmit an AVR device command and return the results; 'cmd' and
  * 'res' must point to at least a 4 byte data buffer
  */
-static int avr910_cmd(PROGRAMMER * pgm, const unsigned char *cmd,
+static int avr910_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                       unsigned char *res)
 {
   char buf[5];
@@ -318,8 +307,7 @@ static int avr910_cmd(PROGRAMMER * pgm, const unsigned char *cmd,
 }
 
 
-static int avr910_parseextparms(PROGRAMMER * pgm, LISTID extparms)
-{
+static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param;
   int rv = 0;
@@ -359,8 +347,7 @@ static int avr910_parseextparms(PROGRAMMER * pgm, LISTID extparms)
 }
 
 
-static int avr910_open(PROGRAMMER * pgm, char * port)
-{
+static int avr910_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   /*
    *  If baudrate was not specified use 19.200 Baud
@@ -393,14 +380,12 @@ static void avr910_close(PROGRAMMER * pgm)
 }
 
 
-static void avr910_display(PROGRAMMER * pgm, const char * p)
-{
+static void avr910_display(const PROGRAMMER *pgm, const char *p) {
   return;
 }
 
 
-static void avr910_set_addr(PROGRAMMER * pgm, unsigned long addr)
-{
+static void avr910_set_addr(const PROGRAMMER *pgm, unsigned long addr) {
   char cmd[3];
 
   cmd[0] = 'A';
@@ -412,7 +397,7 @@ static void avr910_set_addr(PROGRAMMER * pgm, unsigned long addr)
 }
 
 
-static int avr910_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int avr910_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                              unsigned long addr, unsigned char value)
 {
   char cmd[2];
@@ -445,7 +430,7 @@ static int avr910_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int avr910_read_byte_flash(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int avr910_read_byte_flash(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                   unsigned long addr, unsigned char * value)
 {
   char buf[2];
@@ -468,7 +453,7 @@ static int avr910_read_byte_flash(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int avr910_read_byte_eeprom(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int avr910_read_byte_eeprom(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                    unsigned long addr, unsigned char * value)
 {
   avr910_set_addr(pgm, addr);
@@ -479,7 +464,7 @@ static int avr910_read_byte_eeprom(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int avr910_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int avr910_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                             unsigned long addr, unsigned char * value)
 {
   if (strcmp(m->desc, "flash") == 0) {
@@ -494,7 +479,7 @@ static int avr910_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int avr910_paged_write_flash(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, 
+static int avr910_paged_write_flash(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                     unsigned int page_size,
                                     unsigned int addr, unsigned int n_bytes)
 {
@@ -553,8 +538,8 @@ static int avr910_paged_write_flash(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int avr910_paged_write_eeprom(PROGRAMMER * pgm, AVRPART * p,
-                                     AVRMEM * m,
+static int avr910_paged_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p,
+                                     const AVRMEM * m,
                                      unsigned int page_size,
                                      unsigned int addr, unsigned int n_bytes)
 {
@@ -582,7 +567,7 @@ static int avr910_paged_write_eeprom(PROGRAMMER * pgm, AVRPART * p,
 }
 
 
-static int avr910_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int avr910_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                               unsigned int page_size,
                               unsigned int addr, unsigned int n_bytes)
 {
@@ -642,7 +627,7 @@ static int avr910_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int avr910_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int avr910_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                              unsigned int page_size,
                              unsigned int addr, unsigned int n_bytes)
 {
@@ -719,8 +704,7 @@ static int avr910_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 
 /* Signature byte reads are always 3 bytes. */
 
-static int avr910_read_sig_bytes(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m)
-{
+static int avr910_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m) {
   unsigned char tmp;
 
   if (m->size < 3) {
@@ -740,8 +724,7 @@ static int avr910_read_sig_bytes(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m)
 
 const char avr910_desc[] = "Serial programmers using protocol described in application note AVR910";
 
-void avr910_initpgm(PROGRAMMER * pgm)
-{
+void avr910_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "avr910");
 
   /*

--- a/src/avr910.h
+++ b/src/avr910.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char avr910_desc[];
-void avr910_initpgm (PROGRAMMER * pgm);
+void avr910_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -116,7 +116,7 @@
 #       idr              = <num> ;               # IO addr of IDR (OCD) reg
 #       rampz            = <num> ;               # IO addr of RAMPZ reg
 #       spmcr            = <num> ;               # mem addr of SPMC[S]R reg
-#       eecr             = <num> ;               # mem addr of EECR reg only when != 0x3c
+#       eecr             = <num> ;               # mem addr of EECR reg only when != 0x3f
 #       mcu_base         = <num> ;
 #       nvm_base         = <num> ;
 #       ocd_base         = <num> ;

--- a/src/avrftdi.h
+++ b/src/avrftdi.h
@@ -29,7 +29,7 @@ extern "C" {
 
 
 extern const char avrftdi_desc[];
-void avrftdi_initpgm        (PROGRAMMER * pgm);
+void avrftdi_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/avrftdi_tpi.h
+++ b/src/avrftdi_tpi.h
@@ -1,9 +1,10 @@
 #pragma once
 
-//int avrftdi_tpi_write_byte(PROGRAMMER * pgm, unsigned char byte);
-//int avrftdi_tpi_read_byte(PROGRAMMER * pgm, unsigned char * byte);
-int avrftdi_cmd_tpi(PROGRAMMER * pgm, const unsigned char *cmd, int cmd_len,
+//int avrftdi_tpi_write_byte(PROGRAMMER *pgm, unsigned char byte);
+//int avrftdi_tpi_read_byte(PROGRAMMER *pgm, unsigned char * byte);
+int avrftdi_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd, int cmd_len,
 		unsigned char *res, int res_len);
-int avrftdi_tpi_initialize(PROGRAMMER * pgm, AVRPART * p);
+int avrftdi_tpi_initialize(const PROGRAMMER *pgm, const AVRPART *p);
+void avrftdi_tpi_initpgm(PROGRAMMER *pgm);
 
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -69,8 +69,7 @@ int intlog2(unsigned int n) {
  *
  * Set instruction bits in the specified command based on the opcode.
  */
-int avr_set_bits(OPCODE * op, unsigned char * cmd)
-{
+int avr_set_bits(const OPCODE *op, unsigned char *cmd) {
   int i, j, bit;
   unsigned char mask;
 
@@ -96,8 +95,7 @@ int avr_set_bits(OPCODE * op, unsigned char * cmd)
  * Set address bits in the specified command based on the opcode, and
  * the address.
  */
-int avr_set_addr(OPCODE * op, unsigned char * cmd, unsigned long addr)
-{
+int avr_set_addr(const OPCODE *op, unsigned char *cmd, unsigned long addr) {
   int i, j, bit;
   unsigned long value;
   unsigned char mask;
@@ -128,7 +126,7 @@ int avr_set_addr(OPCODE * op, unsigned char * cmd, unsigned long addr)
  * opcode) or, if positive, bn+1 where bn is bit number of the highest
  * necessary bit that the opcode does not provide.
  */
-int avr_set_addr_mem(AVRMEM *mem, int opnum, unsigned char *cmd, unsigned long addr) {
+int avr_set_addr_mem(const AVRMEM *mem, int opnum, unsigned char *cmd, unsigned long addr) {
   int ret, isflash, lo, hi, memsize, pagesize;
   OPCODE *op;
 
@@ -220,8 +218,7 @@ int avr_set_addr_mem(AVRMEM *mem, int opnum, unsigned char *cmd, unsigned long a
  * Set input data bits in the specified command based on the opcode,
  * and the data byte.
  */
-int avr_set_input(OPCODE * op, unsigned char * cmd, unsigned char data)
-{
+int avr_set_input(const OPCODE *op, unsigned char *cmd, unsigned char data) {
   int i, j, bit;
   unsigned char value;
   unsigned char mask;
@@ -858,7 +855,7 @@ const char *opcodename(int opnum) {
 
 
 // Unique string representation of an opcode
-char *opcode2str(OPCODE *op, int opnum, int detailed) {
+char *opcode2str(const OPCODE *op, int opnum, int detailed) {
   char cb, space[1024], *sp = space;
   int compact = 1;
 

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -163,8 +163,7 @@ void bitbang_delay(unsigned int us)
 /*
  * transmit and receive a byte of data to/from the AVR device
  */
-static unsigned char bitbang_txrx(PROGRAMMER * pgm, unsigned char byte)
-{
+static unsigned char bitbang_txrx(const PROGRAMMER *pgm, unsigned char byte) {
   int i;
   unsigned char r, b, rbyte;
 
@@ -208,8 +207,7 @@ static unsigned char bitbang_txrx(PROGRAMMER * pgm, unsigned char byte)
   return rbyte;
 }
 
-static int bitbang_tpi_clk(PROGRAMMER * pgm) 
-{
+static int bitbang_tpi_clk(const PROGRAMMER *pgm)  {
   unsigned char r = 0;
   pgm->setpin(pgm, PIN_AVR_SCK, 1);
 
@@ -220,8 +218,7 @@ static int bitbang_tpi_clk(PROGRAMMER * pgm)
   return r;
 }
 
-void bitbang_tpi_tx(PROGRAMMER * pgm, unsigned char byte) 
-{
+void bitbang_tpi_tx(const PROGRAMMER *pgm, unsigned char byte)  {
   int i;
   unsigned char b, parity;
 
@@ -249,8 +246,7 @@ void bitbang_tpi_tx(PROGRAMMER * pgm, unsigned char byte)
   bitbang_tpi_clk(pgm);
 }
 
-int bitbang_tpi_rx(PROGRAMMER * pgm) 
-{
+int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
   int i;
   unsigned char b, rbyte, parity;
 
@@ -296,26 +292,22 @@ int bitbang_tpi_rx(PROGRAMMER * pgm)
   return rbyte;
 }
 
-int bitbang_rdy_led(PROGRAMMER * pgm, int value)
-{
+int bitbang_rdy_led(const PROGRAMMER *pgm, int value) {
   pgm->setpin(pgm, PIN_LED_RDY, !value);
   return 0;
 }
 
-int bitbang_err_led(PROGRAMMER * pgm, int value)
-{
+int bitbang_err_led(const PROGRAMMER *pgm, int value) {
   pgm->setpin(pgm, PIN_LED_ERR, !value);
   return 0;
 }
 
-int bitbang_pgm_led(PROGRAMMER * pgm, int value)
-{
+int bitbang_pgm_led(const PROGRAMMER *pgm, int value) {
   pgm->setpin(pgm, PIN_LED_PGM, !value);
   return 0;
 }
 
-int bitbang_vfy_led(PROGRAMMER * pgm, int value)
-{
+int bitbang_vfy_led(const PROGRAMMER *pgm, int value) {
   pgm->setpin(pgm, PIN_LED_VFY, !value);
   return 0;
 }
@@ -325,7 +317,7 @@ int bitbang_vfy_led(PROGRAMMER * pgm, int value)
  * transmit an AVR device command and return the results; 'cmd' and
  * 'res' must point to at least a 4 byte data buffer
  */
-int bitbang_cmd(PROGRAMMER * pgm, const unsigned char *cmd,
+int bitbang_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                    unsigned char *res)
 {
   int i;
@@ -350,7 +342,7 @@ int bitbang_cmd(PROGRAMMER * pgm, const unsigned char *cmd,
   return 0;
 }
 
-int bitbang_cmd_tpi(PROGRAMMER * pgm, const unsigned char *cmd,
+int bitbang_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
                        int cmd_len, unsigned char *res, int res_len)
 {
   int i, r;
@@ -392,7 +384,7 @@ int bitbang_cmd_tpi(PROGRAMMER * pgm, const unsigned char *cmd,
  * transmit bytes via SPI and return the results; 'cmd' and
  * 'res' must point to data buffers
  */
-int bitbang_spi(PROGRAMMER * pgm, const unsigned char *cmd,
+int bitbang_spi(const PROGRAMMER *pgm, const unsigned char *cmd,
                    unsigned char *res, int count)
 {
   int i;
@@ -425,8 +417,7 @@ int bitbang_spi(PROGRAMMER * pgm, const unsigned char *cmd,
 /*
  * issue the 'chip erase' command to the AVR device
  */
-int bitbang_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char cmd[4];
   unsigned char res[4];
   AVRMEM *mem;
@@ -486,8 +477,7 @@ int bitbang_chip_erase(PROGRAMMER * pgm, AVRPART * p)
 /*
  * issue the 'program enable' command to the AVR device
  */
-int bitbang_program_enable(PROGRAMMER * pgm, AVRPART * p)
-{
+int bitbang_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char cmd[4];
   unsigned char res[4];
   int i;
@@ -523,8 +513,7 @@ int bitbang_program_enable(PROGRAMMER * pgm, AVRPART * p)
 /*
  * initialize the AVR device and prepare it to accept commands
  */
-int bitbang_initialize(PROGRAMMER * pgm, AVRPART * p)
-{
+int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   int rc;
   int tries;
   int i;
@@ -626,8 +615,7 @@ int bitbang_initialize(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int verify_pin_assigned(PROGRAMMER * pgm, int pin, char * desc)
-{
+static int verify_pin_assigned(const PROGRAMMER *pgm, int pin, char *desc) {
   if (pgm->pinno[pin] == 0) {
     avrdude_message(MSG_INFO, "%s: error: no pin has been assigned for %s\n",
             progname, desc);
@@ -640,8 +628,7 @@ static int verify_pin_assigned(PROGRAMMER * pgm, int pin, char * desc)
 /*
  * Verify all prerequisites for a bit-bang programmer are present.
  */
-int bitbang_check_prerequisites(PROGRAMMER *pgm)
-{
+int bitbang_check_prerequisites(const PROGRAMMER *pgm) {
 
   if (verify_pin_assigned(pgm, PIN_AVR_RESET, "AVR RESET") < 0)
     return -1;

--- a/src/bitbang.h
+++ b/src/bitbang.h
@@ -31,25 +31,25 @@ int bitbang_getpin(int fd, int pin);
 int bitbang_highpulsepin(int fd, int pin);
 void bitbang_delay(unsigned int us);
 
-int bitbang_check_prerequisites(PROGRAMMER *pgm);
+int bitbang_check_prerequisites(const PROGRAMMER *pgm);
 
-int  bitbang_rdy_led        (PROGRAMMER * pgm, int value);
-int  bitbang_err_led        (PROGRAMMER * pgm, int value);
-int  bitbang_pgm_led        (PROGRAMMER * pgm, int value);
-int  bitbang_vfy_led        (PROGRAMMER * pgm, int value);
-int  bitbang_cmd            (PROGRAMMER * pgm, const unsigned char *cmd,
+int  bitbang_rdy_led        (const PROGRAMMER *pgm, int value);
+int  bitbang_err_led        (const PROGRAMMER *pgm, int value);
+int  bitbang_pgm_led        (const PROGRAMMER *pgm, int value);
+int  bitbang_vfy_led        (const PROGRAMMER *pgm, int value);
+int  bitbang_cmd            (const PROGRAMMER *pgm, const unsigned char *cmd,
                                 unsigned char *res);
-int  bitbang_cmd_tpi        (PROGRAMMER * pgm, const unsigned char *cmd,
+int  bitbang_cmd_tpi        (const PROGRAMMER *pgm, const unsigned char *cmd,
                                 int cmd_len, unsigned char *res, int res_len);
-int  bitbang_spi            (PROGRAMMER * pgm, const unsigned char *cmd,
+int  bitbang_spi            (const PROGRAMMER *pgm, const unsigned char *cmd,
                                 unsigned char *res, int count);
-int  bitbang_chip_erase     (PROGRAMMER * pgm, AVRPART * p);
-int  bitbang_program_enable (PROGRAMMER * pgm, AVRPART * p);
-void bitbang_powerup        (PROGRAMMER * pgm);
-void bitbang_powerdown      (PROGRAMMER * pgm);
-int  bitbang_initialize     (PROGRAMMER * pgm, AVRPART * p);
-void bitbang_disable        (PROGRAMMER * pgm);
-void bitbang_enable         (PROGRAMMER * pgm);
+int  bitbang_chip_erase     (const PROGRAMMER *pgm, const AVRPART *p);
+int  bitbang_program_enable (const PROGRAMMER *pgm, const AVRPART *p);
+void bitbang_powerup        (const PROGRAMMER *pgm);
+void bitbang_powerdown      (const PROGRAMMER *pgm);
+int  bitbang_initialize     (const PROGRAMMER *pgm, const AVRPART *p);
+void bitbang_disable        (const PROGRAMMER *pgm);
+void bitbang_enable         (PROGRAMMER *pgm, const AVRPART *p);
 
 #ifdef __cplusplus
 }

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -76,7 +76,7 @@ struct pdata
 	unsigned char pin_dir;		/* Last written pin direction for bitbang mode */
 	unsigned char pin_val;		/* Last written pin values for bitbang mode */
 	int     unread_bytes;		/* How many bytes we expected, but ignored */
-        int     flag;
+	int     flag;
 };
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
 

--- a/src/buspirate.h
+++ b/src/buspirate.h
@@ -26,7 +26,7 @@
 
 extern const char buspirate_desc[];
 extern const char buspirate_bb_desc[];
-void buspirate_initpgm (struct programmer_t *pgm);
-void buspirate_bb_initpgm (struct programmer_t *pgm);
+void buspirate_initpgm(PROGRAMMER *pgm);
+void buspirate_bb_initpgm(PROGRAMMER *pgm);
 
 #endif

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -75,14 +75,12 @@ static void butterfly_teardown(PROGRAMMER * pgm)
   free(pgm->cookie);
 }
 
-static int butterfly_send(PROGRAMMER * pgm, char * buf, size_t len)
-{
+static int butterfly_send(const PROGRAMMER *pgm, char *buf, size_t len) {
   return serial_send(&pgm->fd, (unsigned char *)buf, len);
 }
 
 
-static int butterfly_recv(PROGRAMMER * pgm, char * buf, size_t len)
-{
+static int butterfly_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
   int rv;
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
@@ -95,14 +93,12 @@ static int butterfly_recv(PROGRAMMER * pgm, char * buf, size_t len)
 }
 
 
-static int butterfly_drain(PROGRAMMER * pgm, int display)
-{
+static int butterfly_drain(const PROGRAMMER *pgm, int display) {
   return serial_drain(&pgm->fd, display);
 }
 
 
-static int butterfly_vfy_cmd_sent(PROGRAMMER * pgm, char * errmsg)
-{
+static int butterfly_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
   char c;
 
   butterfly_recv(pgm, &c, 1);
@@ -115,32 +111,28 @@ static int butterfly_vfy_cmd_sent(PROGRAMMER * pgm, char * errmsg)
 }
 
 
-static int butterfly_rdy_led(PROGRAMMER * pgm, int value)
-{
+static int butterfly_rdy_led(const PROGRAMMER *pgm, int value) {
   /* Do nothing. */
 
   return 0;
 }
 
 
-static int butterfly_err_led(PROGRAMMER * pgm, int value)
-{
+static int butterfly_err_led(const PROGRAMMER *pgm, int value) {
   /* Do nothing. */
 
   return 0;
 }
 
 
-static int butterfly_pgm_led(PROGRAMMER * pgm, int value)
-{
+static int butterfly_pgm_led(const PROGRAMMER *pgm, int value) {
   /* Do nothing. */
 
   return 0;
 }
 
 
-static int butterfly_vfy_led(PROGRAMMER * pgm, int value)
-{
+static int butterfly_vfy_led(const PROGRAMMER *pgm, int value) {
   /* Do nothing. */
 
   return 0;
@@ -150,8 +142,7 @@ static int butterfly_vfy_led(PROGRAMMER * pgm, int value)
 /*
  * issue the 'chip erase' command to the butterfly board
  */
-static int butterfly_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+static int butterfly_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   butterfly_send(pgm, "e", 1);
   if (butterfly_vfy_cmd_sent(pgm, "chip erase") < 0)
       return -1;
@@ -160,15 +151,13 @@ static int butterfly_chip_erase(PROGRAMMER * pgm, AVRPART * p)
 }
 
 
-static void butterfly_enter_prog_mode(PROGRAMMER * pgm)
-{
+static void butterfly_enter_prog_mode(const PROGRAMMER *pgm) {
   butterfly_send(pgm, "P", 1);
   butterfly_vfy_cmd_sent(pgm, "enter prog mode");
 }
 
 
-static void butterfly_leave_prog_mode(PROGRAMMER * pgm)
-{
+static void butterfly_leave_prog_mode(const PROGRAMMER *pgm) {
   butterfly_send(pgm, "L", 1);
   butterfly_vfy_cmd_sent(pgm, "leave prog mode");
 }
@@ -177,8 +166,7 @@ static void butterfly_leave_prog_mode(PROGRAMMER * pgm)
 /*
  * issue the 'program enable' command to the AVR device
  */
-static int butterfly_program_enable(PROGRAMMER * pgm, AVRPART * p)
-{
+static int butterfly_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   return -1;
 }
 
@@ -186,8 +174,7 @@ static int butterfly_program_enable(PROGRAMMER * pgm, AVRPART * p)
 /*
  * apply power to the AVR processor
  */
-static void butterfly_powerup(PROGRAMMER * pgm)
-{
+static void butterfly_powerup(const PROGRAMMER *pgm) {
   /* Do nothing. */
 
   return;
@@ -197,8 +184,7 @@ static void butterfly_powerup(PROGRAMMER * pgm)
 /*
  * remove power from the AVR processor
  */
-static void butterfly_powerdown(PROGRAMMER * pgm)
-{
+static void butterfly_powerdown(const PROGRAMMER *pgm) {
   /* Do nothing. */
 
   return;
@@ -209,8 +195,7 @@ static void butterfly_powerdown(PROGRAMMER * pgm)
 /*
  * initialize the AVR device and prepare it to accept commands
  */
-static int butterfly_initialize(PROGRAMMER * pgm, AVRPART * p)
-{
+static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   char id[8];
   char sw[2];
   char hw[2];
@@ -367,22 +352,19 @@ static int butterfly_initialize(PROGRAMMER * pgm, AVRPART * p)
 
 
 
-static void butterfly_disable(PROGRAMMER * pgm)
-{
+static void butterfly_disable(const PROGRAMMER *pgm) {
   butterfly_leave_prog_mode(pgm);
 
   return;
 }
 
 
-static void butterfly_enable(PROGRAMMER * pgm)
-{
+static void butterfly_enable(PROGRAMMER *pgm, const AVRPART *p) {
   return;
 }
 
 
-static int butterfly_open(PROGRAMMER * pgm, char * port)
-{
+static int butterfly_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   strcpy(pgm->port, port);
   /*
@@ -417,14 +399,12 @@ static void butterfly_close(PROGRAMMER * pgm)
 }
 
 
-static void butterfly_display(PROGRAMMER * pgm, const char * p)
-{
+static void butterfly_display(const PROGRAMMER *pgm, const char *p) {
   return;
 }
 
 
-static void butterfly_set_addr(PROGRAMMER * pgm, unsigned long addr)
-{
+static void butterfly_set_addr(const PROGRAMMER *pgm, unsigned long addr) {
   char cmd[3];
 
   cmd[0] = 'A';
@@ -436,8 +416,7 @@ static void butterfly_set_addr(PROGRAMMER * pgm, unsigned long addr)
 }
 
 
-static void butterfly_set_extaddr(PROGRAMMER * pgm, unsigned long addr)
-{
+static void butterfly_set_extaddr(const PROGRAMMER *pgm, unsigned long addr) {
   char cmd[4];
 
   cmd[0] = 'H';
@@ -451,7 +430,7 @@ static void butterfly_set_extaddr(PROGRAMMER * pgm, unsigned long addr)
 
 
 
-static int butterfly_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int butterfly_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                              unsigned long addr, unsigned char value)
 {
   char cmd[6];
@@ -495,7 +474,7 @@ static int butterfly_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int butterfly_read_byte_flash(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int butterfly_read_byte_flash(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                   unsigned long addr, unsigned char * value)
 {
   static int cached = 0;
@@ -536,7 +515,7 @@ static int butterfly_read_byte_flash(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int butterfly_read_byte_eeprom(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int butterfly_read_byte_eeprom(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                    unsigned long addr, unsigned char * value)
 {
   butterfly_set_addr(pgm, addr);
@@ -545,8 +524,7 @@ static int butterfly_read_byte_eeprom(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return 0;
 }
 
-static int butterfly_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, unsigned int addr)
-{
+static int butterfly_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int addr) {
   if (strcmp(m->desc, "flash") == 0)
     return -1;            /* not supported */
   if (strcmp(m->desc, "eeprom") == 0)
@@ -556,7 +534,7 @@ static int butterfly_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, unsig
   return -1;
 }
 
-static int butterfly_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int butterfly_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                             unsigned long addr, unsigned char * value)
 {
   char cmd;
@@ -592,7 +570,7 @@ static int butterfly_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 
 
 
-static int butterfly_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int butterfly_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int page_size,
                                  unsigned int addr, unsigned int n_bytes)
 {
@@ -647,7 +625,7 @@ static int butterfly_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 
 
 
-static int butterfly_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int butterfly_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                 unsigned int page_size,
                                 unsigned int addr, unsigned int n_bytes)
 {
@@ -693,8 +671,7 @@ static int butterfly_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 
 
 /* Signature byte reads are always 3 bytes. */
-static int butterfly_read_sig_bytes(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m)
-{
+static int butterfly_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m) {
   unsigned char tmp;
 
   if (m->size < 3) {
@@ -714,8 +691,7 @@ static int butterfly_read_sig_bytes(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m)
 
 const char butterfly_desc[] = "Atmel Butterfly evaluation board; Atmel AppNotes AVR109, AVR911";
 
-void butterfly_initpgm(PROGRAMMER * pgm)
-{
+void butterfly_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "butterfly");
 
   /*
@@ -755,8 +731,7 @@ void butterfly_initpgm(PROGRAMMER * pgm)
 
 const char butterfly_mk_desc[] = "Mikrokopter.de Butterfly";
 
-void butterfly_mk_initpgm(PROGRAMMER * pgm)
-{
+void butterfly_mk_initpgm(PROGRAMMER *pgm) {
   butterfly_initpgm(pgm);
   strcpy(pgm->type, "butterfly_mk");
   pgm->flag = IS_BUTTERFLY_MK;

--- a/src/butterfly.h
+++ b/src/butterfly.h
@@ -27,8 +27,8 @@ extern "C" {
 
 extern const char butterfly_desc[];
 extern const char butterfly_mk_desc[];
-void butterfly_initpgm (PROGRAMMER * pgm);
-void butterfly_mk_initpgm (PROGRAMMER * pgm);
+void butterfly_initpgm(PROGRAMMER *pgm);
+void butterfly_mk_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -315,7 +315,7 @@ prog_decl :
     |
   K_PROGRAMMER K_PARENT TKN_STRING
     {
-      struct programmer_t * pgm = locate_programmer(programmers, $3->value.string);
+      PROGRAMMER * pgm = locate_programmer(programmers, $3->value.string);
       if (pgm == NULL) {
         yyerror("parent programmer %s not found", $3->value.string);
         free_token($3);

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -38,7 +38,7 @@
 
 #ifndef HAVE_LIBUSB
 
-struct dfu_dev *dfu_open(char *port_name) {
+struct dfu_dev *dfu_open(const char *port_name) {
   avrdude_message(MSG_INFO, "%s: Error: No USB support in this compile of avrdude\n",
     progname);
   return NULL;
@@ -99,8 +99,7 @@ static char * get_usb_string(usb_dev_handle * dev_handle, int index);
 /* EXPORTED FUNCTION DEFINITIONS
  */
 
-struct dfu_dev * dfu_open(char *port_spec)
-{
+struct dfu_dev *dfu_open(const char *port_spec) {
   struct dfu_dev *dfu;
   char *bus_name = NULL;
   char *dev_name = NULL;

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -114,7 +114,7 @@ struct dfu_status {
 
 // FUNCTIONS
 
-extern struct dfu_dev * dfu_open(char *port_spec);
+extern struct dfu_dev *dfu_open(const char *port_spec);
 extern int dfu_init(struct dfu_dev *dfu,
   unsigned short vid, unsigned short pid);
 extern void dfu_close(struct dfu_dev *dfu);

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1809,7 +1809,7 @@ part
     rampz            = <num> ;                # IO addr of RAMPZ reg.
     spmcr            = <num> ;                # mem addr of SPMC[S]R reg.
     eecr             = <num> ;                # mem addr of EECR reg.
-                                              # (only when != 0x3c)
+                                              # (only when != 0x3F)
     is_at90s1200     = <yes/no> ;             # AT90S1200 part
     is_avr32         = <yes/no> ;             # AVR32 part
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -395,7 +395,7 @@ int flip1_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   if (FLIP1(pgm)->dfu == NULL)
     return -1;
 
-  if (strcasecmp(mem->desc, "signature") == 0) {
+  if (strcmp(mem->desc, "signature") == 0) {
     if (flip1_read_sig_bytes(pgm, part, mem) < 0)
       return -1;
     if (addr > mem->size) {
@@ -856,9 +856,9 @@ const char * flip1_mem_unit_str(enum flip1_mem_unit mem_unit)
 }
 
 enum flip1_mem_unit flip1_mem_unit(const char *name) {
-  if (strcasecmp(name, "flash") == 0)
+  if (strcmp(name, "flash") == 0)
     return FLIP1_MEM_UNIT_FLASH;
-  if (strcasecmp(name, "eeprom") == 0)
+  if (strcmp(name, "eeprom") == 0)
     return FLIP1_MEM_UNIT_EEPROM;
   return FLIP1_MEM_UNIT_UNKNOWN;
 }

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -136,23 +136,23 @@ enum flip1_mem_unit {
 
 /* EXPORTED PROGRAMMER FUNCTION PROTOTYPES */
 
-static int flip1_open(PROGRAMMER *pgm, char *port_spec);
-static int flip1_initialize(PROGRAMMER* pgm, AVRPART *part);
+static int flip1_open(PROGRAMMER *pgm, const char *port_spec);
+static int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part);
 static void flip1_close(PROGRAMMER* pgm);
-static void flip1_enable(PROGRAMMER* pgm);
-static void flip1_disable(PROGRAMMER* pgm);
-static void flip1_display(PROGRAMMER* pgm, const char *prefix);
-static int flip1_program_enable(PROGRAMMER* pgm, AVRPART *part);
-static int flip1_chip_erase(PROGRAMMER* pgm, AVRPART *part);
-static int flip1_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static void flip1_enable(PROGRAMMER *pgm, const AVRPART *p);
+static void flip1_disable(const PROGRAMMER *pgm);
+static void flip1_display(const PROGRAMMER *pgm, const char *prefix);
+static int flip1_program_enable(const PROGRAMMER *pgm, const AVRPART *part);
+static int flip1_chip_erase(const PROGRAMMER *pgm, const AVRPART *part);
+static int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char *value);
-static int flip1_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static int flip1_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char value);
-static int flip1_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static int flip1_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes);
-static int flip1_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes);
-static int flip1_read_sig_bytes(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem);
+static int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem);
 static void flip1_setup(PROGRAMMER * pgm);
 static void flip1_teardown(PROGRAMMER * pgm);
 
@@ -162,7 +162,7 @@ static void flip1_teardown(PROGRAMMER * pgm);
 
 static void flip1_show_info(struct flip1 *flip1);
 
-static int flip1_read_memory(PROGRAMMER * pgm,
+static int flip1_read_memory(const PROGRAMMER *pgm,
   enum flip1_mem_unit mem_unit, uint32_t addr, void *ptr, int size);
 static int flip1_write_memory(struct dfu_dev *dfu,
   enum flip1_mem_unit mem_unit, uint32_t addr, const void *ptr, int size);
@@ -176,8 +176,7 @@ static enum flip1_mem_unit flip1_mem_unit(const char *name);
 
 /* THE INITPGM FUNCTION DEFINITIONS */
 
-void flip1_initpgm(PROGRAMMER *pgm)
-{
+void flip1_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "flip1");
 
   /* Mandatory Functions */
@@ -201,14 +200,12 @@ void flip1_initpgm(PROGRAMMER *pgm)
 #ifdef HAVE_LIBUSB
 /* EXPORTED PROGRAMMER FUNCTION DEFINITIONS */
 
-int flip1_open(PROGRAMMER *pgm, char *port_spec)
-{
+int flip1_open(PROGRAMMER *pgm, const char *port_spec) {
   FLIP1(pgm)->dfu = dfu_open(port_spec);
   return (FLIP1(pgm)->dfu != NULL) ? 0 : -1;
 }
 
-int flip1_initialize(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   unsigned short vid, pid;
   int result;
   struct dfu_dev *dfu = FLIP1(pgm)->dfu;
@@ -322,31 +319,26 @@ flip1_initialize_fail:
   return 0;
 }
 
-void flip1_close(PROGRAMMER* pgm)
-{
+void flip1_close(PROGRAMMER *pgm) {
   if (FLIP1(pgm)->dfu != NULL) {
     dfu_close(FLIP1(pgm)->dfu);
     FLIP1(pgm)->dfu = NULL;
   }
 }
 
-void flip1_enable(PROGRAMMER* pgm)
-{
+void flip1_enable(PROGRAMMER *pgm, const AVRPART *p) {
   /* Nothing to do. */
 }
 
-void flip1_disable(PROGRAMMER* pgm)
-{
+void flip1_disable(const PROGRAMMER *pgm) {
   /* Nothing to do. */
 }
 
-void flip1_display(PROGRAMMER* pgm, const char *prefix)
-{
+void flip1_display(const PROGRAMMER *pgm, const char *prefix) {
   /* Nothing to do. */
 }
 
-int flip1_program_enable(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip1_program_enable(const PROGRAMMER *pgm, const AVRPART *part) {
   /* I couldn't find anything that uses this function, although it is marked
    * as "mandatory" in pgm.c. In case anyone does use it, we'll report an
    * error if we failed to initialize.
@@ -355,8 +347,7 @@ int flip1_program_enable(PROGRAMMER* pgm, AVRPART *part)
   return (FLIP1(pgm)->dfu != NULL) ? 0 : -1;
 }
 
-int flip1_chip_erase(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip1_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   struct dfu_status status;
   int cmd_result = 0;
   int aux_result;
@@ -387,7 +378,7 @@ int flip1_chip_erase(PROGRAMMER* pgm, AVRPART *part)
   return 0;
 }
 
-int flip1_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char *value)
 {
   enum flip1_mem_unit mem_unit;
@@ -424,7 +415,7 @@ int flip1_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return flip1_read_memory(pgm, mem_unit, addr, value, 1);
 }
 
-int flip1_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char value)
 {
   enum flip1_mem_unit mem_unit;
@@ -445,7 +436,7 @@ int flip1_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return flip1_write_memory(FLIP1(pgm)->dfu, mem_unit, addr, &value, 1);
 }
 
-int flip1_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   enum flip1_mem_unit mem_unit;
@@ -470,7 +461,7 @@ int flip1_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return flip1_read_memory(pgm, mem_unit, addr, mem->buf + addr, n_bytes);
 }
 
-int flip1_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   enum flip1_mem_unit mem_unit;
@@ -502,8 +493,7 @@ int flip1_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return (result == 0) ? n_bytes : -1;
 }
 
-int flip1_read_sig_bytes(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem)
-{
+int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {
   avrdude_message(MSG_NOTICE2, "%s: flip1_read_sig_bytes(): ", progname);
 
   if (FLIP1(pgm)->dfu == NULL)
@@ -605,7 +595,7 @@ void flip1_show_info(struct flip1 *flip1)
     (unsigned short) flip1->dfu->dev_desc.bMaxPacketSize0);
 }
 
-int flip1_read_memory(PROGRAMMER * pgm,
+int flip1_read_memory(const PROGRAMMER *pgm,
   enum flip1_mem_unit mem_unit, uint32_t addr, void *ptr, int size)
 {
   struct dfu_dev *dfu = FLIP1(pgm)->dfu;
@@ -864,15 +854,13 @@ enum flip1_mem_unit flip1_mem_unit(const char *name) {
 }
 #else /* HAVE_LIBUSB */
 // Dummy functions
-int flip1_open(PROGRAMMER *pgm, char *port_spec)
-{
+int flip1_open(PROGRAMMER *pgm, const char *port_spec) {
   fprintf(stderr, "%s: Error: No USB support in this compile of avrdude\n",
     progname);
   return -1;
 }
 
-int flip1_initialize(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   return -1;
 }
 
@@ -880,54 +868,48 @@ void flip1_close(PROGRAMMER* pgm)
 {
 }
 
-void flip1_enable(PROGRAMMER* pgm)
-{
+void flip1_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
-void flip1_disable(PROGRAMMER* pgm)
-{
+void flip1_disable(const PROGRAMMER *pgm) {
 }
 
-void flip1_display(PROGRAMMER* pgm, const char *prefix)
-{
+void flip1_display(const PROGRAMMER *pgm, const char *prefix) {
 }
 
-int flip1_program_enable(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip1_program_enable(const PROGRAMMER *pgm, const AVRPART *part) {
   return -1;
 }
 
-int flip1_chip_erase(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip1_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   return -1;
 }
 
-int flip1_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char *value)
 {
   return -1;
 }
 
-int flip1_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char value)
 {
   return -1;
 }
 
-int flip1_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   return -1;
 }
 
-int flip1_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   return -1;
 }
 
-int flip1_read_sig_bytes(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem)
-{
+int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {
   return -1;
 }
 

--- a/src/flip1.h
+++ b/src/flip1.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char flip1_desc[];
-extern void flip1_initpgm(PROGRAMMER * pgm);
+extern void flip1_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -905,11 +905,11 @@ const char * flip2_mem_unit_str(enum flip2_mem_unit mem_unit)
 }
 
 enum flip2_mem_unit flip2_mem_unit(const char *name) {
-  if (strcasecmp(name, "application") == 0)
+  if (strcmp(name, "application") == 0)
     return FLIP2_MEM_UNIT_FLASH;
-  if (strcasecmp(name, "eeprom") == 0)
+  if (strcmp(name, "eeprom") == 0)
     return FLIP2_MEM_UNIT_EEPROM;
-  if (strcasecmp(name, "signature") == 0)
+  if (strcmp(name, "signature") == 0)
     return FLIP2_MEM_UNIT_SIGNATURE;
   return FLIP2_MEM_UNIT_UNKNOWN;
 }

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -123,23 +123,23 @@ enum flip2_mem_unit {
 
 /* EXPORTED PROGRAMMER FUNCTION PROTOTYPES */
 
-static int flip2_open(PROGRAMMER *pgm, char *port_spec);
-static int flip2_initialize(PROGRAMMER* pgm, AVRPART *part);
+static int flip2_open(PROGRAMMER *pgm, const char *port_spec);
+static int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part);
 static void flip2_close(PROGRAMMER* pgm);
-static void flip2_enable(PROGRAMMER* pgm);
-static void flip2_disable(PROGRAMMER* pgm);
-static void flip2_display(PROGRAMMER* pgm, const char *prefix);
-static int flip2_program_enable(PROGRAMMER* pgm, AVRPART *part);
-static int flip2_chip_erase(PROGRAMMER* pgm, AVRPART *part);
-static int flip2_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static void flip2_enable(PROGRAMMER *pgm, const AVRPART *p);
+static void flip2_disable(const PROGRAMMER *pgm);
+static void flip2_display(const PROGRAMMER *pgm, const char *prefix);
+static int flip2_program_enable(const PROGRAMMER *pgm, const AVRPART *part);
+static int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part);
+static int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char *value);
-static int flip2_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char value);
-static int flip2_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes);
-static int flip2_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+static int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes);
-static int flip2_read_sig_bytes(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem);
+static int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem);
 static void flip2_setup(PROGRAMMER * pgm);
 static void flip2_teardown(PROGRAMMER * pgm);
 
@@ -170,8 +170,7 @@ static enum flip2_mem_unit flip2_mem_unit(const char *name);
 
 /* THE INITPGM FUNCTION DEFINITIONS */
 
-void flip2_initpgm(PROGRAMMER *pgm)
-{
+void flip2_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "flip2");
 
   /* Mandatory Functions */
@@ -195,14 +194,12 @@ void flip2_initpgm(PROGRAMMER *pgm)
 #ifdef HAVE_LIBUSB
 /* EXPORTED PROGRAMMER FUNCTION DEFINITIONS */
 
-int flip2_open(PROGRAMMER *pgm, char *port_spec)
-{
+int flip2_open(PROGRAMMER *pgm, const char *port_spec) {
   FLIP2(pgm)->dfu = dfu_open(port_spec);
   return (FLIP2(pgm)->dfu != NULL) ? 0 : -1;
 }
 
-int flip2_initialize(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   unsigned short vid, pid;
   int result;
   struct dfu_dev *dfu = FLIP2(pgm)->dfu;
@@ -323,23 +320,19 @@ void flip2_close(PROGRAMMER* pgm)
   }
 }
 
-void flip2_enable(PROGRAMMER* pgm)
-{
+void flip2_enable(PROGRAMMER *pgm, const AVRPART *p) {
   /* Nothing to do. */
 }
 
-void flip2_disable(PROGRAMMER* pgm)
-{
+void flip2_disable(const PROGRAMMER *pgm) {
   /* Nothing to do. */
 }
 
-void flip2_display(PROGRAMMER* pgm, const char *prefix)
-{
+void flip2_display(const PROGRAMMER *pgm, const char *prefix) {
   /* Nothing to do. */
 }
 
-int flip2_program_enable(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip2_program_enable(const PROGRAMMER *pgm, const AVRPART *part) {
   /* I couldn't find anything that uses this function, although it is marked
    * as "mandatory" in pgm.c. In case anyone does use it, we'll report an
    * error if we failed to initialize.
@@ -348,8 +341,7 @@ int flip2_program_enable(PROGRAMMER* pgm, AVRPART *part)
   return (FLIP2(pgm)->dfu != NULL) ? 0 : -1;
 }
 
-int flip2_chip_erase(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   struct dfu_status status;
   int cmd_result = 0;
   int aux_result;
@@ -383,7 +375,7 @@ int flip2_chip_erase(PROGRAMMER* pgm, AVRPART *part)
   return cmd_result;
 }
 
-int flip2_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char *value)
 {
   enum flip2_mem_unit mem_unit;
@@ -406,7 +398,7 @@ int flip2_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return flip2_read_memory(FLIP2(pgm)->dfu, mem_unit, addr, value, 1);
 }
 
-int flip2_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char value)
 {
   enum flip2_mem_unit mem_unit;
@@ -429,7 +421,7 @@ int flip2_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return flip2_write_memory(FLIP2(pgm)->dfu, mem_unit, addr, &value, 1);
 }
 
-int flip2_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   enum flip2_mem_unit mem_unit;
@@ -463,7 +455,7 @@ int flip2_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return (result == 0) ? n_bytes : -1;
 }
 
-int flip2_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   enum flip2_mem_unit mem_unit;
@@ -497,8 +489,7 @@ int flip2_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
   return (result == 0) ? n_bytes : -1;
 }
 
-int flip2_read_sig_bytes(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem)
-{
+int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {
   if (FLIP2(pgm)->dfu == NULL)
     return -1;
 
@@ -918,15 +909,13 @@ enum flip2_mem_unit flip2_mem_unit(const char *name) {
 
 /* EXPORTED PROGRAMMER FUNCTION DEFINITIONS */
 
-int flip2_open(PROGRAMMER *pgm, char *port_spec)
-{
+int flip2_open(PROGRAMMER *pgm, const char *port_spec) {
   fprintf(stderr, "%s: Error: No USB support in this compile of avrdude\n",
     progname);
   return -1;
 }
 
-int flip2_initialize(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   return -1;
 }
 
@@ -934,54 +923,48 @@ void flip2_close(PROGRAMMER* pgm)
 {
 }
 
-void flip2_enable(PROGRAMMER* pgm)
-{
+void flip2_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
-void flip2_disable(PROGRAMMER* pgm)
-{
+void flip2_disable(const PROGRAMMER *pgm) {
 }
 
-void flip2_display(PROGRAMMER* pgm, const char *prefix)
-{
+void flip2_display(const PROGRAMMER *pgm, const char *prefix) {
 }
 
-int flip2_program_enable(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip2_program_enable(const PROGRAMMER *pgm, const AVRPART *part) {
   return -1;
 }
 
-int flip2_chip_erase(PROGRAMMER* pgm, AVRPART *part)
-{
+int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   return -1;
 }
 
-int flip2_read_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char *value)
 {
   return -1;
 }
 
-int flip2_write_byte(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned long addr, unsigned char value)
 {
   return -1;
 }
 
-int flip2_paged_load(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   return -1;
 }
 
-int flip2_paged_write(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem,
+int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
   return -1;
 }
 
-int flip2_read_sig_bytes(PROGRAMMER* pgm, AVRPART *part, AVRMEM *mem)
-{
+int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {
   return -1;
 }
 

--- a/src/flip2.h
+++ b/src/flip2.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char flip2_desc[];
-extern void flip2_initpgm(PROGRAMMER * pgm);
+extern void flip2_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/ft245r.h
+++ b/src/ft245r.h
@@ -2,7 +2,7 @@
 #define ft245r_h
 
 extern const char ft245r_desc[];
-void ft245r_initpgm (PROGRAMMER * pgm);
+void ft245r_initpgm(PROGRAMMER *pgm);
 
 
 #endif /* ft245r_h */

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1976,16 +1976,13 @@ static int jtag3_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
   cmd[2] = 0;
 
   cmd[3] = ( p->flags & AVRPART_HAS_PDI || p->flags & AVRPART_HAS_UPDI ) ? MTYPE_FLASH : MTYPE_FLASH_PAGE;
-  if (strcmp(mem->desc, "flash") == 0 ||
-      strcmp(mem->desc, "application") == 0 ||
-      strcmp(mem->desc, "apptable") == 0 ||
-      strcmp(mem->desc, "boot") == 0) {
+  if (avr_mem_is_flash_type(mem)) {
     addr += mem->offset & (512 * 1024 - 1); /* max 512 KiB flash */
     pagesize = PDATA(pgm)->flash_pagesize;
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->flash_pageaddr;
     cache_ptr = PDATA(pgm)->flash_pagecache;
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (avr_mem_is_eeprom_type(mem)) {
     if ( (pgm->flag & PGM_FL_IS_DW) || ( p->flags & AVRPART_HAS_PDI ) || ( p->flags & AVRPART_HAS_UPDI ) ) {
       cmd[3] = MTYPE_EEPROM;
     } else {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -75,7 +75,7 @@ struct pdata
   bool use_hvupdi;
 
   /* Function to set the appropriate clock parameter */
-  int (*set_sck)(PROGRAMMER *, unsigned char *);
+  int (*set_sck)(const PROGRAMMER *, unsigned char *);
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
@@ -90,25 +90,25 @@ struct pdata
 #define PGM_FL_IS_EDBG          (0x0008)
 #define PGM_FL_IS_UPDI          (0x0010)
 
-static int jtag3_open(PROGRAMMER * pgm, char * port);
-static int jtag3_edbg_prepare(PROGRAMMER * pgm);
-static int jtag3_edbg_signoff(PROGRAMMER * pgm);
-static int jtag3_edbg_send(PROGRAMMER * pgm, unsigned char * data, size_t len);
-static int jtag3_edbg_recv_frame(PROGRAMMER * pgm, unsigned char **msg);
+static int jtag3_open(PROGRAMMER *pgm, const char *port);
+static int jtag3_edbg_prepare(const PROGRAMMER *pgm);
+static int jtag3_edbg_signoff(const PROGRAMMER *pgm);
+static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t len);
+static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg);
 
-static int jtag3_initialize(PROGRAMMER * pgm, AVRPART * p);
-static int jtag3_chip_erase(PROGRAMMER * pgm, AVRPART * p);
-static int jtag3_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p);
+static int jtag3_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
+static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                                 unsigned long addr, unsigned char * value);
-static int jtag3_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                                 unsigned long addr, unsigned char data);
-static int jtag3_set_sck_period(PROGRAMMER * pgm, double v);
-static void jtag3_print_parms1(PROGRAMMER * pgm, const char * p);
-static int jtag3_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtag3_set_sck_period(const PROGRAMMER *pgm, double v);
+static void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p);
+static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                 unsigned int page_size,
                                 unsigned int addr, unsigned int n_bytes);
-static unsigned char jtag3_memtype(PROGRAMMER * pgm, AVRPART * p, unsigned long addr);
-static unsigned int jtag3_memaddr(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, unsigned long addr);
+static unsigned char jtag3_memtype(const PROGRAMMER *pgm, const AVRPART *p, unsigned long addr);
+static unsigned int jtag3_memaddr(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr);
 
 
 void jtag3_setup(PROGRAMMER * pgm)
@@ -188,8 +188,7 @@ static void jtag3_print_data(unsigned char *b, size_t s)
     putc('\n', stderr);
 }
 
-static void jtag3_prmsg(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+static void jtag3_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   int i;
 
   if (verbose >= 4) {
@@ -324,8 +323,7 @@ static int jtag3_errcode(int reason)
   return LIBAVRDUDE_GENERAL_FAILURE;
 }
 
-static void jtag3_prevent(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+static void jtag3_prevent(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   int i;
 
   if (verbose >= 4) {
@@ -416,8 +414,7 @@ static void jtag3_prevent(PROGRAMMER * pgm, unsigned char * data, size_t len)
 
 
 
-int jtag3_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+int jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   unsigned char *buf;
 
   if (pgm->flag & PGM_FL_IS_EDBG)
@@ -450,8 +447,7 @@ int jtag3_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
   return 0;
 }
 
-static int jtag3_edbg_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   unsigned char buf[USBDEV_MAX_XFER_3];
   unsigned char status[USBDEV_MAX_XFER_3];
   int rv;
@@ -533,8 +529,7 @@ static int jtag3_edbg_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
 /*
  * Send out all the CMSIS-DAP stuff needed to prepare the ICE.
  */
-static int jtag3_edbg_prepare(PROGRAMMER * pgm)
-{
+static int jtag3_edbg_prepare(const PROGRAMMER *pgm) {
   unsigned char buf[USBDEV_MAX_XFER_3];
   unsigned char status[USBDEV_MAX_XFER_3];
   int rv;
@@ -591,8 +586,7 @@ static int jtag3_edbg_prepare(PROGRAMMER * pgm)
 /*
  * Send out all the CMSIS-DAP stuff when signing off.
  */
-static int jtag3_edbg_signoff(PROGRAMMER * pgm)
-{
+static int jtag3_edbg_signoff(const PROGRAMMER *pgm) {
   unsigned char buf[USBDEV_MAX_XFER_3];
   unsigned char status[USBDEV_MAX_XFER_3];
   int rv;
@@ -643,8 +637,7 @@ static int jtag3_edbg_signoff(PROGRAMMER * pgm)
 }
 
 
-static int jtag3_drain(PROGRAMMER * pgm, int display)
-{
+static int jtag3_drain(const PROGRAMMER *pgm, int display) {
   return serial_drain(&pgm->fd, display);
 }
 
@@ -657,7 +650,7 @@ static int jtag3_drain(PROGRAMMER * pgm, int display)
  *
  * Caller must eventually free the buffer.
  */
-static int jtag3_recv_frame(PROGRAMMER * pgm, unsigned char **msg) {
+static int jtag3_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
   int rv;
   unsigned char *buf = NULL;
 
@@ -689,7 +682,7 @@ static int jtag3_recv_frame(PROGRAMMER * pgm, unsigned char **msg) {
   return rv;
 }
 
-static int jtag3_edbg_recv_frame(PROGRAMMER * pgm, unsigned char **msg) {
+static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
   int rv, len = 0;
   unsigned char *buf = NULL;
   unsigned char *request;
@@ -803,7 +796,7 @@ static int jtag3_edbg_recv_frame(PROGRAMMER * pgm, unsigned char **msg) {
   return len;
 }
 
-int jtag3_recv(PROGRAMMER * pgm, unsigned char **msg) {
+int jtag3_recv(const PROGRAMMER *pgm, unsigned char **msg) {
   unsigned short r_seqno;
   int rv;
 
@@ -845,7 +838,7 @@ int jtag3_recv(PROGRAMMER * pgm, unsigned char **msg) {
   }
 }
 
-int jtag3_command(PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen,
+int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen,
 		   unsigned char **resp, const char *descr)
 {
   int status;
@@ -890,7 +883,7 @@ int jtag3_command(PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen,
 }
 
 
-int jtag3_getsync(PROGRAMMER * pgm, int mode) {
+int jtag3_getsync(const PROGRAMMER *pgm, int mode) {
 
   unsigned char buf[3], *resp;
 
@@ -921,8 +914,7 @@ int jtag3_getsync(PROGRAMMER * pgm, int mode) {
 /*
  * issue the 'chip erase' command to the AVR device
  */
-static int jtag3_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtag3_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[8], *resp;
 
   buf[0] = SCOPE_AVR;
@@ -941,8 +933,7 @@ static int jtag3_chip_erase(PROGRAMMER * pgm, AVRPART * p)
 /*
  * UPDI 'unlock' -> 'enter progmode' with chip erase key
  */
-static int jtag3_unlock_erase_key(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtag3_unlock_erase_key(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[8], *resp;
 
   buf[0] = 1; /* Enable */
@@ -969,8 +960,7 @@ static int jtag3_unlock_erase_key(PROGRAMMER * pgm, AVRPART * p)
 /*
  * There is no chip erase functionality in debugWire mode.
  */
-static int jtag3_chip_erase_dw(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtag3_chip_erase_dw(const PROGRAMMER *pgm, const AVRPART *p) {
 
   avrdude_message(MSG_INFO, "%s: Chip erase not supported in debugWire mode\n",
 	  progname);
@@ -978,13 +968,11 @@ static int jtag3_chip_erase_dw(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int jtag3_program_enable_dummy(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtag3_program_enable_dummy(const PROGRAMMER *pgm, const AVRPART *p) {
   return 0;
 }
 
-static int jtag3_program_enable(PROGRAMMER * pgm)
-{
+static int jtag3_program_enable(const PROGRAMMER *pgm) {
   unsigned char buf[3], *resp;
   int status;
 
@@ -1005,8 +993,7 @@ static int jtag3_program_enable(PROGRAMMER * pgm)
   return status;
 }
 
-static int jtag3_program_disable(PROGRAMMER * pgm)
-{
+static int jtag3_program_disable(const PROGRAMMER *pgm) {
   unsigned char buf[3], *resp;
 
   if (!PDATA(pgm)->prog_enabled)
@@ -1026,18 +1013,15 @@ static int jtag3_program_disable(PROGRAMMER * pgm)
   return 0;
 }
 
-static int jtag3_set_sck_xmega_pdi(PROGRAMMER *pgm, unsigned char *clk)
-{
+static int jtag3_set_sck_xmega_pdi(const PROGRAMMER *pgm, unsigned char *clk) {
     return jtag3_setparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_PDI, clk, 2);
 }
 
-static int jtag3_set_sck_xmega_jtag(PROGRAMMER *pgm, unsigned char *clk)
-{
+static int jtag3_set_sck_xmega_jtag(const PROGRAMMER *pgm, unsigned char *clk) {
     return jtag3_setparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_JTAG, clk, 2);
 }
 
-static int jtag3_set_sck_mega_jtag(PROGRAMMER *pgm, unsigned char *clk)
-{
+static int jtag3_set_sck_mega_jtag(const PROGRAMMER *pgm, unsigned char *clk) {
     return jtag3_setparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_PROG, clk, 2);
 }
 
@@ -1045,8 +1029,7 @@ static int jtag3_set_sck_mega_jtag(PROGRAMMER *pgm, unsigned char *clk)
 /*
  * initialize the AVR device and prepare it to accept commands
  */
-static int jtag3_initialize(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char conn = 0, parm[4];
   const char *ifname;
   unsigned char cmd[4], *resp;
@@ -1365,12 +1348,11 @@ static int jtag3_initialize(PROGRAMMER * pgm, AVRPART * p)
     md.allow_full_page_bitstream = (p->flags & AVRPART_ALLOWFULLPAGEBITSTREAM) != 0;
     md.idr_address = p->idr;
 
-    if (p->eecr == 0)
-      p->eecr = 0x3f;		/* matches most "modern" mega/tiny AVRs */
-    md.eearh_address = p->eecr - 0x20 + 3;
-    md.eearl_address = p->eecr - 0x20 + 2;
-    md.eecr_address = p->eecr - 0x20;
-    md.eedr_address = p->eecr - 0x20 + 1;
+    unsigned char eecr = p->eecr? p->eecr: 0x3f; // Use default 0x3f if not set
+    md.eearh_address = eecr - 0x20 + 3;
+    md.eearl_address = eecr - 0x20 + 2;
+    md.eecr_address = eecr - 0x20;
+    md.eedr_address = eecr - 0x20 + 1;
     md.spmcr_address = p->spmcr;
     //md.osccal_address = p->osccal;  // do we need it at all?
 
@@ -1459,8 +1441,7 @@ static int jtag3_initialize(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static void jtag3_disable(PROGRAMMER * pgm)
-{
+static void jtag3_disable(const PROGRAMMER *pgm) {
 
   free(PDATA(pgm)->flash_pagecache);
   PDATA(pgm)->flash_pagecache = NULL;
@@ -1475,13 +1456,11 @@ static void jtag3_disable(PROGRAMMER * pgm)
   (void)jtag3_program_disable(pgm);
 }
 
-static void jtag3_enable(PROGRAMMER * pgm)
-{
+static void jtag3_enable(PROGRAMMER *pgm, const AVRPART *p) {
   return;
 }
 
-static int jtag3_parseextparms(PROGRAMMER * pgm, LISTID extparms)
-{
+static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param;
   int rv = 0;
@@ -1524,8 +1503,7 @@ static int jtag3_parseextparms(PROGRAMMER * pgm, LISTID extparms)
   return rv;
 }
 
-int jtag3_open_common(PROGRAMMER * pgm, char * port)
-{
+int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   LNODEID usbpid;
   int rv = -1;
@@ -1620,8 +1598,7 @@ int jtag3_open_common(PROGRAMMER * pgm, char * port)
 
 
 
-static int jtag3_open(PROGRAMMER * pgm, char * port)
-{
+static int jtag3_open(PROGRAMMER *pgm, const char *port) {
   avrdude_message(MSG_NOTICE2, "%s: jtag3_open()\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
@@ -1633,8 +1610,7 @@ static int jtag3_open(PROGRAMMER * pgm, char * port)
   return 0;
 }
 
-static int jtag3_open_dw(PROGRAMMER * pgm, char * port)
-{
+static int jtag3_open_dw(PROGRAMMER *pgm, const char *port) {
   avrdude_message(MSG_NOTICE2, "%s: jtag3_open_dw()\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
@@ -1646,8 +1622,7 @@ static int jtag3_open_dw(PROGRAMMER * pgm, char * port)
   return 0;
 }
 
-static int jtag3_open_pdi(PROGRAMMER * pgm, char * port)
-{
+static int jtag3_open_pdi(PROGRAMMER *pgm, const char *port) {
   avrdude_message(MSG_NOTICE2, "%s: jtag3_open_pdi()\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
@@ -1659,8 +1634,7 @@ static int jtag3_open_pdi(PROGRAMMER * pgm, char * port)
   return 0;
 }
 
-static int jtag3_open_updi(PROGRAMMER * pgm, char * port)
-{
+static int jtag3_open_updi(PROGRAMMER *pgm, const char *port) {
   avrdude_message(MSG_NOTICE2, "%s: jtag3_open_updi()\n", progname);
 
   LNODEID ln;
@@ -1708,7 +1682,7 @@ void jtag3_close(PROGRAMMER * pgm)
   pgm->fd.ifd = -1;
 }
 
-static int jtag3_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int addr)
 {
   unsigned char cmd[8], *resp;
@@ -1754,7 +1728,7 @@ static int jtag3_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return 0;
 }
 
-static int jtag3_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                 unsigned int page_size,
                                 unsigned int addr, unsigned int n_bytes)
 {
@@ -1864,7 +1838,7 @@ static int jtag3_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return n_bytes;
 }
 
-static int jtag3_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtag3_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int page_size,
                                unsigned int addr, unsigned int n_bytes)
 {
@@ -1950,7 +1924,7 @@ static int jtag3_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return n_bytes;
 }
 
-static int jtag3_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			      unsigned long addr, unsigned char * value)
 {
   unsigned char cmd[12];
@@ -2123,7 +2097,7 @@ static int jtag3_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
   return 0;
 }
 
-static int jtag3_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			       unsigned long addr, unsigned char data)
 {
   unsigned char cmd[14];
@@ -2247,8 +2221,7 @@ static int jtag3_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
  * As the STK500 expresses it as a period length (and we actualy do
  * program a period length as well), we rather call it by that name.
  */
-static int jtag3_set_sck_period(PROGRAMMER * pgm, double v)
-{
+static int jtag3_set_sck_period(const PROGRAMMER *pgm, double v) {
   unsigned char parm[2];
   unsigned int clock = 1E-3 / v; /* kHz */
 
@@ -2268,7 +2241,7 @@ static int jtag3_set_sck_period(PROGRAMMER * pgm, double v)
 /*
  * Read (an) emulator parameter(s).
  */
-int jtag3_getparm(PROGRAMMER * pgm, unsigned char scope,
+int jtag3_getparm(const PROGRAMMER *pgm, unsigned char scope,
 		  unsigned char section, unsigned char parm,
 		  unsigned char *value, unsigned char length)
 {
@@ -2310,7 +2283,7 @@ int jtag3_getparm(PROGRAMMER * pgm, unsigned char scope,
 /*
  * Write an emulator parameter.
  */
-int jtag3_setparm(PROGRAMMER * pgm, unsigned char scope,
+int jtag3_setparm(const PROGRAMMER *pgm, unsigned char scope,
 		  unsigned char section, unsigned char parm,
 		  unsigned char *value, unsigned char length)
 {
@@ -2347,8 +2320,7 @@ int jtag3_setparm(PROGRAMMER * pgm, unsigned char scope,
   return status;
 }
 
-int jtag3_read_sib(PROGRAMMER * pgm, AVRPART * p, char * sib)
-{
+int jtag3_read_sib(const PROGRAMMER *pgm, const AVRPART *p, char *sib) {
   int status;
   unsigned char cmd[12];
   unsigned char *resp = NULL;
@@ -2370,8 +2342,7 @@ int jtag3_read_sib(PROGRAMMER * pgm, AVRPART * p, char * sib)
   return 0;
 }
 
-static int jtag3_set_vtarget(PROGRAMMER * pgm, double v)
-{
+static int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
   unsigned uaref, utarg;
   unsigned char buf[2];
 
@@ -2397,8 +2368,7 @@ static int jtag3_set_vtarget(PROGRAMMER * pgm, double v)
   return 0;
 }
 
-static void jtag3_display(PROGRAMMER * pgm, const char * p)
-{
+static void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   unsigned char parms[5];
   unsigned char cmd[4], *resp, c;
   int status;
@@ -2440,8 +2410,7 @@ static void jtag3_display(PROGRAMMER * pgm, const char * p)
 }
 
 
-static void jtag3_print_parms1(PROGRAMMER * pgm, const char * p)
-{
+static void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
   unsigned char buf[2];
 
   if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
@@ -2483,13 +2452,11 @@ static void jtag3_print_parms1(PROGRAMMER * pgm, const char * p)
   }
 }
 
-static void jtag3_print_parms(PROGRAMMER * pgm)
-{
+static void jtag3_print_parms(const PROGRAMMER *pgm) {
   jtag3_print_parms1(pgm, "");
 }
 
-static unsigned char jtag3_memtype(PROGRAMMER * pgm, AVRPART * p, unsigned long addr)
-{
+static unsigned char jtag3_memtype(const PROGRAMMER *pgm, const AVRPART *p, unsigned long addr) {
   if ( p->flags & AVRPART_HAS_PDI ) {
     if (addr >= PDATA(pgm)->boot_start)
       return MTYPE_BOOT_FLASH;
@@ -2500,8 +2467,7 @@ static unsigned char jtag3_memtype(PROGRAMMER * pgm, AVRPART * p, unsigned long 
   }
 }
 
-static unsigned int jtag3_memaddr(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, unsigned long addr)
-{
+static unsigned int jtag3_memaddr(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr) {
   if ((p->flags & AVRPART_HAS_PDI) != 0) {
     if (addr >= PDATA(pgm)->boot_start)
       /*
@@ -2533,8 +2499,7 @@ static unsigned int jtag3_memaddr(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, uns
 
 const char jtag3_desc[] = "Atmel JTAGICE3";
 
-void jtag3_initpgm(PROGRAMMER * pgm)
-{
+void jtag3_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGICE3");
 
   /*
@@ -2568,8 +2533,7 @@ void jtag3_initpgm(PROGRAMMER * pgm)
 
 const char jtag3_dw_desc[] = "Atmel JTAGICE3 in debugWire mode";
 
-void jtag3_dw_initpgm(PROGRAMMER * pgm)
-{
+void jtag3_dw_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGICE3_DW");
 
   /*
@@ -2600,8 +2564,7 @@ void jtag3_dw_initpgm(PROGRAMMER * pgm)
 
 const char jtag3_pdi_desc[] = "Atmel JTAGICE3 in PDI mode";
 
-void jtag3_pdi_initpgm(PROGRAMMER * pgm)
-{
+void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGICE3_PDI");
 
   /*
@@ -2634,8 +2597,7 @@ void jtag3_pdi_initpgm(PROGRAMMER * pgm)
 
 const char jtag3_updi_desc[] = "Atmel JTAGICE3 in UPDI mode";
 
-void jtag3_updi_initpgm(PROGRAMMER * pgm)
-{
+void jtag3_updi_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGICE3_UPDI");
 
   /*

--- a/src/jtag3.h
+++ b/src/jtag3.h
@@ -25,27 +25,27 @@
 extern "C" {
 #endif
 
-int  jtag3_open_common(PROGRAMMER * pgm, char * port);
-int  jtag3_send(PROGRAMMER * pgm, unsigned char * data, size_t len);
-int  jtag3_recv(PROGRAMMER * pgm, unsigned char **msg);
+int  jtag3_open_common(PROGRAMMER *pgm, const char *port);
+int  jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_t len);
+int  jtag3_recv(const PROGRAMMER *pgm, unsigned char **msg);
 void jtag3_close(PROGRAMMER * pgm);
-int  jtag3_getsync(PROGRAMMER * pgm, int mode);
-int  jtag3_getparm(PROGRAMMER * pgm, unsigned char scope,
+int  jtag3_getsync(const PROGRAMMER *pgm, int mode);
+int  jtag3_getparm(const PROGRAMMER *pgm, unsigned char scope,
 		   unsigned char section, unsigned char parm,
 		   unsigned char *value, unsigned char length);
-int jtag3_setparm(PROGRAMMER * pgm, unsigned char scope,
+int jtag3_setparm(const PROGRAMMER *pgm, unsigned char scope,
 		  unsigned char section, unsigned char parm,
 		  unsigned char *value, unsigned char length);
-int jtag3_command(PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen,
+int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen,
 		  unsigned char **resp, const char *descr);
 extern const char jtag3_desc[];
 extern const char jtag3_dw_desc[];
 extern const char jtag3_pdi_desc[];
 extern const char jtag3_updi_desc[];
-void jtag3_initpgm (PROGRAMMER * pgm);
-void jtag3_dw_initpgm (PROGRAMMER * pgm);
-void jtag3_pdi_initpgm (PROGRAMMER * pgm);
-void jtag3_updi_initpgm (PROGRAMMER * pgm);
+void jtag3_initpgm(PROGRAMMER *pgm);
+void jtag3_dw_initpgm(PROGRAMMER *pgm);
+void jtag3_pdi_initpgm(PROGRAMMER *pgm);
+void jtag3_updi_initpgm(PROGRAMMER *pgm);
 
 /*
  * These functions are referenced from stk500v2.c for JTAGICE3 in

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -95,18 +95,18 @@ const static struct {
 /*  {  14400L, 0xf8 }, */ /* not supported by serial driver */
 };
 
-static int jtagmkI_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			      unsigned long addr, unsigned char * value);
-static int jtagmkI_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			       unsigned long addr, unsigned char data);
-static int jtagmkI_set_sck_period(PROGRAMMER * pgm, double v);
-static int jtagmkI_getparm(PROGRAMMER * pgm, unsigned char parm,
+static int jtagmkI_set_sck_period(const PROGRAMMER *pgm, double v);
+static int jtagmkI_getparm(const PROGRAMMER *pgm, unsigned char parm,
 			    unsigned char * value);
-static int jtagmkI_setparm(PROGRAMMER * pgm, unsigned char parm,
+static int jtagmkI_setparm(const PROGRAMMER *pgm, unsigned char parm,
 			    unsigned char value);
-static void jtagmkI_print_parms1(PROGRAMMER * pgm, const char * p);
+static void jtagmkI_print_parms1(const PROGRAMMER *pgm, const char *p);
 
-static int jtagmkI_resync(PROGRAMMER *pgm, int maxtries, int signon);
+static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon);
 
 static void jtagmkI_setup(PROGRAMMER * pgm)
 {
@@ -139,8 +139,7 @@ u16_to_b2(unsigned char *b, unsigned short l)
   b[1] = (l >> 8) & 0xff;
 }
 
-static void jtagmkI_prmsg(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+static void jtagmkI_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   int i;
 
   if (verbose >= 4) {
@@ -193,8 +192,7 @@ static void jtagmkI_prmsg(PROGRAMMER * pgm, unsigned char * data, size_t len)
 }
 
 
-static int jtagmkI_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   unsigned char *buf;
 
   avrdude_message(MSG_DEBUG, "\n%s: jtagmkI_send(): sending %u bytes\n",
@@ -223,8 +221,7 @@ static int jtagmkI_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
   return 0;
 }
 
-static int jtagmkI_recv(PROGRAMMER * pgm, unsigned char * buf, size_t len)
-{
+static int jtagmkI_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
   if (serial_recv(&pgm->fd, buf, len) != 0) {
     avrdude_message(MSG_INFO, "\n%s: jtagmkI_recv(): failed to send command to serial port\n",
                     progname);
@@ -238,14 +235,12 @@ static int jtagmkI_recv(PROGRAMMER * pgm, unsigned char * buf, size_t len)
 }
 
 
-static int jtagmkI_drain(PROGRAMMER * pgm, int display)
-{
+static int jtagmkI_drain(const PROGRAMMER *pgm, int display) {
   return serial_drain(&pgm->fd, display);
 }
 
 
-static int jtagmkI_resync(PROGRAMMER * pgm, int maxtries, int signon)
-{
+static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
   int tries;
   unsigned char buf[4], resp[9];
   long otimeout = serial_recv_timeout;
@@ -316,8 +311,7 @@ static int jtagmkI_resync(PROGRAMMER * pgm, int maxtries, int signon)
   return 0;
 }
 
-static int jtagmkI_getsync(PROGRAMMER * pgm)
-{
+static int jtagmkI_getsync(const PROGRAMMER *pgm) {
   unsigned char buf[1], resp[9];
 
   if (jtagmkI_resync(pgm, 5, 1) < 0) {
@@ -345,8 +339,7 @@ static int jtagmkI_getsync(PROGRAMMER * pgm)
 /*
  * issue the 'chip erase' command to the AVR device
  */
-static int jtagmkI_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkI_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[1], resp[2];
 
   buf[0] = CMD_CHIP_ERASE;
@@ -372,8 +365,7 @@ static int jtagmkI_chip_erase(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static void jtagmkI_set_devdescr(PROGRAMMER * pgm, AVRPART * p)
-{
+static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char resp[2];
   LNODEID ln;
   AVRMEM * m;
@@ -419,8 +411,7 @@ static void jtagmkI_set_devdescr(PROGRAMMER * pgm, AVRPART * p)
 /*
  * Reset the target.
  */
-static int jtagmkI_reset(PROGRAMMER * pgm)
-{
+static int jtagmkI_reset(const PROGRAMMER *pgm) {
   unsigned char buf[1], resp[2];
 
   buf[0] = CMD_RESET;
@@ -445,14 +436,12 @@ static int jtagmkI_reset(PROGRAMMER * pgm)
   return 0;
 }
 
-static int jtagmkI_program_enable_dummy(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkI_program_enable_dummy(const PROGRAMMER *pgm, const AVRPART *p) {
 
   return 0;
 }
 
-static int jtagmkI_program_enable(PROGRAMMER * pgm)
-{
+static int jtagmkI_program_enable(const PROGRAMMER *pgm) {
   unsigned char buf[1], resp[2];
 
   if (PDATA(pgm)->prog_enabled)
@@ -483,8 +472,7 @@ static int jtagmkI_program_enable(PROGRAMMER * pgm)
   return 0;
 }
 
-static int jtagmkI_program_disable(PROGRAMMER * pgm)
-{
+static int jtagmkI_program_disable(const PROGRAMMER *pgm) {
   unsigned char buf[1], resp[2];
 
   if (!PDATA(pgm)->prog_enabled)
@@ -530,8 +518,7 @@ static unsigned char jtagmkI_get_baud(long baud)
 /*
  * initialize the AVR device and prepare it to accept commands
  */
-static int jtagmkI_initialize(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   AVRMEM hfuse;
   unsigned char cmd[1], resp[5];
   unsigned char b;
@@ -621,8 +608,7 @@ static int jtagmkI_initialize(PROGRAMMER * pgm, AVRPART * p)
 }
 
 
-static void jtagmkI_disable(PROGRAMMER * pgm)
-{
+static void jtagmkI_disable(const PROGRAMMER *pgm) {
 
   free(PDATA(pgm)->flash_pagecache);
   PDATA(pgm)->flash_pagecache = NULL;
@@ -632,13 +618,12 @@ static void jtagmkI_disable(PROGRAMMER * pgm)
   (void)jtagmkI_program_disable(pgm);
 }
 
-static void jtagmkI_enable(PROGRAMMER * pgm)
-{
+static void jtagmkI_enable(PROGRAMMER *pgm, const AVRPART *p) {
   return;
 }
 
 
-static int jtagmkI_open(PROGRAMMER * pgm, char * port)
+static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
 {
   size_t i;
 
@@ -712,7 +697,7 @@ static void jtagmkI_close(PROGRAMMER * pgm)
 }
 
 
-static int jtagmkI_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int page_size,
                                unsigned int addr, unsigned int n_bytes)
 {
@@ -846,7 +831,7 @@ static int jtagmkI_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return n_bytes;
 }
 
-static int jtagmkI_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
 			      unsigned int page_size,
                               unsigned int addr, unsigned int n_bytes)
 {
@@ -937,7 +922,7 @@ static int jtagmkI_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return n_bytes;
 }
 
-static int jtagmkI_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			      unsigned long addr, unsigned char * value)
 {
   unsigned char cmd[6];
@@ -1053,7 +1038,7 @@ static int jtagmkI_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
   return 0;
 }
 
-static int jtagmkI_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			       unsigned long addr, unsigned char data)
 {
   unsigned char cmd[6], datacmd[1 * 2 + 1];
@@ -1175,8 +1160,7 @@ static int jtagmkI_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
  * As the STK500 expresses it as a period length (and we actualy do
  * program a period length as well), we rather call it by that name.
  */
-static int jtagmkI_set_sck_period(PROGRAMMER * pgm, double v)
-{
+static int jtagmkI_set_sck_period(const PROGRAMMER *pgm, double v) {
   unsigned char dur;
 
   v = 1 / v;			/* convert to frequency */
@@ -1198,7 +1182,7 @@ static int jtagmkI_set_sck_period(PROGRAMMER * pgm, double v)
  * multi-byte parameters get two different parameter names for
  * their components.
  */
-static int jtagmkI_getparm(PROGRAMMER * pgm, unsigned char parm,
+static int jtagmkI_getparm(const PROGRAMMER *pgm, const unsigned char parm,
 			    unsigned char * value)
 {
   unsigned char buf[2], resp[3];
@@ -1242,7 +1226,7 @@ static int jtagmkI_getparm(PROGRAMMER * pgm, unsigned char parm,
 /*
  * Write an emulator parameter.
  */
-static int jtagmkI_setparm(PROGRAMMER * pgm, unsigned char parm,
+static int jtagmkI_setparm(const PROGRAMMER *pgm, unsigned char parm,
 			    unsigned char value)
 {
   unsigned char buf[3], resp[2];
@@ -1274,9 +1258,7 @@ static int jtagmkI_setparm(PROGRAMMER * pgm, unsigned char parm,
 }
 
 
-static void jtagmkI_display(PROGRAMMER * pgm, const char * p)
-{
-
+static void jtagmkI_display(const PROGRAMMER *pgm, const char *p) {
   unsigned char hw, fw;
 
   if (jtagmkI_getparm(pgm, PARM_HW_VERSION, &hw) < 0 ||
@@ -1292,8 +1274,7 @@ static void jtagmkI_display(PROGRAMMER * pgm, const char * p)
 }
 
 
-static void jtagmkI_print_parms1(PROGRAMMER * pgm, const char * p)
-{
+static void jtagmkI_print_parms1(const PROGRAMMER *pgm, const char *p) {
   unsigned char vtarget, jtag_clock;
   const char *clkstr;
   double clk;
@@ -1337,15 +1318,13 @@ static void jtagmkI_print_parms1(PROGRAMMER * pgm, const char * p)
 }
 
 
-static void jtagmkI_print_parms(PROGRAMMER * pgm)
-{
+static void jtagmkI_print_parms(const PROGRAMMER *pgm) {
   jtagmkI_print_parms1(pgm, "");
 }
 
 const char jtagmkI_desc[] = "Atmel JTAG ICE mkI";
 
-void jtagmkI_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkI_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGMKI");
 
   /*

--- a/src/jtagmkI.h
+++ b/src/jtagmkI.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char jtagmkI_desc[];
-void jtagmkI_initpgm (PROGRAMMER * pgm);
+void jtagmkI_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2253,15 +2253,12 @@ static int jtagmkII_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
 
   addr += mem->offset;
   cmd[1] = ( p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI) ) ? MTYPE_FLASH : MTYPE_FLASH_PAGE;
-  if (strcmp(mem->desc, "flash") == 0 ||
-      strcmp(mem->desc, "application") == 0 ||
-      strcmp(mem->desc, "apptable") == 0 ||
-      strcmp(mem->desc, "boot") == 0) {
+  if (avr_mem_is_flash_type(mem)) {
     pagesize = PDATA(pgm)->flash_pagesize;
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->flash_pageaddr;
     cache_ptr = PDATA(pgm)->flash_pagecache;
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (avr_mem_is_eeprom_type(mem)) {
     if ( (pgm->flag & PGM_FL_IS_DW) || ( p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI) ) ) {
       /* debugWire cannot use page access for EEPROM */
       cmd[1] = MTYPE_EEPROM;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -83,6 +83,11 @@ struct pdata
 
   /* Major firmware version (needed for Xmega programming) */
   unsigned int fwver;
+
+#define FLAGS32_INIT_SMC      1 // Part will undergo chip erase
+#define FLAGS32_WRITE         2 // At least one write operation specified
+  // Couple of flag bits for AVR32 programming
+  int flags32;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
@@ -127,64 +132,57 @@ static struct {
 #define PGM_FL_IS_PDI           (0x0002)
 #define PGM_FL_IS_JTAG          (0x0004)
 
-static int jtagmkII_open(PROGRAMMER * pgm, char * port);
+static int jtagmkII_open(PROGRAMMER *pgm, const char *port);
 
-static int jtagmkII_initialize(PROGRAMMER * pgm, AVRPART * p);
-static int jtagmkII_chip_erase(PROGRAMMER * pgm, AVRPART * p);
-static int jtagmkII_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p);
+static int jtagmkII_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
+static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                                 unsigned long addr, unsigned char * value);
-static int jtagmkII_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                                 unsigned long addr, unsigned char data);
-static int jtagmkII_reset(PROGRAMMER * pgm, unsigned char flags);
-static int jtagmkII_set_sck_period(PROGRAMMER * pgm, double v);
-static int jtagmkII_setparm(PROGRAMMER * pgm, unsigned char parm,
+static int jtagmkII_reset(const PROGRAMMER *pgm, unsigned char flags);
+static int jtagmkII_set_sck_period(const PROGRAMMER *pgm, double v);
+static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
                             unsigned char * value);
-static void jtagmkII_print_parms1(PROGRAMMER * pgm, const char * p);
-static int jtagmkII_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static void jtagmkII_print_parms1(const PROGRAMMER *pgm, const char *p);
+static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                 unsigned int page_size,
                                 unsigned int addr, unsigned int n_bytes);
-static unsigned char jtagmkII_memtype(PROGRAMMER * pgm, AVRPART * p, unsigned long addr);
-static unsigned int jtagmkII_memaddr(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, unsigned long addr);
+static unsigned char jtagmkII_memtype(const PROGRAMMER *pgm, const AVRPART *p, unsigned long addr);
+static unsigned int jtagmkII_memaddr(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr);
 
 // AVR32
 #define ERROR_SAB 0xFFFFFFFF
 
-static int jtagmkII_open32(PROGRAMMER * pgm, char * port);
+static int jtagmkII_open32(PROGRAMMER *pgm, const char *port);
 static void jtagmkII_close32(PROGRAMMER * pgm);
-static int jtagmkII_reset32(PROGRAMMER * pgm, unsigned short flags);
-static int jtagmkII_initialize32(PROGRAMMER * pgm, AVRPART * p);
-static int jtagmkII_chip_erase32(PROGRAMMER * pgm, AVRPART * p);
-static unsigned long jtagmkII_read_SABaddr(PROGRAMMER * pgm, unsigned long addr,
+static int jtagmkII_reset32(const PROGRAMMER *pgm, unsigned short flags);
+static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p);
+static int jtagmkII_chip_erase32(const PROGRAMMER *pgm, const AVRPART *p);
+static unsigned long jtagmkII_read_SABaddr(const PROGRAMMER *pgm, unsigned long addr,
                       unsigned int prefix); // ERROR_SAB illegal
-static int jtagmkII_write_SABaddr(PROGRAMMER * pgm, unsigned long addr,
+static int jtagmkII_write_SABaddr(const PROGRAMMER *pgm, unsigned long addr,
                                   unsigned int prefix, unsigned long val);
-static int jtagmkII_avr32_reset(PROGRAMMER * pgm, unsigned char val,
+static int jtagmkII_avr32_reset(const PROGRAMMER *pgm, unsigned char val,
                                   unsigned char ret1, unsigned char ret2);
-static int jtagmkII_smc_init32(PROGRAMMER * pgm);
-static int jtagmkII_paged_write32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkII_smc_init32(const PROGRAMMER *pgm);
+static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                   unsigned int page_size,
                                   unsigned int addr, unsigned int n_bytes);
-static int jtagmkII_flash_lock32(PROGRAMMER * pgm, unsigned char lock,
+static int jtagmkII_flash_lock32(const PROGRAMMER *pgm, unsigned char lock,
                                   unsigned int page);
-static int jtagmkII_flash_erase32(PROGRAMMER * pgm, unsigned int page);
-static int jtagmkII_flash_write_page32(PROGRAMMER * pgm, unsigned int page);
-static int jtagmkII_flash_clear_pagebuffer32(PROGRAMMER * pgm);
-static int jtagmkII_paged_load32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkII_flash_erase32(const PROGRAMMER *pgm, unsigned int page);
+static int jtagmkII_flash_write_page32(const PROGRAMMER *pgm, unsigned int page);
+static int jtagmkII_flash_clear_pagebuffer32(const PROGRAMMER *pgm);
+static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int page_size,
                                  unsigned int addr, unsigned int n_bytes);
 
-void jtagmkII_setup(PROGRAMMER * pgm)
-{
-  if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_setup(): Out of memory allocating private data\n",
-                    progname);
-    exit(1);
-  }
-  memset(pgm->cookie, 0, sizeof(struct pdata));
+void jtagmkII_setup(PROGRAMMER *pgm) {
+  pgm->cookie = cfg_malloc("jtagmkII_setup()", sizeof(struct pdata));
 }
 
-void jtagmkII_teardown(PROGRAMMER * pgm)
-{
+void jtagmkII_teardown(PROGRAMMER *pgm) {
   free(pgm->cookie);
 }
 
@@ -279,8 +277,7 @@ static void jtagmkII_print_memory(unsigned char *b, size_t s)
     putc('\n', stderr);
 }
 
-static void jtagmkII_prmsg(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+static void jtagmkII_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   int i;
 
   if (verbose >= 4) {
@@ -420,8 +417,7 @@ static void jtagmkII_prmsg(PROGRAMMER * pgm, unsigned char * data, size_t len)
 }
 
 
-int jtagmkII_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
-{
+int jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   unsigned char *buf;
 
   avrdude_message(MSG_DEBUG, "\n%s: jtagmkII_send(): sending %lu bytes\n",
@@ -455,8 +451,7 @@ int jtagmkII_send(PROGRAMMER * pgm, unsigned char * data, size_t len)
 }
 
 
-static int jtagmkII_drain(PROGRAMMER * pgm, int display)
-{
+static int jtagmkII_drain(const PROGRAMMER *pgm, int display) {
   return serial_drain(&pgm->fd, display);
 }
 
@@ -469,7 +464,7 @@ static int jtagmkII_drain(PROGRAMMER * pgm, int display)
  *
  * Caller must eventually free the buffer.
  */
-static int jtagmkII_recv_frame(PROGRAMMER * pgm, unsigned char **msg,
+static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg,
 			       unsigned short * seqno) {
   enum states { sSTART,
 		/* NB: do NOT change the sequence of the following: */
@@ -615,7 +610,7 @@ static int jtagmkII_recv_frame(PROGRAMMER * pgm, unsigned char **msg,
   return msglen;
 }
 
-int jtagmkII_recv(PROGRAMMER * pgm, unsigned char **msg) {
+int jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg) {
   unsigned short r_seqno;
   int rv;
 
@@ -671,7 +666,7 @@ int jtagmkII_recv(PROGRAMMER * pgm, unsigned char **msg) {
 }
 
 
-int jtagmkII_getsync(PROGRAMMER * pgm, int mode) {
+int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
   int tries;
 #define MAXTRIES 10
   unsigned char buf[3], *resp, c = 0xff;
@@ -883,8 +878,7 @@ retry:
 /*
  * issue the 'chip erase' command to the AVR device
  */
-static int jtagmkII_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkII_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   int status, len;
   unsigned char buf[6], *resp, c;
 
@@ -934,8 +928,7 @@ static int jtagmkII_chip_erase(PROGRAMMER * pgm, AVRPART * p)
 /*
  * There is no chip erase functionality in debugWire mode.
  */
-static int jtagmkII_chip_erase_dw(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkII_chip_erase_dw(const PROGRAMMER *pgm, const AVRPART *p) {
 
   avrdude_message(MSG_INFO, "%s: Chip erase not supported in debugWire mode\n",
 	  progname);
@@ -943,8 +936,7 @@ static int jtagmkII_chip_erase_dw(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static void jtagmkII_set_devdescr(PROGRAMMER * pgm, AVRPART * p)
-{
+static void jtagmkII_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   int status;
   unsigned char *resp, c;
   LNODEID ln;
@@ -959,7 +951,7 @@ static void jtagmkII_set_devdescr(PROGRAMMER * pgm, AVRPART * p)
   sendbuf.dd.ucSPMCRAddress = p->spmcr;
   sendbuf.dd.ucRAMPZAddress = p->rampz;
   sendbuf.dd.ucIDRAddress = p->idr;
-  u16_to_b2(sendbuf.dd.EECRAddress, p->eecr);
+  u16_to_b2(sendbuf.dd.EECRAddress, p->eecr? p->eecr: 0x3f); // Unset eecr means 0x3f
   sendbuf.dd.ucAllowFullPageBitstream =
     (p->flags & AVRPART_ALLOWFULLPAGEBITSTREAM) != 0;
   sendbuf.dd.EnablePageProgramming =
@@ -1014,8 +1006,7 @@ static void jtagmkII_set_devdescr(PROGRAMMER * pgm, AVRPART * p)
   }
 }
 
-static void jtagmkII_set_xmega_params(PROGRAMMER * pgm, AVRPART * p)
-{
+static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
   int status;
   unsigned char *resp, c;
   LNODEID ln;
@@ -1095,8 +1086,7 @@ static void jtagmkII_set_xmega_params(PROGRAMMER * pgm, AVRPART * p)
 /*
  * Reset the target.
  */
-static int jtagmkII_reset(PROGRAMMER * pgm, unsigned char flags)
-{
+static int jtagmkII_reset(const PROGRAMMER *pgm, unsigned char flags) {
   int status;
   unsigned char buf[2], *resp, c;
 
@@ -1142,13 +1132,11 @@ static int jtagmkII_reset(PROGRAMMER * pgm, unsigned char flags)
   return 0;
 }
 
-static int jtagmkII_program_enable_INFO(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkII_program_enable_INFO(const PROGRAMMER *pgm, const AVRPART *p) {
   return 0;
 }
 
-static int jtagmkII_program_enable(PROGRAMMER * pgm)
-{
+static int jtagmkII_program_enable(const PROGRAMMER *pgm) {
   int status;
   unsigned char buf[1], *resp, c;
   int use_ext_reset;
@@ -1203,8 +1191,7 @@ static int jtagmkII_program_enable(PROGRAMMER * pgm)
   return 0;
 }
 
-static int jtagmkII_program_disable(PROGRAMMER * pgm)
-{
+static int jtagmkII_program_disable(const PROGRAMMER *pgm) {
   int status;
   unsigned char buf[1], *resp, c;
 
@@ -1296,8 +1283,7 @@ static unsigned char jtagmkII_get_baud(long baud)
 /*
  * initialize the AVR device and prepare it to accept commands
  */
-static int jtagmkII_initialize(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   AVRMEM hfuse;
   unsigned char b;
   int ok;
@@ -1449,8 +1435,7 @@ static int jtagmkII_initialize(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static void jtagmkII_disable(PROGRAMMER * pgm)
-{
+static void jtagmkII_disable(const PROGRAMMER *pgm) {
 
   free(PDATA(pgm)->flash_pagecache);
   PDATA(pgm)->flash_pagecache = NULL;
@@ -1465,13 +1450,11 @@ static void jtagmkII_disable(PROGRAMMER * pgm)
   (void)jtagmkII_program_disable(pgm);
 }
 
-static void jtagmkII_enable(PROGRAMMER * pgm)
-{
+static void jtagmkII_enable(PROGRAMMER * pgm, const AVRPART *p) {
   return;
 }
 
-static int jtagmkII_parseextparms(PROGRAMMER * pgm, LISTID extparms)
-{
+static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param;
   int rv = 0;
@@ -1509,8 +1492,7 @@ static int jtagmkII_parseextparms(PROGRAMMER * pgm, LISTID extparms)
 }
 
 
-static int jtagmkII_open(PROGRAMMER * pgm, char * port)
-{
+static int jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
   avrdude_message(MSG_NOTICE2, "%s: jtagmkII_open()\n", progname);
@@ -1562,8 +1544,7 @@ static int jtagmkII_open(PROGRAMMER * pgm, char * port)
   return 0;
 }
 
-static int jtagmkII_open_dw(PROGRAMMER * pgm, char * port)
-{
+static int jtagmkII_open_dw(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
   avrdude_message(MSG_NOTICE2, "%s: jtagmkII_open_dw()\n", progname);
@@ -1615,8 +1596,7 @@ static int jtagmkII_open_dw(PROGRAMMER * pgm, char * port)
   return 0;
 }
 
-static int jtagmkII_open_pdi(PROGRAMMER * pgm, char * port)
-{
+static int jtagmkII_open_pdi(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
   avrdude_message(MSG_NOTICE2, "%s: jtagmkII_open_pdi()\n", progname);
@@ -1669,8 +1649,7 @@ static int jtagmkII_open_pdi(PROGRAMMER * pgm, char * port)
 }
 
 
-static int jtagmkII_dragon_open(PROGRAMMER * pgm, char * port)
-{
+static int jtagmkII_dragon_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
   avrdude_message(MSG_NOTICE2, "%s: jtagmkII_dragon_open()\n", progname);
@@ -1723,8 +1702,7 @@ static int jtagmkII_dragon_open(PROGRAMMER * pgm, char * port)
 }
 
 
-static int jtagmkII_dragon_open_dw(PROGRAMMER * pgm, char * port)
-{
+static int jtagmkII_dragon_open_dw(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
   avrdude_message(MSG_NOTICE2, "%s: jtagmkII_dragon_open_dw()\n", progname);
@@ -1777,8 +1755,7 @@ static int jtagmkII_dragon_open_dw(PROGRAMMER * pgm, char * port)
 }
 
 
-static int jtagmkII_dragon_open_pdi(PROGRAMMER * pgm, char * port)
-{
+static int jtagmkII_dragon_open_pdi(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
   avrdude_message(MSG_NOTICE2, "%s: jtagmkII_dragon_open_pdi()\n", progname);
@@ -1899,7 +1876,7 @@ void jtagmkII_close(PROGRAMMER * pgm)
   pgm->fd.ifd = -1;
 }
 
-static int jtagmkII_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int addr)
 {
   unsigned char cmd[6];
@@ -1995,7 +1972,7 @@ static int jtagmkII_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return 0;
 }
 
-static int jtagmkII_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                 unsigned int page_size,
                                 unsigned int addr, unsigned int n_bytes)
 {
@@ -2131,7 +2108,7 @@ static int jtagmkII_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return n_bytes;
 }
 
-static int jtagmkII_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int page_size,
                                unsigned int addr, unsigned int n_bytes)
 {
@@ -2233,7 +2210,8 @@ static int jtagmkII_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return n_bytes;
 }
 
-static int jtagmkII_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+
+static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			      unsigned long addr, unsigned char * value)
 {
   unsigned char cmd[10];
@@ -2412,7 +2390,7 @@ fail:
   return -1;
 }
 
-static int jtagmkII_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			       unsigned long addr, unsigned char data)
 {
   unsigned char cmd[12];
@@ -2545,8 +2523,7 @@ fail:
  * As the STK500 expresses it as a period length (and we actualy do
  * program a period length as well), we rather call it by that name.
  */
-static int jtagmkII_set_sck_period(PROGRAMMER * pgm, double v)
-{
+static int jtagmkII_set_sck_period(const PROGRAMMER *pgm, double v) {
   unsigned char dur;
 
   v = 1 / v;			/* convert to frequency */
@@ -2568,7 +2545,7 @@ static int jtagmkII_set_sck_period(PROGRAMMER * pgm, double v)
  * bytes by now, we always copy out 4 bytes to *value, so the caller
  * must have allocated sufficient space.
  */
-int jtagmkII_getparm(PROGRAMMER * pgm, unsigned char parm,
+int jtagmkII_getparm(const PROGRAMMER *pgm, unsigned char parm,
 		     unsigned char * value)
 {
   int status;
@@ -2615,7 +2592,7 @@ int jtagmkII_getparm(PROGRAMMER * pgm, unsigned char parm,
 /*
  * Write an emulator parameter.
  */
-static int jtagmkII_setparm(PROGRAMMER * pgm, unsigned char parm,
+static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
 			    unsigned char * value)
 {
   int status;
@@ -2681,8 +2658,7 @@ static int jtagmkII_setparm(PROGRAMMER * pgm, unsigned char parm,
 }
 
 
-static void jtagmkII_display(PROGRAMMER * pgm, const char * p)
-{
+static void jtagmkII_display(const PROGRAMMER *pgm, const char *p) {
   unsigned char hw[4], fw[4];
 
   if (jtagmkII_getparm(pgm, PAR_HW_VERSION, hw) < 0 ||
@@ -2702,8 +2678,7 @@ static void jtagmkII_display(PROGRAMMER * pgm, const char * p)
 }
 
 
-static void jtagmkII_print_parms1(PROGRAMMER * pgm, const char * p)
-{
+static void jtagmkII_print_parms1(const PROGRAMMER *pgm, const char *p) {
   unsigned char vtarget[4], jtag_clock[4];
   char clkbuf[20];
   double clk;
@@ -2739,13 +2714,11 @@ static void jtagmkII_print_parms1(PROGRAMMER * pgm, const char * p)
   return;
 }
 
-static void jtagmkII_print_parms(PROGRAMMER * pgm)
-{
+static void jtagmkII_print_parms(const PROGRAMMER *pgm) {
   jtagmkII_print_parms1(pgm, "");
 }
 
-static unsigned char jtagmkII_memtype(PROGRAMMER * pgm, AVRPART * p, unsigned long addr)
-{
+static unsigned char jtagmkII_memtype(const PROGRAMMER *pgm, const AVRPART *p, unsigned long addr) {
   if ( p->flags & (AVRPART_HAS_PDI | AVRPART_HAS_UPDI) ) {
     if (addr >= PDATA(pgm)->boot_start)
       return MTYPE_BOOT_FLASH;
@@ -2756,8 +2729,7 @@ static unsigned char jtagmkII_memtype(PROGRAMMER * pgm, AVRPART * p, unsigned lo
   }
 }
 
-static unsigned int jtagmkII_memaddr(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, unsigned long addr)
-{
+static unsigned int jtagmkII_memaddr(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr) {
   /*
    * Xmega devices handled by V7+ firmware don't want to be told their
    * m->offset within the write memory command.
@@ -2786,7 +2758,7 @@ static unsigned int jtagmkII_memaddr(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m, 
 #pragma mark -
 #endif
 
-static int jtagmkII_avr32_reset(PROGRAMMER * pgm, unsigned char val,
+static int jtagmkII_avr32_reset(const PROGRAMMER *pgm, unsigned char val,
                                 unsigned char ret1, unsigned char ret2)
 {
   int status;
@@ -2827,8 +2799,7 @@ static int jtagmkII_avr32_reset(PROGRAMMER * pgm, unsigned char val,
 }
 
 // At init: AVR32_RESET_READ_IR | AVR32_RESET_READ_READ_CHIPINFO
-static int jtagmkII_reset32(PROGRAMMER * pgm, unsigned short flags)
-{
+static int jtagmkII_reset32(const PROGRAMMER *pgm, unsigned short flags) {
   int status, j, lineno;
   unsigned char *resp, buf[3];
   unsigned long val=0;
@@ -3017,8 +2988,7 @@ static int jtagmkII_reset32(PROGRAMMER * pgm, unsigned short flags)
     return -1;
 }
 
-static int jtagmkII_smc_init32(PROGRAMMER * pgm)
-{
+static int jtagmkII_smc_init32(const PROGRAMMER *pgm) {
   int status, lineno;
   unsigned long val;
 
@@ -3120,8 +3090,7 @@ static int jtagmkII_smc_init32(PROGRAMMER * pgm)
 /*
  * initialize the AVR device and prepare it to accept commands
  */
-static int jtagmkII_initialize32(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
   int status, j;
   unsigned char buf[6], *resp;
 
@@ -3197,8 +3166,7 @@ static int jtagmkII_initialize32(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int jtagmkII_chip_erase32(PROGRAMMER * pgm, AVRPART * p)
-{
+static int jtagmkII_chip_erase32(const PROGRAMMER *pgm, const AVRPART *p) {
   int status=0, loops;
   unsigned char *resp, buf[3], x, ret[4], *retP;
   unsigned long val=0;
@@ -3258,7 +3226,7 @@ static int jtagmkII_chip_erase32(PROGRAMMER * pgm, AVRPART * p)
     return -1;
 }
 
-static unsigned long jtagmkII_read_SABaddr(PROGRAMMER * pgm, unsigned long addr,
+static unsigned long jtagmkII_read_SABaddr(const PROGRAMMER *pgm, unsigned long addr,
                                            unsigned int prefix)
 {
   unsigned char buf[6], *resp;
@@ -3320,7 +3288,7 @@ static unsigned long jtagmkII_read_SABaddr(PROGRAMMER * pgm, unsigned long addr,
   return val;
 }
 
-static int jtagmkII_write_SABaddr(PROGRAMMER * pgm, unsigned long addr,
+static int jtagmkII_write_SABaddr(const PROGRAMMER *pgm, unsigned long addr,
                                   unsigned int prefix, unsigned long val)
 {
   unsigned char buf[10], *resp;
@@ -3355,8 +3323,7 @@ static int jtagmkII_write_SABaddr(PROGRAMMER * pgm, unsigned long addr,
   return 0;
 }
 
-static int jtagmkII_open32(PROGRAMMER * pgm, char * port)
-{
+static int jtagmkII_open32(PROGRAMMER *pgm, const char *port) {
   int status;
   unsigned char buf[6], *resp;
   union pinfo pinfo;
@@ -3492,7 +3459,7 @@ static void jtagmkII_close32(PROGRAMMER * pgm)
     goto ret;
 }
 
-static int jtagmkII_paged_load32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int page_size,
                                  unsigned int addr, unsigned int n_bytes)
 {
@@ -3509,23 +3476,16 @@ static int jtagmkII_paged_load32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 
   serial_recv_timeout = 256;
 
-  if(!(p->flags & AVRPART_WRITE)) {
+  if(!(PDATA(pgm)->flags32 & FLAGS32_WRITE)) {
     status = jtagmkII_reset32(pgm, AVR32_RESET_READ);
     if(status != 0) {lineno = __LINE__; goto eRR;}
   }
 
   // Init SMC and set clocks
-  if(!(p->flags & AVRPART_INIT_SMC)) {
+  if(!(PDATA(pgm)->flags32 & FLAGS32_INIT_SMC)) {
     status = jtagmkII_smc_init32(pgm);
     if(status != 0) {lineno = __LINE__; goto eRR;} // PLL 0
-    p->flags |= AVRPART_INIT_SMC;
-  }
-
-  // Init SMC and set clocks
-  if(!(p->flags & AVRPART_INIT_SMC)) {
-    status = jtagmkII_smc_init32(pgm);
-    if(status != 0) {lineno = __LINE__; goto eRR;} // PLL 0
-    p->flags |= AVRPART_INIT_SMC;
+    PDATA(pgm)->flags32 |= FLAGS32_INIT_SMC;
   }
 
   //avrdude_message(MSG_INFO, "\n pageSize=%d bytes=%d pages=%d m->offset=0x%x pgm->page_size %d\n",
@@ -3580,7 +3540,7 @@ static int jtagmkII_paged_load32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
     return -1;
 }
 
-static int jtagmkII_paged_write32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                   unsigned int page_size,
                                   unsigned int addr, unsigned int n_bytes)
 {
@@ -3598,7 +3558,7 @@ static int jtagmkII_paged_write32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 
   status = jtagmkII_reset32(pgm, AVR32_RESET_WRITE);
   if(status != 0) {lineno = __LINE__; goto eRR;}
-  p->flags |= AVRPART_WRITE;
+  PDATA(pgm)->flags32 |= FLAGS32_WRITE;
 
   pages = (n_bytes - addr - 1)/page_size + 1;
   sPageNum = addr/page_size;
@@ -3612,10 +3572,10 @@ static int jtagmkII_paged_write32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   }
 
   // Init SMC and set clocks
-  if(!(p->flags & AVRPART_INIT_SMC)) {
+  if(!(p->flags & FLAGS32_INIT_SMC)) {
     status = jtagmkII_smc_init32(pgm);
     if(status != 0) {lineno = __LINE__; goto eRR;} // PLL 0
-    p->flags |= AVRPART_INIT_SMC;
+    PDATA(pgm)->flags32 |= FLAGS32_INIT_SMC;
   }
 
   // First unlock the pages
@@ -3694,8 +3654,7 @@ static int jtagmkII_paged_write32(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
 }
 
 
-static int jtagmkII_flash_lock32(PROGRAMMER * pgm, unsigned char lock, unsigned int page)
-{
+static int jtagmkII_flash_lock32(const PROGRAMMER *pgm, unsigned char lock, unsigned int page) {
   int status, lineno, i;
   unsigned long val, cmd=0;
 
@@ -3721,8 +3680,7 @@ static int jtagmkII_flash_lock32(PROGRAMMER * pgm, unsigned char lock, unsigned 
     return -1;
 }
 
-static int jtagmkII_flash_erase32(PROGRAMMER * pgm, unsigned int page)
-{
+static int jtagmkII_flash_erase32(const PROGRAMMER *pgm, unsigned int page) {
   int status, lineno, i;
   unsigned long val=0, cmd=0, err=0;
 
@@ -3761,8 +3719,7 @@ static int jtagmkII_flash_erase32(PROGRAMMER * pgm, unsigned int page)
     return -1;
 }
 
-static int jtagmkII_flash_write_page32(PROGRAMMER * pgm, unsigned int page)
-{
+static int jtagmkII_flash_write_page32(const PROGRAMMER *pgm, unsigned int page) {
   int status, lineno, i;
   unsigned long val=0, cmd, err;
 
@@ -3791,8 +3748,7 @@ static int jtagmkII_flash_write_page32(PROGRAMMER * pgm, unsigned int page)
     return -1;
 }
 
-static int jtagmkII_flash_clear_pagebuffer32(PROGRAMMER * pgm)
-{
+static int jtagmkII_flash_clear_pagebuffer32(const PROGRAMMER *pgm) {
   int status, lineno, i;
   unsigned long val=0, cmd, err;
 
@@ -3826,8 +3782,7 @@ static int jtagmkII_flash_clear_pagebuffer32(PROGRAMMER * pgm)
 
 const char jtagmkII_desc[] = "Atmel JTAG ICE mkII";
 
-void jtagmkII_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGMKII");
 
   /*
@@ -3861,8 +3816,7 @@ void jtagmkII_initpgm(PROGRAMMER * pgm)
 
 const char jtagmkII_dw_desc[] = "Atmel JTAG ICE mkII in debugWire mode";
 
-void jtagmkII_dw_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_dw_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGMKII_DW");
 
   /*
@@ -3893,8 +3847,7 @@ void jtagmkII_dw_initpgm(PROGRAMMER * pgm)
 
 const char jtagmkII_pdi_desc[] = "Atmel JTAG ICE mkII in PDI mode";
 
-void jtagmkII_pdi_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_pdi_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGMKII_PDI");
 
   /*
@@ -3926,8 +3879,7 @@ void jtagmkII_pdi_initpgm(PROGRAMMER * pgm)
 
 const char jtagmkII_updi_desc[] = "Atmel JTAG ICE mkII in UPDI mode";
 
-void jtagmkII_updi_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_updi_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGMKII_UPDI");
 
   /*
@@ -3959,8 +3911,7 @@ void jtagmkII_updi_initpgm(PROGRAMMER * pgm)
 
 const char jtagmkII_dragon_desc[] = "Atmel AVR Dragon in JTAG mode";
 
-void jtagmkII_dragon_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_dragon_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "DRAGON_JTAG");
 
   /*
@@ -3994,8 +3945,7 @@ void jtagmkII_dragon_initpgm(PROGRAMMER * pgm)
 
 const char jtagmkII_dragon_dw_desc[] = "Atmel AVR Dragon in debugWire mode";
 
-void jtagmkII_dragon_dw_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_dragon_dw_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "DRAGON_DW");
 
   /*
@@ -4026,8 +3976,7 @@ void jtagmkII_dragon_dw_initpgm(PROGRAMMER * pgm)
 
 const char jtagmkII_avr32_desc[] = "Atmel JTAG ICE mkII in AVR32 mode";
 
-void jtagmkII_avr32_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_avr32_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "JTAGMKII_AVR32");
 
   /*
@@ -4060,8 +4009,7 @@ void jtagmkII_avr32_initpgm(PROGRAMMER * pgm)
 
 const char jtagmkII_dragon_pdi_desc[] = "Atmel AVR Dragon in PDI mode";
 
-void jtagmkII_dragon_pdi_initpgm(PROGRAMMER * pgm)
-{
+void jtagmkII_dragon_pdi_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "DRAGON_PDI");
 
   /*

--- a/src/jtagmkII.h
+++ b/src/jtagmkII.h
@@ -25,11 +25,11 @@
 extern "C" {
 #endif
 
-int  jtagmkII_send(PROGRAMMER * pgm, unsigned char * data, size_t len);
-int  jtagmkII_recv(PROGRAMMER * pgm, unsigned char **msg);
+int  jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, size_t len);
+int  jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg);
 void jtagmkII_close(PROGRAMMER * pgm);
-int  jtagmkII_getsync(PROGRAMMER * pgm, int mode);
-int  jtagmkII_getparm(PROGRAMMER * pgm, unsigned char parm,
+int  jtagmkII_getsync(const PROGRAMMER *pgm, int mode);
+int  jtagmkII_getparm(const PROGRAMMER *pgm, unsigned char parm,
 		      unsigned char * value);
 
 extern const char jtagmkII_desc[];
@@ -40,14 +40,14 @@ extern const char jtagmkII_updi_desc[];
 extern const char jtagmkII_dragon_desc[];
 extern const char jtagmkII_dragon_dw_desc[];
 extern const char jtagmkII_dragon_pdi_desc[];
-void jtagmkII_initpgm (PROGRAMMER * pgm);
-void jtagmkII_avr32_initpgm (PROGRAMMER * pgm);
-void jtagmkII_dw_initpgm (PROGRAMMER * pgm);
-void jtagmkII_pdi_initpgm (PROGRAMMER * pgm);
-void jtagmkII_updi_initpgm (PROGRAMMER * pgm);
-void jtagmkII_dragon_initpgm (PROGRAMMER * pgm);
-void jtagmkII_dragon_dw_initpgm (PROGRAMMER * pgm);
-void jtagmkII_dragon_pdi_initpgm (PROGRAMMER * pgm);
+void jtagmkII_initpgm(PROGRAMMER *pgm);
+void jtagmkII_avr32_initpgm(PROGRAMMER *pgm);
+void jtagmkII_dw_initpgm(PROGRAMMER *pgm);
+void jtagmkII_pdi_initpgm(PROGRAMMER *pgm);
+void jtagmkII_updi_initpgm(PROGRAMMER *pgm);
+void jtagmkII_dragon_initpgm(PROGRAMMER *pgm);
+void jtagmkII_dragon_dw_initpgm(PROGRAMMER *pgm);
+void jtagmkII_dragon_pdi_initpgm(PROGRAMMER *pgm);
 
 /*
  * These functions are referenced from stk500v2.c for JTAG ICE mkII

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -323,16 +323,16 @@ int intlog2(unsigned int n);
 /* Functions for OPCODE structures */
 OPCODE * avr_new_opcode(void);
 void     avr_free_opcode(OPCODE * op);
-int avr_set_bits(OPCODE * op, unsigned char * cmd);
-int avr_set_addr(OPCODE * op, unsigned char * cmd, unsigned long addr);
-int avr_set_addr_mem(AVRMEM *mem, int opnum, unsigned char *cmd, unsigned long addr);
-int avr_set_input(OPCODE * op, unsigned char * cmd, unsigned char data);
+int avr_set_bits(const OPCODE *op, unsigned char *cmd);
+int avr_set_addr(const OPCODE *op, unsigned char *cmd, unsigned long addr);
+int avr_set_addr_mem(const AVRMEM *mem, int opnum, unsigned char *cmd, unsigned long addr);
+int avr_set_input(const OPCODE *op, unsigned char *cmd, unsigned char data);
 int avr_get_output(const OPCODE *op, const unsigned char *res, unsigned char *data);
 int avr_get_output_index(const OPCODE *op);
 char cmdbitchar(CMDBIT cb);
 char *cmdbitstr(CMDBIT cb);
 const char *opcodename(int opnum);
-char *opcode2str(OPCODE *op, int opnum, int detailed);
+char *opcode2str(const OPCODE *op, int opnum, int detailed);
 
 /* Functions for AVRMEM structures */
 AVRMEM * avr_new_memtype(void);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -283,7 +283,6 @@ typedef struct avrpart {
   int           lineno;             /* config file line number */
 } AVRPART;
 
-#define AVR_MEMDESCLEN 64
 typedef struct avrmem {
   const char *desc;           /* memory description ("flash", "eeprom", etc) */
   LISTID comments;            // Used by developer options -p*/[ASsr...]

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -193,8 +193,6 @@ typedef struct opcode {
 #define AVRPART_HAS_DW         0x0040  /* part has a debugWire i/f */
 #define AVRPART_HAS_PDI        0x0080  /* part has PDI i/f rather than ISP (ATxmega) */
 #define AVRPART_AVR32          0x0100  /* part is in AVR32 family */
-#define AVRPART_INIT_SMC       0x0200  /* part will undergo chip erase */
-#define AVRPART_WRITE          0x0400  /* at least one write operation specified */
 #define AVRPART_HAS_TPI        0x0800  /* part has TPI i/f rather than ISP (ATtiny4/5/9/10) */
 #define AVRPART_IS_AT90S1200   0x1000  /* part is an AT90S1200 (needs special treatment) */
 #define AVRPART_HAS_UPDI       0x2000  /* part has UPDI i/f (AVR8X) */
@@ -614,18 +612,17 @@ union pinfo
 };
 
 
-struct serial_device
-{
+struct serial_device {
   // open should return -1 on error, other values on success
-  int (*open)(char * port, union pinfo pinfo, union filedescriptor *fd); 
-  int (*setparams)(union filedescriptor *fd, long baud, unsigned long cflags);
+  int (*open)(const char *port, union pinfo pinfo, union filedescriptor *fd);
+  int (*setparams)(const union filedescriptor *fd, long baud, unsigned long cflags);
   void (*close)(union filedescriptor *fd);
 
-  int (*send)(union filedescriptor *fd, const unsigned char * buf, size_t buflen);
-  int (*recv)(union filedescriptor *fd, unsigned char * buf, size_t buflen);
-  int (*drain)(union filedescriptor *fd, int display);
+  int (*send)(const union filedescriptor *fd, const unsigned char * buf, size_t buflen);
+  int (*recv)(const union filedescriptor *fd, unsigned char * buf, size_t buflen);
+  int (*drain)(const union filedescriptor *fd, int display);
 
-  int (*set_dtr_rts)(union filedescriptor *fd, int is_on);
+  int (*set_dtr_rts)(const union filedescriptor *fd, int is_on);
 
   int flags;
 #define SERDEV_FL_NONE         0x0000 /* no flags */
@@ -684,8 +681,8 @@ typedef enum {
 typedef struct programmer_t {
   LISTID id;
   const char *desc;
-  void (*initpgm)(struct programmer_t *pgm);
-  LISTID        comments;       // Used by developer options -c*/[ASsr...]
+  void (*initpgm)(struct programmer_t *pgm); // Sets up the AVRDUDE programmer
+  LISTID comments;              // Used by developer options -c*/[ASsr...]
   const char *parent_id;        // Used by developer options
   struct pindef_t pin[N_PINS];
   conntype_t conntype;
@@ -712,60 +709,60 @@ typedef struct programmer_t {
   int page_size;                // Page size if the programmer supports paged write/load
   double bitclock;              // JTAG ICE clock period in microseconds
 
-  int  (*rdy_led)        (struct programmer_t * pgm, int value);
-  int  (*err_led)        (struct programmer_t * pgm, int value);
-  int  (*pgm_led)        (struct programmer_t * pgm, int value);
-  int  (*vfy_led)        (struct programmer_t * pgm, int value);
-  int  (*initialize)     (struct programmer_t * pgm, AVRPART * p);
-  void (*display)        (struct programmer_t * pgm, const char * p);
-  void (*enable)         (struct programmer_t * pgm);
-  void (*disable)        (struct programmer_t * pgm);
-  void (*powerup)        (struct programmer_t * pgm);
-  void (*powerdown)      (struct programmer_t * pgm);
-  int  (*program_enable) (struct programmer_t * pgm, AVRPART * p);
-  int  (*chip_erase)     (struct programmer_t * pgm, AVRPART * p);
-  int  (*unlock)         (struct programmer_t * pgm, AVRPART * p);
-  int  (*cmd)            (struct programmer_t * pgm, const unsigned char *cmd,
+  int  (*rdy_led)        (const struct programmer_t *pgm, int value);
+  int  (*err_led)        (const struct programmer_t *pgm, int value);
+  int  (*pgm_led)        (const struct programmer_t *pgm, int value);
+  int  (*vfy_led)        (const struct programmer_t *pgm, int value);
+  int  (*initialize)     (const struct programmer_t *pgm, const AVRPART *p); // Sets up the physical programmer
+  void (*display)        (const struct programmer_t *pgm, const char *p);
+  void (*enable)         (struct programmer_t *pgm, const AVRPART *p);
+  void (*disable)        (const struct programmer_t *pgm);
+  void (*powerup)        (const struct programmer_t *pgm);
+  void (*powerdown)      (const struct programmer_t *pgm);
+  int  (*program_enable) (const struct programmer_t *pgm, const AVRPART *p);
+  int  (*chip_erase)     (const struct programmer_t *pgm, const AVRPART *p);
+  int  (*unlock)         (const struct programmer_t *pgm, const AVRPART *p);
+  int  (*cmd)            (const struct programmer_t *pgm, const unsigned char *cmd,
                           unsigned char *res);
-  int  (*cmd_tpi)        (struct programmer_t * pgm, const unsigned char *cmd,
+  int  (*cmd_tpi)        (const struct programmer_t *pgm, const unsigned char *cmd,
                           int cmd_len, unsigned char res[], int res_len);
-  int  (*spi)            (struct programmer_t * pgm, const unsigned char *cmd,
+  int  (*spi)            (const struct programmer_t *pgm, const unsigned char *cmd,
                           unsigned char *res, int count);
-  int  (*open)           (struct programmer_t * pgm, char * port);
-  void (*close)          (struct programmer_t * pgm);
-  int  (*paged_write)    (struct programmer_t * pgm, AVRPART * p, AVRMEM * m, 
+  int  (*open)           (struct programmer_t *pgm, const char *port);
+  void (*close)          (struct programmer_t *pgm);
+  int  (*paged_write)    (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
                           unsigned int page_size, unsigned int baseaddr,
                           unsigned int n_bytes);
-  int  (*paged_load)     (struct programmer_t * pgm, AVRPART * p, AVRMEM * m,
+  int  (*paged_load)     (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
                           unsigned int page_size, unsigned int baseaddr,
                           unsigned int n_bytes);
-  int  (*page_erase)     (struct programmer_t * pgm, AVRPART * p, AVRMEM * m,
+  int  (*page_erase)     (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
                           unsigned int baseaddr);
-  void (*write_setup)    (struct programmer_t * pgm, AVRPART * p, AVRMEM * m);
-  int  (*write_byte)     (struct programmer_t * pgm, AVRPART * p, AVRMEM * m,
+  void (*write_setup)    (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m);
+  int  (*write_byte)     (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
                           unsigned long addr, unsigned char value);
-  int  (*read_byte)      (struct programmer_t * pgm, AVRPART * p, AVRMEM * m,
-                          unsigned long addr, unsigned char * value);
-  int  (*read_sig_bytes) (struct programmer_t * pgm, AVRPART * p, AVRMEM * m);
-  int  (*read_sib)       (struct programmer_t * pgm, AVRPART * p, char *sib);
-  void (*print_parms)    (struct programmer_t * pgm);
-  int  (*set_vtarget)    (struct programmer_t * pgm, double v);
-  int  (*set_varef)      (struct programmer_t * pgm, unsigned int chan, double v);
-  int  (*set_fosc)       (struct programmer_t * pgm, double v);
-  int  (*set_sck_period) (struct programmer_t * pgm, double v);
-  int  (*setpin)         (struct programmer_t * pgm, int pinfunc, int value);
-  int  (*getpin)         (struct programmer_t * pgm, int pinfunc);
-  int  (*highpulsepin)   (struct programmer_t * pgm, int pinfunc);
-  int  (*parseexitspecs) (struct programmer_t * pgm, char *s);
-  int  (*perform_osccal) (struct programmer_t * pgm);
-  int  (*parseextparams) (struct programmer_t * pgm, LISTID xparams);
-  void (*setup)          (struct programmer_t * pgm);
-  void (*teardown)       (struct programmer_t * pgm);
+  int  (*read_byte)      (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
+                          unsigned long addr, unsigned char *value);
+  int  (*read_sig_bytes) (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m);
+  int  (*read_sib)       (const struct programmer_t *pgm, const AVRPART *p, char *sib);
+  void (*print_parms)    (const struct programmer_t *pgm);
+  int  (*set_vtarget)    (const struct programmer_t *pgm, double v);
+  int  (*set_varef)      (const struct programmer_t *pgm, unsigned int chan, double v);
+  int  (*set_fosc)       (const struct programmer_t *pgm, double v);
+  int  (*set_sck_period) (const struct programmer_t *pgm, double v);
+  int  (*setpin)         (const struct programmer_t *pgm, int pinfunc, int value);
+  int  (*getpin)         (const struct programmer_t *pgm, int pinfunc);
+  int  (*highpulsepin)   (const struct programmer_t *pgm, int pinfunc);
+  int  (*parseexitspecs) (struct programmer_t *pgm, const char *s);
+  int  (*perform_osccal) (const struct programmer_t *pgm);
+  int  (*parseextparams) (const struct programmer_t *pgm, const LISTID xparams);
+  void (*setup)          (struct programmer_t *pgm);
+  void (*teardown)       (struct programmer_t *pgm);
 
   const char *config_file;      // Config file where defined
   int  lineno;                  // Config file line number
   void *cookie;                 // For private use by the programmer
-  char flag;                    // For private use of the programmer
+  char flag;                    // For use by pgm->initpgm()
 } PROGRAMMER;
 
 #ifdef __cplusplus
@@ -812,50 +809,50 @@ extern FP_UpdateProgress update_progress;
 extern "C" {
 #endif
 
-int avr_tpi_poll_nvmbsy(PROGRAMMER *pgm);
-int avr_tpi_chip_erase(PROGRAMMER * pgm, AVRPART * p);
-int avr_tpi_program_enable(PROGRAMMER * pgm, AVRPART * p, unsigned char guard_time);
-int avr_read_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+int avr_tpi_poll_nvmbsy(const PROGRAMMER *pgm);
+int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
+int avr_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p, unsigned char guard_time);
+int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			  unsigned long addr, unsigned char * value);
 
-int avr_read(PROGRAMMER * pgm, AVRPART * p, char * memtype, AVRPART * v);
+int avr_read(const PROGRAMMER * pgm, const AVRPART *p, const char *memtype, AVRPART *v);
 
-int avr_write_page(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr);
 
-int avr_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+int avr_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr, unsigned char data);
 
-int avr_write_byte_default(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			   unsigned long addr, unsigned char data);
 
-int avr_write(PROGRAMMER * pgm, AVRPART * p, char * memtype, int size,
+int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype, int size,
               int auto_erase);
 
-int avr_signature(PROGRAMMER * pgm, AVRPART * p);
+int avr_signature(const PROGRAMMER *pgm, const AVRPART *p);
 
-int avr_verify(AVRPART * p, AVRPART * v, char * memtype, int size);
+int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int size);
 
-int avr_get_cycle_count(PROGRAMMER * pgm, AVRPART * p, int * cycles);
+int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles);
 
-int avr_put_cycle_count(PROGRAMMER * pgm, AVRPART * p, int cycles);
+int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles);
 
 void avr_add_mem_order(const char *str);
 
-int avr_mem_is_flash_type(AVRMEM *mem);
+int avr_mem_is_flash_type(const AVRMEM *mem);
 
-int avr_mem_is_eeprom_type(AVRMEM *mem);
+int avr_mem_is_eeprom_type(const AVRMEM *mem);
 
 int avr_mem_is_known(const char *str);
 
 int avr_mem_might_be_known(const char *str);
 
 #define disable_trailing_ff_removal() avr_mem_hiaddr(NULL)
-int avr_mem_hiaddr(AVRMEM * mem);
+int avr_mem_hiaddr(const AVRMEM * mem);
 
-int avr_chip_erase(PROGRAMMER * pgm, AVRPART * p);
+int avr_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
 
-int avr_unlock(PROGRAMMER * pgm, AVRPART * p);
+int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p);
 
 void report_progress (int completed, int total, char *hdr);
 
@@ -983,7 +980,7 @@ int update_dryrun(struct avrpart *p, UPDATE *upd);
 
 typedef struct programmer_type_t {
   const char * const id;
-  void (*initpgm)(struct programmer_t * pgm);
+  void (*initpgm)(struct programmer_t *pgm);
   const char * const desc;
 } PROGRAMMER_TYPE;
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -842,7 +842,12 @@ int avr_put_cycle_count(PROGRAMMER * pgm, AVRPART * p, int cycles);
 
 void avr_add_mem_order(const char *str);
 
+int avr_mem_is_flash_type(AVRMEM *mem);
+
+int avr_mem_is_eeprom_type(AVRMEM *mem);
+
 int avr_mem_is_known(const char *str);
+
 int avr_mem_might_be_known(const char *str);
 
 #define disable_trailing_ff_removal() avr_mem_hiaddr(NULL)

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -144,8 +144,7 @@ static int linuxgpio_dir_in(unsigned int gpio)
 static int linuxgpio_fds[N_GPIO] ;
 
 
-static int linuxgpio_setpin(PROGRAMMER * pgm, int pinfunc, int value)
-{
+static int linuxgpio_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
   int r;
   int pin = pgm->pinno[pinfunc]; // TODO
 
@@ -171,8 +170,7 @@ static int linuxgpio_setpin(PROGRAMMER * pgm, int pinfunc, int value)
   return 0;
 }
 
-static int linuxgpio_getpin(PROGRAMMER * pgm, int pinfunc)
-{
+static int linuxgpio_getpin(const PROGRAMMER *pgm, int pinfunc) {
   unsigned char invert=0;
   char c;
   int pin = pgm->pinno[pinfunc]; // TODO
@@ -198,11 +196,9 @@ static int linuxgpio_getpin(PROGRAMMER * pgm, int pinfunc)
     return 1-invert;
   else
     return -1;
-
 }
 
-static int linuxgpio_highpulsepin(PROGRAMMER * pgm, int pinfunc)
-{
+static int linuxgpio_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
   int pin = pgm->pinno[pinfunc]; // TODO
   
   if ( linuxgpio_fds[pin & PIN_MASK] < 0 )
@@ -216,34 +212,28 @@ static int linuxgpio_highpulsepin(PROGRAMMER * pgm, int pinfunc)
 
 
 
-static void linuxgpio_display(PROGRAMMER *pgm, const char *p)
-{
+static void linuxgpio_display(const PROGRAMMER *pgm, const char *p) {
     avrdude_message(MSG_INFO, "%sPin assignment  : /sys/class/gpio/gpio{n}\n",p);
     pgm_display_generic_mask(pgm, p, SHOW_AVR_PINS);
 }
 
-static void linuxgpio_enable(PROGRAMMER *pgm)
-{
+static void linuxgpio_enable(PROGRAMMER *pgm, const AVRPART *p) {
   /* nothing */
 }
 
-static void linuxgpio_disable(PROGRAMMER *pgm)
-{
+static void linuxgpio_disable(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static void linuxgpio_powerup(PROGRAMMER *pgm)
-{
+static void linuxgpio_powerup(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static void linuxgpio_powerdown(PROGRAMMER *pgm)
-{
+static void linuxgpio_powerdown(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static int linuxgpio_open(PROGRAMMER *pgm, char *port)
-{
+static int linuxgpio_open(PROGRAMMER *pgm, const char *port) {
   int r, i, pin;
 
   if (bitbang_check_prerequisites(pgm) < 0)
@@ -311,8 +301,7 @@ static void linuxgpio_close(PROGRAMMER *pgm)
   }
 }
 
-void linuxgpio_initpgm(PROGRAMMER *pgm)
-{
+void linuxgpio_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "linuxgpio");
 
   pgm_fill_old_pins(pgm); // TODO to be removed if old pin data no longer needed
@@ -344,8 +333,7 @@ const char linuxgpio_desc[] = "GPIO bitbanging using the Linux sysfs interface";
 
 #else  /* !HAVE_LINUXGPIO */
 
-void linuxgpio_initpgm(PROGRAMMER * pgm)
-{
+void linuxgpio_initpgm(PROGRAMMER *pgm) {
   avrdude_message(MSG_INFO, "%s: Linux sysfs GPIO support not available in this configuration\n",
                   progname);
 }

--- a/src/linuxgpio.h
+++ b/src/linuxgpio.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 extern const char linuxgpio_desc[];
-void linuxgpio_initpgm        (PROGRAMMER * pgm);
+void linuxgpio_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/linuxspi.h
+++ b/src/linuxspi.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 extern const char linuxspi_desc[];
-void linuxspi_initpgm        (PROGRAMMER * pgm);
+void linuxspi_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/main.c
+++ b/src/main.c
@@ -279,7 +279,7 @@ int main(int argc, char * argv [])
   int     calibrate;   /* 1=calibrate RC oscillator, 0=don't */
   char  * port;        /* device port (/dev/xxx) */
   int     terminal;    /* 1=enter terminal mode, 0=don't */
-  char  * exitspecs;   /* exit specs string from command line */
+  const char *exitspecs; /* exit specs string from command line */
   char  * programmer;  /* programmer id */
   char  * partdesc;    /* part id */
   char    sys_config[PATH_MAX]; /* system wide config file */
@@ -869,11 +869,12 @@ int main(int argc, char * argv [])
 
       case CONNTYPE_SPI:
 #ifdef HAVE_LINUXSPI
-        port = *default_spi? default_spi: "unknown";
+        port = cfg_strdup("main()", *default_spi? default_spi: "unknown");
 #endif
         break;
     }
   }
+
 
   if (partdesc == NULL) {
     avrdude_message(MSG_INFO, "%s: No AVR part has been specified, use \"-p Part\"\n\n",
@@ -884,7 +885,6 @@ int main(int argc, char * argv [])
     exit(1);
   }
 
-
   p = locate_part(part_list, partdesc);
   if (p == NULL) {
     avrdude_message(MSG_INFO, "%s: AVR Part \"%s\" not found.\n\n",
@@ -894,7 +894,6 @@ int main(int argc, char * argv [])
     avrdude_message(MSG_INFO, "\n");
     exit(1);
   }
-
 
   if (exitspecs != NULL) {
     if (pgm->parseexitspecs == NULL) {
@@ -908,10 +907,9 @@ int main(int argc, char * argv [])
     }
   }
 
-  if (avr_initmem(p) != 0)
-  {
+  if (avr_initmem(p) != 0) {
     avrdude_message(MSG_INFO, "\n%s: failed to initialize memories\n",
-            progname);
+      progname);
     exit(1);
   }
 
@@ -1024,7 +1022,7 @@ int main(int argc, char * argv [])
   /*
    * enable the programmer
    */
-  pgm->enable(pgm);
+  pgm->enable(pgm, p);
 
   /*
    * turn off all the status leds

--- a/src/main.c
+++ b/src/main.c
@@ -1213,7 +1213,7 @@ int main(int argc, char * argv [])
         m = avr_locate_mem(p, upd->memtype);
         if (m == NULL)
           continue;
-        if ((strcasecmp(m->desc, memname) == 0) && (upd->op == DEVICE_WRITE)) {
+        if ((strcmp(m->desc, memname) == 0) && (upd->op == DEVICE_WRITE)) {
           erase = 1;
           if (quell_progress < 2) {
             avrdude_message(MSG_INFO, "%s: NOTE: \"%s\" memory has been specified, an erase cycle "

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -567,8 +567,7 @@ static void micronucleus_teardown(PROGRAMMER* pgm)
     free(pgm->cookie);
 }
 
-static int micronucleus_initialize(PROGRAMMER* pgm, AVRPART* p)
-{
+static int micronucleus_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_initialize()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
@@ -582,18 +581,15 @@ static int micronucleus_initialize(PROGRAMMER* pgm, AVRPART* p)
     return 0;
 }
 
-static void micronucleus_display(PROGRAMMER* pgm, const char* prefix)
-{
+static void micronucleus_display(const PROGRAMMER *pgm, const char *prefix) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_display()\n", progname);
 }
 
-static void micronucleus_powerup(PROGRAMMER* pgm)
-{
+static void micronucleus_powerup(const PROGRAMMER *pgm) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_powerup()\n", progname);
 }
 
-static void micronucleus_powerdown(PROGRAMMER* pgm)
-{
+static void micronucleus_powerdown(const PROGRAMMER *pgm) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_powerdown()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
@@ -618,24 +614,20 @@ static void micronucleus_powerdown(PROGRAMMER* pgm)
     }
 }
 
-static void micronucleus_enable(PROGRAMMER* pgm)
-{
+static void micronucleus_enable(PROGRAMMER *pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_enable()\n", progname);
 }
 
-static void micronucleus_disable(PROGRAMMER* pgm)
-{
+static void micronucleus_disable(const PROGRAMMER *pgm) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_disable()\n", progname);
 }
 
-static int micronucleus_program_enable(PROGRAMMER* pgm, AVRPART* p)
-{
+static int micronucleus_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_program_enable()\n", progname);
     return 0;
 }
 
-static int micronucleus_read_sig_bytes(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem)
-{
+static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_read_sig_bytes()\n", progname);
 
     if (mem->size < 3)
@@ -651,20 +643,18 @@ static int micronucleus_read_sig_bytes(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem)
     return 0;
 }
 
-static int micronucleus_chip_erase(PROGRAMMER* pgm, AVRPART* p)
-{
+static int micronucleus_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_chip_erase()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
     return micronucleus_erase_device(pdata);
 }
 
-static int micronucleus_open(PROGRAMMER* pgm, char* port)
-{
+static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_open(\"%s\")\n", progname, port);
 
     pdata_t* pdata = PDATA(pgm);
-    char* bus_name = NULL;
+    const char *bus_name = NULL;
     char* dev_name = NULL;
 
     // if no -P was given or '-P usb' was given
@@ -829,7 +819,7 @@ static void micronucleus_close(PROGRAMMER* pgm)
     }
 }
 
-static int micronucleus_read_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char* value)
 {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_read_byte(desc=%s, addr=0x%0X)\n",
@@ -850,7 +840,7 @@ static int micronucleus_read_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     }
 }
 
-static int micronucleus_write_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int micronucleus_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char value)
 {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_write_byte(desc=%s, addr=0x%0X)\n",
@@ -858,7 +848,7 @@ static int micronucleus_write_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     return -1;
 }
 
-static int micronucleus_paged_load(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int micronucleus_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
@@ -867,7 +857,7 @@ static int micronucleus_paged_load(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     return -1;
 }
 
-static int micronucleus_paged_write(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
@@ -926,8 +916,7 @@ static int micronucleus_paged_write(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     }
 }
 
-static int micronucleus_parseextparams(PROGRAMMER* pgm, LISTID xparams)
-{
+static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
     avrdude_message(MSG_DEBUG, "%s: micronucleus_parseextparams()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
@@ -955,8 +944,7 @@ static int micronucleus_parseextparams(PROGRAMMER* pgm, LISTID xparams)
     return 0;
 }
 
-void micronucleus_initpgm(PROGRAMMER* pgm)
-{
+void micronucleus_initpgm(PROGRAMMER *pgm) {
     strcpy(pgm->type, "Micronucleus V2.0");
 
     pgm->setup = micronucleus_setup;
@@ -983,14 +971,12 @@ void micronucleus_initpgm(PROGRAMMER* pgm)
 #else /* !HAVE_LIBUSB */
 
  // Give a proper error if we were not compiled with libusb
-static int micronucleus_nousb_open(struct programmer_t* pgm, char* name)
-{
+static int micronucleus_nousb_open(PROGRAMMER* pgm, const char* name) {
     avrdude_message(MSG_INFO, "%s: error: No usb support. Please compile again with libusb installed.\n", progname);
     return -1;
 }
 
-void micronucleus_initpgm(PROGRAMMER* pgm)
-{
+void micronucleus_initpgm(PROGRAMMER *pgm) {
     strcpy(pgm->type, "micronucleus");
     pgm->open = micronucleus_nousb_open;
 }

--- a/src/micronucleus.h
+++ b/src/micronucleus.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char micronucleus_desc[];
-void micronucleus_initpgm(PROGRAMMER* pgm);
+void micronucleus_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/par.c
+++ b/src/par.c
@@ -73,8 +73,7 @@ static struct ppipins_t ppipins[] = {
 
 #define NPINS (sizeof(ppipins)/sizeof(struct ppipins_t))
 
-static int par_setpin_internal(PROGRAMMER * pgm, int pin, int value)
-{
+static int par_setpin_internal(const PROGRAMMER *pgm, int pin, int value) {
   int inverted;
 
   inverted = pin & PIN_INVERSE;
@@ -102,13 +101,11 @@ static int par_setpin_internal(PROGRAMMER * pgm, int pin, int value)
   return 0;
 }
 
-static int par_setpin(PROGRAMMER * pgm, int pinfunc, int value)
-{
+static int par_setpin(const PROGRAMMER * pgm, int pinfunc, int value) {
   return par_setpin_internal(pgm, pgm->pinno[pinfunc], value);
 }
 
-static void par_setmany(PROGRAMMER * pgm, int pinfunc, int value)
-{
+static void par_setmany(const PROGRAMMER *pgm, int pinfunc, int value) {
   int pin, mask;
   int pinset = pgm->pinno[pinfunc];
 
@@ -121,8 +118,7 @@ static void par_setmany(PROGRAMMER * pgm, int pinfunc, int value)
   }
 }
 
-static int par_getpin(PROGRAMMER * pgm, int pinfunc)
-{
+static int par_getpin(const PROGRAMMER * pgm, int pinfunc) {
   int value;
   int inverted;
   int pin = pgm->pinno[pinfunc];
@@ -150,8 +146,7 @@ static int par_getpin(PROGRAMMER * pgm, int pinfunc)
 }
 
 
-static int par_highpulsepin(PROGRAMMER * pgm, int pinfunc)
-{
+static int par_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
   int inverted;
   int pin = pgm->pinno[pinfunc];
 
@@ -190,8 +185,7 @@ static int par_highpulsepin(PROGRAMMER * pgm, int pinfunc)
 /*
  * apply power to the AVR processor
  */
-static void par_powerup(PROGRAMMER * pgm)
-{
+static void par_powerup(const PROGRAMMER *pgm) {
   par_setmany(pgm, PPI_AVR_VCC, 1);	/* power up */
   usleep(100000);
 }
@@ -200,18 +194,15 @@ static void par_powerup(PROGRAMMER * pgm)
 /*
  * remove power from the AVR processor
  */
-static void par_powerdown(PROGRAMMER * pgm)
-{
+static void par_powerdown(const PROGRAMMER *pgm) {
   par_setmany(pgm, PPI_AVR_VCC, 0);	/* power down */
 }
 
-static void par_disable(PROGRAMMER * pgm)
-{
+static void par_disable(const PROGRAMMER *pgm) {
   par_setmany(pgm, PPI_AVR_BUFF, 1); /* turn off */
 }
 
-static void par_enable(PROGRAMMER * pgm)
-{
+static void par_enable(PROGRAMMER *pgm, const AVRPART *p) {
   /*
    * Prepare to start talking to the connected device - pull reset low
    * first, delay a few milliseconds, then enable the buffer.  This
@@ -232,8 +223,7 @@ static void par_enable(PROGRAMMER * pgm)
   par_setmany(pgm, PPI_AVR_BUFF, 0);
 }
 
-static int par_open(PROGRAMMER * pgm, char * port)
-{
+static int par_open(PROGRAMMER *pgm, const char *port) {
   int rc;
 
   if (bitbang_check_prerequisites(pgm) < 0)
@@ -267,8 +257,7 @@ static int par_open(PROGRAMMER * pgm, char * port)
 }
 
 
-static void par_close(PROGRAMMER * pgm)
-{
+static void par_close(PROGRAMMER *pgm) {
 
   /*
    * Restore pin values before closing,
@@ -331,40 +320,41 @@ static void par_close(PROGRAMMER * pgm)
 /*
  * parse the -E string
  */
-static int par_parseexitspecs(PROGRAMMER * pgm, char *s)
-{
-  char *cp;
+static int par_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
+  char *cp, *s, *str = cfg_strdup("par_parseexitspecs()", sp);
 
-  while ((cp = strtok(s, ","))) {
-    if (strcmp(cp, "reset") == 0) {
+  s = str;
+  while((cp = strtok(s, ","))) {
+    if(strcmp(cp, "reset") == 0)
       pgm->exit_reset = EXIT_RESET_ENABLED;
-    }
-    else if (strcmp(cp, "noreset") == 0) {
+
+    else if(strcmp(cp, "noreset") == 0)
       pgm->exit_reset = EXIT_RESET_DISABLED;
-    }
-    else if (strcmp(cp, "vcc") == 0) {
+
+    else if(strcmp(cp, "vcc") == 0)
       pgm->exit_vcc = EXIT_VCC_ENABLED;
-    }
-    else if (strcmp(cp, "novcc") == 0) {
+
+    else if(strcmp(cp, "novcc") == 0)
       pgm->exit_vcc = EXIT_VCC_DISABLED;
-    }
-    else if (strcmp(cp, "d_high") == 0) {
+
+    else if(strcmp(cp, "d_high") == 0)
       pgm->exit_datahigh = EXIT_DATAHIGH_ENABLED;
-    }
-    else if (strcmp(cp, "d_low") == 0) {
+
+    else if(strcmp(cp, "d_low") == 0)
       pgm->exit_datahigh = EXIT_DATAHIGH_DISABLED;
-    }
+
     else {
+      free(str);
       return -1;
     }
-    s = 0; /* strtok() should be called with the actual string only once */
+    s = NULL; // Only call strtok() once with the actual string
   }
 
+  free(str);
   return 0;
 }
 
-void par_initpgm(PROGRAMMER * pgm)
-{
+void par_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "PPI");
 
   pgm_fill_old_pins(pgm); // TODO to be removed if old pin data no longer needed
@@ -400,10 +390,8 @@ void par_initpgm(PROGRAMMER * pgm)
 
 #else  /* !HAVE_PARPORT */
 
-void par_initpgm(PROGRAMMER * pgm)
-{
-  avrdude_message(MSG_INFO, "%s: parallel port access not available in this configuration\n",
-                  progname);
+void par_initpgm(PROGRAMMER *pgm) {
+  avrdude_message(MSG_INFO, "%s: parallel port access not available in this configuration\n", progname);
 }
 
 #endif /* HAVE_PARPORT */

--- a/src/par.h
+++ b/src/par.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char par_desc[];
-void par_initpgm        (PROGRAMMER * pgm);
+void par_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -28,36 +28,37 @@
 #include "avrdude.h"
 #include "libavrdude.h"
 
-static int  pgm_default_2 (struct programmer_t *, AVRPART *);
-static int  pgm_default_3 (struct programmer_t * pgm, AVRPART * p, AVRMEM * mem,
-			   unsigned long addr, unsigned char * value);
-static void pgm_default_4 (struct programmer_t *);
-static int  pgm_default_5 (struct programmer_t * pgm, AVRPART * p, AVRMEM * mem,
-			   unsigned long addr, unsigned char data);
-static void pgm_default_6 (struct programmer_t *, const char *);
+static void pgm_default(void);
+static int  pgm_default_2(const PROGRAMMER *, const AVRPART *);
+static int  pgm_default_3(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+  unsigned long addr, unsigned char * value);
+static void pgm_default_4(const PROGRAMMER *);
+static int  pgm_default_5(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+  unsigned long addr, unsigned char data);
+static void pgm_default_6(const PROGRAMMER *, const char *);
 
 
-static int pgm_default_open (struct programmer_t *pgm, char * name)
-{
-  avrdude_message(MSG_INFO, "\n%s: Fatal error: Programmer does not support open()",
-               progname);
+static int pgm_default_open(PROGRAMMER *pgm, const char *name) {
+  avrdude_message(MSG_INFO, "\n%s: programmer does not support open()", progname);
   return -1;
 }
 
-static int  pgm_default_led (struct programmer_t * pgm, int value)
-{
-  /*
-   * If programmer has no LEDs, just do nothing.
-   */
+static void pgm_default_close(PROGRAMMER *pgm) {
+  pgm_default();
+}
+
+static void pgm_default_enable(PROGRAMMER *pgm, const AVRPART *p) {
+  pgm_default();
+}
+
+static int pgm_default_led(const PROGRAMMER *pgm, int value) {
+   // If programmer has no LEDs, just do nothing
   return 0;
 }
 
 
-static void pgm_default_powerup_powerdown (struct programmer_t * pgm)
-{
-  /*
-   * If programmer does not support powerup/down, just do nothing.
-   */
+static void pgm_default_powerup_powerdown(const PROGRAMMER *pgm) {
+   // If programmer does not support powerup/down, just do nothing
 }
 
 
@@ -94,14 +95,14 @@ PROGRAMMER *pgm_new(void) {
    */
   pgm->initialize     = pgm_default_2;
   pgm->display        = pgm_default_6;
-  pgm->enable         = pgm_default_4;
+  pgm->enable         = pgm_default_enable;
   pgm->disable        = pgm_default_4;
   pgm->powerup        = pgm_default_powerup_powerdown;
   pgm->powerdown      = pgm_default_powerup_powerdown;
   pgm->program_enable = pgm_default_2;
   pgm->chip_erase     = pgm_default_2;
   pgm->open           = pgm_default_open;
-  pgm->close          = pgm_default_4;
+  pgm->close          = pgm_default_close;
   pgm->read_byte      = pgm_default_3;
   pgm->write_byte     = pgm_default_5;
 
@@ -189,39 +190,33 @@ PROGRAMMER *pgm_dup(const PROGRAMMER *src) {
 }
 
 
-static void pgm_default(void)
-{
+static void pgm_default(void) {
   avrdude_message(MSG_INFO, "%s: programmer operation not supported\n", progname);
 }
 
 
-static int  pgm_default_2 (struct programmer_t * pgm, AVRPART * p)
-{
+static int  pgm_default_2 (const PROGRAMMER *pgm, const AVRPART *p) {
   pgm_default();
   return -1;
 }
 
-static int  pgm_default_3 (struct programmer_t * pgm, AVRPART * p, AVRMEM * mem,
-			   unsigned long addr, unsigned char * value)
-{
+static int  pgm_default_3 (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+			   unsigned long addr, unsigned char * value) {
   pgm_default();
   return -1;
 }
 
-static void pgm_default_4 (struct programmer_t * pgm)
-{
+static void pgm_default_4 (const PROGRAMMER *pgm) {
   pgm_default();
 }
 
-static int  pgm_default_5 (struct programmer_t * pgm, AVRPART * p, AVRMEM * mem,
-			   unsigned long addr, unsigned char data)
-{
+static int  pgm_default_5 (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+			   unsigned long addr, unsigned char data) {
   pgm_default();
   return -1;
 }
 
-static void pgm_default_6 (struct programmer_t * pgm, const char * p)
-{
+static void pgm_default_6 (const PROGRAMMER *pgm, const char *p) {
   pgm_default();
 }
 

--- a/src/pgm_type.c
+++ b/src/pgm_type.c
@@ -129,7 +129,7 @@ const PROGRAMMER_TYPE * locate_programmer_type(const char * id)
 }
 
 // Return type id given the init function or "" if not found
-const char *locate_programmer_type_id(void (*initpgm)(struct programmer_t *pgm)) {
+const char *locate_programmer_type_id(void (*initpgm)(PROGRAMMER *pgm)) {
   for (int i=0; i < sizeof programmers_types/sizeof*programmers_types; i++)
     if(programmers_types[i].initpgm == initpgm)
       return programmers_types[i].id;

--- a/src/pickit2.h
+++ b/src/pickit2.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char pickit2_desc[];
-void pickit2_initpgm (PROGRAMMER * pgm);
+void pickit2_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -118,7 +118,7 @@ static int pin_fill_old_pinlist(const struct pindef_t * const pindef, unsigned i
  *
  * @param[inout] pgm programmer whose pins shall be converted.
  */
-int pgm_fill_old_pins(struct programmer_t * const pgm) {
+int pgm_fill_old_pins(PROGRAMMER * const pgm) {
 
   if (pin_fill_old_pinlist(&(pgm->pin[PPI_AVR_VCC]),  &(pgm->pinno[PPI_AVR_VCC])) < 0)
     return -1;
@@ -218,7 +218,7 @@ const char * pinmask_to_str(const pinmask_t * const pinmask) {
  * @param[in] size the number of entries in checklist
  * @returns 0 if all pin definitions are valid, -1 otherwise
  */
-int pins_check(const struct programmer_t * const pgm, const struct pin_checklist_t * const checklist, const int size, const bool output) {
+int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const checklist, const int size, const bool output) {
   static const struct pindef_t no_valid_pins = {{0}, {0}}; // default value if check list does not contain anything else
   int rv = 0; // return value
   int pinname; // loop counter through pinnames

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -51,7 +51,7 @@ enum {
   PPI_SHADOWREAD
 };
 
-static int ppi_shadow_access(union filedescriptor *fdp, int reg,
+static int ppi_shadow_access(const union filedescriptor *fdp, int reg,
 			     unsigned char *v, unsigned char action)
 {
   static unsigned char shadow[3];
@@ -93,8 +93,7 @@ static int ppi_shadow_access(union filedescriptor *fdp, int reg,
 /*
  * set the indicated bit of the specified register.
  */
-int ppi_set(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_set(const union filedescriptor *fdp, int reg, int bit) {
   unsigned char v;
   int rc;
 
@@ -112,8 +111,7 @@ int ppi_set(union filedescriptor *fdp, int reg, int bit)
 /*
  * clear the indicated bit of the specified register.
  */
-int ppi_clr(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_clr(const union filedescriptor *fdp, int reg, int bit) {
   unsigned char v;
   int rc;
 
@@ -131,8 +129,7 @@ int ppi_clr(union filedescriptor *fdp, int reg, int bit)
 /*
  * get the indicated bit of the specified register.
  */
-int ppi_get(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_get(const union filedescriptor *fdp, int reg, int bit) {
   unsigned char v;
   int rc;
 
@@ -148,8 +145,7 @@ int ppi_get(union filedescriptor *fdp, int reg, int bit)
 /*
  * toggle the indicated bit of the specified register.
  */
-int ppi_toggle(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_toggle(const union filedescriptor *fdp, int reg, int bit) {
   unsigned char v;
   int rc;
 
@@ -167,8 +163,7 @@ int ppi_toggle(union filedescriptor *fdp, int reg, int bit)
 /*
  * get all bits of the specified register.
  */
-int ppi_getall(union filedescriptor *fdp, int reg)
-{
+int ppi_getall(const union filedescriptor *fdp, int reg) {
   unsigned char v;
   int rc;
 
@@ -183,8 +178,7 @@ int ppi_getall(union filedescriptor *fdp, int reg)
 /*
  * set all bits of the specified register to val.
  */
-int ppi_setall(union filedescriptor *fdp, int reg, int val)
-{
+int ppi_setall(const union filedescriptor *fdp, int reg, int val) {
   unsigned char v;
   int rc;
 
@@ -198,8 +192,7 @@ int ppi_setall(union filedescriptor *fdp, int reg, int val)
 }
 
 
-void ppi_open(char * port, union filedescriptor *fdp)
-{
+void ppi_open(const char *port, union filedescriptor *fdp) {
   int fd;
   unsigned char v;
 
@@ -225,8 +218,7 @@ void ppi_open(char * port, union filedescriptor *fdp)
 }
 
 
-void ppi_close(union filedescriptor *fdp)
-{
+void ppi_close(const union filedescriptor *fdp) {
   ppi_release (fdp->ifd);
   close(fdp->ifd);
 }

--- a/src/ppi.h
+++ b/src/ppi.h
@@ -34,21 +34,21 @@ enum {
 extern "C" {
 #endif
 
-int ppi_get       (union filedescriptor *fdp, int reg, int bit);
+int ppi_get       (const union filedescriptor *fdp, int reg, int bit);
 
-int ppi_set       (union filedescriptor *fdp, int reg, int bit);
+int ppi_set       (const union filedescriptor *fdp, int reg, int bit);
 
-int ppi_clr       (union filedescriptor *fdp, int reg, int bit);
+int ppi_clr       (const union filedescriptor *fdp, int reg, int bit);
 
-int ppi_getall    (union filedescriptor *fdp, int reg);
+int ppi_getall    (const union filedescriptor *fdp, int reg);
 
-int ppi_setall    (union filedescriptor *fdp, int reg, int val);
+int ppi_setall    (const union filedescriptor *fdp, int reg, int val);
 
-int ppi_toggle    (union filedescriptor *fdp, int reg, int bit);
+int ppi_toggle    (const union filedescriptor *fdp, int reg, int bit);
 
-void ppi_open     (char * port, union filedescriptor *fdp);
+void ppi_open     (const char *port, union filedescriptor *fdp);
 
-void ppi_close    (union filedescriptor *fdp);
+void ppi_close    (const union filedescriptor *fdp);
 
 #ifdef __cplusplus
 }

--- a/src/ppiwin.c
+++ b/src/ppiwin.c
@@ -84,8 +84,7 @@ static void outb(unsigned char value, unsigned short port);
 
 /* FUNCTION DEFINITIONS */
 
-void ppi_open(char *port, union filedescriptor *fdp)
-{
+void ppi_open(const char *port, union filedescriptor *fdp) {
     unsigned char i;
     int fd;
 	
@@ -138,8 +137,7 @@ void ppi_open(char *port, union filedescriptor *fdp)
 
 
 #define DRIVERNAME      "\\\\.\\giveio"
-static int winnt_pp_open(void)
-{
+static int winnt_pp_open(void) {
     // Only try to use giveio under Windows NT/2000/XP.
     OSVERSIONINFO ver_info;
 
@@ -178,8 +176,7 @@ static int winnt_pp_open(void)
 
 
 
-void ppi_close(union filedescriptor *fdp)
-{
+void ppi_close(const union filedescriptor *fdp) {
     return;
 }
 
@@ -188,8 +185,7 @@ void ppi_close(union filedescriptor *fdp)
 /*
  * set the indicated bit of the specified register.
  */
-int ppi_set(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_set(const union filedescriptor *fdp, int reg, int bit) {
     unsigned char v;
     unsigned short port;
 
@@ -204,8 +200,7 @@ int ppi_set(union filedescriptor *fdp, int reg, int bit)
 /*
  * clear the indicated bit of the specified register.
  */
-int ppi_clr(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_clr(const union filedescriptor *fdp, int reg, int bit) {
     unsigned char v;
     unsigned short port;
 
@@ -221,8 +216,7 @@ int ppi_clr(union filedescriptor *fdp, int reg, int bit)
 /*
  * get the indicated bit of the specified register.
  */
-int ppi_get(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_get(const union filedescriptor *fdp, int reg, int bit) {
     unsigned char v;
 
     v = inb(port_get(fdp, reg));
@@ -237,8 +231,7 @@ int ppi_get(union filedescriptor *fdp, int reg, int bit)
 /*
  * toggle the indicated bit of the specified register.
  */
-int ppi_toggle(union filedescriptor *fdp, int reg, int bit)
-{
+int ppi_toggle(const union filedescriptor *fdp, int reg, int bit) {
     unsigned char v;
     unsigned short port;
 
@@ -255,8 +248,7 @@ int ppi_toggle(union filedescriptor *fdp, int reg, int bit)
 /*
  * get all bits of the specified register.
  */
-int ppi_getall(union filedescriptor *fdp, int reg)
-{
+int ppi_getall(const union filedescriptor *fdp, int reg) {
     unsigned char v;
 
     v = inb(port_get(fdp, reg));
@@ -270,8 +262,7 @@ int ppi_getall(union filedescriptor *fdp, int reg)
 /*
  * set all bits of the specified register to val.
  */
-int ppi_setall(union filedescriptor *fdp, int reg, int val)
-{
+int ppi_setall(const union filedescriptor *fdp, int reg, int val) {
     outb((unsigned char)val, port_get(fdp, reg));
     return 0;
 }
@@ -280,15 +271,13 @@ int ppi_setall(union filedescriptor *fdp, int reg, int val)
 
 
 /* Calculate port address to access. */
-static unsigned short port_get(union filedescriptor *fdp, int reg)
-{
+static unsigned short port_get(const union filedescriptor *fdp, int reg) {
     return((unsigned short)(fdp->ifd + reg2offset(reg)));
 }
 
 
 /* Convert register enum to offset of base address. */
-static unsigned char reg2offset(int reg)
-{
+static unsigned char reg2offset(int reg) {
     unsigned char offset = 0;
 
     switch(reg)
@@ -315,8 +304,7 @@ static unsigned char reg2offset(int reg)
 
 
 /* Read in value from port. */
-static unsigned char inb(unsigned short port)
-{
+static unsigned char inb(unsigned short port) {
     unsigned char t;
     
 	asm volatile ("in %1, %0"
@@ -328,8 +316,7 @@ static unsigned char inb(unsigned short port)
 
 
 /* Write value to port. */
-static void outb(unsigned char value, unsigned short port)
-{
+static void outb(unsigned char value, unsigned short port) {
     asm volatile ("out %1, %0"
         :
         : "d" (port), "a" (value) );

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -96,8 +96,7 @@ static void usbCloseDevice(union filedescriptor *fdp)
 
 /* ------------------------------------------------------------------------- */
 
-static int usbSetReport(union filedescriptor *fdp, int reportType, char *buffer, int len)
-{
+static int usbSetReport(const union filedescriptor *fdp, int reportType, char *buffer, int len) {
   hid_device *udev = (hid_device *)fdp->usb.handle;
   int bytesSent = -1;
 
@@ -122,7 +121,7 @@ static int usbSetReport(union filedescriptor *fdp, int reportType, char *buffer,
 
 /* ------------------------------------------------------------------------- */
 
-static int usbGetReport(union filedescriptor *fdp, int reportType, int reportNumber,
+static int usbGetReport(const union filedescriptor *fdp, int reportType, int reportNumber,
 			char *buffer, int *len)
 {
   hid_device *udev = (hid_device *)fdp->usb.handle;
@@ -221,7 +220,7 @@ static char *usbErrorText(int usbErrno)
 
 /* ------------------------------------------------------------------------- */
 
-static int avrdoper_open(char *port, union pinfo pinfo, union filedescriptor *fdp)
+static int avrdoper_open(const char *port, union pinfo pinfo, union filedescriptor *fdp)
 {
     int rval;
     char *vname = "obdev.at";
@@ -255,7 +254,7 @@ static int  chooseDataSize(int len)
     return i - 1;
 }
 
-static int avrdoper_send(union filedescriptor *fdp, const unsigned char *buf, size_t buflen)
+static int avrdoper_send(const union filedescriptor *fdp, const unsigned char *buf, size_t buflen)
 {
     if(verbose > 3)
         dumpBlock("Send", buf, buflen);
@@ -282,8 +281,7 @@ static int avrdoper_send(union filedescriptor *fdp, const unsigned char *buf, si
 
 /* ------------------------------------------------------------------------- */
 
-static int avrdoperFillBuffer(union filedescriptor *fdp)
-{
+static int avrdoperFillBuffer(const union filedescriptor *fdp) {
     int bytesPending = reportDataSizes[1];  /* guess how much data is buffered in device */
 
     avrdoperRxPosition = avrdoperRxLength = 0;
@@ -316,7 +314,7 @@ static int avrdoperFillBuffer(union filedescriptor *fdp)
     return 0;
 }
 
-static int avrdoper_recv(union filedescriptor *fdp, unsigned char *buf, size_t buflen)
+static int avrdoper_recv(const union filedescriptor *fdp, unsigned char *buf, size_t buflen)
 {
     unsigned char   *p = buf;
     int             remaining = buflen;
@@ -341,7 +339,7 @@ static int avrdoper_recv(union filedescriptor *fdp, unsigned char *buf, size_t b
 
 /* ------------------------------------------------------------------------- */
 
-static int avrdoper_drain(union filedescriptor *fdp, int display)
+static int avrdoper_drain(const union filedescriptor *fdp, int display)
 {
     do{
         if (avrdoperFillBuffer(fdp) < 0)
@@ -352,7 +350,7 @@ static int avrdoper_drain(union filedescriptor *fdp, int display)
 
 /* ------------------------------------------------------------------------- */
 
-static int avrdoper_set_dtr_rts(union filedescriptor *fdp, int is_on)
+static int avrdoper_set_dtr_rts(const union filedescriptor *fdp, int is_on)
 {
 	avrdude_message(MSG_INFO, "%s: AVR-Doper doesn't support DTR/RTS setting\n", progname);
     return -1;

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -122,8 +122,7 @@ static struct baud_mapping baud_lookup_table [] = {
 static struct termios original_termios;
 static int saved_original_termios;
 
-static speed_t serial_baud_lookup(long baud, bool *nonstandard)
-{
+static speed_t serial_baud_lookup(long baud, bool *nonstandard) {
   struct baud_mapping *map = baud_lookup_table;
 
   *nonstandard = false;
@@ -146,8 +145,7 @@ static speed_t serial_baud_lookup(long baud, bool *nonstandard)
   return baud;
 }
 
-static int ser_setparams(union filedescriptor *fd, long baud, unsigned long cflags)
-{
+static int ser_setparams(const union filedescriptor *fd, long baud, unsigned long cflags) {
   int rc;
   struct termios termios;
   bool nonstandard;
@@ -283,9 +281,7 @@ static int ser_setparams(union filedescriptor *fd, long baud, unsigned long cfla
  * terminal/console server with serial parameters configured
  * appropriately (e. g. 115200-8-N-1 for a STK500.)
  */
-static int
-net_open(const char *port, union filedescriptor *fdp)
-{
+static int net_open(const char *port, union filedescriptor *fdp) {
   char *hp, *hstr, *pstr;
   int s, fd, ret = -1;
   struct addrinfo hints;
@@ -361,8 +357,7 @@ error:
 }
 
 
-static int ser_set_dtr_rts(union filedescriptor *fdp, int is_on)
-{
+static int ser_set_dtr_rts(const union filedescriptor *fdp, int is_on) {
   unsigned int	ctl;
   int           r;
 
@@ -390,8 +385,7 @@ static int ser_set_dtr_rts(union filedescriptor *fdp, int is_on)
   return 0;
 }
 
-static int ser_open(char * port, union pinfo pinfo, union filedescriptor *fdp)
-{
+static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *fdp) {
   int rc;
   int fd;
 
@@ -428,8 +422,7 @@ static int ser_open(char * port, union pinfo pinfo, union filedescriptor *fdp)
   return 0;
 }
 
-static void ser_close(union filedescriptor *fd)
-{
+static void ser_close(union filedescriptor *fd) {
   /*
    * restore original termios settings from ser_open
    */
@@ -446,8 +439,7 @@ static void ser_close(union filedescriptor *fd)
 }
 
 
-static int ser_send(union filedescriptor *fd, const unsigned char * buf, size_t buflen)
-{
+static int ser_send(const union filedescriptor *fd, const unsigned char * buf, size_t buflen) {
   int rc;
   const unsigned char * p = buf;
   size_t len = buflen;
@@ -491,8 +483,7 @@ static int ser_send(union filedescriptor *fd, const unsigned char * buf, size_t 
 }
 
 
-static int ser_recv(union filedescriptor *fd, unsigned char * buf, size_t buflen)
-{
+static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t buflen) {
   struct timeval timeout, to2;
   fd_set rfds;
   int nfds;
@@ -564,8 +555,7 @@ static int ser_recv(union filedescriptor *fd, unsigned char * buf, size_t buflen
 }
 
 
-static int ser_drain(union filedescriptor *fd, int display)
-{
+static int ser_drain(const union filedescriptor *fd, int display) {
   struct timeval timeout;
   fd_set rfds;
   int nfds;

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -95,8 +95,7 @@ static BOOL serial_w32SetTimeOut(HANDLE hComPort, DWORD timeout) // in ms
 	return SetCommTimeouts(hComPort, &ctmo);
 }
 
-static int ser_setparams(union filedescriptor *fd, long baud, unsigned long cflags)
-{
+static int ser_setparams(const union filedescriptor *fd, long baud, unsigned long cflags) {
 	if (serial_over_ethernet) {
 		return -ENOTTY;
 	} else {
@@ -150,9 +149,7 @@ static int ser_setparams(union filedescriptor *fd, long baud, unsigned long cfla
 	}
 }
 
-static int
-net_open(const char *port, union filedescriptor *fdp)
-{
+static int net_open(const char *port, union filedescriptor *fdp) {
 	WSADATA wsaData;
 	LPVOID lpMsgBuf;
 
@@ -243,8 +240,7 @@ net_open(const char *port, union filedescriptor *fdp)
 }
 
 
-static int ser_open(char * port, union pinfo pinfo, union filedescriptor *fdp)
-{
+static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *fdp) {
 	LPVOID lpMsgBuf;
 	HANDLE hComPort=INVALID_HANDLE_VALUE;
 	char *newname = 0;
@@ -325,8 +321,7 @@ static int ser_open(char * port, union pinfo pinfo, union filedescriptor *fdp)
 }
 
 
-static void ser_close(union filedescriptor *fd)
-{
+static void ser_close(union filedescriptor *fd) {
 	if (serial_over_ethernet) {
 		closesocket(fd->ifd);
 		WSACleanup();
@@ -339,8 +334,7 @@ static void ser_close(union filedescriptor *fd)
 	}
 }
 
-static int ser_set_dtr_rts(union filedescriptor *fd, int is_on)
-{
+static int ser_set_dtr_rts(const union filedescriptor *fd, int is_on) {
 	if (serial_over_ethernet) {
 		return 0;
 	} else {
@@ -357,8 +351,7 @@ static int ser_set_dtr_rts(union filedescriptor *fd, int is_on)
 	}
 }
 
-static int net_send(union filedescriptor *fd, const unsigned char * buf, size_t buflen)
-{
+static int net_send(const union filedescriptor *fd, const unsigned char * buf, size_t buflen) {
 	LPVOID lpMsgBuf;
 	int rc;
 	const unsigned char *p = buf;
@@ -417,8 +410,7 @@ static int net_send(union filedescriptor *fd, const unsigned char * buf, size_t 
 }
 
 
-static int ser_send(union filedescriptor *fd, const unsigned char * buf, size_t buflen)
-{
+static int ser_send(const union filedescriptor *fd, const unsigned char * buf, size_t buflen) {
 	if (serial_over_ethernet) {
 		return net_send(fd, buf, buflen);
 	}
@@ -476,8 +468,7 @@ static int ser_send(union filedescriptor *fd, const unsigned char * buf, size_t 
 }
 
 
-static int net_recv(union filedescriptor *fd, unsigned char * buf, size_t buflen)
-{
+static int net_recv(const union filedescriptor *fd, unsigned char * buf, size_t buflen) {
 	LPVOID lpMsgBuf;
 	struct timeval timeout, to2;
 	fd_set rfds;
@@ -570,8 +561,7 @@ reselect:
 	return 0;
 }
 
-static int ser_recv(union filedescriptor *fd, unsigned char * buf, size_t buflen)
-{
+static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t buflen) {
 	if (serial_over_ethernet) {
 		return net_recv(fd, buf, buflen);
 	}
@@ -639,8 +629,7 @@ static int ser_recv(union filedescriptor *fd, unsigned char * buf, size_t buflen
   return 0;
 }
 
-static int net_drain(union filedescriptor *fd, int display)
-{
+static int net_drain(const union filedescriptor *fd, int display) {
 	LPVOID lpMsgBuf;
 	struct timeval timeout;
 	fd_set rfds;
@@ -718,8 +707,7 @@ static int net_drain(union filedescriptor *fd, int display)
 	return 0;
 }
 
-static int ser_drain(union filedescriptor *fd, int display)
-{
+static int ser_drain(const union filedescriptor *fd, int display) {
 	if (serial_over_ethernet) {
 		return net_drain(fd, display);
 	}

--- a/src/serbb.h
+++ b/src/serbb.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char serbb_desc[];
-void serbb_initpgm        (PROGRAMMER * pgm);
+void serbb_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -70,8 +70,7 @@ static char *serpins[DB9PINS + 1] =
   { "NONE", "CD", "RXD", "TXD", "DTR", "GND", "DSR", "RTS", "CTS", "RI" };
 #endif
 
-static int serbb_setpin(PROGRAMMER * pgm, int pinfunc, int value)
-{
+static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
   unsigned int	ctl;
   int           r;
   int pin = pgm->pinno[pinfunc]; // get its value
@@ -127,8 +126,7 @@ static int serbb_setpin(PROGRAMMER * pgm, int pinfunc, int value)
   return 0;
 }
 
-static int serbb_getpin(PROGRAMMER * pgm, int pinfunc)
-{
+static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
   unsigned int	ctl;
   unsigned char invert;
   int           r;
@@ -178,8 +176,7 @@ static int serbb_getpin(PROGRAMMER * pgm, int pinfunc)
   }
 }
 
-static int serbb_highpulsepin(PROGRAMMER * pgm, int pinfunc)
-{
+static int serbb_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
   int pin = pgm->pinno[pinfunc]; // replace pin name by its value
 
   if ( (pin & PIN_MASK) < 1 || (pin & PIN_MASK) > DB9PINS )
@@ -193,33 +190,27 @@ static int serbb_highpulsepin(PROGRAMMER * pgm, int pinfunc)
 
 
 
-static void serbb_display(PROGRAMMER *pgm, const char *p)
-{
+static void serbb_display(const PROGRAMMER *pgm, const char *p) {
   /* MAYBE */
 }
 
-static void serbb_enable(PROGRAMMER *pgm)
-{
+static void serbb_enable(PROGRAMMER *pgm, const AVRPART *p) {
   /* nothing */
 }
 
-static void serbb_disable(PROGRAMMER *pgm)
-{
+static void serbb_disable(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static void serbb_powerup(PROGRAMMER *pgm)
-{
+static void serbb_powerup(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static void serbb_powerdown(PROGRAMMER *pgm)
-{
+static void serbb_powerdown(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static int serbb_open(PROGRAMMER *pgm, char *port)
-{
+static int serbb_open(PROGRAMMER *pgm, const char *port) {
   struct termios mode;
   int flags;
   int r;
@@ -276,8 +267,7 @@ static int serbb_open(PROGRAMMER *pgm, char *port)
   return(0);
 }
 
-static void serbb_close(PROGRAMMER *pgm)
-{
+static void serbb_close(PROGRAMMER *pgm) {
   if (pgm->fd.ifd != -1)
   {
 	  (void)tcsetattr(pgm->fd.ifd, TCSANOW, &oldmode);
@@ -289,8 +279,7 @@ static void serbb_close(PROGRAMMER *pgm)
 
 const char serbb_desc[] = "Serial port bitbanging";
 
-void serbb_initpgm(PROGRAMMER *pgm)
-{
+void serbb_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "SERBB");
 
   pgm_fill_old_pins(pgm); // TODO to be removed if old pin data no longer needed

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -61,8 +61,7 @@ static int dtr, rts, txd;
 
 #define DB9PINS 9
 
-static int serbb_setpin(PROGRAMMER * pgm, int pinfunc, int value)
-{
+static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
 	int pin = pgm->pinno[pinfunc];
 	HANDLE hComPort = (HANDLE)pgm->fd.pfd;
         LPVOID lpMsgBuf;
@@ -129,8 +128,7 @@ static int serbb_setpin(PROGRAMMER * pgm, int pinfunc, int value)
         return 0;
 }
 
-static int serbb_getpin(PROGRAMMER * pgm, int pinfunc)
-{
+static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
 	int pin = pgm->pinno[pinfunc];
 	HANDLE hComPort = (HANDLE)pgm->fd.pfd;
         LPVOID lpMsgBuf;
@@ -216,8 +214,7 @@ static int serbb_getpin(PROGRAMMER * pgm, int pinfunc)
         return rv;
 }
 
-static int serbb_highpulsepin(PROGRAMMER * pgm, int pinfunc)
-{
+static int serbb_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
 	    int pin = pgm->pinno[pinfunc];
         if ( (pin & PIN_MASK) < 1 || (pin & PIN_MASK) > DB9PINS )
           return -1;
@@ -229,33 +226,27 @@ static int serbb_highpulsepin(PROGRAMMER * pgm, int pinfunc)
 }
 
 
-static void serbb_display(PROGRAMMER *pgm, const char *p)
-{
+static void serbb_display(const PROGRAMMER *pgm, const char *p) {
   /* MAYBE */
 }
 
-static void serbb_enable(PROGRAMMER *pgm)
-{
+static void serbb_enable(PROGRAMMER *pgm, const AVRPART *p) {
   /* nothing */
 }
 
-static void serbb_disable(PROGRAMMER *pgm)
-{
+static void serbb_disable(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static void serbb_powerup(PROGRAMMER *pgm)
-{
+static void serbb_powerup(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static void serbb_powerdown(PROGRAMMER *pgm)
-{
+static void serbb_powerdown(const PROGRAMMER *pgm) {
   /* nothing */
 }
 
-static int serbb_open(PROGRAMMER *pgm, char *port)
-{
+static int serbb_open(PROGRAMMER *pgm, const char *port) {
         DCB dcb;
 	LPVOID lpMsgBuf;
 	HANDLE hComPort = INVALID_HANDLE_VALUE;
@@ -319,8 +310,7 @@ static int serbb_open(PROGRAMMER *pgm, char *port)
         return 0;
 }
 
-static void serbb_close(PROGRAMMER *pgm)
-{
+static void serbb_close(PROGRAMMER *pgm) {
 	HANDLE hComPort=(HANDLE)pgm->fd.pfd;
 	if (hComPort != INVALID_HANDLE_VALUE)
 	{
@@ -335,8 +325,7 @@ static void serbb_close(PROGRAMMER *pgm)
 
 const char serbb_desc[] = "Serial port bitbanging";
 
-void serbb_initpgm(PROGRAMMER *pgm)
-{
+void serbb_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "SERBB");
 
   pgm_fill_old_pins(pgm); // TODO to be removed if old pin data no longer needed

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -43,8 +43,8 @@
 #include "updi_nvm.h"
 #include "updi_constants.h"
 
-static int serialupdi_enter_progmode(PROGRAMMER * pgm);
-static int serialupdi_leave_progmode(PROGRAMMER * pgm);
+static int serialupdi_enter_progmode(const PROGRAMMER *pgm);
+static int serialupdi_leave_progmode(const PROGRAMMER *pgm);
 
 static void serialupdi_setup(PROGRAMMER * pgm)
 {
@@ -64,8 +64,7 @@ static void serialupdi_teardown(PROGRAMMER * pgm)
   free(pgm->cookie);
 }
 
-static int serialupdi_open(PROGRAMMER * pgm, char * port)
-{
+static int serialupdi_open(PROGRAMMER *pgm, const char *port) {
   strcpy(pgm->port, port);
   return updi_link_open(pgm);
 }
@@ -75,8 +74,7 @@ typedef enum {
   RELEASE_RESET
 } reset_mode;
 
-static int serialupdi_reset(PROGRAMMER * pgm, reset_mode mode)
-{
+static int serialupdi_reset(const PROGRAMMER *pgm, reset_mode mode) {
 /*
     def reset(self, apply_reset):
         """
@@ -102,8 +100,7 @@ static int serialupdi_reset(PROGRAMMER * pgm, reset_mode mode)
   return -1;
 }
 
-static int serialupdi_reset_connection(PROGRAMMER * pgm)
-{
+static int serialupdi_reset_connection(const PROGRAMMER *pgm) {
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
     avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
     return -1;
@@ -117,8 +114,7 @@ static int serialupdi_reset_connection(PROGRAMMER * pgm)
   return updi_link_init(pgm);
 }
 
-static int serialupdi_decode_sib(PROGRAMMER * pgm, updi_sib_info * sib_info)
-{
+static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info) {
   char * str_ptr;
 
   sib_info->sib_string[SIB_INFO_STRING_LENGTH]=0;
@@ -192,7 +188,7 @@ static void serialupdi_close(PROGRAMMER * pgm)
   updi_link_close(pgm);
 }
 
-static int serialupdi_wait_for_unlock(PROGRAMMER * pgm, unsigned int ms) {
+static int serialupdi_wait_for_unlock(const PROGRAMMER *pgm, unsigned int ms) {
 /*
     def wait_unlocked(self, timeout_ms):
         """
@@ -236,7 +232,7 @@ typedef enum {
   WAIT_FOR_UROW_HIGH
 } urow_wait_mode;
 
-static int serialupdi_wait_for_urow(PROGRAMMER * pgm, unsigned int ms, urow_wait_mode mode) {
+static int serialupdi_wait_for_urow(const PROGRAMMER *pgm, unsigned int ms, urow_wait_mode mode) {
 /*
     def wait_urow_prog(self, timeout_ms, wait_for_high):
         """
@@ -286,8 +282,7 @@ static int serialupdi_wait_for_urow(PROGRAMMER * pgm, unsigned int ms, urow_wait
   return -1;
 }
 
-static int serialupdi_in_prog_mode(PROGRAMMER * pgm, uint8_t * in_prog_mode)
-{
+static int serialupdi_in_prog_mode(const PROGRAMMER *pgm, uint8_t *in_prog_mode) {
 /*
     def in_prog_mode(self):
         """
@@ -315,8 +310,7 @@ static int serialupdi_in_prog_mode(PROGRAMMER * pgm, uint8_t * in_prog_mode)
   return 0;
 }
 
-static int serialupdi_enter_progmode(PROGRAMMER * pgm)
-{
+static int serialupdi_enter_progmode(const PROGRAMMER *pgm) {
 /*
 def enter_progmode(self):
         """
@@ -415,8 +409,7 @@ def enter_progmode(self):
   return 0;
 }
 
-static int serialupdi_leave_progmode(PROGRAMMER * pgm)
-{
+static int serialupdi_leave_progmode(const PROGRAMMER *pgm) {
 /*
     def leave_progmode(self):
         """
@@ -441,7 +434,7 @@ static int serialupdi_leave_progmode(PROGRAMMER * pgm)
   return updi_write_cs(pgm, UPDI_CS_CTRLB, (1 << UPDI_CTRLB_UPDIDIS_BIT) | (1 << UPDI_CTRLB_CCDETDIS_BIT));
 }
 
-static int serialupdi_write_userrow(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int serialupdi_write_userrow(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                     unsigned int page_size,
                                     unsigned int addr, unsigned int n_bytes)
 {
@@ -576,8 +569,7 @@ static int serialupdi_write_userrow(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return 0;
 }
 
-static int serialupdi_initialize(PROGRAMMER * pgm, AVRPART * p)
-{
+static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t value;
   uint8_t reset_link_required=0;
   
@@ -660,26 +652,23 @@ static int serialupdi_initialize(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static void serialupdi_disable(PROGRAMMER * pgm)
-{
+static void serialupdi_disable(const PROGRAMMER *pgm) {
   /* Do nothing. */
 
   return;
 }
 
-static void serialupdi_enable(PROGRAMMER * pgm)
-{
+static void serialupdi_enable(PROGRAMMER * pgm, const AVRPART *p) {
   /* Do nothing. */
 
   return;
 }
 
-static void serialupdi_display(PROGRAMMER * pgm, const char * p)
-{
+static void serialupdi_display(const PROGRAMMER *pgm, const char *p) {
   return;
 }
 
-static int serialupdi_cmd(PROGRAMMER * pgm, const unsigned char * cmd,
+static int serialupdi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                           unsigned char * res)
 {
   avrdude_message(MSG_INFO, "%s: error: cmd %s[%s] not implemented yet\n",
@@ -687,20 +676,19 @@ static int serialupdi_cmd(PROGRAMMER * pgm, const unsigned char * cmd,
   return -1;
 }
 
-static int serialupdi_program_enable(PROGRAMMER * pgm, AVRPART * p)
-{
+static int serialupdi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   avrdude_message(MSG_INFO, "%s: error: program enable not implemented yet\n",
     	    progname);
   return -1;
 }
 
-static int serialupdi_read_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem, 
+static int serialupdi_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                                 unsigned long addr, unsigned char * value)
 {
   return updi_read_byte(pgm, mem->offset + addr, value);
 }
 
-static int serialupdi_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
+static int serialupdi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                                  unsigned long addr, unsigned char value)
 {
   if (strstr(mem->desc, "fuse") != 0) {
@@ -723,7 +711,7 @@ static int serialupdi_write_byte(PROGRAMMER * pgm, AVRPART * p, AVRMEM * mem,
 }
 
 
-static int serialupdi_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int serialupdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int page_size,
                                  unsigned int addr, unsigned int n_bytes)
 {
@@ -750,7 +738,7 @@ static int serialupdi_paged_load(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   }
 }
 
-static int serialupdi_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                   unsigned int page_size,
                                   unsigned int addr, unsigned int n_bytes)
 {
@@ -806,8 +794,7 @@ static int serialupdi_paged_write(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   }
 }
 
-static int serialupdi_unlock(PROGRAMMER * pgm, AVRPART * p)
-{
+static int serialupdi_unlock(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def unlock(self):
         """
@@ -875,8 +862,7 @@ static int serialupdi_unlock(PROGRAMMER * pgm, AVRPART * p)
   return serialupdi_enter_progmode(pgm);
 }
 
-static int serialupdi_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+static int serialupdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t value;
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
@@ -896,7 +882,7 @@ static int serialupdi_chip_erase(PROGRAMMER * pgm, AVRPART * p)
   return -1;
 }
 
-static int serialupdi_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
+static int serialupdi_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int baseaddr)
 {
   avrdude_message(MSG_INFO, "%s: error: page erase not implemented yet\n",
@@ -904,7 +890,7 @@ static int serialupdi_page_erase(PROGRAMMER * pgm, AVRPART * p, AVRMEM * m,
   return -1;
 }
 
-static int serialupdi_read_signature(PROGRAMMER * pgm, AVRPART *p, AVRMEM *m) {
+static int serialupdi_read_signature(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m) {
 
   uint8_t value;
 
@@ -926,7 +912,7 @@ static int serialupdi_read_signature(PROGRAMMER * pgm, AVRPART *p, AVRMEM *m) {
   return 3;
 }
 
-static int serialupdi_read_sib(PROGRAMMER * pgm, AVRPART *p, char *sib) {
+static int serialupdi_read_sib(const PROGRAMMER *pgm, const AVRPART *p, char *sib) {
 
   updi_sib_info * sib_info = updi_get_sib_info(pgm);
 
@@ -935,8 +921,7 @@ static int serialupdi_read_sib(PROGRAMMER * pgm, AVRPART *p, char *sib) {
   return 0;
 }
 
-static int serialupdi_parseextparms(PROGRAMMER * pgm, LISTID extparms)
-{
+static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param;
   char rts_mode[5];
@@ -965,8 +950,7 @@ static int serialupdi_parseextparms(PROGRAMMER * pgm, LISTID extparms)
   return rv;
 }
 
-void serialupdi_initpgm(PROGRAMMER * pgm)
-{
+void serialupdi_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "serialupdi");
 
   /*

--- a/src/serialupdi.h
+++ b/src/serialupdi.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 extern const char serialupdi_desc[];
-void serialupdi_initpgm (PROGRAMMER * pgm);
+void serialupdi_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -26,15 +26,25 @@ extern "C" {
 #endif
 
 extern const char stk500_desc[];
-void stk500_initpgm (PROGRAMMER * pgm);
+void stk500_initpgm(PROGRAMMER *pgm);
 
 /* used by arduino.c to avoid duplicate code */
-int stk500_getsync(PROGRAMMER * pgm);
-int stk500_drain(PROGRAMMER * pgm, int display);
+int stk500_getsync(const PROGRAMMER *pgm);
+int stk500_drain(const PROGRAMMER *pgm, int display);
 
 #ifdef __cplusplus
 }
 #endif
+
+#include "xbee.h"
+
+struct pdata {
+  unsigned char ext_addr_byte;  // Record ext-addr byte set in the target device (if used)
+  int retry_attempts;           // Number of connection attempts provided by the user
+  int xbeeResetPin;             // Piggy back variable used by xbee programmmer
+};
+
+#define PDATA(pgm) ((struct pdata *)(pgm->cookie))
 
 #endif
 

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -38,8 +38,7 @@
 #include "stk500.h"
 #include "stk500v2.h"
 
-static int stk500generic_open(PROGRAMMER * pgm, char * port)
-{
+static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
   stk500_initpgm(pgm);
   if (pgm->open(pgm, port) >= 0)
     {
@@ -80,8 +79,7 @@ static void stk500generic_teardown(PROGRAMMER * pgm)
 
 const char stk500generic_desc[] = "Atmel STK500, autodetect firmware version";
 
-void stk500generic_initpgm(PROGRAMMER * pgm)
-{
+void stk500generic_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "STK500GENERIC");
 
   pgm->open           = stk500generic_open;

--- a/src/stk500generic.h
+++ b/src/stk500generic.h
@@ -22,7 +22,7 @@
 #define stk500generic_h__
 
 extern const char stk500generic_desc[];
-void stk500generic_initpgm (PROGRAMMER * pgm);
+void stk500generic_initpgm(PROGRAMMER *pgm);
 
 #endif
 

--- a/src/stk500v2.h
+++ b/src/stk500v2.h
@@ -37,22 +37,22 @@ extern const char stk500v2_jtag3_desc[];
 extern const char stk600_desc[];
 extern const char stk600hvsp_desc[];
 extern const char stk600pp_desc[];
-void stk500v2_initpgm (PROGRAMMER * pgm);
-void stk500hvsp_initpgm (PROGRAMMER * pgm);
-void stk500pp_initpgm (PROGRAMMER * pgm);
-void stk500v2_jtagmkII_initpgm(PROGRAMMER * pgm);
-void stk500v2_jtag3_initpgm(PROGRAMMER * pgm);
-void stk500v2_dragon_hvsp_initpgm(PROGRAMMER * pgm);
-void stk500v2_dragon_isp_initpgm(PROGRAMMER * pgm);
-void stk500v2_dragon_pp_initpgm(PROGRAMMER * pgm);
-void stk600_initpgm (PROGRAMMER * pgm);
-void stk600hvsp_initpgm (PROGRAMMER * pgm);
-void stk600pp_initpgm (PROGRAMMER * pgm);
+void stk500v2_initpgm(PROGRAMMER *pgm);
+void stk500hvsp_initpgm(PROGRAMMER *pgm);
+void stk500pp_initpgm(PROGRAMMER *pgm);
+void stk500v2_jtagmkII_initpgm(PROGRAMMER *pgm);
+void stk500v2_jtag3_initpgm(PROGRAMMER *pgm);
+void stk500v2_dragon_hvsp_initpgm(PROGRAMMER *pgm);
+void stk500v2_dragon_isp_initpgm(PROGRAMMER *pgm);
+void stk500v2_dragon_pp_initpgm(PROGRAMMER *pgm);
+void stk600_initpgm(PROGRAMMER *pgm);
+void stk600hvsp_initpgm(PROGRAMMER *pgm);
+void stk600pp_initpgm(PROGRAMMER *pgm);
 
 void stk500v2_setup(PROGRAMMER * pgm);
 void stk500v2_teardown(PROGRAMMER * pgm);
-int stk500v2_drain(PROGRAMMER * pgm, int display);
-int stk500v2_getsync(PROGRAMMER * pgm);
+int stk500v2_drain(const PROGRAMMER *pgm, int display);
+int stk500v2_getsync(const PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/stk500v2_private.h
+++ b/src/stk500v2_private.h
@@ -312,7 +312,7 @@ struct pdata
     }
         pgmtype;
 
-  AVRPART *lastpart;
+  const AVRPART *lastpart;
 
   /* Start address of Xmega boot area */
   unsigned long boot_start;

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -86,8 +86,7 @@ static void delay_ms(uint32_t duration)
     usleep(duration * 1000);
 }
 
-static int teensy_get_bootloader_info(pdata_t* pdata, AVRPART* p)
-{
+static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
     switch (pdata->hid_usage)
     {
     case 0x19:
@@ -253,8 +252,7 @@ static void teensy_teardown(PROGRAMMER* pgm)
     free(pgm->cookie);
 }
 
-static int teensy_initialize(PROGRAMMER* pgm, AVRPART* p)
-{
+static int teensy_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: teensy_initialize()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
@@ -268,18 +266,15 @@ static int teensy_initialize(PROGRAMMER* pgm, AVRPART* p)
     return 0;
 }
 
-static void teensy_display(PROGRAMMER* pgm, const char* prefix)
-{
+static void teensy_display(const PROGRAMMER *pgm, const char *prefix) {
     avrdude_message(MSG_DEBUG, "%s: teensy_display()\n", progname);
 }
 
-static void teensy_powerup(PROGRAMMER* pgm)
-{
+static void teensy_powerup(const PROGRAMMER *pgm) {
     avrdude_message(MSG_DEBUG, "%s: teensy_powerup()\n", progname);
 }
 
-static void teensy_powerdown(PROGRAMMER* pgm)
-{
+static void teensy_powerdown(const PROGRAMMER *pgm) {
     avrdude_message(MSG_DEBUG, "%s: teensy_powerdown()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
@@ -297,24 +292,20 @@ static void teensy_powerdown(PROGRAMMER* pgm)
     }
 }
 
-static void teensy_enable(PROGRAMMER* pgm)
-{
+static void teensy_enable(PROGRAMMER* pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: teensy_enable()\n", progname);
 }
 
-static void teensy_disable(PROGRAMMER* pgm)
-{
+static void teensy_disable(const PROGRAMMER *pgm) {
     avrdude_message(MSG_DEBUG, "%s: teensy_disable()\n", progname);
 }
 
-static int teensy_program_enable(PROGRAMMER* pgm, AVRPART* p)
-{
+static int teensy_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: teensy_program_enable()\n", progname);
     return 0;
 }
 
-static int teensy_read_sig_bytes(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem)
-{
+static int teensy_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
     avrdude_message(MSG_DEBUG, "%s: teensy_read_sig_bytes()\n", progname);
 
     if (mem->size < 3)
@@ -329,8 +320,7 @@ static int teensy_read_sig_bytes(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem)
     return 0;
 }
 
-static int teensy_chip_erase(PROGRAMMER* pgm, AVRPART* p)
-{
+static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     avrdude_message(MSG_DEBUG, "%s: teensy_chip_erase()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
@@ -341,12 +331,11 @@ static int teensy_chip_erase(PROGRAMMER* pgm, AVRPART* p)
     return 0;
 }
 
-static int teensy_open(PROGRAMMER* pgm, char* port)
-{
+static int teensy_open(PROGRAMMER *pgm, const char *port) {
     avrdude_message(MSG_DEBUG, "%s: teensy_open(\"%s\")\n", progname, port);
 
     pdata_t* pdata = PDATA(pgm);
-    char* bus_name = NULL;
+    const char *bus_name = NULL;
     char* dev_name = NULL;
 
     // if no -P was given or '-P usb' was given
@@ -472,7 +461,7 @@ static void teensy_close(PROGRAMMER* pgm)
     }
 }
 
-static int teensy_read_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char* value)
 {
     avrdude_message(MSG_DEBUG, "%s: teensy_read_byte(desc=%s, addr=0x%0X)\n",
@@ -493,7 +482,7 @@ static int teensy_read_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     }
 }
 
-static int teensy_write_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int teensy_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char value)
 {
     avrdude_message(MSG_DEBUG, "%s: teensy_write_byte(desc=%s, addr=0x%0X)\n",
@@ -501,7 +490,7 @@ static int teensy_write_byte(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     return -1;
 }
 
-static int teensy_paged_load(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int teensy_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
@@ -510,7 +499,7 @@ static int teensy_paged_load(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     return -1;
 }
 
-static int teensy_paged_write(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
+static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
@@ -567,8 +556,7 @@ static int teensy_paged_write(PROGRAMMER* pgm, AVRPART* p, AVRMEM* mem,
     }
 }
 
-static int teensy_parseextparams(PROGRAMMER* pgm, LISTID xparams)
-{
+static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
     avrdude_message(MSG_DEBUG, "%s: teensy_parseextparams()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
@@ -596,8 +584,7 @@ static int teensy_parseextparams(PROGRAMMER* pgm, LISTID xparams)
     return 0;
 }
 
-void teensy_initpgm(PROGRAMMER* pgm)
-{
+void teensy_initpgm(PROGRAMMER *pgm) {
     strcpy(pgm->type, "teensy");
 
     pgm->setup = teensy_setup;
@@ -624,14 +611,12 @@ void teensy_initpgm(PROGRAMMER* pgm)
 #else /* !HAVE_LIBHIDAPI */
 
  // Give a proper error if we were not compiled with libhidapi
-static int teensy_nousb_open(struct programmer_t* pgm, char* name)
-{
+static int teensy_nousb_open(PROGRAMMER *pgm, const char *name) {
     avrdude_message(MSG_INFO, "%s: error: No HID support. Please compile again with libhidapi installed.\n", progname);
     return -1;
 }
 
-void teensy_initpgm(PROGRAMMER* pgm)
-{
+void teensy_initpgm(PROGRAMMER *pgm) {
     strcpy(pgm->type, "teensy");
     pgm->open = teensy_nousb_open;
 }

--- a/src/teensy.h
+++ b/src/teensy.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 extern const char teensy_desc[];
-void teensy_initpgm(PROGRAMMER* pgm);
+void teensy_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/term.c
+++ b/src/term.c
@@ -252,7 +252,7 @@ static int cmd_dump(PROGRAMMER * pgm, struct avrpart * p,
   }
 
   enum { read_size = 256 };
-  static char prevmem[AVR_MEMDESCLEN] = {0x00};
+  static const char *prevmem = "";
   char * memtype = argv[1];
   AVRMEM * mem = avr_locate_mem(p, memtype);
   if (mem == NULL) {
@@ -282,7 +282,7 @@ static int cmd_dump(PROGRAMMER * pgm, struct avrpart * p,
   // Get no. bytes to read if present
   static int len = read_size;
   if (argc >= 3) {
-    memset(prevmem, 0x00, sizeof(prevmem));
+    prevmem = cache_string("");
     if (strcmp(argv[argc - 1], "...") == 0) {
       if (argc == 3)
         addr = 0;
@@ -303,8 +303,7 @@ static int cmd_dump(PROGRAMMER * pgm, struct avrpart * p,
     if (strncmp(prevmem, memtype, strlen(memtype)) != 0) {
       addr = 0;
       len  = read_size;
-      strncpy(prevmem, memtype, sizeof(prevmem) - 1);
-      prevmem[sizeof(prevmem) - 1] = 0;
+      prevmem = cache_string(mem->desc);
     }
     if (addr >= maxsize)
       addr = 0; // Wrap around

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -39,8 +39,7 @@
 #include "updi_constants.h"
 #include "updi_state.h"
 
-static void updi_set_rtsdtr_mode(PROGRAMMER* pgm)
-{
+static void updi_set_rtsdtr_mode(const PROGRAMMER *pgm) {
   updi_rts_mode rts_mode = updi_get_rts_mode(pgm);
 
   if (rts_mode == RTS_MODE_DEFAULT) {
@@ -87,8 +86,7 @@ static void updi_physical_close(PROGRAMMER* pgm)
   pgm->fd.ifd = -1;
 }
 
-static int updi_physical_send(PROGRAMMER * pgm, unsigned char * buf, size_t len)
-{
+static int updi_physical_send(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
   size_t i;
   int rv;
 
@@ -106,8 +104,7 @@ static int updi_physical_send(PROGRAMMER * pgm, unsigned char * buf, size_t len)
   return rv;
 }
 
-static int updi_physical_recv(PROGRAMMER * pgm, unsigned char * buf, size_t len)
-{
+static int updi_physical_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
   size_t i;
   int rv;
 
@@ -131,8 +128,7 @@ static int updi_physical_recv(PROGRAMMER * pgm, unsigned char * buf, size_t len)
   return len;
 }
 
-static int updi_physical_send_double_break(PROGRAMMER * pgm)
-{
+static int updi_physical_send_double_break(const PROGRAMMER *pgm) {
   unsigned char buffer[1];
 
   avrdude_message(MSG_DEBUG, "%s: Sending double break\n", progname);
@@ -171,8 +167,7 @@ static int updi_physical_send_double_break(PROGRAMMER * pgm)
   return 0;
 }
 
-int updi_physical_sib(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size)
-{
+int updi_physical_sib(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size) {
 /*
     def sib(self):
         """
@@ -196,8 +191,7 @@ int updi_physical_sib(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size)
   return updi_physical_recv(pgm, buffer, size);
 }
 
-int updi_link_open(PROGRAMMER * pgm) 
-{
+int updi_link_open(PROGRAMMER *pgm)  {
   unsigned char init_buffer[1];
 
   if (updi_physical_open(pgm, pgm->baudrate? pgm->baudrate: 115200, SERIAL_8E2) < 0) {
@@ -208,13 +202,11 @@ int updi_link_open(PROGRAMMER * pgm)
   return updi_physical_send(pgm, init_buffer, 1);
 }
 
-void updi_link_close(PROGRAMMER * pgm)
-{
+void updi_link_close(PROGRAMMER *pgm) {
   updi_physical_close(pgm);
 }
 
-static int updi_link_init_session_parameters(PROGRAMMER * pgm) 
-{
+static int updi_link_init_session_parameters(const PROGRAMMER *pgm)  {
 /*
     def _init_session_parameters(self):
         """
@@ -234,8 +226,7 @@ static int updi_link_init_session_parameters(PROGRAMMER * pgm)
   return 0;
 }
 
-static int updi_link_check(PROGRAMMER * pgm)
-{
+static int updi_link_check(const PROGRAMMER *pgm) {
 /*
     def _check_datalink(self):
         """
@@ -269,8 +260,7 @@ static int updi_link_check(PROGRAMMER * pgm)
 }
 
 
-int updi_link_init(PROGRAMMER * pgm)
-{
+int updi_link_init(const PROGRAMMER *pgm) {
 /*
     def init_datalink(self):
         """
@@ -308,8 +298,7 @@ int updi_link_init(PROGRAMMER * pgm)
   return 0;
 }
 
-int updi_link_ldcs(PROGRAMMER * pgm, uint8_t address, uint8_t * value) 
-{
+int updi_link_ldcs(const PROGRAMMER *pgm, uint8_t address, uint8_t *value)  {
 /*
     def ldcs(self, address):
         """
@@ -347,8 +336,7 @@ int updi_link_ldcs(PROGRAMMER * pgm, uint8_t address, uint8_t * value)
   return 0;
 }
 
-int updi_link_stcs(PROGRAMMER * pgm, uint8_t address, uint8_t value)
-{
+int updi_link_stcs(const PROGRAMMER *pgm, uint8_t address, uint8_t value) {
 /*
     def stcs(self, address, value):
         """
@@ -368,8 +356,7 @@ int updi_link_stcs(PROGRAMMER * pgm, uint8_t address, uint8_t value)
   return updi_physical_send(pgm, buffer, 3);
 }
 
-int updi_link_ld_ptr_inc(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size)
-{
+int updi_link_ld_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size) {
 /*
     def ld_ptr_inc(self, size):
         """
@@ -394,8 +381,7 @@ int updi_link_ld_ptr_inc(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size
   return updi_physical_recv(pgm, buffer, size);
 }
 
-int updi_link_ld_ptr_inc16(PROGRAMMER * pgm, unsigned char * buffer, uint16_t words)
-{
+int updi_link_ld_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t words) {
 /*
     def ld_ptr_inc16(self, words):
         """
@@ -420,8 +406,7 @@ int updi_link_ld_ptr_inc16(PROGRAMMER * pgm, unsigned char * buffer, uint16_t wo
   return updi_physical_recv(pgm, buffer, words << 2);
 }
 
-int updi_link_st_ptr_inc(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size)
-{
+int updi_link_st_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size) {
 /*
     def st_ptr_inc(self, data):
         """
@@ -484,8 +469,7 @@ int updi_link_st_ptr_inc(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size
   return 0;
 }
 
-int updi_link_st_ptr_inc16(PROGRAMMER * pgm, unsigned char * buffer, uint16_t words)
-{
+int updi_link_st_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t words) {
 /*
     def st_ptr_inc16(self, data):
         """
@@ -550,7 +534,7 @@ int updi_link_st_ptr_inc16(PROGRAMMER * pgm, unsigned char * buffer, uint16_t wo
   return 0;
 }
 
-int updi_link_st_ptr_inc16_RSD(PROGRAMMER * pgm, unsigned char * buffer, uint16_t words, int blocksize) {
+int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t words, int blocksize) {
 /*
     def st_ptr_inc16_RSD(self, data, blocksize):
         """
@@ -653,8 +637,7 @@ int updi_link_st_ptr_inc16_RSD(PROGRAMMER * pgm, unsigned char * buffer, uint16_
   return 0;
 }
 
-int updi_link_repeat(PROGRAMMER * pgm, uint16_t repeats)
-{
+int updi_link_repeat(const PROGRAMMER *pgm, uint16_t repeats) {
 /*
     def repeat(self, repeats):
         """
@@ -683,8 +666,7 @@ int updi_link_repeat(PROGRAMMER * pgm, uint16_t repeats)
   return updi_physical_send(pgm, buffer, 3);
 }
 
-int updi_link_read_sib(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size)
-{
+int updi_link_read_sib(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size) {
 /*
     def read_sib(self):
         """
@@ -695,8 +677,7 @@ int updi_link_read_sib(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size)
   return updi_physical_sib(pgm, buffer, size);
 }
 
-int updi_link_key(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size_type, uint16_t size)
-{
+int updi_link_key(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size_type, uint16_t size) {
 /*
     def key(self, size, key):
         """
@@ -732,8 +713,7 @@ int updi_link_key(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size_type, u
   return updi_physical_send(pgm, reversed_key, size);
 }
 
-int updi_link_ld(PROGRAMMER * pgm, uint32_t address, uint8_t * value)
-{
+int updi_link_ld(const PROGRAMMER *pgm, uint32_t address, uint8_t *value) {
 /*
     def ld(self, address):
         """
@@ -768,8 +748,7 @@ int updi_link_ld(PROGRAMMER * pgm, uint32_t address, uint8_t * value)
   return 0;
 }
 
-int updi_link_ld16(PROGRAMMER * pgm, uint32_t address, uint16_t * value)
-{
+int updi_link_ld16(const PROGRAMMER *pgm, uint32_t address, uint16_t *value) {
 /*
     def ld16(self, address):
         """
@@ -804,8 +783,7 @@ int updi_link_ld16(PROGRAMMER * pgm, uint32_t address, uint16_t * value)
   return 0;
 }
 
-static int updi_link_st_data_phase(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size)
-{
+static int updi_link_st_data_phase(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size) {
 /*
     def _st_data_phase(self, values):
         """
@@ -848,8 +826,7 @@ static int updi_link_st_data_phase(PROGRAMMER * pgm, unsigned char * buffer, uin
   return 0;
 }
 
-int updi_link_st(PROGRAMMER * pgm, uint32_t address, uint8_t value)
-{
+int updi_link_st(const PROGRAMMER *pgm, uint32_t address, uint8_t value) {
 /*
     def st(self, address, value):
         """
@@ -879,8 +856,7 @@ int updi_link_st(PROGRAMMER * pgm, uint32_t address, uint8_t value)
   return updi_link_st_data_phase(pgm, send_buffer, 1);
 }
 
-int updi_link_st16(PROGRAMMER * pgm, uint32_t address, uint16_t value)
-{
+int updi_link_st16(const PROGRAMMER *pgm, uint32_t address, uint16_t value) {
 /*
     def st16(self, address, value):
         """
@@ -911,8 +887,7 @@ int updi_link_st16(PROGRAMMER * pgm, uint32_t address, uint16_t value)
   return updi_link_st_data_phase(pgm, send_buffer, 2);
 }
 
-int updi_link_st_ptr(PROGRAMMER * pgm, uint32_t address)
-{
+int updi_link_st_ptr(const PROGRAMMER *pgm, uint32_t address) {
 /*
     def st_ptr(self, address):
         """

--- a/src/updi_link.h
+++ b/src/updi_link.h
@@ -35,22 +35,22 @@ extern "C" {
 
 int updi_link_open(PROGRAMMER * pgm);
 void updi_link_close(PROGRAMMER * pgm);
-int updi_link_init(PROGRAMMER * pgm);
-int updi_link_ldcs(PROGRAMMER * pgm, uint8_t address, uint8_t * value);
-int updi_link_stcs(PROGRAMMER * pgm, uint8_t address, uint8_t value);
-int updi_link_ld_ptr_inc(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size);
-int updi_link_ld_ptr_inc16(PROGRAMMER * pgm, unsigned char * buffer, uint16_t words);
-int updi_link_st_ptr_inc(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size);
-int updi_link_st_ptr_inc16(PROGRAMMER * pgm, unsigned char * buffer, uint16_t words);
-int updi_link_st_ptr_inc16_RSD(PROGRAMMER * pgm, unsigned char * buffer, uint16_t words, int blocksize);
-int updi_link_repeat(PROGRAMMER * pgm, uint16_t repeats);
-int updi_link_read_sib(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size);
-int updi_link_key(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size_type, uint16_t size);
-int updi_link_ld(PROGRAMMER * pgm, uint32_t address, uint8_t * value);
-int updi_link_ld16(PROGRAMMER * pgm, uint32_t address, uint16_t * value);
-int updi_link_st(PROGRAMMER * pgm, uint32_t address, uint8_t value);
-int updi_link_st16(PROGRAMMER * pgm, uint32_t address, uint16_t value);
-int updi_link_st_ptr(PROGRAMMER * pgm, uint32_t address);
+int updi_link_init(const PROGRAMMER *pgm);
+int updi_link_ldcs(const PROGRAMMER *pgm, uint8_t address, uint8_t *value);
+int updi_link_stcs(const PROGRAMMER *pgm, uint8_t address, uint8_t value);
+int updi_link_ld_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size);
+int updi_link_ld_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t words);
+int updi_link_st_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size);
+int updi_link_st_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t words);
+int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t words, int blocksize);
+int updi_link_repeat(const PROGRAMMER *pgm, uint16_t repeats);
+int updi_link_read_sib(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size);
+int updi_link_key(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size_type, uint16_t size);
+int updi_link_ld(const PROGRAMMER *pgm, uint32_t address, uint8_t *value);
+int updi_link_ld16(const PROGRAMMER *pgm, uint32_t address, uint16_t *value);
+int updi_link_st(const PROGRAMMER *pgm, uint32_t address, uint8_t value);
+int updi_link_st16(const PROGRAMMER *pgm, uint32_t address, uint16_t value);
+int updi_link_st_ptr(const PROGRAMMER *pgm, uint32_t address);
 
 #ifdef __cplusplus
 }

--- a/src/updi_nvm.c
+++ b/src/updi_nvm.c
@@ -47,8 +47,7 @@ typedef enum
 
 #define USE_DEFAULT_COMMAND 0xFF
 
-static int nvm_chip_erase_V0(PROGRAMMER * pgm, AVRPART * p)
-{
+static int nvm_chip_erase_V0(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def chip_erase(self):
         """
@@ -88,8 +87,7 @@ static int nvm_chip_erase_V0(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int nvm_erase_flash_page_V0(PROGRAMMER * pgm, AVRPART * p, uint32_t address)
-{
+static int nvm_erase_flash_page_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address) {
 /*
     def erase_flash_page(self, address):
         """
@@ -136,8 +134,7 @@ static int nvm_erase_flash_page_V0(PROGRAMMER * pgm, AVRPART * p, uint32_t addre
   return 0;
 }
 
-static int nvm_erase_eeprom_V0(PROGRAMMER * pgm, AVRPART * p)
-{
+static int nvm_erase_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def erase_eeprom(self):
         """
@@ -172,8 +169,7 @@ static int nvm_erase_eeprom_V0(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int nvm_erase_user_row_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint16_t size)
-{
+static int nvm_erase_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size) {
 /*
     def erase_user_row(self, address, size):
         """
@@ -226,14 +222,13 @@ static int nvm_erase_user_row_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address,
   return 0;
 }
 
-static int nvm_write_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, 
+static int nvm_write_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer,
                         uint16_t size, access_mode mode, uint8_t nvm_command);
 
-static int nvm_write_eeprom_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size);
+static int nvm_write_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 
 
-static int nvm_write_flash_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_flash_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_flash(self, address, data):
         """
@@ -247,8 +242,7 @@ static int nvm_write_flash_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, un
   return nvm_write_V0(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
-static int nvm_write_user_row_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_user_row(self, address, data):
         """
@@ -263,8 +257,7 @@ static int nvm_write_user_row_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address,
   return nvm_write_eeprom_V0(pgm, p, address, buffer, size);
 }
 
-static int nvm_write_eeprom_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):
         """
@@ -279,8 +272,7 @@ static int nvm_write_eeprom_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, u
   return nvm_write_V0(pgm, p, address, buffer, size, DONT_USE_WORD_ACCESS, UPDI_V0_NVMCTRL_CTRLA_ERASE_WRITE_PAGE);
 }
 
-static int nvm_write_fuse_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint8_t value)
-{
+static int nvm_write_fuse_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value) {
 /*
     def write_fuse(self, address, data):
         """
@@ -340,7 +332,7 @@ static int nvm_write_fuse_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uin
   return 0;
 }
 
-static int nvm_write_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, 
+static int nvm_write_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer,
                         uint16_t size, access_mode mode, uint8_t nvm_command)
 {
 /*
@@ -423,8 +415,7 @@ static int nvm_write_V0(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned
   return 0;
 }
 
-static int nvm_chip_erase_V2(PROGRAMMER * pgm, AVRPART * p)
-{
+static int nvm_chip_erase_V2(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def chip_erase(self):
         """
@@ -463,8 +454,7 @@ static int nvm_chip_erase_V2(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int nvm_erase_flash_page_V2(PROGRAMMER * pgm, AVRPART * p, uint32_t address)
-{
+static int nvm_erase_flash_page_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address) {
 /*
     def erase_flash_page(self, address):
         """
@@ -515,8 +505,7 @@ static int nvm_erase_flash_page_V2(PROGRAMMER * pgm, AVRPART * p, uint32_t addre
   return 0;
 }
 
-static int nvm_erase_eeprom_V2(PROGRAMMER * pgm, AVRPART * p)
-{
+static int nvm_erase_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def erase_eeprom(self):
         """
@@ -560,8 +549,7 @@ static int nvm_erase_eeprom_V2(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int nvm_erase_user_row_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint16_t size)
-{
+static int nvm_erase_user_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size) {
 /*
     def erase_user_row(self, address, size):
         """
@@ -578,11 +566,10 @@ static int nvm_erase_user_row_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address,
   return nvm_erase_flash_page_V2(pgm, p, address);
 }
 
-static int nvm_write_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, 
+static int nvm_write_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer,
                         uint16_t size, access_mode mode);
 
-static int nvm_write_flash_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_flash_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_flash(self, address, data):
         """
@@ -596,8 +583,7 @@ static int nvm_write_flash_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, un
   return nvm_write_V2(pgm, p, address, buffer, size, USE_WORD_ACCESS);
 }
 
-static int nvm_write_user_row_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_user_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_user_row(self, address, data):
         """
@@ -612,8 +598,7 @@ static int nvm_write_user_row_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address,
   return nvm_write_V2(pgm, p, address, buffer, size, DONT_USE_WORD_ACCESS);
 }
 
-static int nvm_write_eeprom_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):
         """
@@ -668,8 +653,7 @@ static int nvm_write_eeprom_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, u
   return 0;
 }
 
-static int nvm_write_fuse_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint8_t value)
-{
+static int nvm_write_fuse_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value) {
 /*
     def write_fuse(self, address, data):
         """
@@ -686,7 +670,7 @@ static int nvm_write_fuse_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uin
   return nvm_write_eeprom_V2(pgm, p, address, buffer, 1);
 }
 
-static int nvm_write_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, 
+static int nvm_write_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer,
                         uint16_t size, access_mode mode)
 {
 /*
@@ -755,8 +739,7 @@ static int nvm_write_V2(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned
   return 0;
 }
 
-static int nvm_chip_erase_V3(PROGRAMMER * pgm, AVRPART * p)
-{
+static int nvm_chip_erase_V3(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def chip_erase(self):
         """
@@ -805,8 +788,7 @@ static int nvm_chip_erase_V3(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int nvm_erase_flash_page_V3(PROGRAMMER * pgm, AVRPART * p, uint32_t address)
-{
+static int nvm_erase_flash_page_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address) {
 /*
     def erase_flash_page(self, address):
         """
@@ -858,8 +840,7 @@ static int nvm_erase_flash_page_V3(PROGRAMMER * pgm, AVRPART * p, uint32_t addre
   return 0;
 }
 
-static int nvm_erase_eeprom_V3(PROGRAMMER * pgm, AVRPART * p)
-{
+static int nvm_erase_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def erase_eeprom(self):
         """
@@ -903,8 +884,7 @@ static int nvm_erase_eeprom_V3(PROGRAMMER * pgm, AVRPART * p)
   return 0;
 }
 
-static int nvm_erase_user_row_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint16_t size)
-{
+static int nvm_erase_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size) {
 /*
     def erase_user_row(self, address, size):
         """
@@ -923,11 +903,10 @@ static int nvm_erase_user_row_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address,
   return nvm_erase_flash_page_V3(pgm, p, address);
 }
 
-static int nvm_write_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, 
+static int nvm_write_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer,
                         uint16_t size, access_mode mode, uint8_t nvm_command);
 
-static int nvm_write_flash_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_flash_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_flash(self, address, data):
         """
@@ -941,8 +920,7 @@ static int nvm_write_flash_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, un
   return nvm_write_V3(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
-static int nvm_write_user_row_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_user_row(self, address, data):
         """
@@ -957,8 +935,7 @@ static int nvm_write_user_row_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address,
   return nvm_write_V3(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
-static int nvm_write_eeprom_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+static int nvm_write_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):
         """
@@ -973,8 +950,7 @@ static int nvm_write_eeprom_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, u
   return nvm_write_V3(pgm, p, address, buffer, size, DONT_USE_WORD_ACCESS, UPDI_V3_NVMCTRL_CTRLA_EEPROM_PAGE_ERASE_WRITE);
 }
 
-static int nvm_write_fuse_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint8_t value)
-{
+static int nvm_write_fuse_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value) {
 /*
     def write_fuse(self, address, data):
         """
@@ -990,7 +966,7 @@ static int nvm_write_fuse_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uin
   return nvm_write_eeprom_V3(pgm, p, address, buffer, 1);
 }
 
-static int nvm_write_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, 
+static int nvm_write_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer,
                         uint16_t size, access_mode mode, uint8_t nvm_command)
 {
 /*
@@ -1081,8 +1057,7 @@ static int nvm_write_V3(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned
 }
 
 
-int updi_nvm_chip_erase(PROGRAMMER * pgm, AVRPART * p)
-{
+int updi_nvm_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1097,8 +1072,7 @@ int updi_nvm_chip_erase(PROGRAMMER * pgm, AVRPART * p)
   }
 }
 
-int updi_nvm_erase_flash_page(PROGRAMMER * pgm, AVRPART *p, uint32_t address)
-{
+int updi_nvm_erase_flash_page(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1113,8 +1087,7 @@ int updi_nvm_erase_flash_page(PROGRAMMER * pgm, AVRPART *p, uint32_t address)
   }
 }
 
-int updi_nvm_erase_eeprom(PROGRAMMER * pgm, AVRPART *p)
-{
+int updi_nvm_erase_eeprom(const PROGRAMMER *pgm, const AVRPART *p) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1129,8 +1102,7 @@ int updi_nvm_erase_eeprom(PROGRAMMER * pgm, AVRPART *p)
   }
 }
 
-int updi_nvm_erase_user_row(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint16_t size)
-{
+int updi_nvm_erase_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1145,8 +1117,7 @@ int updi_nvm_erase_user_row(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint
   }
 }
 
-int updi_nvm_write_flash(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+int updi_nvm_write_flash(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1161,8 +1132,7 @@ int updi_nvm_write_flash(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigne
   }
 }
 
-int updi_nvm_write_user_row(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+int updi_nvm_write_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1177,8 +1147,7 @@ int updi_nvm_write_user_row(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsi
   }
 }
 
-int updi_nvm_write_eeprom(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size)
-{
+int updi_nvm_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1193,8 +1162,7 @@ int updi_nvm_write_eeprom(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsign
   }
 }
 
-int updi_nvm_write_fuse(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint8_t value)
-{
+int updi_nvm_write_fuse(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value) {
   switch(updi_get_nvm_mode(pgm))
   {
     case UPDI_NVM_MODE_V0:
@@ -1209,8 +1177,7 @@ int updi_nvm_write_fuse(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint8_t 
   }
 }
 
-int updi_nvm_wait_ready(PROGRAMMER * pgm, AVRPART *p)
-{
+int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p) {
 /*
     def wait_nvm_ready(self):
         """
@@ -1257,8 +1224,7 @@ int updi_nvm_wait_ready(PROGRAMMER * pgm, AVRPART *p)
   return -1;
 }
 
-int updi_nvm_command(PROGRAMMER * pgm, AVRPART *p, uint8_t command)
-{
+int updi_nvm_command(const PROGRAMMER *pgm, const AVRPART *p, uint8_t command) {
 /*
     def execute_nvm_command(self, command):
         """

--- a/src/updi_nvm.h
+++ b/src/updi_nvm.h
@@ -33,16 +33,16 @@
 extern "C" {
 #endif
 
-int updi_nvm_chip_erase(PROGRAMMER * pgm, AVRPART * p);
-int updi_nvm_erase_flash_page(PROGRAMMER * pgm, AVRPART *p, uint32_t address);
-int updi_nvm_erase_eeprom(PROGRAMMER * pgm, AVRPART *p);
-int updi_nvm_erase_user_row(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint16_t size);
-int updi_nvm_write_flash(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size);
-int updi_nvm_write_user_row(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size);
-int updi_nvm_write_eeprom(PROGRAMMER * pgm, AVRPART *p, uint32_t address, unsigned char * buffer, uint16_t size);
-int updi_nvm_write_fuse(PROGRAMMER * pgm, AVRPART *p, uint32_t address, uint8_t value);
-int updi_nvm_wait_ready(PROGRAMMER * pgm, AVRPART *p);
-int updi_nvm_command(PROGRAMMER * pgm, AVRPART *p, uint8_t command);
+int updi_nvm_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
+int updi_nvm_erase_flash_page(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address);
+int updi_nvm_erase_eeprom(const PROGRAMMER *pgm, const AVRPART *p);
+int updi_nvm_erase_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size);
+int updi_nvm_write_flash(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_fuse(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value);
+int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p);
+int updi_nvm_command(const PROGRAMMER *pgm, const AVRPART *p, uint8_t command);
 
 #ifdef __cplusplus
 }

--- a/src/updi_readwrite.c
+++ b/src/updi_readwrite.c
@@ -39,8 +39,7 @@
 #include "updi_link.h"
 #include "updi_readwrite.h"
 
-int updi_read_cs(PROGRAMMER * pgm, uint8_t address, uint8_t * value)
-{
+int updi_read_cs(const PROGRAMMER *pgm, uint8_t address, uint8_t *value) {
 /*
     def read_cs(self, address):
         """
@@ -54,8 +53,7 @@ int updi_read_cs(PROGRAMMER * pgm, uint8_t address, uint8_t * value)
   return updi_link_ldcs(pgm, address, value);
 }
 
-int updi_write_cs(PROGRAMMER * pgm, uint8_t address, uint8_t value)
-{
+int updi_write_cs(const PROGRAMMER *pgm, uint8_t address, uint8_t value) {
 /*
     def write_cs(self, address, value):
         """
@@ -69,8 +67,7 @@ int updi_write_cs(PROGRAMMER * pgm, uint8_t address, uint8_t value)
   return updi_link_stcs(pgm, address, value);
 }
 
-int updi_write_key(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size_type, uint16_t size)
-{
+int updi_write_key(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size_type, uint16_t size) {
 /*
     def write_key(self, size, key):
         """
@@ -84,8 +81,7 @@ int updi_write_key(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size_type, 
   return updi_link_key(pgm, buffer, size_type, size);
 }
 
-int updi_read_sib(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size)
-{
+int updi_read_sib(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size) {
 /*
     def read_sib(self):
         """
@@ -98,8 +94,7 @@ int updi_read_sib(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size)
   return updi_link_read_sib(pgm, buffer, size);
 }
 
-int updi_read_byte(PROGRAMMER * pgm, uint32_t address, uint8_t * value)
-{
+int updi_read_byte(const PROGRAMMER *pgm, uint32_t address, uint8_t *value) {
 /*
     def read_byte(self, address):
         """
@@ -113,8 +108,7 @@ int updi_read_byte(PROGRAMMER * pgm, uint32_t address, uint8_t * value)
   return updi_link_ld(pgm, address, value);
 }
 
-int updi_write_byte(PROGRAMMER * pgm, uint32_t address, uint8_t value)
-{
+int updi_write_byte(const PROGRAMMER *pgm, uint32_t address, uint8_t value) {
 /*
     def write_byte(self, address, value):
         """
@@ -128,8 +122,7 @@ int updi_write_byte(PROGRAMMER * pgm, uint32_t address, uint8_t value)
   return updi_link_st(pgm, address, value);
 }
 
-int updi_read_data(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size)
-{
+int updi_read_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size) {
 /*
     def read_data(self, address, size):
         """
@@ -174,8 +167,7 @@ int updi_read_data(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_
   return updi_link_ld_ptr_inc(pgm, buffer, size);
 }
 
-int updi_write_data(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size)
-{
+int updi_write_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size) {
 /*
     def write_data(self, address, data):
         """
@@ -228,8 +220,7 @@ int updi_write_data(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16
   return updi_link_st_ptr_inc(pgm, buffer, size);
 }
 
-int updi_read_data_words(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size)
-{
+int updi_read_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size) {
 /*
     def read_data_words(self, address, words):
         """
@@ -275,8 +266,7 @@ int updi_read_data_words(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, u
   return updi_link_ld_ptr_inc16(pgm, buffer, size);
 }
 
-int updi_write_data_words(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size)
-{
+int updi_write_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size) {
 /*
     def write_data_words(self, address, data):
         """

--- a/src/updi_readwrite.h
+++ b/src/updi_readwrite.h
@@ -33,16 +33,16 @@
 extern "C" {
 #endif
 
-int updi_read_cs(PROGRAMMER * pgm, uint8_t address, uint8_t * value);
-int updi_write_cs(PROGRAMMER * pgm, uint8_t address, uint8_t value);
-int updi_write_key(PROGRAMMER * pgm, unsigned char * buffer, uint8_t size_type, uint16_t size);
-int updi_read_sib(PROGRAMMER * pgm, unsigned char * buffer, uint16_t size);
-int updi_read_byte(PROGRAMMER * pgm, uint32_t address, uint8_t * value);
-int updi_write_byte(PROGRAMMER * pgm, uint32_t address, uint8_t value);
-int updi_read_data(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size);
-int updi_write_data(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size);
-int updi_read_data_words(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size);
-int updi_write_data_words(PROGRAMMER * pgm, uint32_t address, uint8_t * buffer, uint16_t size);
+int updi_read_cs(const PROGRAMMER *pgm, uint8_t address, uint8_t *value);
+int updi_write_cs(const PROGRAMMER *pgm, uint8_t address, uint8_t value);
+int updi_write_key(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size_type, uint16_t size);
+int updi_read_sib(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t size);
+int updi_read_byte(const PROGRAMMER *pgm, uint32_t address, uint8_t *value);
+int updi_write_byte(const PROGRAMMER *pgm, uint32_t address, uint8_t value);
+int updi_read_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size);
+int updi_write_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size);
+int updi_read_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size);
+int updi_write_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uint16_t size);
 
 #ifdef __cplusplus
 }

--- a/src/updi_state.c
+++ b/src/updi_state.c
@@ -29,37 +29,30 @@
 #include "libavrdude.h"
 #include "updi_state.h"
 
-updi_sib_info* updi_get_sib_info(PROGRAMMER * pgm)
-{
+updi_sib_info* updi_get_sib_info(const PROGRAMMER *pgm) {
   return &((updi_state *)(pgm->cookie))->sib_info;
 }
 
-updi_datalink_mode updi_get_datalink_mode(PROGRAMMER * pgm)
-{
+updi_datalink_mode updi_get_datalink_mode(const PROGRAMMER *pgm) {
   return ((updi_state *)(pgm->cookie))->datalink_mode;
 }
 
-void updi_set_datalink_mode(PROGRAMMER * pgm, updi_datalink_mode mode)
-{
+void updi_set_datalink_mode(const PROGRAMMER *pgm, updi_datalink_mode mode) {
   ((updi_state *)(pgm->cookie))->datalink_mode = mode;
 }
 
-updi_nvm_mode updi_get_nvm_mode(PROGRAMMER * pgm)
-{
+updi_nvm_mode updi_get_nvm_mode(const PROGRAMMER *pgm) {
   return ((updi_state *)(pgm->cookie))->nvm_mode;
 }
 
-void updi_set_nvm_mode(PROGRAMMER * pgm, updi_nvm_mode mode)
-{
+void updi_set_nvm_mode(const PROGRAMMER *pgm, updi_nvm_mode mode) {
   ((updi_state *)(pgm->cookie))->nvm_mode = mode;
 }
 
-updi_rts_mode updi_get_rts_mode(PROGRAMMER * pgm)
-{
+updi_rts_mode updi_get_rts_mode(const PROGRAMMER *pgm) {
   return ((updi_state *)(pgm->cookie))->rts_mode;
 }
 
-void updi_set_rts_mode(PROGRAMMER * pgm, updi_rts_mode mode)
-{
+void updi_set_rts_mode(const PROGRAMMER *pgm, updi_rts_mode mode) {
   ((updi_state *)(pgm->cookie))->rts_mode = mode;
 }

--- a/src/updi_state.h
+++ b/src/updi_state.h
@@ -80,13 +80,13 @@ typedef struct
 extern "C" {
 #endif
 
-updi_sib_info* updi_get_sib_info(PROGRAMMER * pgm);
-updi_datalink_mode updi_get_datalink_mode(PROGRAMMER * pgm);
-void updi_set_datalink_mode(PROGRAMMER * pgm, updi_datalink_mode mode);
-updi_nvm_mode updi_get_nvm_mode(PROGRAMMER * pgm);
-void updi_set_nvm_mode(PROGRAMMER * pgm, updi_nvm_mode mode);
-updi_rts_mode updi_get_rts_mode(PROGRAMMER * pgm);
-void updi_set_rts_mode(PROGRAMMER * pgm, updi_rts_mode mode);
+updi_sib_info* updi_get_sib_info(const PROGRAMMER *pgm);
+updi_datalink_mode updi_get_datalink_mode(const PROGRAMMER *pgm);
+void updi_set_datalink_mode(const PROGRAMMER *pgm, updi_datalink_mode mode);
+updi_nvm_mode updi_get_nvm_mode(const PROGRAMMER *pgm);
+void updi_set_nvm_mode(const PROGRAMMER *pgm, updi_nvm_mode mode);
+updi_rts_mode updi_get_rts_mode(const PROGRAMMER *pgm);
+void updi_set_rts_mode(const PROGRAMMER *pgm, updi_rts_mode mode);
 
 #ifdef __cplusplus
 }

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -46,8 +46,7 @@
  * The "baud" parameter is meaningless for USB devices, so we reuse it
  * to pass the desired USB device ID.
  */
-static int usbhid_open(char * port, union pinfo pinfo, union filedescriptor *fd)
-{
+static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor *fd) {
   hid_device *dev;
   char *serno, *cp2;
   size_t x;
@@ -233,7 +232,7 @@ static void usbhid_close(union filedescriptor *fd)
 }
 
 
-static int usbhid_send(union filedescriptor *fd, const unsigned char *bp, size_t mlen)
+static int usbhid_send(const union filedescriptor *fd, const unsigned char *bp, size_t mlen)
 {
   hid_device *udev = (hid_device *)fd->usb.handle;
   int rv;
@@ -282,7 +281,7 @@ static int usbhid_send(union filedescriptor *fd, const unsigned char *bp, size_t
   return 0;
 }
 
-static int usbhid_recv(union filedescriptor *fd, unsigned char *buf, size_t nbytes)
+static int usbhid_recv(const union filedescriptor *fd, unsigned char *buf, size_t nbytes)
 {
   hid_device *udev = (hid_device *)fd->usb.handle;
   int i, rv;
@@ -320,7 +319,7 @@ static int usbhid_recv(union filedescriptor *fd, unsigned char *buf, size_t nbyt
   return rv;
 }
 
-static int usbhid_drain(union filedescriptor *fd, int display)
+static int usbhid_drain(const union filedescriptor *fd, int display)
 {
   /*
    * There is not much point in trying to flush any data

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -62,8 +62,7 @@ static int usb_interface;
  * The "baud" parameter is meaningless for USB devices, so we reuse it
  * to pass the desired USB device ID.
  */
-static int usbdev_open(char * port, union pinfo pinfo, union filedescriptor *fd)
-{
+static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor *fd) {
   char string[256];
   char product[256];
   struct usb_bus *bus;
@@ -328,7 +327,7 @@ static void usbdev_close(union filedescriptor *fd)
 }
 
 
-static int usbdev_send(union filedescriptor *fd, const unsigned char *bp, size_t mlen)
+static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, size_t mlen)
 {
   usb_dev_handle *udev = (usb_dev_handle *)fd->usb.handle;
   int rv;
@@ -415,7 +414,7 @@ usb_fill_buf(usb_dev_handle *udev, int maxsize, int ep, int use_interrupt_xfer)
   return 0;
 }
 
-static int usbdev_recv(union filedescriptor *fd, unsigned char *buf, size_t nbytes)
+static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_t nbytes)
 {
   usb_dev_handle *udev = (usb_dev_handle *)fd->usb.handle;
   int i, amnt;
@@ -470,7 +469,7 @@ static int usbdev_recv(union filedescriptor *fd, unsigned char *buf, size_t nbyt
  *
  * This is used for the AVRISP mkII device.
  */
-static int usbdev_recv_frame(union filedescriptor *fd, unsigned char *buf, size_t nbytes)
+static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf, size_t nbytes)
 {
   usb_dev_handle *udev = (usb_dev_handle *)fd->usb.handle;
   int rv, n;
@@ -570,7 +569,7 @@ static int usbdev_recv_frame(union filedescriptor *fd, unsigned char *buf, size_
   return n;
 }
 
-static int usbdev_drain(union filedescriptor *fd, int display)
+static int usbdev_drain(const union filedescriptor *fd, int display)
 {
   /*
    * There is not much point in trying to flush any data

--- a/src/usbasp.h
+++ b/src/usbasp.h
@@ -130,7 +130,7 @@ extern "C" {
 #endif
 
 extern const char usbasp_desc[];
-void usbasp_initpgm (PROGRAMMER * pgm);
+void usbasp_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/usbtiny.h
+++ b/src/usbtiny.h
@@ -59,7 +59,7 @@ extern "C" {
 #endif
 
 extern const char usbtiny_desc[];
-void usbtiny_initpgm (PROGRAMMER * pgm);
+void usbtiny_initpgm(PROGRAMMER *pgm);
 
 #ifdef __cplusplus
 }

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -109,8 +109,7 @@ static void wiring_teardown(PROGRAMMER * pgm)
   stk500v2_teardown(pgm);
 }
 
-static int wiring_parseextparms(PROGRAMMER * pgm, LISTID extparms)
-{
+static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param;
   int rv = 0;
@@ -143,8 +142,7 @@ static int wiring_parseextparms(PROGRAMMER * pgm, LISTID extparms)
   return rv;
 }
 
-static int wiring_open(PROGRAMMER * pgm, char * port)
-{
+static int wiring_open(PROGRAMMER *pgm, const char *port) {
   int timetosnooze;
   void *mycookie = STK500V2PDATA(pgm)->chained_pdata;
   union pinfo pinfo;
@@ -205,8 +203,7 @@ static void wiring_close(PROGRAMMER * pgm)
 
 const char wiring_desc[] = "http://wiring.org.co/, Basically STK500v2 protocol, with some glue to trigger the bootloader.";
 
-void wiring_initpgm(PROGRAMMER * pgm)
-{
+void wiring_initpgm(PROGRAMMER *pgm) {
   /* The Wiring bootloader uses a near-complete STK500v2 protocol. */
 
   stk500v2_initpgm(pgm);

--- a/src/wiring.h
+++ b/src/wiring.h
@@ -22,7 +22,7 @@
 #define wiring_h__
 
 extern const char wiring_desc[];
-void wiring_initpgm(PROGRAMMER * pgm);
+void wiring_initpgm(PROGRAMMER *pgm);
 
 #endif
 

--- a/src/xbee.h
+++ b/src/xbee.h
@@ -22,6 +22,27 @@
 #define xbee_h__
 
 extern const char xbee_desc[];
-void xbee_initpgm (PROGRAMMER * pgm);
+void xbee_initpgm(PROGRAMMER *pgm);
+
+/*
+ * For non-direct mode (Over-The-Air) we need to issue XBee commands
+ * to the remote XBee in order to reset the AVR CPU and initiate the
+ * XBeeBoot bootloader.
+ *
+ * XBee IO port 3 is a somewhat-arbitrarily chosen pin that can be
+ * connected directly to the AVR reset pin.
+ *
+ * Note that port 7 was not used because it is the only pin that can
+ * be used as a CTS flow control output.  Port 6 is the only pin that
+ * can be used as an RTS flow control input.
+ *
+ * Some off-the-shelf Arduino shields select a different pin.  For
+ * example this one uses XBee IO port 7.
+ *
+ * https://wiki.dfrobot.com/Xbee_Shield_For_Arduino__no_Xbee___SKU_DFR0015_
+ */
+#ifndef XBEE_DEFAULT_RESET_PIN
+#define XBEE_DEFAULT_RESET_PIN 3
+#endif
 
 #endif


### PR DESCRIPTION
This PR updates the AVRDUDE programmer interface:
 - Use `const` in the 40 or so PROGRAMMER functions where appropriate; this to keep developers who create a new programmer on the straight and narrow to
     + Enforce `cookie` is used for allocated data (and not some "unused" entry in the AVRPART or PROGRAMMER structure)
     + Document which of the programmer function do not (should not) change AVRPART, AVRMEM or PROGRAMMER structures (note that buf and tags contents can still be modified as they are pointers)
 - Change `void (*enable)(PROGRAMMER * pgm)` to `void (*enable)(PROGRAMMER *pgm, const AVRPART *p)`; this allows changes in the PROGRAMMER structure after the part is known (think UPDI, PDI, ... that were not around when the programmer interface was first conceived)

In order to get meaningful `const` properties for the PROGRAMMER, AVRPART and AVRMEM arguments, some code needed to be moved around, otherwise a network of "tainted" assignments risked rendering not much `const`:
 - Change `void (*enable)(PROGRAMMER * pgm)` to `void (*enable)(PROGRAMMER *pgm, const AVRPART *p)`; this allows changes in the PROGRAMMER structure after the part is known. For example, use TPI, UPDI, PDI functions in that programmer appropriate to the part. This used to be done later in the process, eg, in the `initialize()` function, which "taints" all other programmer functions wrt `const` and sometimes requires other finessing with flags etc. Much clearer with the modified `enable()` interface.
 - Move TPI initpgm-type code from `initialize()` to `enable()` --- note that `initpgm()` does not have the info at the time when it is called whether or not TPI is required.
 - `buspirate.c`: move pgm->flag to PDATA(pgm)->flag (so legitimate modification of the flag does not change PROGRAMMER structure)
 - Move `AVRPART_INIT_SMC` and `AVRPART_WRITE` bits from the `flags` field in AVRPART to jtagmkII.c's private data `flags32` field as `FLAGS32_INIT_SMC` and `FLAGS32_WRITE` bits
 - Move the `xbeeResetPin` component to private data in `stk500.c` as this is needed by xbee when it saddles on the `stk500` code (previously, the `flags` component of the part was re-dedicated to this)
 - Change the way the "chained" private data are used in `jtag3.c` whilst keeping the PROGRAMMER structure read-only otherwise
 - In `stk500v2.c` move the STK600 initpgm update from `stk500v2_initialize()` to `stk500v2_enable()` so the former keeps the PROGRAMMER structure read-only (for `const` assertion). Whilst I know that this remains functionally the same, I did not understand initialisation conditions in the first place and still don't (always a sign of unnecessary complexity, but there you go)
 - In `usbasp` change the code from changing PROGRAMMER functions late to dispatching to TPI or regular SPI protocol functions at runtime; reason being the decision whether to use TPI protocol is done at run-time depending on the capability of the attached programmer
