### PR TITLE
Rewrite avrdude.conf.in with developer options

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -303,8 +303,8 @@
 #define AT86RF401   0xD0
 
 #define AT89START   0xE0
-#define AT89S51	    0xE0
-#define AT89S52	    0xE1
+#define AT89S51     0xE0
+#define AT89S52     0xE1
 
 # The following table lists the devices in the original AVR910
 # appnote:
@@ -382,14 +382,14 @@ default_spi        = "@DEFAULT_SPI_PORT@";
 #------------------------------------------------------------
 
 programmer
-    id                  = "bsd";
-    desc                = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
-    type                = "par";
-    vcc                 = 2, 3, 4, 5;
-    reset               = 7;
-    sck                 = 8;
-    mosi                = 9;
-    miso                = 10;
+    id                     = "bsd";
+    desc                   = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
+    type                   = "par";
+    vcc                    = 2, 3, 4, 5;
+    reset                  = 7;
+    sck                    = 8;
+    mosi                   = 9;
+    miso                   = 10;
 ;
 
 #------------------------------------------------------------
@@ -397,14 +397,14 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk200";
-    desc                = "STK200";
-    type                = "par";
-    buff                = 4, 5;
-    reset               = 9;
-    sck                 = 6;
-    mosi                = 7;
-    miso                = 10;
+    id                     = "stk200";
+    desc                   = "STK200";
+    type                   = "par";
+    buff                   = 4, 5;
+    reset                  = 9;
+    sck                    = 6;
+    mosi                   = 7;
+    miso                   = 10;
 ;
 
 #------------------------------------------------------------
@@ -417,10 +417,9 @@ programmer
 # programming is currently in progress.
 
 programmer parent "stk200"
-    id                  = "pony-stk200";
-    desc                = "Pony Prog STK200";
-    type                = "par";
-    pgmled              = 8;
+    id                     = "pony-stk200";
+    desc                   = "Pony Prog STK200";
+    pgmled                 = 8;
 ;
 
 #------------------------------------------------------------
@@ -428,13 +427,13 @@ programmer parent "stk200"
 #------------------------------------------------------------
 
 programmer
-    id                  = "dt006";
-    desc                = "Dontronics DT006";
-    type                = "par";
-    reset               = 4;
-    sck                 = 5;
-    mosi                = 2;
-    miso                = 11;
+    id                     = "dt006";
+    desc                   = "Dontronics DT006";
+    type                   = "par";
+    reset                  = 4;
+    sck                    = 5;
+    mosi                   = 2;
+    miso                   = 11;
 ;
 
 #------------------------------------------------------------
@@ -442,9 +441,8 @@ programmer
 #------------------------------------------------------------
 
 programmer parent "dt006"
-    id                  = "bascom";
-    desc                = "Bascom SAMPLE programming cable";
-    type                = "par";
+    id                     = "bascom";
+    desc                   = "Bascom SAMPLE programming cable";
 ;
 
 #------------------------------------------------------------
@@ -452,19 +450,19 @@ programmer parent "dt006"
 #------------------------------------------------------------
 
 programmer
-    id                  = "alf";
-    desc                = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
-    type                = "par";
-    vcc                 = 2, 3, 4, 5;
-    buff                = 6;
-    reset               = 7;
-    sck                 = 8;
-    mosi                = 9;
-    miso                = 10;
-    errled              = 1;
-    rdyled              = 14;
-    pgmled              = 16;
-    vfyled              = 17;
+    id                     = "alf";
+    desc                   = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
+    type                   = "par";
+    vcc                    = 2, 3, 4, 5;
+    buff                   = 6;
+    reset                  = 7;
+    sck                    = 8;
+    mosi                   = 9;
+    miso                   = 10;
+    errled                 = 1;
+    rdyled                 = 14;
+    pgmled                 = 16;
+    vfyled                 = 17;
 ;
 
 #------------------------------------------------------------
@@ -472,14 +470,14 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "sp12";
-    desc                = "Steve Bolt's Programmer";
-    type                = "par";
-    vcc                 = 4, 5, 6, 7, 8;
-    reset               = 3;
-    sck                 = 2;
-    mosi                = 9;
-    miso                = 11;
+    id                     = "sp12";
+    desc                   = "Steve Bolt's Programmer";
+    type                   = "par";
+    vcc                    = 4, 5, 6, 7, 8;
+    reset                  = 3;
+    sck                    = 2;
+    mosi                   = 9;
+    miso                   = 11;
 ;
 
 #------------------------------------------------------------
@@ -487,13 +485,13 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "picoweb";
-    desc                = "Picoweb Programming Cable, http://www.picoweb.net/";
-    type                = "par";
-    reset               = 2;
-    sck                 = 3;
-    mosi                = 4;
-    miso                = 13;
+    id                     = "picoweb";
+    desc                   = "Picoweb Programming Cable, http://www.picoweb.net/";
+    type                   = "par";
+    reset                  = 2;
+    sck                    = 3;
+    mosi                   = 4;
+    miso                   = 13;
 ;
 
 #------------------------------------------------------------
@@ -501,13 +499,13 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "abcmini";
-    desc                = "ABCmini Board, aka Dick Smith HOTCHIP";
-    type                = "par";
-    reset               = 4;
-    sck                 = 3;
-    mosi                = 2;
-    miso                = 10;
+    id                     = "abcmini";
+    desc                   = "ABCmini Board, aka Dick Smith HOTCHIP";
+    type                   = "par";
+    reset                  = 4;
+    sck                    = 3;
+    mosi                   = 2;
+    miso                   = 10;
 ;
 
 #------------------------------------------------------------
@@ -515,13 +513,13 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "futurlec";
-    desc                = "Futurlec.com programming cable.";
-    type                = "par";
-    reset               = 3;
-    sck                 = 2;
-    mosi                = 1;
-    miso                = 10;
+    id                     = "futurlec";
+    desc                   = "Futurlec.com programming cable.";
+    type                   = "par";
+    reset                  = 3;
+    sck                    = 2;
+    mosi                   = 1;
+    miso                   = 10;
 ;
 
 #------------------------------------------------------------
@@ -537,15 +535,15 @@ programmer
 # to SCK (plus vcc/gnd of course)
 
 programmer
-    id                  = "xil";
-    desc                = "Xilinx JTAG cable";
-    type                = "par";
-    vcc                 = 6;
-    buff                = 5;
-    reset               = 4;
-    sck                 = 3;
-    mosi                = 2;
-    miso                = 13;
+    id                     = "xil";
+    desc                   = "Xilinx JTAG cable";
+    type                   = "par";
+    vcc                    = 6;
+    buff                   = 5;
+    reset                  = 4;
+    sck                    = 3;
+    mosi                   = 2;
+    miso                   = 13;
 ;
 
 #------------------------------------------------------------
@@ -553,14 +551,14 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "dapa";
-    desc                = "Direct AVR Parallel Access cable";
-    type                = "par";
-    vcc                 = 3;
-    reset               = 16;
-    sck                 = 1;
-    mosi                = 2;
-    miso                = 11;
+    id                     = "dapa";
+    desc                   = "Direct AVR Parallel Access cable";
+    type                   = "par";
+    vcc                    = 3;
+    reset                  = 16;
+    sck                    = 1;
+    mosi                   = 2;
+    miso                   = 11;
 ;
 
 #------------------------------------------------------------
@@ -568,13 +566,13 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "atisp";
-    desc                = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
-    type                = "par";
-    reset               = ~6;
-    sck                 = ~8;
-    mosi                = ~7;
-    miso                = ~10;
+    id                     = "atisp";
+    desc                   = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
+    type                   = "par";
+    reset                  = ~6;
+    sck                    = ~8;
+    mosi                   = ~7;
+    miso                   = ~10;
 ;
 
 #------------------------------------------------------------
@@ -582,13 +580,13 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "ere-isp-avr";
-    desc                = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
-    type                = "par";
-    reset               = ~4;
-    sck                 = 3;
-    mosi                = 2;
-    miso                = 10;
+    id                     = "ere-isp-avr";
+    desc                   = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
+    type                   = "par";
+    reset                  = ~4;
+    sck                    = 3;
+    mosi                   = 2;
+    miso                   = 10;
 ;
 
 #------------------------------------------------------------
@@ -596,14 +594,14 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "blaster";
-    desc                = "Altera ByteBlaster";
-    type                = "par";
-    buff                = 14;
-    reset               = 3;
-    sck                 = 2;
-    mosi                = 8;
-    miso                = 11;
+    id                     = "blaster";
+    desc                   = "Altera ByteBlaster";
+    type                   = "par";
+    buff                   = 14;
+    reset                  = 3;
+    sck                    = 2;
+    mosi                   = 8;
+    miso                   = 11;
 ;
 
 #------------------------------------------------------------
@@ -614,11 +612,10 @@ programmer
 # disconnect port (download on http://electropol.free.fr/spip/spip.php?article27)
 
 programmer parent "pony-stk200"
-    id                  = "frank-stk200";
-    desc                = "Frank STK200";
-    type                = "par";
-    vcc                 = 5;
-    buff                = ; # delete buff pin assignment
+    id                     = "frank-stk200";
+    desc                   = "Frank STK200";
+    vcc                    = 5;
+    buff                   = ; # delete buff pin assignment
 ;
 
 #------------------------------------------------------------
@@ -629,42 +626,45 @@ programmer parent "pony-stk200"
 # http://www.atmel.com/dyn/products/tools_card.asp?tool_id=2877
 
 programmer
-    id                  = "89isp";
-    desc                = "Atmel at89isp cable";
-    type                = "par";
-    reset               = 17;
-    sck                 = 1;
-    mosi                = 2;
-    miso                = 10;
+    id                     = "89isp";
+    desc                   = "Atmel at89isp cable";
+    type                   = "par";
+    reset                  = 17;
+    sck                    = 1;
+    mosi                   = 2;
+    miso                   = 10;
 ;
 @HAVE_PARPORT_END@
 
 @HAVE_LINUXGPIO_BEGIN@
-#------------------------------------------------------------
-# linuxgpio
-#------------------------------------------------------------
 
-#This programmer bitbangs GPIO lines using the Linux sysfs GPIO interface
+# This programmer bitbangs GPIO lines using the Linux sysfs GPIO interface
 #
-#To enable it set the configuration below to match the GPIO lines connected to the
-#relevant ISP header pins and uncomment the entry definition. In case you don't
-#have the required permissions to edit this system wide config file put the
-#entry in a separate <your name>.conf file and use it with -C+<your name>.conf
-#on the command line.
+# To enable it set the configuration below to match the GPIO lines connected
+# to the relevant ISP header pins and uncomment the entry definition. In case
+# you don't have the required permissions to edit this system wide config
+# file put the entry in a separate <your name>.conf file and use it with
+# -C+<your name>.conf on the command line.
 #
-#To check if your avrdude build has support for the linuxgpio programmer compiled in,
-#use -c?type on the command line and look for linuxgpio in the list. If it's not available
-#you need pass the --enable-linuxgpio=yes option to configure and recompile avrdude.
+# To check if your avrdude build has support for the linuxgpio programmer
+# compiled in, use -c?type on the command line and look for linuxgpio in the
+# list. If it's not available you need pass the --enable-linuxgpio=yes option
+# to configure and recompile avrdude.
 #
-#programmer
-#  id    = "linuxgpio";
-#  desc  = "Use the Linux sysfs interface to bitbang GPIO lines";
-#  type  = "linuxgpio";
-#  reset = ?;
-#  sck   = ?;
-#  mosi  = ?;
-#  miso  = ?;
-#;
+#
+# #------------------------------------------------------------
+# # linuxgpio
+# #------------------------------------------------------------
+#
+# programmer
+#     id                   = "linuxgpio";
+#     desc                 = "Use the Linux sysfs interface to bitbang GPIO lines";
+#     type                 = "linuxgpio";
+#     reset                = ?;
+#     sck                  = ?;
+#     mosi                 = ?;
+#     miso                 = ?;
+# ;
 @HAVE_LINUXGPIO_END@
 
 @HAVE_LINUXSPI_BEGIN@
@@ -679,11 +679,11 @@ programmer
 #
 
 programmer
-    id                  = "linuxspi";
-    desc                = "Use Linux SPI device in /dev/spidev*";
-    type                = "linuxspi";
-    connection_type     = spi;
-    reset               = 25;    # Pi GPIO number - this is J8:22
+    id                     = "linuxspi";
+    desc                   = "Use Linux SPI device in /dev/spidev*";
+    type                   = "linuxspi";
+    connection_type        = spi;
+    reset                  = 25;    # Pi GPIO number - this is J8:22
 ;
 @HAVE_LINUXSPI_END@
 
@@ -699,10 +699,10 @@ programmer
 # Basically STK500v2 protocol, with some glue to trigger the bootloader
 
 programmer
-    id                  = "wiring";
-    desc                = "Wiring";
-    type                = "wiring";
-    connection_type     = serial;
+    id                     = "wiring";
+    desc                   = "Wiring";
+    type                   = "wiring";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -710,10 +710,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "arduino";
-    desc                = "Arduino";
-    type                = "arduino";
-    connection_type     = serial;
+    id                     = "arduino";
+    desc                   = "Arduino";
+    type                   = "arduino";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -721,10 +721,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "xbee";
-    desc                = "XBee Series 2 Over-The-Air (XBeeBoot)";
-    type                = "xbee";
-    connection_type     = serial;
+    id                     = "xbee";
+    desc                   = "XBee Series 2 Over-The-Air (XBeeBoot)";
+    type                   = "xbee";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -752,25 +752,25 @@ programmer
 # these FTDI ICs has been designed.
 
 programmer
-    id                  = "avrftdi";
-    desc                = "FT2232D based generic programmer";
-    type                = "avrftdi";
-    connection_type     = usb;
-    usbvid              = 0x0403;
-    usbpid              = 0x6010;
-    usbdev              = "A";
-#ISP-signals - lower ADBUS-Nibble (default)
-    reset               = 3;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
-#LED SIGNALs - higher ADBUS-Nibble
-#  errled = 4;
-#  rdyled = 5;
-#  pgmled = 6;
-#  vfyled = 7;
-#Buffer Signal - ACBUS - Nibble
-#  buff   = 8;
+    id                     = "avrftdi";
+    desc                   = "FT2232D based generic programmer";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6010;
+    usbdev                 = "A";
+#   ISP-signals - lower ADBUS-Nibble (default)
+    reset                  = 3;
+    sck                    = 0;
+    mosi                   = 1;
+    miso                   = 2;
+#   LED SIGNALs - higher ADBUS-Nibble
+#   errled                 = 4;
+#   rdyled                 = 5;
+#   pgmled                 = 6;
+#   vfyled                 = 7;
+#   Buffer Signal - ACBUS - Nibble
+#   buff                   = 8;
 ;
 
 #------------------------------------------------------------
@@ -781,27 +781,27 @@ programmer
 # 4 LEDs directly attached, all active low.
 
 programmer
-    id                  = "2232HIO";
-    desc                = "FT2232H based generic programmer";
-    type                = "avrftdi";
-    connection_type     = usb;
-    usbvid              = 0x0403;
+    id                     = "2232HIO";
+    desc                   = "FT2232H based generic programmer";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
 # Note: This PID is reserved for generic H devices and
 # should be programmed into the EEPROM
-#  usbpid     = 0x8A48;
-    usbpid              = 0x6010;
-    usbdev              = "A";
-    buff                = ~4;
+#   usbpid                 = 0x8A48;
+    usbpid                 = 0x6010;
+    usbdev                 = "A";
+    buff                   = ~4;
 #ISP-signals
-    reset               = 3;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
+    reset                  = 3;
+    sck                    = 0;
+    mosi                   = 1;
+    miso                   = 2;
 #LED SIGNALs
-    errled              = ~11;
-    rdyled              = ~14;
-    pgmled              = ~13;
-    vfyled              = ~12;
+    errled                 = ~11;
+    rdyled                 = ~14;
+    pgmled                 = ~13;
+    vfyled                 = ~12;
 ;
 
 #------------------------------------------------------------
@@ -812,10 +812,9 @@ programmer
 #device ID of 0x6011.
 
 programmer parent "avrftdi"
-    id                  = "4232h";
-    desc                = "FT4232H based generic programmer";
-    type                = "avrftdi";
-    usbpid              = 0x6011;
+    id                     = "4232h";
+    desc                   = "FT4232H based generic programmer";
+    usbpid                 = 0x6011;
 ;
 
 #------------------------------------------------------------
@@ -823,24 +822,23 @@ programmer parent "avrftdi"
 #------------------------------------------------------------
 
 programmer
-    id                  = "jtagkey";
-    desc                = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
-    type                = "avrftdi";
-    connection_type     = usb;
-    usbvid              = 0x0403;
-# Note: This PID is used in all JTAGKey variants
-    usbpid              = 0xcff8;
-    usbdev              = "A";
-    buff                = ~4;
-#ISP-signals => 20 - Pin connector on JTAGKey
-    reset               = 3; # TMS 7 violet
-    sck                 = 0; # TCK 9 white
-    mosi                = 1; # TDI 5 green
-    miso                = 2; # TDO 13 orange
-# VTG           VREF 1 brown with red tip
-# GND           GND 20 black
-# The colors are on the 20 pin breakout cable
-# from Amontec
+    id                     = "jtagkey";
+    desc                   = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
+#   Note: This PID is used in all JTAGKey variants
+    usbpid                 = 0xcff8;
+    usbdev                 = "A";
+    buff                   = ~4;
+#   ISP-signals => 20 - Pin connector on JTAGKey
+    reset                  = 3; # TMS 7 violet
+    sck                    = 0; # TCK 9 white
+    mosi                   = 1; # TDI 5 green
+    miso                   = 2; # TDO 13 orange
+#   VTG           VREF 1 brown with red tip
+#   GND           GND 20 black
+# The colors are on the 20 pin breakout cable from Amontec
 ;
 
 #------------------------------------------------------------
@@ -848,18 +846,18 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "ft232h";
-    desc                = "FT232H in MPSSE mode";
-    type                = "avrftdi";
-    connection_type     = usb;
-    usbvid              = 0x0403;
-    usbpid              = 0x6014;
-    usbdev              = "A";
+    id                     = "ft232h";
+    desc                   = "FT232H in MPSSE mode";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6014;
+    usbdev                 = "A";
 #ISP-signals
-    reset               = 3; # AD3 (TMS)
-    sck                 = 0; # AD0 (TCK)
-    mosi                = 1; # AD1 (TDI)
-    miso                = 2; # AD2 (TDO)
+    reset                  = 3; # AD3 (TMS)
+    sck                    = 0; # AD0 (TCK)
+    mosi                   = 1; # AD1 (TDI)
+    miso                   = 2; # AD2 (TDO)
 ;
 
 #------------------------------------------------------------
@@ -875,10 +873,9 @@ programmer
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
 
 programmer parent "ft232h"
-    id                  = "um232h";
-    desc                = "UM232H module from FTDI";
-    type                = "avrftdi";
-    usbpid              = 0x6014;
+    id                     = "um232h";
+    desc                   = "UM232H module from FTDI";
+    usbpid                 = 0x6014;
 ;
 
 #------------------------------------------------------------
@@ -894,10 +891,9 @@ programmer parent "ft232h"
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
 
 programmer parent "ft232h"
-    id                  = "c232hm";
-    desc                = "C232HM cable from FTDI";
-    type                = "avrftdi";
-    usbpid              = 0x6014;
+    id                     = "c232hm";
+    desc                   = "C232HM cable from FTDI";
+    usbpid                 = 0x6014;
 ;
 
 #------------------------------------------------------------
@@ -919,13 +915,12 @@ programmer parent "ft232h"
 # It is basically the same entry as jtagkey with different usb ids.
 
 programmer parent "jtagkey"
-    id                  = "o-link";
-    desc                = "O-Link, OpenJTAG from www.100ask.net";
-    type                = "avrftdi";
-    usbvid              = 0x1457;
-    usbpid              = 0x5118;
-    usbvendor           = "www.100ask.net";
-    usbproduct          = "USB<=>JTAG&RS232";
+    id                     = "o-link";
+    desc                   = "O-Link, OpenJTAG from www.100ask.net";
+    usbvid                 = 0x1457;
+    usbpid                 = 0x5118;
+    usbvendor              = "www.100ask.net";
+    usbproduct             = "USB<=>JTAG&RS232";
 ;
 
 #------------------------------------------------------------
@@ -935,16 +930,16 @@ programmer parent "jtagkey"
 # http://wiki.openmoko.org/wiki/Debug_Board_v3
 
 programmer
-    id                  = "openmoko";
-    desc                = "Openmoko debug board (v3)";
-    type                = "avrftdi";
-    usbvid              = 0x1457;
-    usbpid              = 0x5118;
-    usbdev              = "A";
-    reset               = 3; # TMS 7
-    sck                 = 0; # TCK 9
-    mosi                = 1; # TDI 5
-    miso                = 2; # TDO 13
+    id                     = "openmoko";
+    desc                   = "Openmoko debug board (v3)";
+    type                   = "avrftdi";
+    usbvid                 = 0x1457;
+    usbpid                 = 0x5118;
+    usbdev                 = "A";
+    reset                  = 3; # TMS 7
+    sck                    = 0; # TCK 9
+    mosi                   = 1; # TDI 5
+    miso                   = 2; # TDO 13
 ;
 
 #------------------------------------------------------------
@@ -955,22 +950,22 @@ programmer
 # Schematic and user manual: http://www.cs.put.poznan.pl/wswitala/download/pdf/811EVBK.pdf
 
 programmer
-    id                  = "lm3s811";
-    desc                = "Luminary Micro LM3S811 Eval Board (Rev. A)";
-    type                = "avrftdi";
-    connection_type     = usb;
-    usbvid              = 0x0403;
-    usbpid              = 0xbcd9;
-    usbdev              = "A";
-    usbvendor           = "LMI";
-    usbproduct          = "LM3S811 Evaluation Board";
+    id                     = "lm3s811";
+    desc                   = "Luminary Micro LM3S811 Eval Board (Rev. A)";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0xbcd9;
+    usbdev                 = "A";
+    usbvendor              = "LMI";
+    usbproduct             = "LM3S811 Evaluation Board";
 # Enable correct buffers
-    buff                = 7;
+    buff                   = 7;
 #ISP-signals - lower ACBUS-Nibble (default)
-    reset               = 3;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
+    reset                  = 3;
+    sck                    = 0;
+    mosi                   = 1;
+    miso                   = 2;
 ;
 
 #------------------------------------------------------------
@@ -980,18 +975,18 @@ programmer
 # submitted as bug #46020
 
 programmer
-    id                  = "tumpa";
-    desc                = "TIAO USB Multi-Protocol Adapter";
-    type                = "avrftdi";
-    connection_type     = usb;
-    usbvid              = 0x0403;
-    usbpid              = 0x8a98;
-    usbdev              = "A";
-    usbvendor           = "TIAO";
-    reset               = 3; # TMS 7
-    sck                 = 0; # TCK 9
-    mosi                = 1; # TDI 5
-    miso                = 2; # TDO 13
+    id                     = "tumpa";
+    desc                   = "TIAO USB Multi-Protocol Adapter";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x8a98;
+    usbdev                 = "A";
+    usbvendor              = "TIAO";
+    reset                  = 3; # TMS 7
+    sck                    = 0; # TCK 9
+    mosi                   = 1; # TDI 5
+    miso                   = 2; # TDO 13
 ;
 
 #------------------------------------------------------------
@@ -1016,19 +1011,19 @@ programmer
 #  * Powering target from JTAG pin 19 allows KT-LINK current measurement.
 
 programmer
-    id                  = "ktlink";
-    desc                = "KT-LINK FT2232H interface with IO switching and voltage buffers.";
-    type                = "avrftdi";
-    connection_type     = usb;
-    usbvid              = 0x0403;
-    usbpid              = 0xbbe2;
-    usbdev              = "A";
-    buff                = 5, ~10, ~13, ~14;
-    reset               = 8;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
-    rdyled              = ~15;
+    id                     = "ktlink";
+    desc                   = "KT-LINK FT2232H interface with IO switching and voltage buffers.";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0xbbe2;
+    usbdev                 = "A";
+    buff                   = 5, ~10, ~13, ~14;
+    reset                  = 8;
+    sck                    = 0;
+    mosi                   = 1;
+    miso                   = 2;
+    rdyled                 = ~15;
 ;
 
 #------------------------------------------------------------
@@ -1036,11 +1031,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "serialupdi";
-    desc                = "SerialUPDI";
-    type                = "serialupdi";
-    connection_type     = serial;
-    hvupdi_support      = 1;
+    id                     = "serialupdi";
+    desc                   = "SerialUPDI";
+    type                   = "serialupdi";
+    connection_type        = serial;
+    hvupdi_support         = 1;
 ;
 
 #------------------------------------------------------------
@@ -1048,10 +1043,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "avrisp";
-    desc                = "Atmel AVR ISP";
-    type                = "stk500";
-    connection_type     = serial;
+    id                     = "avrisp";
+    desc                   = "Atmel AVR ISP";
+    type                   = "stk500";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1059,10 +1054,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "avrispv2";
-    desc                = "Atmel AVR ISP V2";
-    type                = "stk500v2";
-    connection_type     = serial;
+    id                     = "avrispv2";
+    desc                   = "Atmel AVR ISP V2";
+    type                   = "stk500v2";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1070,10 +1065,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "avrispmkII";
-    desc                = "Atmel AVR ISP mkII";
-    type                = "stk500v2";
-    connection_type     = usb;
+    id                     = "avrispmkII";
+    desc                   = "Atmel AVR ISP mkII";
+    type                   = "stk500v2";
+    connection_type        = usb;
 ;
 
 #------------------------------------------------------------
@@ -1081,8 +1076,7 @@ programmer
 #------------------------------------------------------------
 
 programmer parent "avrispmkII"
-    id                  = "avrisp2";
-    type                = "stk500v2";
+    id                     = "avrisp2";
 ;
 
 #------------------------------------------------------------
@@ -1090,10 +1084,10 @@ programmer parent "avrispmkII"
 #------------------------------------------------------------
 
 programmer
-    id                  = "buspirate";
-    desc                = "The Bus Pirate";
-    type                = "buspirate";
-    connection_type     = serial;
+    id                     = "buspirate";
+    desc                   = "The Bus Pirate";
+    type                   = "buspirate";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1101,17 +1095,17 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "buspirate_bb";
-    desc                = "The Bus Pirate (bitbang interface, supports TPI)";
-    type                = "buspirate_bb";
-    connection_type     = serial;
+    id                     = "buspirate_bb";
+    desc                   = "The Bus Pirate (bitbang interface, supports TPI)";
+    type                   = "buspirate_bb";
+    connection_type        = serial;
   # pins are bits in bitbang byte (numbers are 87654321)
   # 1|POWER|PULLUP|AUX|MOSI|CLK|MISO|CS
-    reset               = 1;
-    sck                 = 3;
-    mosi                = 4;
-    miso                = 2;
-  #vcc    = 7; This is internally set independent of this setting.
+    reset                  = 1;
+    sck                    = 3;
+    mosi                   = 4;
+    miso                   = 2;
+  # vcc                    = 7; # Internally set independent of this setting
 ;
 
 #------------------------------------------------------------
@@ -1124,10 +1118,10 @@ programmer
 # below instead.
 
 programmer
-    id                  = "stk500";
-    desc                = "Atmel STK500";
-    type                = "stk500generic";
-    connection_type     = serial;
+    id                     = "stk500";
+    desc                   = "Atmel STK500";
+    type                   = "stk500generic";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1135,10 +1129,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk500v1";
-    desc                = "Atmel STK500 Version 1.x firmware";
-    type                = "stk500";
-    connection_type     = serial;
+    id                     = "stk500v1";
+    desc                   = "Atmel STK500 Version 1.x firmware";
+    type                   = "stk500";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1146,10 +1140,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "mib510";
-    desc                = "Crossbow MIB510 programming board";
-    type                = "stk500";
-    connection_type     = serial;
+    id                     = "mib510";
+    desc                   = "Crossbow MIB510 programming board";
+    type                   = "stk500";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1157,10 +1151,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk500v2";
-    desc                = "Atmel STK500 Version 2.x firmware";
-    type                = "stk500v2";
-    connection_type     = serial;
+    id                     = "stk500v2";
+    desc                   = "Atmel STK500 Version 2.x firmware";
+    type                   = "stk500v2";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1168,10 +1162,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk500pp";
-    desc                = "Atmel STK500 V2 in parallel programming mode";
-    type                = "stk500pp";
-    connection_type     = serial;
+    id                     = "stk500pp";
+    desc                   = "Atmel STK500 V2 in parallel programming mode";
+    type                   = "stk500pp";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1179,10 +1173,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk500hvsp";
-    desc                = "Atmel STK500 V2 in high-voltage serial programming mode";
-    type                = "stk500hvsp";
-    connection_type     = serial;
+    id                     = "stk500hvsp";
+    desc                   = "Atmel STK500 V2 in high-voltage serial programming mode";
+    type                   = "stk500hvsp";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1190,10 +1184,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk600";
-    desc                = "Atmel STK600";
-    type                = "stk600";
-    connection_type     = usb;
+    id                     = "stk600";
+    desc                   = "Atmel STK600";
+    type                   = "stk600";
+    connection_type        = usb;
 ;
 
 #------------------------------------------------------------
@@ -1201,10 +1195,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk600pp";
-    desc                = "Atmel STK600 in parallel programming mode";
-    type                = "stk600pp";
-    connection_type     = usb;
+    id                     = "stk600pp";
+    desc                   = "Atmel STK600 in parallel programming mode";
+    type                   = "stk600pp";
+    connection_type        = usb;
 ;
 
 #------------------------------------------------------------
@@ -1212,10 +1206,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "stk600hvsp";
-    desc                = "Atmel STK600 in high-voltage serial programming mode";
-    type                = "stk600hvsp";
-    connection_type     = usb;
+    id                     = "stk600hvsp";
+    desc                   = "Atmel STK600 in high-voltage serial programming mode";
+    type                   = "stk600hvsp";
+    connection_type        = usb;
 ;
 
 #------------------------------------------------------------
@@ -1223,10 +1217,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "avr910";
-    desc                = "Atmel Low Cost Serial Programmer";
-    type                = "avr910";
-    connection_type     = serial;
+    id                     = "avr910";
+    desc                   = "Atmel Low Cost Serial Programmer";
+    type                   = "avr910";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1234,14 +1228,14 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "ft245r";
-    desc                = "FT245R Synchronous BitBang";
-    type                = "ftdi_syncbb";
-    connection_type     = usb;
-    reset               = 4; # D4
-    sck                 = 0; # D0
-    mosi                = 2; # D2
-    miso                = 1; # D1
+    id                     = "ft245r";
+    desc                   = "FT245R Synchronous BitBang";
+    type                   = "ftdi_syncbb";
+    connection_type        = usb;
+    reset                  = 4; # D4
+    sck                    = 0; # D0
+    mosi                   = 2; # D2
+    miso                   = 1; # D1
 ;
 
 #------------------------------------------------------------
@@ -1249,14 +1243,14 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "ft232r";
-    desc                = "FT232R Synchronous BitBang";
-    type                = "ftdi_syncbb";
-    connection_type     = usb;
-    reset               = 4;  # DTR
-    sck                 = 0;  # TxD
-    mosi                = 2;  # RTS
-    miso                = 1;  # RxD
+    id                     = "ft232r";
+    desc                   = "FT232R Synchronous BitBang";
+    type                   = "ftdi_syncbb";
+    connection_type        = usb;
+    reset                  = 4;  # DTR
+    sck                    = 0;  # TxD
+    mosi                   = 2;  # RTS
+    miso                   = 1;  # RxD
 ;
 
 #------------------------------------------------------------
@@ -1266,14 +1260,14 @@ programmer
 # see http://www.bitwizard.nl/wiki/index.php/FTDI_ATmega
 
 programmer
-    id                  = "bwmega";
-    desc                = "BitWizard ftdi_atmega builtin programmer";
-    type                = "ftdi_syncbb";
-    connection_type     = usb;
-    reset               = 7;  # RI
-    sck                 = 6;  # DCD
-    mosi                = 3;  # CTS
-    miso                = 5;  # DSR
+    id                     = "bwmega";
+    desc                   = "BitWizard ftdi_atmega builtin programmer";
+    type                   = "ftdi_syncbb";
+    connection_type        = usb;
+    reset                  = 7;  # RI
+    sck                    = 6;  # DCD
+    mosi                   = 3;  # CTS
+    miso                   = 5;  # DSR
 ;
 
 #------------------------------------------------------------
@@ -1284,14 +1278,14 @@ programmer
 # Note: pins are numbered from 1!
 
 programmer
-    id                  = "arduino-ft232r";
-    desc                = "Arduino: FT232R connected to ISP";
-    type                = "ftdi_syncbb";
-    connection_type     = usb;
-    reset               = 7;  # RI  X3(4)
-    sck                 = 5;  # DSR X3(2)
-    mosi                = 6;  # DCD X3(3)
-    miso                = 3;  # CTS X3(1)
+    id                     = "arduino-ft232r";
+    desc                   = "Arduino: FT232R connected to ISP";
+    type                   = "ftdi_syncbb";
+    connection_type        = usb;
+    reset                  = 7;  # RI  X3(4)
+    sck                    = 5;  # DSR X3(2)
+    mosi                   = 6;  # DCD X3(3)
+    miso                   = 3;  # CTS X3(1)
 ;
 
 #------------------------------------------------------------
@@ -1299,15 +1293,15 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "tc2030";
-    desc                = "Tag-Connect TC2030";
-    type                = "ftdi_syncbb";
-    connection_type     = usb;
+    id                     = "tc2030";
+    desc                   = "Tag-Connect TC2030";
+    type                   = "ftdi_syncbb";
+    connection_type        = usb;
   #                      FOR TPI devices:
-    reset               = 3;  # CTS = D3 (wire to ~RESET)
-    sck                 = 2;  # RTS = D2 (wire to SCK)
-    mosi                = 0;  # TxD = D0 (wire to TPIDATA via 1k resistor)
-    miso                = 1;  # RxD = D1 (wire to TPIDATA directly)
+    reset                  = 3;  # CTS = D3 (wire to ~RESET)
+    sck                    = 2;  # RTS = D2 (wire to SCK)
+    mosi                   = 0;  # TxD = D0 (wire to TPIDATA via 1k resistor)
+    miso                   = 1;  # RxD = D1 (wire to TPIDATA directly)
 ;
 
 #------------------------------------------------------------
@@ -1317,9 +1311,8 @@ programmer
 # website mentioned above uses this id
 
 programmer parent "arduino-ft232r"
-    id                  = "diecimila";
-    desc                = "alias for arduino-ft232r";
-    type                = "ftdi_syncbb";
+    id                     = "diecimila";
+    desc                   = "alias for arduino-ft232r";
 ;
 
 #------------------------------------------------------------
@@ -1334,14 +1327,14 @@ programmer parent "arduino-ft232r"
 # http://akizukidenshi.com/download/ds/akizuki/k6096_manual_20130816.pdf
 
 programmer
-    id                  = "uncompatino";
-    desc                = "uncompatino with all pairs of pins shorted";
-    type                = "ftdi_syncbb";
-    connection_type     = usb;
-    reset               = 7; # ri
-    sck                 = 5; # dsr
-    mosi                = 6; # dcd
-    miso                = 3; # cts
+    id                     = "uncompatino";
+    desc                   = "uncompatino with all pairs of pins shorted";
+    type                   = "ftdi_syncbb";
+    connection_type        = usb;
+    reset                  = 7; # ri
+    sck                    = 5; # dsr
+    mosi                   = 6; # dcd
+    miso                   = 3; # cts
 ;
 
 #------------------------------------------------------------
@@ -1363,14 +1356,14 @@ programmer
 # the following table is adjusted.
 
 programmer
-    id                  = "ttl232r";
-    desc                = "FTDI TTL232R-5V with ICSP adapter";
-    type                = "ftdi_syncbb";
-    connection_type     = usb;
-    reset               = 0; # txd
-    sck                 = 1; # rxd
-    mosi                = 3; # cts
-    miso                = 2; # rts
+    id                     = "ttl232r";
+    desc                   = "FTDI TTL232R-5V with ICSP adapter";
+    type                   = "ftdi_syncbb";
+    connection_type        = usb;
+    reset                  = 0; # txd
+    sck                    = 1; # rxd
+    mosi                   = 3; # cts
+    miso                   = 2; # rts
 ;
 
 #------------------------------------------------------------
@@ -1378,24 +1371,24 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "usbasp";
-    desc                = "USBasp, http://www.fischl.de/usbasp/";
-    type                = "usbasp";
-    connection_type     = usb;
-    usbvid              = 0x16c0; # VOTI
-    usbpid              = 0x05dc; # Obdev's free shared PID
-    usbvendor           = "www.fischl.de";
-    usbproduct          = "USBasp";
+    id                     = "usbasp";
+    desc                   = "USBasp, http://www.fischl.de/usbasp/";
+    type                   = "usbasp";
+    connection_type        = usb;
+    usbvid                 = 0x16c0; # VOTI
+    usbpid                 = 0x05dc; # Obdev's free shared PID
+    usbvendor              = "www.fischl.de";
+    usbproduct             = "USBasp";
   # following variants are autodetected for id "usbasp"
 
   # original usbasp from fischl.de
   # see above "usbasp"
 
   # old usbasp from fischl.de
-  #usbvid     = 0x03EB; # ATMEL
-  #usbpid     = 0xC7B4; # (unoffical) USBasp
-  #usbvendor  = "www.fischl.de";
-  #usbproduct = "USBasp";
+  # usbvid                 = 0x03EB; # ATMEL
+  # usbpid                 = 0xC7B4; # (unoffical) USBasp
+  # usbvendor              = "www.fischl.de";
+  # usbproduct             = "USBasp";
 
   # NIBObee (only if -P nibobee is given on command line)
   # see below "nibobee"
@@ -1406,14 +1399,14 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "nibobee";
-    desc                = "NIBObee";
-    type                = "usbasp";
-    connection_type     = usb;
-    usbvid              = 0x16c0; # VOTI
-    usbpid              = 0x092f; # NIBObee PID
-    usbvendor           = "www.nicai-systems.com";
-    usbproduct          = "NIBObee";
+    id                     = "nibobee";
+    desc                   = "NIBObee";
+    type                   = "usbasp";
+    connection_type        = usb;
+    usbvid                 = 0x16c0; # VOTI
+    usbpid                 = 0x092f; # NIBObee PID
+    usbvendor              = "www.nicai-systems.com";
+    usbproduct             = "NIBObee";
 ;
 
 #------------------------------------------------------------
@@ -1421,14 +1414,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "usbasp-clone";
-    desc                = "Any usbasp clone with correct VID/PID";
-    type                = "usbasp";
-    connection_type     = usb;
-    usbvid              = 0x16c0; # VOTI
-    usbpid              = 0x05dc; # Obdev's free shared PID
-  #usbvendor  = "";
-  #usbproduct = "";
+    id                     = "usbasp-clone";
+    desc                   = "Any usbasp clone with correct VID/PID";
+    type                   = "usbasp";
+    connection_type        = usb;
+    usbvid                 = 0x16c0; # VOTI
+    usbpid                 = 0x05dc; # Obdev's free shared PID
 ;
 
 #------------------------------------------------------------
@@ -1441,12 +1432,12 @@ programmer
 # connects to TPIDATA.
 
 programmer
-    id                  = "usbtiny";
-    desc                = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
-    type                = "usbtiny";
-    connection_type     = usb;
-    usbvid              = 0x1781;
-    usbpid              = 0x0c9f;
+    id                     = "usbtiny";
+    desc                   = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
+    type                   = "usbtiny";
+    connection_type        = usb;
+    usbvid                 = 0x1781;
+    usbpid                 = 0x0c9f;
 ;
 
 #------------------------------------------------------------
@@ -1454,12 +1445,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "arduinoisp";
-    desc                = "Arduino ISP Programmer";
-    type                = "usbtiny";
-    connection_type     = usb;
-    usbvid              = 0x2341;
-    usbpid              = 0x0049;
+    id                     = "arduinoisp";
+    desc                   = "Arduino ISP Programmer";
+    type                   = "usbtiny";
+    connection_type        = usb;
+    usbvid                 = 0x2341;
+    usbpid                 = 0x0049;
 ;
 
 #------------------------------------------------------------
@@ -1467,12 +1458,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "arduinoisporg";
-    desc                = "Arduino ISP Programmer";
-    type                = "usbtiny";
-    connection_type     = usb;
-    usbvid              = 0x2a03;
-    usbpid              = 0x0049;
+    id                     = "arduinoisporg";
+    desc                   = "Arduino ISP Programmer";
+    type                   = "usbtiny";
+    connection_type        = usb;
+    usbvid                 = 0x2a03;
+    usbpid                 = 0x0049;
 ;
 
 #------------------------------------------------------------
@@ -1482,12 +1473,12 @@ programmer
 # commercial version of USBtiny, using a separate VID/PID
 
 programmer
-    id                  = "ehajo-isp";
-    desc                = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
-    type                = "usbtiny";
-    connection_type     = usb;
-    usbvid              = 0x16d0;
-    usbpid              = 0x0ba5;
+    id                     = "ehajo-isp";
+    desc                   = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
+    type                   = "usbtiny";
+    connection_type        = usb;
+    usbvid                 = 0x16d0;
+    usbpid                 = 0x0ba5;
 ;
 
 #------------------------------------------------------------
@@ -1498,12 +1489,12 @@ programmer
 # https://github.com/IowaScaledEngineering/ckt-avrprogrammer
 
 programmer
-    id                  = "iseavrprog";
-    desc                = "USBtiny-based programmer, https://iascaled.com";
-    type                = "usbtiny";
-    connection_type     = usb;
-    usbvid              = 0x1209;
-    usbpid              = 0x6570;
+    id                     = "iseavrprog";
+    desc                   = "USBtiny-based programmer, https://iascaled.com";
+    type                   = "usbtiny";
+    connection_type        = usb;
+    usbvid                 = 0x1209;
+    usbpid                 = 0x6570;
 ;
 
 #------------------------------------------------------------
@@ -1511,12 +1502,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "micronucleus";
-    desc                = "Micronucleus Bootloader";
-    type                = "micronucleus";
-    connection_type     = usb;
-    usbvid              = 0x16d0;
-    usbpid              = 0x0753;
+    id                     = "micronucleus";
+    desc                   = "Micronucleus Bootloader";
+    type                   = "micronucleus";
+    connection_type        = usb;
+    usbvid                 = 0x16d0;
+    usbpid                 = 0x0753;
 ;
 
 #------------------------------------------------------------
@@ -1524,12 +1515,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "teensy";
-    desc                = "Teensy Bootloader";
-    type                = "teensy";
-    connection_type     = usb;
-    usbvid              = 0x16c0;
-    usbpid              = 0x0478;
+    id                     = "teensy";
+    desc                   = "Teensy Bootloader";
+    type                   = "teensy";
+    connection_type        = usb;
+    usbvid                 = 0x16c0;
+    usbpid                 = 0x0478;
 ;
 
 #------------------------------------------------------------
@@ -1537,10 +1528,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "butterfly";
-    desc                = "Atmel Butterfly Development Board";
-    type                = "butterfly";
-    connection_type     = serial;
+    id                     = "butterfly";
+    desc                   = "Atmel Butterfly Development Board";
+    type                   = "butterfly";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1548,10 +1539,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "avr109";
-    desc                = "Atmel AppNote AVR109 Boot Loader";
-    type                = "butterfly";
-    connection_type     = serial;
+    id                     = "avr109";
+    desc                   = "Atmel AppNote AVR109 Boot Loader";
+    type                   = "butterfly";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1559,10 +1550,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "avr911";
-    desc                = "Atmel AppNote AVR911 AVROSP";
-    type                = "butterfly";
-    connection_type     = serial;
+    id                     = "avr911";
+    desc                   = "Atmel AppNote AVR911 AVROSP";
+    type                   = "butterfly";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1572,10 +1563,10 @@ programmer
 # suggested in http://forum.mikrokopter.de/topic-post48317.html
 
 programmer
-    id                  = "mkbutterfly";
-    desc                = "Mikrokopter.de Butterfly";
-    type                = "butterfly_mk";
-    connection_type     = serial;
+    id                     = "mkbutterfly";
+    desc                   = "Mikrokopter.de Butterfly";
+    type                   = "butterfly_mk";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -1583,8 +1574,7 @@ programmer
 #------------------------------------------------------------
 
 programmer parent "mkbutterfly"
-    id                  = "butterfly_mk";
-    type                = "butterfly_mk";
+    id                     = "butterfly_mk";
 ;
 
 #------------------------------------------------------------
@@ -1592,11 +1582,11 @@ programmer parent "mkbutterfly"
 #------------------------------------------------------------
 
 programmer
-    id                  = "jtagmkI";
-    desc                = "Atmel JTAG ICE (mkI)";
-    type                = "jtagmki";
-    connection_type     = serial;
-    baudrate            = 115200;    # default is 115200
+    id                     = "jtagmkI";
+    desc                   = "Atmel JTAG ICE (mkI)";
+    type                   = "jtagmki";
+    connection_type        = serial;
+    baudrate               = 115200;    # default is 115200
 ;
 
 #------------------------------------------------------------
@@ -1606,8 +1596,7 @@ programmer
 # easier to type
 
 programmer parent "jtagmkI"
-    id                  = "jtag1";
-    type                = "jtagmki";
+    id                     = "jtag1";
 ;
 
 #------------------------------------------------------------
@@ -1617,9 +1606,8 @@ programmer parent "jtagmkI"
 # easier to type
 
 programmer parent "jtag1"
-    id                  = "jtag1slow";
-    type                = "jtagmki";
-    baudrate            = 19200;
+    id                     = "jtag1slow";
+    baudrate               = 19200;
 ;
 
 #------------------------------------------------------------
@@ -1632,11 +1620,11 @@ programmer parent "jtag1"
 # still free to use a serial port with the -P option.
 
 programmer
-    id                  = "jtagmkII";
-    desc                = "Atmel JTAG ICE mkII";
-    type                = "jtagmkii";
-    connection_type     = usb;
-    baudrate            = 19200;    # default is 19200
+    id                     = "jtagmkII";
+    desc                   = "Atmel JTAG ICE mkII";
+    type                   = "jtagmkii";
+    connection_type        = usb;
+    baudrate               = 19200;    # default is 19200
 ;
 
 #------------------------------------------------------------
@@ -1646,8 +1634,7 @@ programmer
 # easier to type
 
 programmer parent "jtagmkII"
-    id                  = "jtag2slow";
-    type                = "jtagmkii";
+    id                     = "jtag2slow";
 ;
 
 #------------------------------------------------------------
@@ -1657,9 +1644,8 @@ programmer parent "jtagmkII"
 # JTAG ICE mkII @ 115200 Bd
 
 programmer parent "jtag2slow"
-    id                  = "jtag2fast";
-    type                = "jtagmkii";
-    baudrate            = 115200;
+    id                     = "jtag2fast";
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1669,8 +1655,7 @@ programmer parent "jtag2slow"
 # make the fast one the default, people will love that
 
 programmer parent "jtag2fast"
-    id                  = "jtag2";
-    type                = "jtagmkii";
+    id                     = "jtag2";
 ;
 
 #------------------------------------------------------------
@@ -1680,11 +1665,11 @@ programmer parent "jtag2fast"
 # JTAG ICE mkII in ISP mode
 
 programmer
-    id                  = "jtag2isp";
-    desc                = "Atmel JTAG ICE mkII in ISP mode";
-    type                = "jtagmkii_isp";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "jtag2isp";
+    desc                   = "Atmel JTAG ICE mkII in ISP mode";
+    type                   = "jtagmkii_isp";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1694,11 +1679,11 @@ programmer
 # JTAG ICE mkII in debugWire mode
 
 programmer
-    id                  = "jtag2dw";
-    desc                = "Atmel JTAG ICE mkII in debugWire mode";
-    type                = "jtagmkii_dw";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "jtag2dw";
+    desc                   = "Atmel JTAG ICE mkII in debugWire mode";
+    type                   = "jtagmkii_dw";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1708,11 +1693,11 @@ programmer
 # JTAG ICE mkII in AVR32 mode
 
 programmer
-    id                  = "jtagmkII_avr32";
-    desc                = "Atmel JTAG ICE mkII im AVR32 mode";
-    type                = "jtagmkii_avr32";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "jtagmkII_avr32";
+    desc                   = "Atmel JTAG ICE mkII im AVR32 mode";
+    type                   = "jtagmkii_avr32";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1722,11 +1707,11 @@ programmer
 # JTAG ICE mkII in AVR32 mode
 
 programmer
-    id                  = "jtag2avr32";
-    desc                = "Atmel JTAG ICE mkII im AVR32 mode";
-    type                = "jtagmkii_avr32";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "jtag2avr32";
+    desc                   = "Atmel JTAG ICE mkII im AVR32 mode";
+    type                   = "jtagmkii_avr32";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1736,11 +1721,11 @@ programmer
 # JTAG ICE mkII in PDI mode
 
 programmer
-    id                  = "jtag2pdi";
-    desc                = "Atmel JTAG ICE mkII PDI mode";
-    type                = "jtagmkii_pdi";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "jtag2pdi";
+    desc                   = "Atmel JTAG ICE mkII PDI mode";
+    type                   = "jtagmkii_pdi";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1750,11 +1735,11 @@ programmer
 # AVR Dragon in JTAG mode
 
 programmer
-    id                  = "dragon_jtag";
-    desc                = "Atmel AVR Dragon in JTAG mode";
-    type                = "dragon_jtag";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "dragon_jtag";
+    desc                   = "Atmel AVR Dragon in JTAG mode";
+    type                   = "dragon_jtag";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1764,11 +1749,11 @@ programmer
 # AVR Dragon in ISP mode
 
 programmer
-    id                  = "dragon_isp";
-    desc                = "Atmel AVR Dragon in ISP mode";
-    type                = "dragon_isp";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "dragon_isp";
+    desc                   = "Atmel AVR Dragon in ISP mode";
+    type                   = "dragon_isp";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1778,11 +1763,11 @@ programmer
 # AVR Dragon in PP mode
 
 programmer
-    id                  = "dragon_pp";
-    desc                = "Atmel AVR Dragon in PP mode";
-    type                = "dragon_pp";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "dragon_pp";
+    desc                   = "Atmel AVR Dragon in PP mode";
+    type                   = "dragon_pp";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1792,11 +1777,11 @@ programmer
 # AVR Dragon in HVSP mode
 
 programmer
-    id                  = "dragon_hvsp";
-    desc                = "Atmel AVR Dragon in HVSP mode";
-    type                = "dragon_hvsp";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "dragon_hvsp";
+    desc                   = "Atmel AVR Dragon in HVSP mode";
+    type                   = "dragon_hvsp";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1806,11 +1791,11 @@ programmer
 # AVR Dragon in debugWire mode
 
 programmer
-    id                  = "dragon_dw";
-    desc                = "Atmel AVR Dragon in debugWire mode";
-    type                = "dragon_dw";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "dragon_dw";
+    desc                   = "Atmel AVR Dragon in debugWire mode";
+    type                   = "dragon_dw";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1820,11 +1805,11 @@ programmer
 # AVR Dragon in PDI mode
 
 programmer
-    id                  = "dragon_pdi";
-    desc                = "Atmel AVR Dragon in PDI mode";
-    type                = "dragon_pdi";
-    connection_type     = usb;
-    baudrate            = 115200;
+    id                     = "dragon_pdi";
+    desc                   = "Atmel AVR Dragon in PDI mode";
+    type                   = "dragon_pdi";
+    connection_type        = usb;
+    baudrate               = 115200;
 ;
 
 #------------------------------------------------------------
@@ -1832,11 +1817,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "jtag3";
-    desc                = "Atmel AVR JTAGICE3 in JTAG mode";
-    type                = "jtagice3";
-    connection_type     = usb;
-    usbpid              = 0x2110, 0x2140;
+    id                     = "jtag3";
+    desc                   = "Atmel AVR JTAGICE3 in JTAG mode";
+    type                   = "jtagice3";
+    connection_type        = usb;
+    usbpid                 = 0x2110, 0x2140;
 ;
 
 #------------------------------------------------------------
@@ -1844,11 +1829,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "jtag3pdi";
-    desc                = "Atmel AVR JTAGICE3 in PDI mode";
-    type                = "jtagice3_pdi";
-    connection_type     = usb;
-    usbpid              = 0x2110, 0x2140;
+    id                     = "jtag3pdi";
+    desc                   = "Atmel AVR JTAGICE3 in PDI mode";
+    type                   = "jtagice3_pdi";
+    connection_type        = usb;
+    usbpid                 = 0x2110, 0x2140;
 ;
 
 #------------------------------------------------------------
@@ -1856,12 +1841,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "jtag3updi";
-    desc                = "Atmel AVR JTAGICE3 in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x2110, 0x2140;
-    hvupdi_support      = 1;
+    id                     = "jtag3updi";
+    desc                   = "Atmel AVR JTAGICE3 in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x2110, 0x2140;
+    hvupdi_support         = 1;
 ;
 
 #------------------------------------------------------------
@@ -1869,11 +1854,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "jtag3dw";
-    desc                = "Atmel AVR JTAGICE3 in debugWIRE mode";
-    type                = "jtagice3_dw";
-    connection_type     = usb;
-    usbpid              = 0x2110, 0x2140;
+    id                     = "jtag3dw";
+    desc                   = "Atmel AVR JTAGICE3 in debugWIRE mode";
+    type                   = "jtagice3_dw";
+    connection_type        = usb;
+    usbpid                 = 0x2110, 0x2140;
 ;
 
 #------------------------------------------------------------
@@ -1881,11 +1866,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "jtag3isp";
-    desc                = "Atmel AVR JTAGICE3 in ISP mode";
-    type                = "jtagice3_isp";
-    connection_type     = usb;
-    usbpid              = 0x2110, 0x2140;
+    id                     = "jtag3isp";
+    desc                   = "Atmel AVR JTAGICE3 in ISP mode";
+    type                   = "jtagice3_isp";
+    connection_type        = usb;
+    usbpid                 = 0x2110, 0x2140;
 ;
 
 #------------------------------------------------------------
@@ -1893,11 +1878,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "xplainedpro";
-    desc                = "Atmel AVR XplainedPro in JTAG mode";
-    type                = "jtagice3";
-    connection_type     = usb;
-    usbpid              = 0x2111;
+    id                     = "xplainedpro";
+    desc                   = "Atmel AVR XplainedPro in JTAG mode";
+    type                   = "jtagice3";
+    connection_type        = usb;
+    usbpid                 = 0x2111;
 ;
 
 #------------------------------------------------------------
@@ -1905,12 +1890,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "xplainedpro_updi";
-    desc                = "Atmel AVR XplainedPro in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x2111;
-    hvupdi_support      = 1;
+    id                     = "xplainedpro_updi";
+    desc                   = "Atmel AVR XplainedPro in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x2111;
+    hvupdi_support         = 1;
 ;
 
 #------------------------------------------------------------
@@ -1918,11 +1903,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "xplainedmini";
-    desc                = "Atmel AVR XplainedMini in ISP mode";
-    type                = "jtagice3_isp";
-    connection_type     = usb;
-    usbpid              = 0x2145;
+    id                     = "xplainedmini";
+    desc                   = "Atmel AVR XplainedMini in ISP mode";
+    type                   = "jtagice3_isp";
+    connection_type        = usb;
+    usbpid                 = 0x2145;
 ;
 
 #------------------------------------------------------------
@@ -1930,11 +1915,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "xplainedmini_dw";
-    desc                = "Atmel AVR XplainedMini in debugWIRE mode";
-    type                = "jtagice3_dw";
-    connection_type     = usb;
-    usbpid              = 0x2145;
+    id                     = "xplainedmini_dw";
+    desc                   = "Atmel AVR XplainedMini in debugWIRE mode";
+    type                   = "jtagice3_dw";
+    connection_type        = usb;
+    usbpid                 = 0x2145;
 ;
 
 #------------------------------------------------------------
@@ -1942,12 +1927,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "xplainedmini_updi";
-    desc                = "Atmel AVR XplainedMini in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x2145;
-    hvupdi_support      = 1;
+    id                     = "xplainedmini_updi";
+    desc                   = "Atmel AVR XplainedMini in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x2145;
+    hvupdi_support         = 1;
 ;
 
 #------------------------------------------------------------
@@ -1955,11 +1940,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "atmelice";
-    desc                = "Atmel-ICE (ARM/AVR) in JTAG mode";
-    type                = "jtagice3";
-    connection_type     = usb;
-    usbpid              = 0x2141;
+    id                     = "atmelice";
+    desc                   = "Atmel-ICE (ARM/AVR) in JTAG mode";
+    type                   = "jtagice3";
+    connection_type        = usb;
+    usbpid                 = 0x2141;
 ;
 
 #------------------------------------------------------------
@@ -1967,11 +1952,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "atmelice_pdi";
-    desc                = "Atmel-ICE (ARM/AVR) in PDI mode";
-    type                = "jtagice3_pdi";
-    connection_type     = usb;
-    usbpid              = 0x2141;
+    id                     = "atmelice_pdi";
+    desc                   = "Atmel-ICE (ARM/AVR) in PDI mode";
+    type                   = "jtagice3_pdi";
+    connection_type        = usb;
+    usbpid                 = 0x2141;
 ;
 
 #------------------------------------------------------------
@@ -1979,12 +1964,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "atmelice_updi";
-    desc                = "Atmel-ICE (ARM/AVR) in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x2141;
-    hvupdi_support      = 1;
+    id                     = "atmelice_updi";
+    desc                   = "Atmel-ICE (ARM/AVR) in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x2141;
+    hvupdi_support         = 1;
 ;
 
 #------------------------------------------------------------
@@ -1992,11 +1977,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "atmelice_dw";
-    desc                = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
-    type                = "jtagice3_dw";
-    connection_type     = usb;
-    usbpid              = 0x2141;
+    id                     = "atmelice_dw";
+    desc                   = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
+    type                   = "jtagice3_dw";
+    connection_type        = usb;
+    usbpid                 = 0x2141;
 ;
 
 #------------------------------------------------------------
@@ -2004,11 +1989,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "atmelice_isp";
-    desc                = "Atmel-ICE (ARM/AVR) in ISP mode";
-    type                = "jtagice3_isp";
-    connection_type     = usb;
-    usbpid              = 0x2141;
+    id                     = "atmelice_isp";
+    desc                   = "Atmel-ICE (ARM/AVR) in ISP mode";
+    type                   = "jtagice3_isp";
+    connection_type        = usb;
+    usbpid                 = 0x2141;
 ;
 
 #------------------------------------------------------------
@@ -2016,11 +2001,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "powerdebugger";
-    desc                = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
-    type                = "jtagice3";
-    connection_type     = usb;
-    usbpid              = 0x2144;
+    id                     = "powerdebugger";
+    desc                   = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
+    type                   = "jtagice3";
+    connection_type        = usb;
+    usbpid                 = 0x2144;
 ;
 
 #------------------------------------------------------------
@@ -2028,11 +2013,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "powerdebugger_pdi";
-    desc                = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
-    type                = "jtagice3_pdi";
-    connection_type     = usb;
-    usbpid              = 0x2144;
+    id                     = "powerdebugger_pdi";
+    desc                   = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
+    type                   = "jtagice3_pdi";
+    connection_type        = usb;
+    usbpid                 = 0x2144;
 ;
 
 #------------------------------------------------------------
@@ -2040,12 +2025,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "powerdebugger_updi";
-    desc                = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x2144;
-    hvupdi_support      = 0, 1;
+    id                     = "powerdebugger_updi";
+    desc                   = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x2144;
+    hvupdi_support         = 0, 1;
 ;
 
 #------------------------------------------------------------
@@ -2053,11 +2038,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "powerdebugger_dw";
-    desc                = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
-    type                = "jtagice3_dw";
-    connection_type     = usb;
-    usbpid              = 0x2144;
+    id                     = "powerdebugger_dw";
+    desc                   = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
+    type                   = "jtagice3_dw";
+    connection_type        = usb;
+    usbpid                 = 0x2144;
 ;
 
 #------------------------------------------------------------
@@ -2065,11 +2050,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "powerdebugger_isp";
-    desc                = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
-    type                = "jtagice3_isp";
-    connection_type     = usb;
-    usbpid              = 0x2144;
+    id                     = "powerdebugger_isp";
+    desc                   = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
+    type                   = "jtagice3_isp";
+    connection_type        = usb;
+    usbpid                 = 0x2144;
 ;
 
 #------------------------------------------------------------
@@ -2077,12 +2062,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "pickit4_updi";
-    desc                = "MPLAB(R) PICkit 4 in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x2177, 0x2178, 0x2179;
-    hvupdi_support      = 0, 1, 2;
+    id                     = "pickit4_updi";
+    desc                   = "MPLAB(R) PICkit 4 in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x2177, 0x2178, 0x2179;
+    hvupdi_support         = 0, 1, 2;
 ;
 
 #------------------------------------------------------------
@@ -2090,11 +2075,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "pickit4_pdi";
-    desc                = "MPLAB(R) PICkit 4 in PDI mode";
-    type                = "jtagice3_pdi";
-    connection_type     = usb;
-    usbpid              = 0x2177, 0x2178, 0x2179;
+    id                     = "pickit4_pdi";
+    desc                   = "MPLAB(R) PICkit 4 in PDI mode";
+    type                   = "jtagice3_pdi";
+    connection_type        = usb;
+    usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
 
 #------------------------------------------------------------
@@ -2102,11 +2087,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "pickit4_isp";
-    desc                = "MPLAB(R) PICkit 4 in ISP mode";
-    type                = "jtagice3_isp";
-    connection_type     = usb;
-    usbpid              = 0x2177, 0x2178, 0x2179;
+    id                     = "pickit4_isp";
+    desc                   = "MPLAB(R) PICkit 4 in ISP mode";
+    type                   = "jtagice3_isp";
+    connection_type        = usb;
+    usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
 
 #------------------------------------------------------------
@@ -2114,12 +2099,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "snap_updi";
-    desc                = "MPLAB(R) SNAP in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x217f, 0x2180, 0x2181;
-    hvupdi_support      = 1;
+    id                     = "snap_updi";
+    desc                   = "MPLAB(R) SNAP in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x217f, 0x2180, 0x2181;
+    hvupdi_support         = 1;
 ;
 
 #------------------------------------------------------------
@@ -2127,11 +2112,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "snap_pdi";
-    desc                = "MPLAB(R) SNAP in PDI mode";
-    type                = "jtagice3_pdi";
-    connection_type     = usb;
-    usbpid              = 0x217f, 0x2180, 0x2181;
+    id                     = "snap_pdi";
+    desc                   = "MPLAB(R) SNAP in PDI mode";
+    type                   = "jtagice3_pdi";
+    connection_type        = usb;
+    usbpid                 = 0x217f, 0x2180, 0x2181;
 ;
 
 #------------------------------------------------------------
@@ -2139,11 +2124,11 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "snap_isp";
-    desc                = "MPLAB(R) SNAP in ISP mode";
-    type                = "jtagice3_isp";
-    connection_type     = usb;
-    usbpid              = 0x217f, 0x2180, 0x2181;
+    id                     = "snap_isp";
+    desc                   = "MPLAB(R) SNAP in ISP mode";
+    type                   = "jtagice3_isp";
+    connection_type        = usb;
+    usbpid                 = 0x217f, 0x2180, 0x2181;
 ;
 
 #------------------------------------------------------------
@@ -2151,12 +2136,12 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "pkobn_updi";
-    desc                = "Curiosity nano (nEDBG) in UPDI mode";
-    type                = "jtagice3_updi";
-    connection_type     = usb;
-    usbpid              = 0x2175;
-    hvupdi_support      = 1;
+    id                     = "pkobn_updi";
+    desc                   = "Curiosity nano (nEDBG) in UPDI mode";
+    type                   = "jtagice3_updi";
+    connection_type        = usb;
+    usbpid                 = 0x2175;
+    hvupdi_support         = 1;
 ;
 
 #------------------------------------------------------------
@@ -2164,10 +2149,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "pavr";
-    desc                = "Jason Kyle's pAVR Serial Programmer";
-    type                = "avr910";
-    connection_type     = serial;
+    id                     = "pavr";
+    desc                   = "Jason Kyle's pAVR Serial Programmer";
+    type                   = "avr910";
+    connection_type        = serial;
 ;
 
 #------------------------------------------------------------
@@ -2175,10 +2160,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "pickit2";
-    desc                = "MicroChip's PICkit2 Programmer";
-    type                = "pickit2";
-    connection_type     = usb;
+    id                     = "pickit2";
+    desc                   = "MicroChip's PICkit2 Programmer";
+    type                   = "pickit2";
+    connection_type        = usb;
 ;
 
 #------------------------------------------------------------
@@ -2186,10 +2171,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "flip1";
-    desc                = "FLIP USB DFU protocol version 1 (doc7618)";
-    type                = "flip1";
-    connection_type     = usb;
+    id                     = "flip1";
+    desc                   = "FLIP USB DFU protocol version 1 (doc7618)";
+    type                   = "flip1";
+    connection_type        = usb;
 ;
 
 #------------------------------------------------------------
@@ -2197,10 +2182,10 @@ programmer
 #------------------------------------------------------------
 
 programmer
-    id                  = "flip2";
-    desc                = "FLIP USB DFU protocol version 2 (AVR4023)";
-    type                = "flip2";
-    connection_type     = usb;
+    id                     = "flip2";
+    desc                   = "FLIP USB DFU protocol version 2 (AVR4023)";
+    type                   = "flip2";
+    connection_type        = usb;
 ;
 
 #------------------------------------------------------------
@@ -2228,14 +2213,14 @@ programmer
 # reset=!txd sck=rts mosi=dtr miso=cts
 
 programmer
-    id                  = "ponyser";
-    desc                = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
-    type                = "serbb";
-    connection_type     = serial;
-    reset               = ~3;
-    sck                 = 7;
-    mosi                = 4;
-    miso                = 8;
+    id                     = "ponyser";
+    desc                   = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
+    type                   = "serbb";
+    connection_type        = serial;
+    reset                  = ~3;
+    sck                    = 7;
+    mosi                   = 4;
+    miso                   = 8;
 ;
 
 #------------------------------------------------------------
@@ -2246,9 +2231,8 @@ programmer
 # reset=!txd sck=rts mosi=dtr miso=cts
 
 programmer parent "ponyser"
-    id                  = "siprog";
-    desc                = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
-    type                = "serbb";
+    id                     = "siprog";
+    desc                   = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
 ;
 
 #------------------------------------------------------------
@@ -2259,14 +2243,14 @@ programmer parent "ponyser"
 # reset=rts sck=dtr mosi=txd miso=cts
 
 programmer
-    id                  = "dasa";
-    desc                = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
-    type                = "serbb";
-    connection_type     = serial;
-    reset               = 7;
-    sck                 = 4;
-    mosi                = 3;
-    miso                = 8;
+    id                     = "dasa";
+    desc                   = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
+    type                   = "serbb";
+    connection_type        = serial;
+    reset                  = 7;
+    sck                    = 4;
+    mosi                   = 3;
+    miso                   = 8;
 ;
 
 #------------------------------------------------------------
@@ -2277,32 +2261,32 @@ programmer
 # reset=!dtr sck=rts mosi=txd miso=cts
 
 programmer
-    id                  = "dasa3";
-    desc                = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
-    type                = "serbb";
-    connection_type     = serial;
-    reset               = ~4;
-    sck                 = 7;
-    mosi                = 3;
-    miso                = 8;
+    id                     = "dasa3";
+    desc                   = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
+    type                   = "serbb";
+    connection_type        = serial;
+    reset                  = ~4;
+    sck                    = 7;
+    mosi                   = 3;
+    miso                   = 8;
 ;
 
 #------------------------------------------------------------
-# c2n232i
+# C2N232i
 #------------------------------------------------------------
 
 # C2N232i (jumper configuration "auto")
 # reset=dtr sck=!rts mosi=!txd miso=!cts
 
 programmer
-    id                  = "c2n232i";
-    desc                = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
-    type                = "serbb";
-    connection_type     = serial;
-    reset               = 4;
-    sck                 = ~7;
-    mosi                = ~3;
-    miso                = ~8;
+    id                     = "c2n232i";
+    desc                   = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
+    type                   = "serbb";
+    connection_type        = serial;
+    reset                  = 4;
+    sck                    = ~7;
+    mosi                   = ~3;
+    miso                   = ~8;
 ;
 
 #------------------------------------------------------------
@@ -2313,13 +2297,14 @@ programmer
 # https://github.com/ElTangas/jtag2updi
 
 programmer
-    id                  = "jtag2updi";
-    desc                = "JTAGv2 to UPDI bridge";
-    type                = "jtagmkii_updi";
-    connection_type     = serial;
-    baudrate            = 115200;
-    hvupdi_support      = 1;
+    id                     = "jtag2updi";
+    desc                   = "JTAGv2 to UPDI bridge";
+    type                   = "jtagmkii_updi";
+    connection_type        = serial;
+    baudrate               = 115200;
+    hvupdi_support         = 1;
 ;
+
 
 #
 # PART DEFINITIONS
@@ -2332,58 +2317,58 @@ programmer
 # This is an HVSP-only device.
 
 part
-    desc                = "ATtiny11";
-    id                  = "t11";
-    stk500_devcode      = 0x11;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x90 0x04;
-    serial              = no;
-    timeout             = 200;
-    hvsp_controlstack   =
+    desc                   = "ATtiny11";
+    id                     = "t11";
+    stk500_devcode         = 0x11;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x90 0x04;
+    serial                 = no;
+    timeout                = 200;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
         0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 50;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 50;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
+    synchcycles            = 6;
 
     memory "eeprom"
-        size            = 64;
-        delay           = 5;
-        blocksize       = 64;
-        readsize        = 256;
+        size               = 64;
+        delay              = 5;
+        blocksize          = 64;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 1024;
-        delay           = 3;
-        blocksize       = 128;
-        readsize        = 256;
+        size               = 1024;
+        delay              = 3;
+        blocksize          = 128;
+        readsize           = 256;
     ;
 
     memory "fuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lock"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "signature"
-        size            = 3;
+        size               = 3;
     ;
 
     memory "calibration"
-        size            = 1;
+        size               = 1;
     ;
 ;
 
@@ -2392,91 +2377,91 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny12";
-    id                  = "t12";
-    stk500_devcode      = 0x12;
-    avr910_devcode      = 0x55;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x90 0x05;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny12";
+    id                     = "t12";
+    stk500_devcode         = 0x12;
+    avr910_devcode         = 0x55;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x90 0x05;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
         0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 50;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 50;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 64;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 8;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        size               = 64;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 8;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 1024;
-        min_write_delay = 4500;
-        max_write_delay = 20000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 5;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 1024;
+        min_write_delay    = 4500;
+        max_write_delay    = 20000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 5;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--101x.xxxx--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--101x.xxxx--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -2485,113 +2470,113 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny13";
-    id                  = "t13";
-    stk500_devcode      = 0x14;
-    chip_erase_delay    = 4000;
-    signature           = 0x1e 0x90 0x07;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny13";
+    id                     = "t13";
+    stk500_devcode         = 0x14;
+    chip_erase_delay       = 4000;
+    signature              = 0x1e 0x90 0x07;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
         0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    flash_instr         =  0xb4, 0x0e, 0x1e;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x0e, 0x1e;
+    eeprom_instr           =
         0xbb, 0xfe, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x0e, 0xb4, 0x0e, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 90;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 90;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    ocdrev              = 0;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    ocdrev                 = 0;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 64;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 5;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--xxaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--xxaa.aa00--xxxx.xxxx";
+        size               = 64;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 5;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--xxaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--xxaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 1024;
-        page_size       = 32;
-        num_pages       = 32;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.000a--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.000a--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.000a--aaaa.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 1024;
+        page_size          = 32;
+        num_pages          = 32;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.000a--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.000a--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.000a--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 2;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 2;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -2600,8 +2585,8 @@ part
 #------------------------------------------------------------
 
 part parent "t13"
-    desc                = "ATtiny13A";
-    id                  = "t13a";
+    desc                   = "ATtiny13A";
+    id                     = "t13a";
 ;
 
 #------------------------------------------------------------
@@ -2609,92 +2594,92 @@ part parent "t13"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny15";
-    id                  = "t15";
-    stk500_devcode      = 0x13;
-    avr910_devcode      = 0x56;
-    chip_erase_delay    = 8200;
-    signature           = 0x1e 0x90 0x06;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny15";
+    id                     = "t15";
+    stk500_devcode         = 0x13;
+    avr910_devcode         = 0x56;
+    chip_erase_delay       = 8200;
+    signature              = 0x1e 0x90 0x06;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
         0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 16;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 50;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 16;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 50;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    hvspcmdexedelay     = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    hvspcmdexedelay        = 5;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 64;
-        min_write_delay = 8200;
-        max_write_delay = 8200;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 10;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        size               = 64;
+        min_write_delay    = 8200;
+        max_write_delay    = 8200;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 10;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 1024;
-        min_write_delay = 4100;
-        max_write_delay = 4100;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 5;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 1024;
+        min_write_delay    = 4100;
+        max_write_delay    = 4100;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 5;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.xxoo";
-        write           = "1010.1100--101x.xxxx--xxxx.xxxx--iiii.11ii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.xxoo";
+        write              = "1010.1100--101x.xxxx--xxxx.xxxx--iiii.11ii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -2703,77 +2688,77 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90S1200";
-    id                  = "1200";
-    stk500_devcode      = 0x33;
-    avr910_devcode      = 0x13;
-    chip_erase_delay    = 20000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x90 0x01;
-    is_at90s1200        = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 1;
-    pollvalue           = 0xff;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "AT90S1200";
+    id                     = "1200";
+    stk500_devcode         = 0x33;
+    avr910_devcode         = 0x13;
+    chip_erase_delay       = 20000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x90 0x01;
+    is_at90s1200           = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 1;
+    pollvalue              = 0xff;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 64;
-        min_write_delay = 4000;
-        max_write_delay = 9000;
-        readback        = 0x00 0xff;
-        mode            = 4;
-        delay           = 20;
-        blocksize       = 32;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        size               = 64;
+        min_write_delay    = 4000;
+        max_write_delay    = 9000;
+        readback           = 0x00 0xff;
+        mode               = 4;
+        delay              = 20;
+        blocksize          = 32;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 1024;
-        min_write_delay = 4000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 2;
-        delay           = 15;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 1024;
+        min_write_delay    = 4000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 2;
+        delay              = 15;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -2782,75 +2767,75 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90S4414";
-    id                  = "4414";
-    stk500_devcode      = 0x50;
-    avr910_devcode      = 0x28;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x92 0x01;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "AT90S4414";
+    id                     = "4414";
+    stk500_devcode         = 0x50;
+    avr910_devcode         = 0x28;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x92 0x01;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0x80 0x7f;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 256;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0x80 0x7f;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 4096;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0x7f 0x7f;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        size               = 4096;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0x7f 0x7f;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -2859,75 +2844,75 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90S2313";
-    id                  = "2313";
-    stk500_devcode      = 0x40;
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x91 0x01;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "AT90S2313";
+    id                     = "2313";
+    stk500_devcode         = 0x40;
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x91 0x01;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        min_write_delay = 4000;
-        max_write_delay = 9000;
-        readback        = 0x80 0x7f;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        size               = 128;
+        min_write_delay    = 4000;
+        max_write_delay    = 9000;
+        readback           = 0x80 0x7f;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 2048;
-        min_write_delay = 4000;
-        max_write_delay = 9000;
-        readback        = 0x7f 0x7f;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        size               = 2048;
+        min_write_delay    = 4000;
+        max_write_delay    = 9000;
+        readback           = 0x7f 0x7f;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        write           = "1010.1100--111x.xiix--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        write              = "1010.1100--111x.xiix--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -2937,81 +2922,81 @@ part
 
 part
 ##### WARNING: No XML file for device 'AT90S2333'! #####
-    desc                = "AT90S2333";
-    id                  = "2333";
-    stk500_devcode      = 0x42;
-    avr910_devcode      = 0x34;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x91 0x05;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "AT90S2333";
+    id                     = "2333";
+    stk500_devcode         = 0x42;
+    avr910_devcode         = 0x34;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x91 0x05;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0x00 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        size               = 128;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0x00 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 2048;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        size               = 2048;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
         pwroff_after_write = yes;
-        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
-        write           = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
+        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
+        write              = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -3020,85 +3005,85 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90S2343";
-    id                  = "2343";
-    stk500_devcode      = 0x43;
-    avr910_devcode      = 0x4c;
-    chip_erase_delay    = 18000;
-    signature           = 0x1e 0x91 0x03;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    hvsp_controlstack   =
+    desc                   = "AT90S2343";
+    id                     = "2343";
+    stk500_devcode         = 0x43;
+    avr910_devcode         = 0x4c;
+    chip_erase_delay       = 18000;
+    signature              = 0x1e 0x91 0x03;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
         0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 50;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 50;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0x00 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--0000.0000--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.0000--xaaa.aaaa--iiii.iiii";
+        size               = 128;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0x00 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--0000.0000--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.0000--xaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 2048;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 128;
-        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        size               = 2048;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 128;
+        read_lo            = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
-        write           = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
+        write              = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -3107,81 +3092,81 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90S4433";
-    id                  = "4433";
-    stk500_devcode      = 0x51;
-    avr910_devcode      = 0x30;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x92 0x03;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "AT90S4433";
+    id                     = "4433";
+    stk500_devcode         = 0x51;
+    avr910_devcode         = 0x30;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x92 0x03;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0x00 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
+        size               = 256;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0x00 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 4096;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        size               = 4096;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
         pwroff_after_write = yes;
-        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
-        write           = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
+        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
+        write              = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -3191,54 +3176,54 @@ part
 
 part
 ##### WARNING: No XML file for device 'AT90S4434'! #####
-    desc                = "AT90S4434";
-    id                  = "4434";
-    stk500_devcode      = 0x52;
-    avr910_devcode      = 0x6c;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x92 0x02;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    desc                   = "AT90S4434";
+    id                     = "4434";
+    stk500_devcode         = 0x52;
+    avr910_devcode         = 0x6c;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x92 0x02;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0x00 0xff;
-        read            = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
+        size               = 256;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0x00 0xff;
+        read               = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 4096;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0xff 0xff;
-        read_lo         = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        size               = 4096;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0xff 0xff;
+        read_lo            = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
-        write           = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
+        write              = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -3247,76 +3232,76 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90S8515";
-    id                  = "8515";
-    stk500_devcode      = 0x60;
-    avr910_devcode      = 0x38;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x93 0x01;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "AT90S8515";
+    id                     = "8515";
+    stk500_devcode         = 0x60;
+    avr910_devcode         = 0x38;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x93 0x01;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        min_write_delay = 4000;
-        max_write_delay = 9000;
-        readback        = 0x80 0x7f;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 512;
+        min_write_delay    = 4000;
+        max_write_delay    = 9000;
+        readback           = 0x80 0x7f;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 8192;
-        min_write_delay = 4000;
-        max_write_delay = 9000;
-        readback        = 0x7f 0x7f;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        size               = 8192;
+        min_write_delay    = 4000;
+        max_write_delay    = 9000;
+        readback           = 0x7f 0x7f;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -3325,80 +3310,80 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90S8535";
-    id                  = "8535";
-    stk500_devcode      = 0x61;
-    avr910_devcode      = 0x68;
-    chip_erase_delay    = 20000;
-    signature           = 0x1e 0x93 0x03;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "AT90S8535";
+    id                     = "8535";
+    stk500_devcode         = 0x61;
+    avr910_devcode         = 0x68;
+    chip_erase_delay       = 20000;
+    signature              = 0x1e 0x93 0x03;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0x00 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 512;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0x00 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        size            = 8192;
-        min_write_delay = 9000;
-        max_write_delay = 20000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write_lo        = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
-        write_hi        = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        size               = 8192;
+        min_write_delay    = 9000;
+        max_write_delay    = 20000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write_lo           = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        write_hi           = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxxo";
-        write           = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxxo";
+        write              = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooxx.xxxx";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooxx.xxxx";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -3407,84 +3392,84 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega103";
-    id                  = "m103";
-    stk500_devcode      = 0xb1;
-    avr910_devcode      = 0x41;
-    chip_erase_delay    = 112000;
-    signature           = 0x1e 0x97 0x01;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega103";
+    id                     = "m103";
+    stk500_devcode         = 0xb1;
+    avr910_devcode         = 0x41;
+    chip_erase_delay       = 112000;
+    signature              = 0x1e 0x97 0x01;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x8e, 0x9e, 0x2e, 0x3e, 0xae, 0xbe,
         0x4e, 0x5e, 0xce, 0xde, 0x6e, 0x7e, 0xee, 0xde,
         0x66, 0x76, 0xe6, 0xf6, 0x6a, 0x7a, 0xea, 0x7a,
         0x7f, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 15;
-    programfusepulsewidth = 2;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
     programlockpolltimeout = 10;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        min_write_delay = 4000;
-        max_write_delay = 9000;
-        readback        = 0x80 0x7f;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        size               = 4096;
+        min_write_delay    = 4000;
+        max_write_delay    = 9000;
+        readback           = 0x80 0x7f;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x20000;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 22000;
-        max_write_delay = 56000;
-        readback        = 0xff 0xff;
-        mode            = 17;
-        delay           = 70;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x20000;
+        page_size          = 256;
+        num_pages          = 512;
+        min_write_delay    = 22000;
+        max_write_delay    = 56000;
+        readback           = 0xff 0xff;
+        mode               = 17;
+        delay              = 70;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxox.o1oo";
-        write           = "1010.1100--1011.i1ii--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxox.o1oo";
+        write              = "1010.1100--1011.i1ii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
-        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -3493,115 +3478,115 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega64";
-    id                  = "m64";
-    stk500_devcode      = 0xa0;
-    avr910_devcode      = 0x45;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x96 0x02;
-    reset               = io;
-    has_jtag            = yes;
+    desc                   = "ATmega64";
+    id                     = "m64";
+    stk500_devcode         = 0xa0;
+    avr910_devcode         = 0x45;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x96 0x02;
+    reset                  = io;
+    has_jtag               = yes;
     allowfullpagebitstream = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x22;
-    spmcr               = 0x68;
-    ocdrev              = 2;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x22;
+    spmcr                  = 0x68;
+    ocdrev                 = 2;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 20;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        size               = 2048;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 20;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x10000;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x10000;
+        page_size          = 256;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -3610,8 +3595,8 @@ part
 #------------------------------------------------------------
 
 part parent "m64"
-    desc                = "ATmega64A";
-    id                  = "m64a";
+    desc                   = "ATmega64A";
+    id                     = "m64a";
 ;
 
 #------------------------------------------------------------
@@ -3619,116 +3604,116 @@ part parent "m64"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega128";
-    id                  = "m128";
-    stk500_devcode      = 0xb2;
-    avr910_devcode      = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x97 0x02;
-    reset               = io;
-    has_jtag            = yes;
+    desc                   = "ATmega128";
+    id                     = "m128";
+    stk500_devcode         = 0xb2;
+    avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x97 0x02;
+    reset                  = io;
+    has_jtag               = yes;
     allowfullpagebitstream = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x22;
-    rampz               = 0x3b;
-    spmcr               = 0x68;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x22;
+    rampz                  = 0x3b;
+    spmcr                  = 0x68;
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 12;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        size               = 4096;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 12;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x20000;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x20000;
+        page_size          = 256;
+        num_pages          = 512;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -3737,8 +3722,8 @@ part
 #------------------------------------------------------------
 
 part parent "m128"
-    desc                = "ATmega128A";
-    id                  = "m128a";
+    desc                   = "ATmega128A";
+    id                     = "m128a";
 ;
 
 #------------------------------------------------------------
@@ -3746,119 +3731,119 @@ part parent "m128"
 #------------------------------------------------------------
 
 part
-    desc                = "AT90CAN128";
-    id                  = "c128";
-    stk500_devcode      = 0xb3;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-#    avr910_devcode   = 0x43;
-    signature           = 0x1e 0x97 0x81;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90CAN128";
+    id                     = "c128";
+    stk500_devcode         = 0xb3;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+#   avr910_devcode         = 0x43;
+    signature              = 0x1e 0x97 0x81;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    eecr                = 0x3f;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    eecr                   = 0x3f;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--000x.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 4096;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--000x.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x20000;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x20000;
+        page_size          = 256;
+        num_pages          = 512;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -3867,119 +3852,119 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90CAN64";
-    id                  = "c64";
-    stk500_devcode      = 0xb3;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-#    avr910_devcode   = 0x43;
-    signature           = 0x1e 0x96 0x81;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90CAN64";
+    id                     = "c64";
+    stk500_devcode         = 0xb3;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+#   avr910_devcode         = 0x43;
+    signature              = 0x1e 0x96 0x81;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    eecr                = 0x3f;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    eecr                   = 0x3f;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--000x.xaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+        size               = 2048;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--000x.xaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x10000;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x10000;
+        page_size          = 256;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -3988,119 +3973,119 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90CAN32";
-    id                  = "c32";
-    stk500_devcode      = 0xb3;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-#    avr910_devcode   = 0x43;
-    signature           = 0x1e 0x95 0x81;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90CAN32";
+    id                     = "c32";
+    stk500_devcode         = 0xb3;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+#   avr910_devcode         = 0x43;
+    signature              = 0x1e 0x95 0x81;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    eecr                = 0x3f;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    eecr                   = 0x3f;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxaa--aaaa.a000--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 256;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 256;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -4109,111 +4094,111 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega16";
-    id                  = "m16";
-    stk500_devcode      = 0x82;
-    avr910_devcode      = 0x74;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x94 0x03;
-    reset               = io;
-    has_jtag            = yes;
+    desc                   = "ATmega16";
+    id                     = "m16";
+    stk500_devcode         = 0x82;
+    avr910_devcode         = 0x74;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x94 0x03;
+    reset                  = io;
+    has_jtag               = yes;
     allowfullpagebitstream = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    progmodedelay          = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 2;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 2;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--000x.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--000x.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -4222,8 +4207,8 @@ part
 #------------------------------------------------------------
 
 part parent "m16"
-    desc                = "ATmega16A";
-    id                  = "m16a";
+    desc                   = "ATmega16A";
+    id                     = "m16a";
 ;
 
 #------------------------------------------------------------
@@ -4231,119 +4216,119 @@ part parent "m16"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega324P";
-    id                  = "m324p";
-    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode      = 0x74;
-    chip_erase_delay    = 55000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x95 0x08;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega324P";
+    id                     = "m324p";
+    stk500_devcode         = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode         = 0x74;
+    chip_erase_delay       = 55000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x95 0x08;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xaaa--aaaa.aa00--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xaaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0aaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 128;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0aaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -4352,17 +4337,17 @@ part
 #------------------------------------------------------------
 
 part parent "m324p"
-    desc                = "ATmega164P";
-    id                  = "m164p";
-    signature           = 0x1e 0x94 0x0a;
+    desc                   = "ATmega164P";
+    id                     = "m164p";
+    signature              = 0x1e 0x94 0x0a;
 
     memory "eeprom"
-        size            = 512;
+        size               = 512;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        num_pages       = 128;
+        size               = 0x4000;
+        num_pages          = 128;
     ;
 ;
 
@@ -4371,8 +4356,8 @@ part parent "m324p"
 #------------------------------------------------------------
 
 part parent "m164p"
-    desc                = "ATmega164PA";
-    id                  = "m164pa";
+    desc                   = "ATmega164PA";
+    id                     = "m164pa";
 ;
 
 #------------------------------------------------------------
@@ -4380,9 +4365,9 @@ part parent "m164p"
 #------------------------------------------------------------
 
 part parent "m164p"
-    desc                = "ATmega164A";
-    id                  = "m164a";
-    signature           = 0x1e 0x94 0x0f;
+    desc                   = "ATmega164A";
+    id                     = "m164a";
+    signature              = 0x1e 0x94 0x0f;
 ;
 
 #------------------------------------------------------------
@@ -4390,9 +4375,9 @@ part parent "m164p"
 #------------------------------------------------------------
 
 part parent "m324p"
-    desc                = "ATmega324PB";
-    id                  = "m324pb";
-    signature           = 0x1e 0x95 0x17;
+    desc                   = "ATmega324PB";
+    id                     = "m324pb";
+    signature              = 0x1e 0x95 0x17;
 ;
 
 #------------------------------------------------------------
@@ -4400,9 +4385,9 @@ part parent "m324p"
 #------------------------------------------------------------
 
 part parent "m324p"
-    desc                = "ATmega324PA";
-    id                  = "m324pa";
-    signature           = 0x1e 0x95 0x11;
+    desc                   = "ATmega324PA";
+    id                     = "m324pa";
+    signature              = 0x1e 0x95 0x11;
 ;
 
 #------------------------------------------------------------
@@ -4410,9 +4395,9 @@ part parent "m324p"
 #------------------------------------------------------------
 
 part parent "m324p"
-    desc                = "ATmega324A";
-    id                  = "m324a";
-    signature           = 0x1e 0x95 0x15;
+    desc                   = "ATmega324A";
+    id                     = "m324a";
+    signature              = 0x1e 0x95 0x15;
 ;
 
 #------------------------------------------------------------
@@ -4420,116 +4405,116 @@ part parent "m324p"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega644";
-    id                  = "m644";
-    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode      = 0x74;
-    chip_erase_delay    = 55000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x96 0x09;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega644";
+    id                     = "m644";
+    stk500_devcode         = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode         = 0x74;
+    chip_erase_delay       = 55000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x96 0x09;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--00xx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 2048;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--00xx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x10000;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x10000;
+        page_size          = 256;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -4538,8 +4523,8 @@ part
 #------------------------------------------------------------
 
 part parent "m644"
-    desc                = "ATmega644A";
-    id                  = "m644a";
+    desc                   = "ATmega644A";
+    id                     = "m644a";
 ;
 
 #------------------------------------------------------------
@@ -4547,9 +4532,9 @@ part parent "m644"
 #------------------------------------------------------------
 
 part parent "m644"
-    desc                = "ATmega644P";
-    id                  = "m644p";
-    signature           = 0x1e 0x96 0x0a;
+    desc                   = "ATmega644P";
+    id                     = "m644p";
+    signature              = 0x1e 0x96 0x0a;
 ;
 
 #------------------------------------------------------------
@@ -4557,9 +4542,9 @@ part parent "m644"
 #------------------------------------------------------------
 
 part parent "m644"
-    desc                = "ATmega644PA";
-    id                  = "m644pa";
-    signature           = 0x1e 0x96 0x0a;
+    desc                   = "ATmega644PA";
+    id                     = "m644pa";
+    signature              = 0x1e 0x96 0x0a;
 ;
 
 #------------------------------------------------------------
@@ -4567,120 +4552,120 @@ part parent "m644"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega1284";
-    id                  = "m1284";
-    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode      = 0x74;
-    chip_erase_delay    = 55000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x97 0x06;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega1284";
+    id                     = "m1284";
+    stk500_devcode         = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode         = 0x74;
+    chip_erase_delay       = 55000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x97 0x06;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--00xx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 4096;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--00xx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x20000;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x20000;
+        page_size          = 256;
+        num_pages          = 512;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -4689,9 +4674,9 @@ part
 #------------------------------------------------------------
 
 part parent "m1284"
-    desc                = "ATmega1284P";
-    id                  = "m1284p";
-    signature           = 0x1e 0x97 0x05;
+    desc                   = "ATmega1284P";
+    id                     = "m1284p";
+    signature              = 0x1e 0x97 0x05;
 ;
 
 #------------------------------------------------------------
@@ -4699,117 +4684,117 @@ part parent "m1284"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega162";
-    id                  = "m162";
-    stk500_devcode      = 0x83;
-    avr910_devcode      = 0x63;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x94 0x04;
-    reset               = io;
-    has_jtag            = yes;
+    desc                   = "ATmega162";
+    id                     = "m162";
+    stk500_devcode         = 0x83;
+    avr910_devcode         = 0x63;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x94 0x04;
+    reset                  = io;
+    has_jtag               = yes;
     allowfullpagebitstream = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x04;
-    spmcr               = 0x57;
-    ocdrev              = 2;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x04;
+    spmcr                  = 0x57;
+    ocdrev                 = 2;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 16000;
+        max_write_delay    = 16000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 16000;
+        max_write_delay    = 16000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+        size               = 1;
+        min_write_delay    = 16000;
+        max_write_delay    = 16000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 16000;
+        max_write_delay    = 16000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--00xx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--00xx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--00xx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--00xx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -4818,99 +4803,99 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega163";
-    id                  = "m163";
-    stk500_devcode      = 0x81;
-    avr910_devcode      = 0x64;
-    chip_erase_delay    = 32000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x94 0x02;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega163";
+    id                     = "m163";
+    stk500_devcode         = 0x81;
+    avr910_devcode         = 0x64;
+    chip_erase_delay       = 32000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x94 0x02;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 30;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 30;
     programfusepolltimeout = 2;
     programlockpolltimeout = 2;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        min_write_delay = 4000;
-        max_write_delay = 4000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 512;
+        min_write_delay    = 4000;
+        max_write_delay    = 4000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-        readback        = 0xff 0xff;
-        mode            = 17;
-        delay           = 20;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 16000;
+        max_write_delay    = 16000;
+        readback           = 0xff 0xff;
+        mode               = 17;
+        delay              = 20;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--ooxx.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--ii11.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--ooxx.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--ii11.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--xxxx.1ooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--1111.1iii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--xxxx.1ooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--1111.1iii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.0000--xxxx.0xxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.0000--xxxx.0xxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -4919,117 +4904,117 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega169";
-    id                  = "m169";
-    stk500_devcode      = 0x85;
-    avr910_devcode      = 0x78;
-    chip_erase_delay    = 9000;
-    signature           = 0x1e 0x94 0x05;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega169";
+    id                     = "m169";
+    stk500_devcode         = 0x85;
+    avr910_devcode         = 0x78;
+    chip_erase_delay       = 9000;
+    signature              = 0x1e 0x94 0x05;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 2;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 2;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -5038,10 +5023,10 @@ part
 #------------------------------------------------------------
 
 part parent "m169"
-    desc                = "ATmega169A";
-    id                  = "m169a";
-    signature           = 0x1e 0x94 0x11;
-    reset               = io;
+    desc                   = "ATmega169A";
+    id                     = "m169a";
+    signature              = 0x1e 0x94 0x11;
+    reset                  = io;
 ;
 
 #------------------------------------------------------------
@@ -5049,9 +5034,9 @@ part parent "m169"
 #------------------------------------------------------------
 
 part parent "m169"
-    desc                = "ATmega169P";
-    id                  = "m169p";
-    reset               = io;
+    desc                   = "ATmega169P";
+    id                     = "m169p";
+    reset                  = io;
 ;
 
 #------------------------------------------------------------
@@ -5059,9 +5044,9 @@ part parent "m169"
 #------------------------------------------------------------
 
 part parent "m169"
-    desc                = "ATmega169PA";
-    id                  = "m169pa";
-    reset               = io;
+    desc                   = "ATmega169PA";
+    id                     = "m169pa";
+    reset                  = io;
 ;
 
 #------------------------------------------------------------
@@ -5069,119 +5054,119 @@ part parent "m169"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega329";
-    id                  = "m329";
-#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
-#    avr910_devcode   = 0x?;  # try the ATmega169 one:
-    avr910_devcode      = 0x75;
-    chip_erase_delay    = 9000;
-    signature           = 0x1e 0x95 0x03;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega329";
+    id                     = "m329";
+#   stk500_devcode         = 0x85; # no STK500 support, only STK500v2
+#   avr910_devcode         = 0x?;  # try the ATmega169 one:
+    avr910_devcode         = 0x75;
+    chip_erase_delay       = 9000;
+    signature              = 0x1e 0x95 0x03;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 128;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -5190,8 +5175,8 @@ part
 #------------------------------------------------------------
 
 part parent "m329"
-    desc                = "ATmega329A";
-    id                  = "m329a";
+    desc                   = "ATmega329A";
+    id                     = "m329a";
 ;
 
 #------------------------------------------------------------
@@ -5199,9 +5184,9 @@ part parent "m329"
 #------------------------------------------------------------
 
 part parent "m329"
-    desc                = "ATmega329P";
-    id                  = "m329p";
-    signature           = 0x1e 0x95 0x0b;
+    desc                   = "ATmega329P";
+    id                     = "m329p";
+    signature              = 0x1e 0x95 0x0b;
 ;
 
 #------------------------------------------------------------
@@ -5209,9 +5194,9 @@ part parent "m329"
 #------------------------------------------------------------
 
 part parent "m329"
-    desc                = "ATmega329PA";
-    id                  = "m329pa";
-    signature           = 0x1e 0x95 0x0b;
+    desc                   = "ATmega329PA";
+    id                     = "m329pa";
+    signature              = 0x1e 0x95 0x0b;
 ;
 
 #------------------------------------------------------------
@@ -5219,9 +5204,9 @@ part parent "m329"
 #------------------------------------------------------------
 
 part parent "m329"
-    desc                = "ATmega3290";
-    id                  = "m3290";
-    signature           = 0x1e 0x95 0x04;
+    desc                   = "ATmega3290";
+    id                     = "m3290";
+    signature              = 0x1e 0x95 0x04;
 ;
 
 #------------------------------------------------------------
@@ -5229,9 +5214,9 @@ part parent "m329"
 #------------------------------------------------------------
 
 part parent "m329"
-    desc                = "ATmega3290A";
-    id                  = "m3290a";
-    signature           = 0x1e 0x95 0x04;
+    desc                   = "ATmega3290A";
+    id                     = "m3290a";
+    signature              = 0x1e 0x95 0x04;
 ;
 
 #------------------------------------------------------------
@@ -5239,9 +5224,9 @@ part parent "m329"
 #------------------------------------------------------------
 
 part parent "m329"
-    desc                = "ATmega3290P";
-    id                  = "m3290p";
-    signature           = 0x1e 0x95 0x0c;
+    desc                   = "ATmega3290P";
+    id                     = "m3290p";
+    signature              = 0x1e 0x95 0x0c;
 ;
 
 #------------------------------------------------------------
@@ -5249,9 +5234,9 @@ part parent "m329"
 #------------------------------------------------------------
 
 part parent "m329"
-    desc                = "ATmega3290PA";
-    id                  = "m3290pa";
-    signature           = 0x1e 0x95 0x0c;
+    desc                   = "ATmega3290PA";
+    id                     = "m3290pa";
+    signature              = 0x1e 0x95 0x0c;
 ;
 
 #------------------------------------------------------------
@@ -5259,119 +5244,119 @@ part parent "m329"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega649";
-    id                  = "m649";
-#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
-#    avr910_devcode   = 0x?;  # try the ATmega169 one:
-    avr910_devcode      = 0x75;
-    chip_erase_delay    = 9000;
-    signature           = 0x1e 0x96 0x03;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega649";
+    id                     = "m649";
+#   stk500_devcode         = 0x85; # no STK500 support, only STK500v2
+#   avr910_devcode         = 0x?;  # try the ATmega169 one:
+    avr910_devcode         = 0x75;
+    chip_erase_delay       = 9000;
+    signature              = 0x1e 0x96 0x03;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+        size               = 2048;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x10000;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x10000;
+        page_size          = 256;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -5380,8 +5365,8 @@ part
 #------------------------------------------------------------
 
 part parent "m649"
-    desc                = "ATmega649A";
-    id                  = "m649a";
+    desc                   = "ATmega649A";
+    id                     = "m649a";
 ;
 
 #------------------------------------------------------------
@@ -5389,9 +5374,9 @@ part parent "m649"
 #------------------------------------------------------------
 
 part parent "m649"
-    desc                = "ATmega649P";
-    id                  = "m649p";
-    signature           = 0x1e 0x96 0x0b;
+    desc                   = "ATmega649P";
+    id                     = "m649p";
+    signature              = 0x1e 0x96 0x0b;
 ;
 
 #------------------------------------------------------------
@@ -5399,9 +5384,9 @@ part parent "m649"
 #------------------------------------------------------------
 
 part parent "m649"
-    desc                = "ATmega6490";
-    id                  = "m6490";
-    signature           = 0x1e 0x96 0x04;
+    desc                   = "ATmega6490";
+    id                     = "m6490";
+    signature              = 0x1e 0x96 0x04;
 ;
 
 #------------------------------------------------------------
@@ -5409,9 +5394,9 @@ part parent "m649"
 #------------------------------------------------------------
 
 part parent "m649"
-    desc                = "ATmega6490A";
-    id                  = "m6490a";
-    signature           = 0x1e 0x96 0x04;
+    desc                   = "ATmega6490A";
+    id                     = "m6490a";
+    signature              = 0x1e 0x96 0x04;
 ;
 
 #------------------------------------------------------------
@@ -5419,9 +5404,9 @@ part parent "m649"
 #------------------------------------------------------------
 
 part parent "m649"
-    desc                = "ATmega6490P";
-    id                  = "m6490p";
-    signature           = 0x1e 0x96 0x0c;
+    desc                   = "ATmega6490P";
+    id                     = "m6490p";
+    signature              = 0x1e 0x96 0x0c;
 ;
 
 #------------------------------------------------------------
@@ -5429,109 +5414,109 @@ part parent "m649"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega32";
-    id                  = "m32";
-    stk500_devcode      = 0x91;
-    avr910_devcode      = 0x72;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x95 0x02;
-    reset               = io;
-    has_jtag            = yes;
+    desc                   = "ATmega32";
+    id                     = "m32";
+    stk500_devcode         = 0x91;
+    avr910_devcode         = 0x72;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x95 0x02;
+    reset                  = io;
+    has_jtag               = yes;
     allowfullpagebitstream = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 2;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 2;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 10;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 10;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 128;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -5540,86 +5525,86 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega161";
-    id                  = "m161";
-    stk500_devcode      = 0x80;
-    avr910_devcode      = 0x60;
-    chip_erase_delay    = 28000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x94 0x01;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega161";
+    id                     = "m161";
+    stk500_devcode         = 0x80;
+    avr910_devcode         = 0x60;
+    chip_erase_delay       = 28000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x94 0x01;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 30;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 30;
     programfusepolltimeout = 2;
     programlockpolltimeout = 2;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        min_write_delay = 3400;
-        max_write_delay = 3400;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 5;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 512;
+        min_write_delay    = 3400;
+        max_write_delay    = 3400;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 5;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 14000;
-        max_write_delay = 14000;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 16;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 14000;
+        max_write_delay    = 14000;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 16;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "fuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xoxo.oooo";
-        write           = "1010.1100--101x.xxxx--xxxx.xxxx--1i1i.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xoxo.oooo";
+        write              = "1010.1100--101x.xxxx--xxxx.xxxx--1i1i.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 ;
 
@@ -5628,8 +5613,8 @@ part
 #------------------------------------------------------------
 
 part parent "m32"
-    desc                = "ATmega32A";
-    id                  = "m32a";
+    desc                   = "ATmega32A";
+    id                     = "m32a";
 ;
 
 #------------------------------------------------------------
@@ -5637,106 +5622,106 @@ part parent "m32"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega8";
-    id                  = "m8";
-    stk500_devcode      = 0x70;
-    avr910_devcode      = 0x76;
-    chip_erase_delay    = 10000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-    signature           = 0x1e 0x93 0x07;
-    reset               = io;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega8";
+    id                     = "m8";
+    stk500_devcode         = 0x70;
+    avr910_devcode         = 0x76;
+    chip_erase_delay       = 10000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+    signature              = 0x1e 0x93 0x07;
+    reset                  = io;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 2;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 2;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 20;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 20;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0x00;
-        mode            = 33;
-        delay           = 10;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0x00;
+        mode               = 33;
+        delay              = 10;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -5745,8 +5730,8 @@ part
 #------------------------------------------------------------
 
 part parent "m8"
-    desc                = "ATmega8A";
-    id                  = "m8a";
+    desc                   = "ATmega8A";
+    id                     = "m8a";
 ;
 
 #------------------------------------------------------------
@@ -5754,98 +5739,98 @@ part parent "m8"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega8515";
-    id                  = "m8515";
-    stk500_devcode      = 0x63;
-    avr910_devcode      = 0x3a;
-    chip_erase_delay    = 9000;
-    signature           = 0x1e 0x93 0x06;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega8515";
+    id                     = "m8515";
+    stk500_devcode         = 0x63;
+    avr910_devcode         = 0x3a;
+    chip_erase_delay       = 9000;
+    signature              = 0x1e 0x93 0x06;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 20;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 512;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 20;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -5854,100 +5839,100 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega8535";
-    id                  = "m8535";
-    stk500_devcode      = 0x64;
-    avr910_devcode      = 0x69;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x93 0x08;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATmega8535";
+    id                     = "m8535";
+    stk500_devcode         = 0x64;
+    avr910_devcode         = 0x69;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x93 0x08;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 20;
-        blocksize       = 128;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+        size               = 512;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 20;
+        blocksize          = 128;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 2000;
+        max_write_delay    = 2000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -5956,103 +5941,103 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny26";
-    id                  = "t26";
-    stk500_devcode      = 0x21;
-    avr910_devcode      = 0x5e;
-    chip_erase_delay    = 9000;
-    pagel               = 0xb3;
-    bs2                 = 0xb2;
-    signature           = 0x1e 0x91 0x09;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny26";
+    id                     = "t26";
+    stk500_devcode         = 0x21;
+    avr910_devcode         = 0x5e;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xb3;
+    bs2                    = 0xb2;
+    signature              = 0x1e 0x91 0x09;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
         0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
         0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
         0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 2;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 2;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 4;
-        delay           = 10;
-        blocksize       = 64;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        size               = 128;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 4;
+        delay              = 10;
+        blocksize          = 64;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 2048;
-        page_size       = 32;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 33;
-        delay           = 6;
-        blocksize       = 16;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxx.xxaa--aaaa.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 2048;
+        page_size          = 32;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 33;
+        delay              = 6;
+        blocksize          = 16;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxx.xxaa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--xxxi.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--xxxi.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
-        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write              = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 4;
-        read            = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 4;
+        read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -6061,122 +6046,122 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny261";
-    id                  = "t261";
-    chip_erase_delay    = 4000;
-    pagel               = 0xb3;
-    bs2                 = 0xb2;
-#    stk500_devcode      = 0x21;
-#    avr910_devcode      = 0x5e;
-    signature           = 0x1e 0x91 0x0c;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny261";
+    id                     = "t261";
+    chip_erase_delay       = 4000;
+    pagel                  = 0xb3;
+    bs2                    = 0xb2;
+#   stk500_devcode         = 0x21;
+#   avr910_devcode         = 0x5e;
+    signature              = 0x1e 0x91 0x0c;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
         0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
         0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
         0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb4, 0x00, 0x10;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x00, 0x10;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x00, 0xb4, 0x00, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 2;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 2;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 4;
-        num_pages       = 32;
-        min_write_delay = 4000;
-        max_write_delay = 4000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+        size               = 128;
+        page_size          = 4;
+        num_pages          = 32;
+        min_write_delay    = 4000;
+        max_write_delay    = 4000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 2048;
-        page_size       = 32;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxx.xxaa--aaaa.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 2048;
+        page_size          = 32;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxx.xxaa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
-        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write              = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -6185,8 +6170,8 @@ part
 #------------------------------------------------------------
 
 part parent "t261"
-    desc                = "ATtiny261A";
-    id                  = "t261a";
+    desc                   = "ATtiny261A";
+    id                     = "t261a";
 ;
 
 #------------------------------------------------------------
@@ -6194,122 +6179,122 @@ part parent "t261"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny461";
-    id                  = "t461";
-    chip_erase_delay    = 4000;
-    pagel               = 0xb3;
-    bs2                 = 0xb2;
-#    stk500_devcode      = 0x21;
-#    avr910_devcode      = 0x5e;
-    signature           = 0x1e 0x92 0x08;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny461";
+    id                     = "t461";
+    chip_erase_delay       = 4000;
+    pagel                  = 0xb3;
+    bs2                    = 0xb2;
+#   stk500_devcode         = 0x21;
+#   avr910_devcode         = 0x5e;
+    signature              = 0x1e 0x92 0x08;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
         0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
         0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
         0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb4, 0x00, 0x10;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x00, 0x10;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x00, 0xb4, 0x00, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 2;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 2;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 4;
-        num_pages       = 64;
-        min_write_delay = 4000;
-        max_write_delay = 4000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+        size               = 256;
+        page_size          = 4;
+        num_pages          = 64;
+        min_write_delay    = 4000;
+        max_write_delay    = 4000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 4096;
-        page_size       = 64;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxx.xaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 4096;
+        page_size          = 64;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxx.xaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
-        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write              = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -6318,8 +6303,8 @@ part
 #------------------------------------------------------------
 
 part parent "t461"
-    desc                = "ATtiny461A";
-    id                  = "t461a";
+    desc                   = "ATtiny461A";
+    id                     = "t461a";
 ;
 
 #------------------------------------------------------------
@@ -6327,122 +6312,122 @@ part parent "t461"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny861";
-    id                  = "t861";
-    chip_erase_delay    = 4000;
-    pagel               = 0xb3;
-    bs2                 = 0xb2;
-#    stk500_devcode      = 0x21;
-#    avr910_devcode      = 0x5e;
-    signature           = 0x1e 0x93 0x0d;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny861";
+    id                     = "t861";
+    chip_erase_delay       = 4000;
+    pagel                  = 0xb3;
+    bs2                    = 0xb2;
+#   stk500_devcode         = 0x21;
+#   avr910_devcode         = 0x5e;
+    signature              = 0x1e 0x93 0x0d;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
         0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
         0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
         0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb4, 0x00, 0x10;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x00, 0x10;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x00, 0xb4, 0x00, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 2;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 2;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        num_pages       = 128;
-        min_write_delay = 4000;
-        max_write_delay = 4000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        num_pages          = 128;
+        min_write_delay    = 4000;
+        max_write_delay    = 4000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxx.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxx.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
-        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write              = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -6451,8 +6436,8 @@ part
 #------------------------------------------------------------
 
 part parent "t861"
-    desc                = "ATtiny861A";
-    id                  = "t861a";
+    desc                   = "ATtiny861A";
+    id                     = "t861a";
 ;
 
 #------------------------------------------------------------
@@ -6462,45 +6447,45 @@ part parent "t861"
 # This is an HVPP-only device.
 
 part
-    desc                = "ATtiny28";
-    id                  = "t28";
-    stk500_devcode      = 0x22;
-    avr910_devcode      = 0x5c;
-    signature           = 0x1e 0x91 0x07;
-    serial              = no;
-    pp_controlstack     =
+    desc                   = "ATtiny28";
+    id                     = "t28";
+    stk500_devcode         = 0x22;
+    avr910_devcode         = 0x5c;
+    signature              = 0x1e 0x91 0x07;
+    serial                 = no;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
 
     memory "flash"
-        size            = 2048;
-        page_size       = 2;
-        delay           = 5;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 2;
+        delay              = 5;
+        readsize           = 256;
     ;
 
     memory "fuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lock"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "signature"
-        size            = 3;
+        size               = 3;
     ;
 
     memory "calibration"
-        size            = 1;
+        size               = 1;
     ;
 ;
 
@@ -6509,123 +6494,123 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega48";
-    id                  = "m48";
-    stk500_devcode      = 0x59;
-    chip_erase_delay    = 45000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-#    avr910_devcode   = 0x;
-    signature           = 0x1e 0x92 0x05;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega48";
+    id                     = "m48";
+    stk500_devcode         = 0x59;
+    chip_erase_delay       = 45000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x92 0x05;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+        size               = 256;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 4096;
-        page_size       = 64;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 4096;
+        page_size          = 64;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -6634,8 +6619,8 @@ part
 #------------------------------------------------------------
 
 part parent "m48"
-    desc                = "ATmega48A";
-    id                  = "m48a";
+    desc                   = "ATmega48A";
+    id                     = "m48a";
 ;
 
 #------------------------------------------------------------
@@ -6643,9 +6628,9 @@ part parent "m48"
 #------------------------------------------------------------
 
 part parent "m48"
-    desc                = "ATmega48P";
-    id                  = "m48p";
-    signature           = 0x1e 0x92 0x0a;
+    desc                   = "ATmega48P";
+    id                     = "m48p";
+    signature              = 0x1e 0x92 0x0a;
 ;
 
 #------------------------------------------------------------
@@ -6653,9 +6638,9 @@ part parent "m48"
 #------------------------------------------------------------
 
 part parent "m48"
-    desc                = "ATmega48PA";
-    id                  = "m48pa";
-    signature           = 0x1e 0x92 0x0a;
+    desc                   = "ATmega48PA";
+    id                     = "m48pa";
+    signature              = 0x1e 0x92 0x0a;
 ;
 
 #------------------------------------------------------------
@@ -6663,10 +6648,10 @@ part parent "m48"
 #------------------------------------------------------------
 
 part parent "m48"
-    desc                = "ATmega48PB";
-    id                  = "m48pb";
-    chip_erase_delay    = 10500;
-    signature           = 0x1e 0x92 0x10;
+    desc                   = "ATmega48PB";
+    id                     = "m48pb";
+    chip_erase_delay       = 10500;
+    signature              = 0x1e 0x92 0x10;
 ;
 
 #------------------------------------------------------------
@@ -6674,124 +6659,124 @@ part parent "m48"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega88";
-    id                  = "m88";
-    stk500_devcode      = 0x73;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-#    avr910_devcode   = 0x;
-    signature           = 0x1e 0x93 0x0a;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega88";
+    id                     = "m88";
+    stk500_devcode         = 0x73;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x93 0x0a;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -6800,8 +6785,8 @@ part
 #------------------------------------------------------------
 
 part parent "m88"
-    desc                = "ATmega88A";
-    id                  = "m88a";
+    desc                   = "ATmega88A";
+    id                     = "m88a";
 ;
 
 #------------------------------------------------------------
@@ -6809,9 +6794,9 @@ part parent "m88"
 #------------------------------------------------------------
 
 part parent "m88"
-    desc                = "ATmega88P";
-    id                  = "m88p";
-    signature           = 0x1e 0x93 0x0f;
+    desc                   = "ATmega88P";
+    id                     = "m88p";
+    signature              = 0x1e 0x93 0x0f;
 ;
 
 #------------------------------------------------------------
@@ -6819,9 +6804,9 @@ part parent "m88"
 #------------------------------------------------------------
 
 part parent "m88"
-    desc                = "ATmega88PA";
-    id                  = "m88pa";
-    signature           = 0x1e 0x93 0x0f;
+    desc                   = "ATmega88PA";
+    id                     = "m88pa";
+    signature              = 0x1e 0x93 0x0f;
 ;
 
 #------------------------------------------------------------
@@ -6829,10 +6814,10 @@ part parent "m88"
 #------------------------------------------------------------
 
 part parent "m88"
-    desc                = "ATmega88PB";
-    id                  = "m88pb";
-    chip_erase_delay    = 10500;
-    signature           = 0x1e 0x93 0x16;
+    desc                   = "ATmega88PB";
+    id                     = "m88pb";
+    chip_erase_delay       = 10500;
+    signature              = 0x1e 0x93 0x16;
 ;
 
 #------------------------------------------------------------
@@ -6840,124 +6825,124 @@ part parent "m88"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega168";
-    id                  = "m168";
-    stk500_devcode      = 0x86;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-    # avr910_devcode = 0x;
-    signature           = 0x1e 0x94 0x06;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega168";
+    id                     = "m168";
+    stk500_devcode         = 0x86;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x94 0x06;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--000a.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--000a.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -6966,8 +6951,8 @@ part
 #------------------------------------------------------------
 
 part parent "m168"
-    desc                = "ATmega168A";
-    id                  = "m168a";
+    desc                   = "ATmega168A";
+    id                     = "m168a";
 ;
 
 #------------------------------------------------------------
@@ -6975,9 +6960,9 @@ part parent "m168"
 #------------------------------------------------------------
 
 part parent "m168"
-    desc                = "ATmega168P";
-    id                  = "m168p";
-    signature           = 0x1e 0x94 0x0b;
+    desc                   = "ATmega168P";
+    id                     = "m168p";
+    signature              = 0x1e 0x94 0x0b;
 ;
 
 #------------------------------------------------------------
@@ -6985,9 +6970,9 @@ part parent "m168"
 #------------------------------------------------------------
 
 part parent "m168"
-    desc                = "ATmega168PA";
-    id                  = "m168pa";
-    signature           = 0x1e 0x94 0x0b;
+    desc                   = "ATmega168PA";
+    id                     = "m168pa";
+    signature              = 0x1e 0x94 0x0b;
 ;
 
 #------------------------------------------------------------
@@ -6995,10 +6980,10 @@ part parent "m168"
 #------------------------------------------------------------
 
 part parent "m168"
-    desc                = "ATmega168PB";
-    id                  = "m168pb";
-    chip_erase_delay    = 10500;
-    signature           = 0x1e 0x94 0x15;
+    desc                   = "ATmega168PB";
+    id                     = "m168pb";
+    chip_erase_delay       = 10500;
+    signature              = 0x1e 0x94 0x15;
 ;
 
 #------------------------------------------------------------
@@ -7006,123 +6991,123 @@ part parent "m168"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny828";
-    id                  = "t828";
-    stk500_devcode      = 0x86;
-    chip_erase_delay    = 15000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-    # avr910_devcode = 0x;
-    signature           = 0x1e 0x93 0x14;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny828";
+    id                     = "t828";
+    stk500_devcode         = 0x86;
+    chip_erase_delay       = 15000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x93 0x14;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 5;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 256;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 5;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--111i.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--111i.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -7131,8 +7116,8 @@ part
 #------------------------------------------------------------
 
 part parent "t828"
-    desc                = "ATtiny828R";
-    id                  = "t828r";
+    desc                   = "ATtiny828R";
+    id                     = "t828r";
 ;
 
 #------------------------------------------------------------
@@ -7140,122 +7125,122 @@ part parent "t828"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny87";
-    id                  = "t87";
-## no STK500 devcode in XML file, use the ATtiny45 one
-    stk500_devcode      = 0x14;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 15000;
-    signature           = 0x1e 0x93 0x87;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny87";
+    id                     = "t87";
+#   no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode         = 0x14;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 15000;
+    signature              = 0x1e 0x93 0x87;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
         0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
         0x06, 0x16, 0x46, 0x56, 0x0a, 0x1a, 0x4a, 0x5a,
         0x1e, 0x7c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 20;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 20;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    spmcr               = 0x57;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    spmcr                  = 0x57;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 128;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 128;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
 #   ATtiny87 has Signature Bytes: 0x1E 0x93 0x87.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -7264,123 +7249,123 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny167";
-    id                  = "t167";
-## no STK500 devcode in XML file, use the ATtiny45 one
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 15000;
-    signature           = 0x1e 0x94 0x87;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny167";
+    id                     = "t167";
+#   no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = 0x??;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 15000;
+    signature              = 0x1e 0x94 0x87;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
         0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
         0x06, 0x16, 0x46, 0x56, 0x0a, 0x1a, 0x4a, 0x5a,
         0x1e, 0x7c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 20;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 20;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    spmcr               = 0x57;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    spmcr                  = 0x57;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--000a.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--000a.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
 #   ATtiny167 has Signature Bytes: 0x1E 0x94 0x87.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -7389,124 +7374,124 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny48";
-    id                  = "t48";
-    stk500_devcode      = 0x73;
-    chip_erase_delay    = 15000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-#    avr910_devcode   = 0x;
-    signature           = 0x1e 0x92 0x09;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny48";
+    id                     = "t48";
+    stk500_devcode         = 0x73;
+    chip_erase_delay       = 15000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x92 0x09;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 64;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 64;
-        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+        size               = 64;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 64;
+        read               = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 4096;
-        page_size       = 64;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 4096;
+        page_size          = 64;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.111i";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.111i";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -7515,124 +7500,124 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny88";
-    id                  = "t88";
-    stk500_devcode      = 0x73;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-#    avr910_devcode   = 0x;
-    signature           = 0x1e 0x93 0x11;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny88";
+    id                     = "t88";
+    stk500_devcode         = 0x73;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x93 0x11;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 64;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 64;
-        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+        size               = 64;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 64;
+        read               = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -7641,124 +7626,124 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega328";
-    id                  = "m328";
-    stk500_devcode      = 0x86;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc2;
-    # avr910_devcode    = 0x;
-    signature           = 0x1e 0x95 0x14;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega328";
+    id                     = "m328";
+    stk500_devcode         = 0x86;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc2;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x95 0x14;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 128;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -7767,9 +7752,9 @@ part
 #------------------------------------------------------------
 
 part parent "m328"
-    desc                = "ATmega328P";
-    id                  = "m328p";
-    signature           = 0x1e 0x95 0x0f;
+    desc                   = "ATmega328P";
+    id                     = "m328p";
+    signature              = 0x1e 0x95 0x0f;
 ;
 
 #------------------------------------------------------------
@@ -7777,13 +7762,13 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    desc                = "ATmega328PB";
-    id                  = "m328pb";
-    chip_erase_delay    = 10500;
-    signature           = 0x1e 0x95 0x16;
+    desc                   = "ATmega328PB";
+    id                     = "m328pb";
+    chip_erase_delay       = 10500;
+    signature              = 0x1e 0x95 0x16;
 
     memory "efuse"
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 ;
 
@@ -7792,15 +7777,15 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    desc                = "ATmega32M1";
-    id                  = "m32m1";
-    bs2                 = 0xe2;
-    # stk500_devcode    = 0x;
-    # avr910_devcode    = 0x;
-    signature           = 0x1e 0x95 0x84;
+    desc                   = "ATmega32M1";
+    id                     = "m32m1";
+    bs2                    = 0xe2;
+#   stk500_devcode         = 0x??;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x95 0x84;
 
     memory "efuse"
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxii.iiii";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxii.iiii";
     ;
 ;
 
@@ -7809,34 +7794,34 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    desc                = "ATmega64M1";
-    id                  = "m64m1";
-    bs2                 = 0xe2;
-    # stk500_devcode    = 0x;
-    # avr910_devcode    = 0x;
-    signature           = 0x1e 0x96 0x84;
+    desc                   = "ATmega64M1";
+    id                     = "m64m1";
+    bs2                    = 0xe2;
+#   stk500_devcode         = 0x??;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x96 0x84;
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 8;
-        read            = "1010.0000--000x.xaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+        size               = 2048;
+        page_size          = 8;
+        read               = "1010.0000--000x.xaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        size               = 0x10000;
+        page_size          = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "efuse"
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxii.iiii";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxii.iiii";
     ;
 ;
 
@@ -7845,129 +7830,129 @@ part parent "m328"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny2313";
-    id                  = "t2313";
-    stk500_devcode      = 0x23;
-##   Use the ATtiny26 devcode:
-    avr910_devcode      = 0x5e;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd4;
-    bs2                 = 0xd6;
-    signature           = 0x1e 0x91 0x0a;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny2313";
+    id                     = "t2313";
+    stk500_devcode         = 0x23;
+#   Use the ATtiny26 devcode:
+    avr910_devcode         = 0x5e;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd4;
+    bs2                    = 0xd6;
+    signature              = 0x1e 0x91 0x0a;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
         0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
         0x26, 0x36, 0x66, 0x76, 0x2a, 0x3a, 0x6a, 0x7a,
         0x2e, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb2, 0x0f, 0x1f;
-    eeprom_instr        =
+    flash_instr            =  0xb2, 0x0f, 0x1f;
+    eeprom_instr           =
         0xbb, 0xfe, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xba, 0x0f, 0xb2, 0x0f, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 0;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 0;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+        size               = 128;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 2048;
-        page_size       = 32;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        paged              = yes;
+        size               = 2048;
+        page_size          = 32;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
 # The information in the data sheet of April/2004 is wrong, this works:
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
 # The information in the data sheet of April/2004 is wrong, this works:
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
 # The information in the data sheet of April/2004 is wrong, this works:
-        writepage       = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
+        writepage          = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 #   ATtiny2313 has Signature Bytes: 0x1E 0x91 0x0A.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 # The Tiny2313 has calibration data for both 4 MHz and 8 MHz.
 # The information in the data sheet of April/2004 is wrong, this works:
 
     memory "calibration"
-        size            = 2;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 2;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -7976,8 +7961,8 @@ part
 #------------------------------------------------------------
 
 part parent "t2313"
-    desc                = "ATtiny2313A";
-    id                  = "t2313a";
+    desc                   = "ATtiny2313A";
+    id                     = "t2313a";
 ;
 
 #------------------------------------------------------------
@@ -7985,124 +7970,124 @@ part parent "t2313"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny4313";
-    id                  = "t4313";
-    stk500_devcode      = 0x23;
-##   Use the ATtiny26 devcode:
-    avr910_devcode      = 0x5e;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd4;
-    bs2                 = 0xd6;
-    signature           = 0x1e 0x92 0x0d;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny4313";
+    id                     = "t4313";
+    stk500_devcode         = 0x23;
+#   Use the ATtiny26 devcode:
+    avr910_devcode         = 0x5e;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd4;
+    bs2                    = 0xd6;
+    signature              = 0x1e 0x92 0x0d;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
         0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
         0x26, 0x36, 0x66, 0x76, 0x2a, 0x3a, 0x6a, 0x7a,
         0x2e, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb2, 0x0f, 0x1f;
-    eeprom_instr        =
+    flash_instr            =  0xb2, 0x0f, 0x1f;
+    eeprom_instr           =
         0xbb, 0xfe, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xba, 0x0f, 0xb2, 0x0f, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 0;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 0;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+        size               = 256;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 4096;
-        page_size       = 64;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 4096;
+        page_size          = 64;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 #   ATtiny4313 has Signature Bytes: 0x1E 0x92 0x0D.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 2;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 2;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -8111,122 +8096,122 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90PWM2";
-    id                  = "pwm2";
-    stk500_devcode      = 0x65;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd8;
-    bs2                 = 0xe2;
-##  avr910_devcode   = ?;
-    signature           = 0x1e 0x93 0x81;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90PWM2";
+    id                     = "pwm2";
+    stk500_devcode         = 0x65;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd8;
+    bs2                    = 0xe2;
+#   avr910_devcode         = ?;
+    signature              = 0x1e 0x93 0x81;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 #   AT90PWM2 has Signature Bytes: 0x1E 0x93 0x81.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--00xx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--00xx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -8237,8 +8222,8 @@ part
 # Completely identical to AT90PWM2 (including the signature!)
 
 part parent "pwm2"
-    desc                = "AT90PWM3";
-    id                  = "pwm3";
+    desc                   = "AT90PWM3";
+    id                     = "pwm3";
 ;
 
 #------------------------------------------------------------
@@ -8247,10 +8232,10 @@ part parent "pwm2"
 # Same as AT90PWM2 but different signature.
 
 part parent "pwm2"
-    desc                = "AT90PWM2B";
-    id                  = "pwm2b";
-    signature           = 0x1e 0x93 0x83;
-    ocdrev              = 1;
+    desc                   = "AT90PWM2B";
+    id                     = "pwm2b";
+    signature              = 0x1e 0x93 0x83;
+    ocdrev                 = 1;
 ;
 
 #------------------------------------------------------------
@@ -8260,8 +8245,8 @@ part parent "pwm2"
 # Completely identical to AT90PWM2B (including the signature!)
 
 part parent "pwm2b"
-    desc                = "AT90PWM3B";
-    id                  = "pwm3b";
+    desc                   = "AT90PWM3B";
+    id                     = "pwm3b";
 ;
 
 #------------------------------------------------------------
@@ -8271,20 +8256,20 @@ part parent "pwm2b"
 # Similar to AT90PWM3B, but with 16 kiB flash, 512 B EEPROM, and 1024 B SRAM.
 
 part parent "pwm3b"
-    desc                = "AT90PWM316";
-    id                  = "pwm316";
-    signature           = 0x1e 0x94 0x83;
+    desc                   = "AT90PWM316";
+    id                     = "pwm316";
+    signature              = 0x1e 0x94 0x83;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 128;
-        mode            = 33;
-        blocksize       = 128;
-        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        size               = 0x4000;
+        page_size          = 128;
+        mode               = 33;
+        blocksize          = 128;
+        read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 ;
 
@@ -8294,8 +8279,8 @@ part parent "pwm3b"
 # Completely identical to AT90PWM316 (including the signature!)
 
 part parent "pwm316"
-    desc                = "AT90PWM216";
-    id                  = "pwm216";
+    desc                   = "AT90PWM216";
+    id                     = "pwm216";
 ;
 
 #------------------------------------------------------------
@@ -8303,126 +8288,126 @@ part parent "pwm316"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny25";
-    id                  = "t25";
-## no STK500 devcode in XML file, use the ATtiny45 one
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 4500;
-    signature           = 0x1e 0x91 0x08;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny25";
+    id                     = "t25";
+#  no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = ?;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 4500;
+    signature              = 0x1e 0x91 0x08;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
         0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    flash_instr         =  0xb4, 0x02, 0x12;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x02, 0x12;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x02, 0xb4, 0x02, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+        size               = 128;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 2048;
-        page_size       = 32;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 2048;
+        page_size          = 32;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 #   ATtiny25 has Signature Bytes: 0x1E 0x91 0x08.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -8431,125 +8416,125 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny45";
-    id                  = "t45";
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 4500;
-    signature           = 0x1e 0x92 0x06;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny45";
+    id                     = "t45";
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = ?;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 4500;
+    signature              = 0x1e 0x92 0x06;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
         0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    flash_instr         =  0xb4, 0x02, 0x12;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x02, 0x12;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x02, 0xb4, 0x02, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+        size               = 256;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 4096;
-        page_size       = 64;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 4096;
+        page_size          = 64;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 #   ATtiny45 has Signature Bytes: 0x1E 0x92 0x08. (Data sheet 2586C-AVR-06/05 (doc2586.pdf) indicates otherwise!)
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -8558,126 +8543,126 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny85";
-    id                  = "t85";
-## no STK500 devcode in XML file, use the ATtiny45 one
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 4500;
-    signature           = 0x1e 0x93 0x0b;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny85";
+    id                     = "t85";
+#   no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = ?;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 4500;
+    signature              = 0x1e 0x93 0x0b;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
         0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    flash_instr         =  0xb4, 0x02, 0x12;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x02, 0x12;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x02, 0xb4, 0x02, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 #   ATtiny85 has Signature Bytes: 0x1E 0x93 0x08.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -8687,119 +8672,119 @@ part
 # Almost same as ATmega1280, except for different memory sizes
 
 part
-    desc                = "ATmega640";
-    id                  = "m640";
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x96 0x08;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega640";
+    id                     = "m640";
+#   stk500_devcode         = 0xB2;
+#   avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x96 0x08;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 4096;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x10000;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x10000;
+        page_size          = 256;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -8808,119 +8793,119 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega1280";
-    id                  = "m1280";
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x97 0x03;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega1280";
+    id                     = "m1280";
+#   stk500_devcode         = 0xB2;
+#   avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x97 0x03;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 4096;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x20000;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x20000;
+        page_size          = 256;
+        num_pages          = 512;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -8930,9 +8915,9 @@ part
 # Identical to ATmega1280
 
 part parent "m1280"
-    desc                = "ATmega1281";
-    id                  = "m1281";
-    signature           = 0x1e 0x97 0x04;
+    desc                   = "ATmega1281";
+    id                     = "m1281";
+    signature              = 0x1e 0x97 0x04;
 ;
 
 #------------------------------------------------------------
@@ -8940,120 +8925,120 @@ part parent "m1280"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega2560";
-    id                  = "m2560";
-    stk500_devcode      = 0xb2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x98 0x01;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega2560";
+    id                     = "m2560";
+    stk500_devcode         = 0xb2;
+#   avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x98 0x01;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    ocdrev              = 4;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    ocdrev                 = 4;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 4096;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x40000;
-        page_size       = 256;
-        num_pages       = 1024;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        load_ext_addr   = "0100.1101--0000.0000--0000.000a--0000.0000";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x40000;
+        page_size          = 256;
+        num_pages          = 1024;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        load_ext_addr      = "0100.1101--0000.0000--0000.000a--0000.0000";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -9062,9 +9047,9 @@ part
 #------------------------------------------------------------
 
 part parent "m2560"
-    desc                = "ATmega2561";
-    id                  = "m2561";
-    signature           = 0x1e 0x98 0x02;
+    desc                   = "ATmega2561";
+    id                     = "m2561";
+    signature              = 0x1e 0x98 0x02;
 ;
 
 #------------------------------------------------------------
@@ -9073,20 +9058,20 @@ part parent "m2560"
 # Identical to ATmega2561 but half the ROM
 
 part parent "m2561"
-    desc                = "ATmega128RFA1";
-    id                  = "m128rfa1";
-    chip_erase_delay    = 55000;
-    bs2                 = 0xe2;
-    signature           = 0x1e 0xa7 0x01;
-    ocdrev              = 3;
+    desc                   = "ATmega128RFA1";
+    id                     = "m128rfa1";
+    chip_erase_delay       = 55000;
+    bs2                    = 0xe2;
+    signature              = 0x1e 0xa7 0x01;
+    ocdrev                 = 3;
 
     memory "flash"
-        size            = 0x20000;
-        num_pages       = 512;
-        min_write_delay = 50000;
-        max_write_delay = 50000;
-        delay           = 20;
-        load_ext_addr   = NULL;
+        size               = 0x20000;
+        num_pages          = 512;
+        min_write_delay    = 50000;
+        max_write_delay    = 50000;
+        delay              = 20;
+        load_ext_addr      = NULL;
     ;
 ;
 
@@ -9095,19 +9080,19 @@ part parent "m2561"
 #------------------------------------------------------------
 
 part parent "m2561"
-    desc                = "ATmega256RFR2";
-    id                  = "m256rfr2";
-    chip_erase_delay    = 18500;
-    bs2                 = 0xe2;
-    signature           = 0x1e 0xa8 0x02;
+    desc                   = "ATmega256RFR2";
+    id                     = "m256rfr2";
+    chip_erase_delay       = 18500;
+    bs2                    = 0xe2;
+    signature              = 0x1e 0xa8 0x02;
 
     memory "eeprom"
-        size            = 8192;
-        min_write_delay = 13000;
-        max_write_delay = 13000;
-        read            = "1010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxa.aaaa--aaaa.aaaa--iiii.iiii";
-        writepage       = "1100.0010--00xa.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 8192;
+        min_write_delay    = 13000;
+        max_write_delay    = 13000;
+        read               = "1010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxa.aaaa--aaaa.aaaa--iiii.iiii";
+        writepage          = "1100.0010--00xa.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 ;
 
@@ -9116,9 +9101,9 @@ part parent "m2561"
 #------------------------------------------------------------
 
 part parent "m128rfa1"
-    desc                = "ATmega128RFR2";
-    id                  = "m128rfr2";
-    signature           = 0x1e 0xa7 0x02;
+    desc                   = "ATmega128RFR2";
+    id                     = "m128rfr2";
+    signature              = 0x1e 0xa7 0x02;
 ;
 
 #------------------------------------------------------------
@@ -9126,25 +9111,25 @@ part parent "m128rfa1"
 #------------------------------------------------------------
 
 part parent "m128rfa1"
-    desc                = "ATmega64RFR2";
-    id                  = "m64rfr2";
-    signature           = 0x1e 0xa6 0x02;
+    desc                   = "ATmega64RFR2";
+    id                     = "m64rfr2";
+    signature              = 0x1e 0xa6 0x02;
 
     memory "eeprom"
-        size            = 2048;
-        min_write_delay = 13000;
-        max_write_delay = 13000;
-        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+        size               = 2048;
+        min_write_delay    = 13000;
+        max_write_delay    = 13000;
+        read               = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        size            = 0x10000;
-        num_pages       = 256;
-        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        writepage       = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        size               = 0x10000;
+        num_pages          = 256;
+        read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        writepage          = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 ;
 
@@ -9153,9 +9138,9 @@ part parent "m128rfa1"
 #------------------------------------------------------------
 
 part parent "m256rfr2"
-    desc                = "ATmega2564RFR2";
-    id                  = "m2564rfr2";
-    signature           = 0x1e 0xa8 0x03;
+    desc                   = "ATmega2564RFR2";
+    id                     = "m2564rfr2";
+    signature              = 0x1e 0xa8 0x03;
 ;
 
 #------------------------------------------------------------
@@ -9163,9 +9148,9 @@ part parent "m256rfr2"
 #------------------------------------------------------------
 
 part parent "m128rfr2"
-    desc                = "ATmega1284RFR2";
-    id                  = "m1284rfr2";
-    signature           = 0x1e 0xa7 0x03;
+    desc                   = "ATmega1284RFR2";
+    id                     = "m1284rfr2";
+    signature              = 0x1e 0xa7 0x03;
 ;
 
 #------------------------------------------------------------
@@ -9173,9 +9158,9 @@ part parent "m128rfr2"
 #------------------------------------------------------------
 
 part parent "m64rfr2"
-    desc                = "ATmega644RFR2";
-    id                  = "m644rfr2";
-    signature           = 0x1e 0xa6 0x03;
+    desc                   = "ATmega644RFR2";
+    id                     = "m644rfr2";
+    signature              = 0x1e 0xa6 0x03;
 ;
 
 #------------------------------------------------------------
@@ -9183,126 +9168,126 @@ part parent "m64rfr2"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny24";
-    id                  = "t24";
-## no STK500 devcode in XML file, use the ATtiny45 one
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 4500;
-    signature           = 0x1e 0x91 0x0b;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny24";
+    id                     = "t24";
+#   no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = ?;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 4500;
+    signature              = 0x1e 0x91 0x0b;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
         0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0f;
-    flash_instr         =  0xb4, 0x07, 0x17;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x07, 0x17;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 70;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+        size               = 128;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 2048;
-        page_size       = 32;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 2048;
+        page_size          = 32;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
 #   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -9311,8 +9296,8 @@ part
 #------------------------------------------------------------
 
 part parent "t24"
-    desc                = "ATtiny24A";
-    id                  = "t24a";
+    desc                   = "ATtiny24A";
+    id                     = "t24a";
 ;
 
 #------------------------------------------------------------
@@ -9320,126 +9305,126 @@ part parent "t24"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny44";
-    id                  = "t44";
-## no STK500 devcode in XML file, use the ATtiny45 one
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 4500;
-    signature           = 0x1e 0x92 0x07;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny44";
+    id                     = "t44";
+#   no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = ?;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 4500;
+    signature              = 0x1e 0x92 0x07;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
         0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0f;
-    flash_instr         =  0xb4, 0x07, 0x17;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x07, 0x17;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 70;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+        size               = 256;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 4096;
-        page_size       = 64;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 4096;
+        page_size          = 64;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
 #   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -9448,8 +9433,8 @@ part
 #------------------------------------------------------------
 
 part parent "t44"
-    desc                = "ATtiny44A";
-    id                  = "t44a";
+    desc                   = "ATtiny44A";
+    id                     = "t44a";
 ;
 
 #------------------------------------------------------------
@@ -9457,126 +9442,126 @@ part parent "t44"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny84";
-    id                  = "t84";
-## no STK500 devcode in XML file, use the ATtiny45 one
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 4500;
-    signature           = 0x1e 0x93 0x0c;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    hvsp_controlstack   =
+    desc                   = "ATtiny84";
+    id                     = "t84";
+#   no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = ?;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 4500;
+    signature              = 0x1e 0x93 0x0c;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    hvsp_controlstack      =
         0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
         0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
         0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0f;
-    flash_instr         =  0xb4, 0x07, 0x17;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x07, 0x17;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
+    hventerstabdelay       = 100;
+    latchcycles            = 1;
+    togglevtg              = 1;
+    poweroffdelay          = 25;
+    resetdelayus           = 70;
+    hvleavestabdelay       = 100;
+    resetdelay             = 25;
+    chiperasepolltimeout   = 40;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-    synchcycles         = 6;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    synchcycles            = 6;
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 64;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 32;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 64;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 32;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
 #   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -9585,8 +9570,8 @@ part
 #------------------------------------------------------------
 
 part parent "t84"
-    desc                = "ATtiny84A";
-    id                  = "t84a";
+    desc                   = "ATtiny84A";
+    id                     = "t84a";
 ;
 
 #------------------------------------------------------------
@@ -9594,21 +9579,21 @@ part parent "t84"
 #------------------------------------------------------------
 
 part parent "t44"
-    desc                = "ATtiny441";
-    id                  = "t441";
-    signature           = 0x1e 0x92 0x15;
+    desc                   = "ATtiny441";
+    id                     = "t441";
+    signature              = 0x1e 0x92 0x15;
 
     memory "flash"
-        page_size       = 16;
-        num_pages       = 256;
-        blocksize       = 16;
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.xaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.xaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.0aaa--aaaa.axxx--xxxx.xxxx";
+        page_size          = 16;
+        num_pages          = 256;
+        blocksize          = 16;
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.0aaa--aaaa.axxx--xxxx.xxxx";
     ;
 
     memory "efuse"
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 ;
 
@@ -9617,21 +9602,21 @@ part parent "t44"
 #------------------------------------------------------------
 
 part parent "t84"
-    desc                = "ATtiny841";
-    id                  = "t841";
-    signature           = 0x1e 0x93 0x15;
+    desc                   = "ATtiny841";
+    id                     = "t841";
+    signature              = 0x1e 0x93 0x15;
 
     memory "flash"
-        page_size       = 16;
-        num_pages       = 512;
-        blocksize       = 16;
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.xaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.xaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.aaaa--aaaa.axxx--xxxx.xxxx";
+        page_size          = 16;
+        num_pages          = 512;
+        blocksize          = 16;
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.aaaa--aaaa.axxx--xxxx.xxxx";
     ;
 
     memory "efuse"
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 ;
 
@@ -9640,125 +9625,125 @@ part parent "t84"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny43U";
-    id                  = "t43u";
-    stk500_devcode      = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode      = 0x20;
-    chip_erase_delay    = 1000;
-    signature           = 0x1e 0x92 0x0c;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny43U";
+    id                     = "t43u";
+    stk500_devcode         = 0x14;
+#   avr910_devcode         = ?;
+#   Try the AT90S2313 devcode:
+    avr910_devcode         = 0x20;
+    chip_erase_delay       = 1000;
+    signature              = 0x1e 0x92 0x0c;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
         0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
         0x06, 0x16, 0x46, 0x56, 0x0a, 0x1a, 0x4a, 0x5a,
         0x1e, 0x7c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb4, 0x07, 0x17;
-    eeprom_instr        =
+    flash_instr            =  0xb4, 0x07, 0x17;
+    eeprom_instr           =
         0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
         0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
         0x99, 0xe1, 0xbb, 0xac;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 20;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 20;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = yes;
-        size            = 64;
-        page_size       = 4;
-        num_pages       = 16;
-        min_write_delay = 4000;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 5;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxx--00aa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxx--00aa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxx--00aa.aa00--xxxx.xxxx";
+        paged              = yes;
+        size               = 64;
+        page_size          = 4;
+        num_pages          = 16;
+        min_write_delay    = 4000;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 5;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxx--00aa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxx--00aa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxx--00aa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 4096;
-        page_size       = 64;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 64;
-        readsize        = 256;
-        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 4096;
+        page_size          = 64;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 64;
+        readsize           = 256;
+        read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -9767,120 +9752,120 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega16U4";
-    id                  = "m16u4";
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x94 0x88;
-    usbpid              = 0x2ff4;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega16U4";
+    id                     = "m16u4";
+#   stk500_devcode         = 0xB2;
+#   avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x94 0x88;
+    usbpid                 = 0x2ff4;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--00oo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--00oo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -9889,120 +9874,120 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega32U4";
-    id                  = "m32u4";
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x95 0x87;
-    usbpid              = 0x2ff4;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega32U4";
+    id                     = "m32u4";
+#   stk500_devcode         = 0xB2;
+#   avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x95 0x87;
+    usbpid                 = 0x2ff4;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xaaa--aaaa.aa00--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xaaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 128;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -10011,120 +9996,120 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AT90USB646";
-    id                  = "usb646";
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x96 0x82;
-    usbpid              = 0x2ff9;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90USB646";
+    id                     = "usb646";
+#   stk500_devcode         = 0xB2;
+#   avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x96 0x82;
+    usbpid                 = 0x2ff9;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+        size               = 2048;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x10000;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x10000;
+        page_size          = 256;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -10134,8 +10119,8 @@ part
 # identical to AT90USB646
 
 part parent "usb646"
-    desc                = "AT90USB647";
-    id                  = "usb647";
+    desc                   = "AT90USB647";
+    id                     = "usb647";
 ;
 
 #------------------------------------------------------------
@@ -10143,120 +10128,120 @@ part parent "usb646"
 #------------------------------------------------------------
 
 part
-    desc                = "AT90USB1286";
-    id                  = "usb1286";
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x97 0x82;
-    usbpid              = 0x2ffb;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90USB1286";
+    id                     = "usb1286";
+#   stk500_devcode         = 0xB2;
+#   avr910_devcode         = 0x43;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x97 0x82;
+    usbpid                 = 0x2ffb;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    rampz               = 0x3b;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    rampz                  = 0x3b;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+        size               = 4096;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x20000;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 256;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x20000;
+        page_size          = 256;
+        num_pages          = 512;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 256;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -10266,8 +10251,8 @@ part
 # identical to AT90USB1286
 
 part parent "usb1286"
-    desc                = "AT90USB1287";
-    id                  = "usb1287";
+    desc                   = "AT90USB1287";
+    id                     = "usb1287";
 ;
 
 #------------------------------------------------------------
@@ -10275,609 +10260,588 @@ part parent "usb1286"
 #------------------------------------------------------------
 
 part
-    desc                = "AT90USB162";
-    id                  = "usb162";
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc6;
-    signature           = 0x1e 0x94 0x82;
-    usbpid              = 0x2ffa;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90USB162";
+    id                     = "usb162";
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc6;
+    signature              = 0x1e 0x94 0x82;
+    usbpid                 = 0x2ffa;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        num_pages       = 128;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        num_pages          = 128;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
 #------------------------------------------------------------
 # AT90USB82
 #------------------------------------------------------------
-# Changes against AT90USB162 (beside IDs)
-#    memory "flash"
-#        size            = 8192;
-#        num_pages       = 64;
 
 part
-    desc                = "AT90USB82";
-    id                  = "usb82";
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc6;
-    signature           = 0x1e 0x93 0x82;
-    usbpid              = 0x2ff7;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "AT90USB82";
+    id                     = "usb82";
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc6;
+    signature              = 0x1e 0x93 0x82;
+    usbpid                 = 0x2ff7;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        num_pages       = 128;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        num_pages          = 128;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 128;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 128;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
 #------------------------------------------------------------
 # ATmega32U2
 #------------------------------------------------------------
-# Changes against AT90USB162 (beside IDs)
-#    memory "flash"
-#        size            = 32768;
-#        num_pages       = 256;
-#    memory "eeprom"
-#        size            = 1024;
-#        num_pages       = 256;
+
 part
-    desc                = "ATmega32U2";
-    id                  = "m32u2";
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc6;
-    signature           = 0x1e 0x95 0x8a;
-    usbpid              = 0x2ff0;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega32U2";
+    id                     = "m32u2";
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc6;
+    signature              = 0x1e 0x95 0x8a;
+    usbpid                 = 0x2ff0;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 4;
-        num_pages       = 256;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 4;
+        num_pages          = 256;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 128;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
 #------------------------------------------------------------
 # ATmega16U2
 #------------------------------------------------------------
-# Changes against ATmega32U2 (beside IDs)
-#    memory "flash"
-#        size            = 16384;
-#        num_pages       = 128;
-#    memory "eeprom"
-#        size            = 512;
-#        num_pages       = 128;
+
 part
-    desc                = "ATmega16U2";
-    id                  = "m16u2";
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc6;
-    signature           = 0x1e 0x94 0x89;
-    usbpid              = 0x2fef;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega16U2";
+    id                     = "m16u2";
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc6;
+    signature              = 0x1e 0x94 0x89;
+    usbpid                 = 0x2fef;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        num_pages       = 128;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        num_pages          = 128;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
 #------------------------------------------------------------
 # ATmega8U2
 #------------------------------------------------------------
-# Changes against ATmega16U2 (beside IDs)
-#    memory "flash"
-#        size            = 8192;
-#        page_size       = 64;
-#        blocksize       = 64;
 
 part
-    desc                = "ATmega8U2";
-    id                  = "m8u2";
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xc6;
-    signature           = 0x1e 0x93 0x89;
-    usbpid              = 0x2fee;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega8U2";
+    id                     = "m8u2";
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xc6;
+    signature              = 0x1e 0x93 0x89;
+    usbpid                 = 0x2fee;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    ocdrev              = 1;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    ocdrev                 = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        num_pages       = 128;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        num_pages          = 128;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 8192;
-        page_size       = 128;
-        num_pages       = 64;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 8192;
+        page_size          = 128;
+        num_pages          = 64;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -10886,118 +10850,118 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega165";
-    id                  = "m165";
-#   stk500_devcode   = 0x??;
-#   avr910_devcode   = 0x??;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x94 0x10;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega165";
+    id                     = "m165";
+#   stk500_devcode         = 0x??;
+#   avr910_devcode         = 0x??;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x94 0x10;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 6;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 6;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    eecr                = 0x3f;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    eecr                   = 0x3f;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        num_pages       = 128;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        mode            = 65;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--0000.00xa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.00xa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--0000.00xa--aaaa.aa00--xxxx.xxxx";
+        size               = 512;
+        page_size          = 4;
+        num_pages          = 128;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        mode               = 65;
+        delay              = 20;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--0000.00xa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.00xa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--0000.00xa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--0000.xxxx--xxaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--0000.xxxx--xxaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 128;
+        num_pages          = 128;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--0000.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--0000.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--0000.0000--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--0000.0000--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--0000.0000--xxxx.xxxx--oooo.oooo";
     ;
 ;
 
@@ -11006,8 +10970,8 @@ part
 #------------------------------------------------------------
 
 part parent "m165"
-    desc                = "ATmega165A";
-    id                  = "m165a";
+    desc                   = "ATmega165A";
+    id                     = "m165a";
 ;
 
 #------------------------------------------------------------
@@ -11015,9 +10979,9 @@ part parent "m165"
 #------------------------------------------------------------
 
 part parent "m165"
-    desc                = "ATmega165P";
-    id                  = "m165p";
-    signature           = 0x1e 0x94 0x07;
+    desc                   = "ATmega165P";
+    id                     = "m165p";
+    signature              = 0x1e 0x94 0x07;
 ;
 
 #------------------------------------------------------------
@@ -11025,9 +10989,9 @@ part parent "m165"
 #------------------------------------------------------------
 
 part parent "m165"
-    desc                = "ATmega165PA";
-    id                  = "m165pa";
-    signature           = 0x1e 0x94 0x07;
+    desc                   = "ATmega165PA";
+    id                     = "m165pa";
+    signature              = 0x1e 0x94 0x07;
 ;
 
 #------------------------------------------------------------
@@ -11035,121 +10999,121 @@ part parent "m165"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega325";
-    id                  = "m325";
-#   stk500_devcode   = 0x??; # No STK500v1 support?
-#   avr910_devcode   = 0x??; # Try the ATmega16 one
-    avr910_devcode      = 0x74;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x95 0x05;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega325";
+    id                     = "m325";
+#   stk500_devcode         = 0x??; # No STK500v1 support?
+#   avr910_devcode         = 0x??; # Try the ATmega16 one
+    avr910_devcode         = 0x74;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x95 0x05;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--0000.0000--0000.0000";
-    pgm_enable          = "1010.1100--0101.0011--0000.0000--0000.0000";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--0000.0000--0000.0000";
+    pgm_enable             = "1010.1100--0101.0011--0000.0000--0000.0000";
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.00aa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--0000.00aa--aaaa.aa00--xxxx.xxxx";
+        size               = 1024;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.00aa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--0000.00aa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x8000;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--0000.0000--aaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--0000.0000--aaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--0aaa.aaaa--aaaa.aaaa--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x8000;
+        page_size          = 128;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--0000.0000--aaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--0000.0000--aaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--0aaa.aaaa--aaaa.aaaa--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--1010.0000--0000.0000--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--1010.0000--0000.0000--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--0000.0000--oooo.oooo";
-        write           = "1010.1100--1010.1000--0000.0000--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--0000.0000--oooo.oooo";
+        write              = "1010.1100--1010.1000--0000.0000--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--0000.0000--oooo.oooo";
-        write           = "1010.1100--1010.0100--0000.0000--1111.1iii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--0000.0000--oooo.oooo";
+        write              = "1010.1100--1010.0100--0000.0000--1111.1iii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1110.0000--0000.0000--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1110.0000--0000.0000--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--0000.0000--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--0000.0000--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--0000.0000--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -11158,8 +11122,8 @@ part
 #------------------------------------------------------------
 
 part parent "m325"
-    desc                = "ATmega325A";
-    id                  = "m325a";
+    desc                   = "ATmega325A";
+    id                     = "m325a";
 ;
 
 #------------------------------------------------------------
@@ -11167,9 +11131,9 @@ part parent "m325"
 #------------------------------------------------------------
 
 part parent "m325"
-    desc                = "ATmega325P";
-    id                  = "m325p";
-    signature           = 0x1e 0x95 0x0d;
+    desc                   = "ATmega325P";
+    id                     = "m325p";
+    signature              = 0x1e 0x95 0x0d;
 ;
 
 #------------------------------------------------------------
@@ -11177,9 +11141,9 @@ part parent "m325"
 #------------------------------------------------------------
 
 part parent "m325"
-    desc                = "ATmega325PA";
-    id                  = "m325pa";
-    signature           = 0x1e 0x95 0x0d;
+    desc                   = "ATmega325PA";
+    id                     = "m325pa";
+    signature              = 0x1e 0x95 0x0d;
 ;
 
 #------------------------------------------------------------
@@ -11187,121 +11151,121 @@ part parent "m325"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega645";
-    id                  = "m645";
-#   stk500_devcode   = 0x??; # No STK500v1 support?
-#   avr910_devcode   = 0x??; # Try the ATmega16 one
-    avr910_devcode      = 0x74;
-    chip_erase_delay    = 9000;
-    pagel               = 0xd7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x96 0x05;
-    reset               = io;
-    has_jtag            = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATmega645";
+    id                     = "m645";
+#   stk500_devcode         = 0x??; # No STK500v1 support?
+#   avr910_devcode         = 0x??; # Try the ATmega16 one
+    avr910_devcode         = 0x74;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xd7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x96 0x05;
+    reset                  = io;
+    has_jtag               = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    latchcycles            = 5;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    ocdrev              = 3;
-    chip_erase          = "1010.1100--1000.0000--0000.0000--0000.0000";
-    pgm_enable          = "1010.1100--0101.0011--0000.0000--0000.0000";
+    idr                    = 0x31;
+    spmcr                  = 0x57;
+    ocdrev                 = 3;
+    chip_erase             = "1010.1100--1000.0000--0000.0000--0000.0000";
+    pgm_enable             = "1010.1100--0101.0011--0000.0000--0000.0000";
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 8;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 8;
-        readsize        = 256;
-        read            = "1010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--0000.0aaa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
-        writepage       = "1100.0010--0000.0aaa--aaaa.a000--xxxx.xxxx";
+        size               = 2048;
+        page_size          = 8;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 8;
+        readsize           = 256;
+        read               = "1010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--0000.0aaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage          = "1100.0010--0000.0aaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x10000;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 10;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--0000.0000--aaaa.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--0000.0000--aaaa.aaaa--iiii.iiii";
-        writepage       = "0100.1100--aaaa.aaaa--aaaa.aaaa--0000.0000";
+        paged              = yes;
+        size               = 0x10000;
+        page_size          = 256;
+        num_pages          = 256;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 10;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--0000.0000--aaaa.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--0000.0000--aaaa.aaaa--iiii.iiii";
+        writepage          = "0100.1100--aaaa.aaaa--aaaa.aaaa--0000.0000";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.0000--0000.0000--oooo.oooo";
-        write           = "1010.1100--1010.0000--0000.0000--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.0000--0000.0000--oooo.oooo";
+        write              = "1010.1100--1010.0000--0000.0000--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.1000--0000.0000--oooo.oooo";
-        write           = "1010.1100--1010.1000--0000.0000--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.1000--0000.0000--oooo.oooo";
+        write              = "1010.1100--1010.1000--0000.0000--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.0000--0000.1000--0000.0000--oooo.oooo";
-        write           = "1010.1100--1010.0100--0000.0000--1111.1iii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.0000--0000.1000--0000.0000--oooo.oooo";
+        write              = "1010.1100--1010.0100--0000.0000--1111.1iii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1110.0000--0000.0000--11ii.iiii";
+        size               = 1;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1110.0000--0000.0000--11ii.iiii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--0000.0000--0000.00aa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--0000.0000--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--0000.0000--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -11310,8 +11274,8 @@ part
 #------------------------------------------------------------
 
 part parent "m645"
-    desc                = "ATmega645A";
-    id                  = "m645a";
+    desc                   = "ATmega645A";
+    id                     = "m645a";
 ;
 
 #------------------------------------------------------------
@@ -11319,9 +11283,9 @@ part parent "m645"
 #------------------------------------------------------------
 
 part parent "m645"
-    desc                = "ATmega645P";
-    id                  = "m645p";
-    signature           = 0x1e 0x96 0x0d;
+    desc                   = "ATmega645P";
+    id                     = "m645p";
+    signature              = 0x1e 0x96 0x0d;
 ;
 
 #------------------------------------------------------------
@@ -11329,9 +11293,9 @@ part parent "m645"
 #------------------------------------------------------------
 
 part parent "m325"
-    desc                = "ATmega3250";
-    id                  = "m3250";
-    signature           = 0x1e 0x95 0x06;
+    desc                   = "ATmega3250";
+    id                     = "m3250";
+    signature              = 0x1e 0x95 0x06;
 ;
 
 #------------------------------------------------------------
@@ -11339,9 +11303,9 @@ part parent "m325"
 #------------------------------------------------------------
 
 part parent "m325"
-    desc                = "ATmega3250A";
-    id                  = "m3250a";
-    signature           = 0x1e 0x95 0x06;
+    desc                   = "ATmega3250A";
+    id                     = "m3250a";
+    signature              = 0x1e 0x95 0x06;
 ;
 
 #------------------------------------------------------------
@@ -11349,9 +11313,9 @@ part parent "m325"
 #------------------------------------------------------------
 
 part parent "m325"
-    desc                = "ATmega3250P";
-    id                  = "m3250p";
-    signature           = 0x1e 0x95 0x0e;
+    desc                   = "ATmega3250P";
+    id                     = "m3250p";
+    signature              = 0x1e 0x95 0x0e;
 ;
 
 #------------------------------------------------------------
@@ -11359,9 +11323,9 @@ part parent "m325"
 #------------------------------------------------------------
 
 part parent "m325"
-    desc                = "ATmega3250PA";
-    id                  = "m3250pa";
-    signature           = 0x1e 0x95 0x0e;
+    desc                   = "ATmega3250PA";
+    id                     = "m3250pa";
+    signature              = 0x1e 0x95 0x0e;
 ;
 
 #------------------------------------------------------------
@@ -11369,9 +11333,9 @@ part parent "m325"
 #------------------------------------------------------------
 
 part parent "m645"
-    desc                = "ATmega6450";
-    id                  = "m6450";
-    signature           = 0x1e 0x96 0x06;
+    desc                   = "ATmega6450";
+    id                     = "m6450";
+    signature              = 0x1e 0x96 0x06;
 ;
 
 #------------------------------------------------------------
@@ -11379,9 +11343,9 @@ part parent "m645"
 #------------------------------------------------------------
 
 part parent "m645"
-    desc                = "ATmega6450A";
-    id                  = "m6450a";
-    signature           = 0x1e 0x96 0x06;
+    desc                   = "ATmega6450A";
+    id                     = "m6450a";
+    signature              = 0x1e 0x96 0x06;
 ;
 
 #------------------------------------------------------------
@@ -11389,9 +11353,9 @@ part parent "m645"
 #------------------------------------------------------------
 
 part parent "m645"
-    desc                = "ATmega6450P";
-    id                  = "m6450p";
-    signature           = 0x1e 0x96 0x0e;
+    desc                   = "ATmega6450P";
+    id                     = "m6450p";
+    signature              = 0x1e 0x96 0x0e;
 ;
 
 #------------------------------------------------------------
@@ -11399,52 +11363,52 @@ part parent "m645"
 #------------------------------------------------------------
 
 part
-    desc                = "AVR XMEGA family common values";
-    id                  = ".xmega";
-    has_pdi             = yes;
-    mcu_base            = 0x0090;
-    nvm_base            = 0x01c0;
+    desc                   = "AVR XMEGA family common values";
+    id                     = ".xmega";
+    has_pdi                = yes;
+    mcu_base               = 0x0090;
+    nvm_base               = 0x01c0;
 
     memory "fuse1"
-        size            = 1;
-        offset          = 0x8f0021;
+        size               = 1;
+        offset             = 0x8f0021;
     ;
 
     memory "fuse2"
-        size            = 1;
-        offset          = 0x8f0022;
+        size               = 1;
+        offset             = 0x8f0022;
     ;
 
     memory "fuse4"
-        size            = 1;
-        offset          = 0x8f0024;
+        size               = 1;
+        offset             = 0x8f0024;
     ;
 
     memory "fuse5"
-        size            = 1;
-        offset          = 0x8f0025;
+        size               = 1;
+        offset             = 0x8f0025;
     ;
 
     memory "lock"
-        size            = 1;
-        offset          = 0x8f0027;
+        size               = 1;
+        offset             = 0x8f0027;
     ;
 
     memory "signature"
-        size            = 3;
-        offset          = 0x1000090;
+        size               = 3;
+        offset             = 0x1000090;
     ;
 
     memory "prodsig"
-        size            = 50;
-        page_size       = 50;
-        offset          = 0x8e0200;
-        readsize        = 50;
+        size               = 50;
+        page_size          = 50;
+        offset             = 0x8e0200;
+        readsize           = 50;
     ;
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset          = 0x1000000;
+        offset             = 0x1000000;
     ;
 ;
 
@@ -11453,51 +11417,51 @@ part
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega16A4U";
-    id                  = "x16a4u";
-    signature           = 0x1e 0x94 0x41;
-    usbpid              = 0x2fe3;
+    desc                   = "ATxmega16A4U";
+    id                     = "x16a4u";
+    signature              = 0x1e 0x94 0x41;
+    usbpid                 = 0x2fe3;
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 1024;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x5000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x5000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x4000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 4096;
-        page_size       = 256;
-        offset          = 0x803000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 256;
+        offset             = 0x803000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 4096;
-        page_size       = 256;
-        offset          = 0x804000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 256;
+        offset             = 0x804000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 256;
-        page_size       = 256;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 256;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -11506,9 +11470,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    desc                = "ATxmega16C4";
-    id                  = "x16c4";
-    signature           = 0x1e 0x94 0x43;
+    desc                   = "ATxmega16C4";
+    id                     = "x16c4";
+    signature              = 0x1e 0x94 0x43;
 ;
 
 #------------------------------------------------------------
@@ -11516,9 +11480,9 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    desc                = "ATxmega16D4";
-    id                  = "x16d4";
-    signature           = 0x1e 0x94 0x42;
+    desc                   = "ATxmega16D4";
+    id                     = "x16d4";
+    signature              = 0x1e 0x94 0x42;
 ;
 
 #------------------------------------------------------------
@@ -11526,12 +11490,12 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    desc                = "ATxmega16A4";
-    id                  = "x16a4";
+    desc                   = "ATxmega16A4";
+    id                     = "x16a4";
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 ;
 
@@ -11540,51 +11504,51 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega32A4U";
-    id                  = "x32a4u";
-    signature           = 0x1e 0x95 0x41;
-    usbpid              = 0x2fe4;
+    desc                   = "ATxmega32A4U";
+    id                     = "x32a4u";
+    signature              = 0x1e 0x95 0x41;
+    usbpid                 = 0x2fe4;
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 1024;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x9000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x9000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x8000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 4096;
-        page_size       = 256;
-        offset          = 0x807000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 256;
+        offset             = 0x807000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 4096;
-        page_size       = 256;
-        offset          = 0x808000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 256;
+        offset             = 0x808000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 256;
-        page_size       = 256;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 256;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -11593,9 +11557,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    desc                = "ATxmega32C4";
-    id                  = "x32c4";
-    signature           = 0x1e 0x95 0x44;
+    desc                   = "ATxmega32C4";
+    id                     = "x32c4";
+    signature              = 0x1e 0x95 0x44;
 ;
 
 #------------------------------------------------------------
@@ -11603,9 +11567,9 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    desc                = "ATxmega32D4";
-    id                  = "x32d4";
-    signature           = 0x1e 0x95 0x42;
+    desc                   = "ATxmega32D4";
+    id                     = "x32d4";
+    signature              = 0x1e 0x95 0x42;
 ;
 
 #------------------------------------------------------------
@@ -11613,12 +11577,12 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    desc                = "ATxmega32A4";
-    id                  = "x32a4";
+    desc                   = "ATxmega32A4";
+    id                     = "x32a4";
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 ;
 
@@ -11627,51 +11591,51 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega64A4U";
-    id                  = "x64a4u";
-    signature           = 0x1e 0x96 0x46;
-    usbpid              = 0x2fe5;
+    desc                   = "ATxmega64A4U";
+    id                     = "x64a4u";
+    signature              = 0x1e 0x96 0x46;
+    usbpid                 = 0x2fe5;
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x11000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x11000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x10000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 4096;
-        page_size       = 256;
-        offset          = 0x80f000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 256;
+        offset             = 0x80f000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 4096;
-        page_size       = 256;
-        offset          = 0x810000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 256;
+        offset             = 0x810000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 256;
-        page_size       = 256;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 256;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -11680,10 +11644,10 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    desc                = "ATxmega64C3";
-    id                  = "x64c3";
-    signature           = 0x1e 0x96 0x49;
-    usbpid              = 0x2fd6;
+    desc                   = "ATxmega64C3";
+    id                     = "x64c3";
+    signature              = 0x1e 0x96 0x49;
+    usbpid                 = 0x2fd6;
 ;
 
 #------------------------------------------------------------
@@ -11691,9 +11655,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    desc                = "ATxmega64D3";
-    id                  = "x64d3";
-    signature           = 0x1e 0x96 0x4a;
+    desc                   = "ATxmega64D3";
+    id                     = "x64d3";
+    signature              = 0x1e 0x96 0x4a;
 ;
 
 #------------------------------------------------------------
@@ -11701,9 +11665,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    desc                = "ATxmega64D4";
-    id                  = "x64d4";
-    signature           = 0x1e 0x96 0x47;
+    desc                   = "ATxmega64D4";
+    id                     = "x64d4";
+    signature              = 0x1e 0x96 0x47;
 ;
 
 #------------------------------------------------------------
@@ -11711,14 +11675,14 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    desc                = "ATxmega64A1";
-    id                  = "x64a1";
-    signature           = 0x1e 0x96 0x4e;
-    has_jtag            = yes;
+    desc                   = "ATxmega64A1";
+    id                     = "x64a1";
+    signature              = 0x1e 0x96 0x4e;
+    has_jtag               = yes;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 ;
 
@@ -11727,9 +11691,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    desc                = "ATxmega64A1U";
-    id                  = "x64a1u";
-    usbpid              = 0x2fe8;
+    desc                   = "ATxmega64A1U";
+    id                     = "x64a1u";
+    usbpid                 = 0x2fe8;
 ;
 
 #------------------------------------------------------------
@@ -11737,9 +11701,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    desc                = "ATxmega64A3";
-    id                  = "x64a3";
-    signature           = 0x1e 0x96 0x42;
+    desc                   = "ATxmega64A3";
+    id                     = "x64a3";
+    signature              = 0x1e 0x96 0x42;
 ;
 
 #------------------------------------------------------------
@@ -11747,9 +11711,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    desc                = "ATxmega64A3U";
-    id                  = "x64a3u";
-    signature           = 0x1e 0x96 0x42;
+    desc                   = "ATxmega64A3U";
+    id                     = "x64a3u";
+    signature              = 0x1e 0x96 0x42;
 ;
 
 #------------------------------------------------------------
@@ -11757,9 +11721,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    desc                = "ATxmega64A4";
-    id                  = "x64a4";
-    signature           = 0x1e 0x96 0x46;
+    desc                   = "ATxmega64A4";
+    id                     = "x64a4";
+    signature              = 0x1e 0x96 0x46;
 ;
 
 #------------------------------------------------------------
@@ -11767,10 +11731,10 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    desc                = "ATxmega64B1";
-    id                  = "x64b1";
-    signature           = 0x1e 0x96 0x52;
-    usbpid              = 0x2fe1;
+    desc                   = "ATxmega64B1";
+    id                     = "x64b1";
+    signature              = 0x1e 0x96 0x52;
+    usbpid                 = 0x2fe1;
 ;
 
 #------------------------------------------------------------
@@ -11778,10 +11742,10 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    desc                = "ATxmega64B3";
-    id                  = "x64b3";
-    signature           = 0x1e 0x96 0x51;
-    usbpid              = 0x2fdf;
+    desc                   = "ATxmega64B3";
+    id                     = "x64b3";
+    signature              = 0x1e 0x96 0x51;
+    usbpid                 = 0x2fdf;
 ;
 
 #------------------------------------------------------------
@@ -11789,51 +11753,51 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega128C3";
-    id                  = "x128c3";
-    signature           = 0x1e 0x97 0x52;
-    usbpid              = 0x2fd7;
+    desc                   = "ATxmega128C3";
+    id                     = "x128c3";
+    signature              = 0x1e 0x97 0x52;
+    usbpid                 = 0x2fd7;
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x22000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x22000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x81e000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x81e000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x820000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x820000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 512;
-        page_size       = 512;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 512;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -11842,9 +11806,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    desc                = "ATxmega128D3";
-    id                  = "x128d3";
-    signature           = 0x1e 0x97 0x48;
+    desc                   = "ATxmega128D3";
+    id                     = "x128d3";
+    signature              = 0x1e 0x97 0x48;
 ;
 
 #------------------------------------------------------------
@@ -11852,12 +11816,12 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    desc                = "ATxmega128D4";
-    id                  = "x128d4";
-    signature           = 0x1e 0x97 0x47;
+    desc                   = "ATxmega128D4";
+    id                     = "x128d4";
+    signature              = 0x1e 0x97 0x47;
 
     memory "flash"
-        page_size       = 256;
+        page_size          = 256;
     ;
 ;
 
@@ -11866,14 +11830,14 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    desc                = "ATxmega128A1";
-    id                  = "x128a1";
-    signature           = 0x1e 0x97 0x4c;
-    has_jtag            = yes;
+    desc                   = "ATxmega128A1";
+    id                     = "x128a1";
+    signature              = 0x1e 0x97 0x4c;
+    has_jtag               = yes;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 ;
 
@@ -11882,9 +11846,9 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    desc                = "ATxmega128A1revD";
-    id                  = "x128a1d";
-    signature           = 0x1e 0x97 0x41;
+    desc                   = "ATxmega128A1revD";
+    id                     = "x128a1d";
+    signature              = 0x1e 0x97 0x41;
 ;
 
 #------------------------------------------------------------
@@ -11892,9 +11856,9 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    desc                = "ATxmega128A1U";
-    id                  = "x128a1u";
-    usbpid              = 0x2fed;
+    desc                   = "ATxmega128A1U";
+    id                     = "x128a1u";
+    usbpid                 = 0x2fed;
 ;
 
 #------------------------------------------------------------
@@ -11902,9 +11866,9 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    desc                = "ATxmega128A3";
-    id                  = "x128a3";
-    signature           = 0x1e 0x97 0x42;
+    desc                   = "ATxmega128A3";
+    id                     = "x128a3";
+    signature              = 0x1e 0x97 0x42;
 ;
 
 #------------------------------------------------------------
@@ -11912,10 +11876,10 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    desc                = "ATxmega128A3U";
-    id                  = "x128a3u";
-    signature           = 0x1e 0x97 0x42;
-    usbpid              = 0x2fe6;
+    desc                   = "ATxmega128A3U";
+    id                     = "x128a3u";
+    signature              = 0x1e 0x97 0x42;
+    usbpid                 = 0x2fe6;
 ;
 
 #------------------------------------------------------------
@@ -11923,56 +11887,56 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega128A4";
-    id                  = "x128a4";
-    signature           = 0x1e 0x97 0x46;
-    has_jtag            = yes;
+    desc                   = "ATxmega128A4";
+    id                     = "x128a4";
+    signature              = 0x1e 0x97 0x46;
+    has_jtag               = yes;
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x22000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x22000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 4096;
-        page_size       = 512;
-        offset          = 0x81f000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 512;
+        offset             = 0x81f000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x820000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x820000;
+        readsize           = 256;
     ;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 
     memory "usersig"
-        size            = 512;
-        page_size       = 512;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 512;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -11981,51 +11945,51 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega128A4U";
-    id                  = "x128a4u";
-    signature           = 0x1e 0x97 0x46;
-    usbpid              = 0x2fde;
+    desc                   = "ATxmega128A4U";
+    id                     = "x128a4u";
+    signature              = 0x1e 0x97 0x46;
+    usbpid                 = 0x2fde;
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x22000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x22000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x20000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 4096;
-        page_size       = 256;
-        offset          = 0x81f000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 256;
+        offset             = 0x81f000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 8192;
-        page_size       = 256;
-        offset          = 0x820000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 256;
+        offset             = 0x820000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 256;
-        page_size       = 256;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 256;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12034,57 +11998,57 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega128B1";
-    id                  = "x128b1";
-    signature           = 0x1e 0x97 0x4d;
-    usbpid              = 0x2fea;
-    has_jtag            = yes;
+    desc                   = "ATxmega128B1";
+    id                     = "x128b1";
+    signature              = 0x1e 0x97 0x4d;
+    usbpid                 = 0x2fea;
+    has_jtag               = yes;
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x22000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x22000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x20000;
-        page_size       = 256;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 256;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 8192;
-        page_size       = 256;
-        offset          = 0x81e000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 256;
+        offset             = 0x81e000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 8192;
-        page_size       = 256;
-        offset          = 0x820000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 256;
+        offset             = 0x820000;
+        readsize           = 256;
     ;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 
     memory "usersig"
-        size            = 256;
-        page_size       = 256;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 256;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12093,10 +12057,10 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x128b1"
-    desc                = "ATxmega128B3";
-    id                  = "x128b3";
-    signature           = 0x1e 0x97 0x4b;
-    usbpid              = 0x2fe0;
+    desc                   = "ATxmega128B3";
+    id                     = "x128b3";
+    signature              = 0x1e 0x97 0x4b;
+    usbpid                 = 0x2fe0;
 ;
 
 #------------------------------------------------------------
@@ -12104,51 +12068,51 @@ part parent "x128b1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega192C3";
-    id                  = "x192c3";
-    signature           = 0x1e 0x97 0x51;
-    # usbpid            = 0x2f??;
+    desc                   = "ATxmega192C3";
+    id                     = "x192c3";
+    signature              = 0x1e 0x97 0x51;
+#   usbpid                 = 0x2f??;
 
     memory "eeprom"
-        size            = 2048;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x32000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x32000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x30000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x30000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x82e000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x82e000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x830000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x830000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 512;
-        page_size       = 512;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 512;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12157,9 +12121,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x192c3"
-    desc                = "ATxmega192D3";
-    id                  = "x192d3";
-    signature           = 0x1e 0x97 0x49;
+    desc                   = "ATxmega192D3";
+    id                     = "x192d3";
+    signature              = 0x1e 0x97 0x49;
 ;
 
 #------------------------------------------------------------
@@ -12167,14 +12131,14 @@ part parent "x192c3"
 #------------------------------------------------------------
 
 part parent "x192c3"
-    desc                = "ATxmega192A1";
-    id                  = "x192a1";
-    signature           = 0x1e 0x97 0x4e;
-    has_jtag            = yes;
+    desc                   = "ATxmega192A1";
+    id                     = "x192a1";
+    signature              = 0x1e 0x97 0x4e;
+    has_jtag               = yes;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 ;
 
@@ -12183,9 +12147,9 @@ part parent "x192c3"
 #------------------------------------------------------------
 
 part parent "x192a1"
-    desc                = "ATxmega192A3";
-    id                  = "x192a3";
-    signature           = 0x1e 0x97 0x44;
+    desc                   = "ATxmega192A3";
+    id                     = "x192a3";
+    signature              = 0x1e 0x97 0x44;
 ;
 
 #------------------------------------------------------------
@@ -12193,10 +12157,10 @@ part parent "x192a1"
 #------------------------------------------------------------
 
 part parent "x192a1"
-    desc                = "ATxmega192A3U";
-    id                  = "x192a3u";
-    signature           = 0x1e 0x97 0x44;
-    usbpid              = 0x2fe7;
+    desc                   = "ATxmega192A3U";
+    id                     = "x192a3u";
+    signature              = 0x1e 0x97 0x44;
+    usbpid                 = 0x2fe7;
 ;
 
 #------------------------------------------------------------
@@ -12204,51 +12168,51 @@ part parent "x192a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega256C3";
-    id                  = "x256c3";
-    signature           = 0x1e 0x98 0x46;
-    usbpid              = 0x2fda;
+    desc                   = "ATxmega256C3";
+    id                     = "x256c3";
+    signature              = 0x1e 0x98 0x46;
+    usbpid                 = 0x2fda;
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x42000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x42000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x40000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x40000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x83e000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x83e000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x840000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x840000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 512;
-        page_size       = 512;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 512;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12257,9 +12221,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x256c3"
-    desc                = "ATxmega256D3";
-    id                  = "x256d3";
-    signature           = 0x1e 0x98 0x44;
+    desc                   = "ATxmega256D3";
+    id                     = "x256d3";
+    signature              = 0x1e 0x98 0x44;
 ;
 
 #------------------------------------------------------------
@@ -12267,13 +12231,13 @@ part parent "x256c3"
 #------------------------------------------------------------
 
 part parent "x256c3"
-    desc                = "ATxmega256A1";
-    id                  = "x256a1";
-    has_jtag            = yes;
+    desc                   = "ATxmega256A1";
+    id                     = "x256a1";
+    has_jtag               = yes;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x8f0020;
+        size               = 1;
+        offset             = 0x8f0020;
     ;
 ;
 
@@ -12282,9 +12246,9 @@ part parent "x256c3"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    desc                = "ATxmega256A3";
-    id                  = "x256a3";
-    signature           = 0x1e 0x98 0x42;
+    desc                   = "ATxmega256A3";
+    id                     = "x256a3";
+    signature              = 0x1e 0x98 0x42;
 ;
 
 #------------------------------------------------------------
@@ -12292,10 +12256,10 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    desc                = "ATxmega256A3U";
-    id                  = "x256a3u";
-    signature           = 0x1e 0x98 0x42;
-    usbpid              = 0x2fec;
+    desc                   = "ATxmega256A3U";
+    id                     = "x256a3u";
+    signature              = 0x1e 0x98 0x42;
+    usbpid                 = 0x2fec;
 ;
 
 #------------------------------------------------------------
@@ -12303,9 +12267,9 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    desc                = "ATxmega256A3B";
-    id                  = "x256a3b";
-    signature           = 0x1e 0x98 0x43;
+    desc                   = "ATxmega256A3B";
+    id                     = "x256a3b";
+    signature              = 0x1e 0x98 0x43;
 ;
 
 #------------------------------------------------------------
@@ -12313,10 +12277,10 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    desc                = "ATxmega256A3BU";
-    id                  = "x256a3bu";
-    signature           = 0x1e 0x98 0x43;
-    usbpid              = 0x2fe2;
+    desc                   = "ATxmega256A3BU";
+    id                     = "x256a3bu";
+    signature              = 0x1e 0x98 0x43;
+    usbpid                 = 0x2fe2;
 ;
 
 #------------------------------------------------------------
@@ -12324,51 +12288,51 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega384C3";
-    id                  = "x384c3";
-    signature           = 0x1e 0x98 0x45;
-    usbpid              = 0x2fdb;
+    desc                   = "ATxmega384C3";
+    id                     = "x384c3";
+    signature              = 0x1e 0x98 0x45;
+    usbpid                 = 0x2fdb;
 
     memory "eeprom"
-        size            = 4096;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x62000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x62000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x60000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x60000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x85e000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x85e000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 8192;
-        page_size       = 512;
-        offset          = 0x860000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 512;
+        offset             = 0x860000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 512;
-        page_size       = 512;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 512;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12377,9 +12341,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x384c3"
-    desc                = "ATxmega384D3";
-    id                  = "x384d3";
-    signature           = 0x1e 0x98 0x47;
+    desc                   = "ATxmega384D3";
+    id                     = "x384d3";
+    signature              = 0x1e 0x98 0x47;
 ;
 
 #------------------------------------------------------------
@@ -12387,50 +12351,50 @@ part parent "x384c3"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega8E5";
-    id                  = "x8e5";
-    signature           = 0x1e 0x93 0x41;
+    desc                   = "ATxmega8E5";
+    id                     = "x8e5";
+    signature              = 0x1e 0x93 0x41;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x2800;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x2800;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 8192;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 2048;
-        page_size       = 128;
-        offset          = 0x801800;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 128;
+        offset             = 0x801800;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 2048;
-        page_size       = 128;
-        offset          = 0x802000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 128;
+        offset             = 0x802000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 128;
-        page_size       = 128;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 128;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12439,50 +12403,50 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega16E5";
-    id                  = "x16e5";
-    signature           = 0x1e 0x94 0x45;
+    desc                   = "ATxmega16E5";
+    id                     = "x16e5";
+    signature              = 0x1e 0x94 0x45;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x5000;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x5000;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x4000;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 4096;
-        page_size       = 128;
-        offset          = 0x803000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 128;
+        offset             = 0x803000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 4096;
-        page_size       = 128;
-        offset          = 0x804000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 128;
+        offset             = 0x804000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 128;
-        page_size       = 128;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 128;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12491,50 +12455,50 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    desc                = "ATxmega32E5";
-    id                  = "x32e5";
-    signature           = 0x1e 0x95 0x4c;
+    desc                   = "ATxmega32E5";
+    id                     = "x32e5";
+    signature              = 0x1e 0x95 0x4c;
 
     memory "eeprom"
-        size            = 1024;
-        page_size       = 32;
-        offset          = 0x8c0000;
-        readsize        = 256;
+        size               = 1024;
+        page_size          = 32;
+        offset             = 0x8c0000;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x9000;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x9000;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "application"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 
     memory "apptable"
-        size            = 4096;
-        page_size       = 128;
-        offset          = 0x807000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 128;
+        offset             = 0x807000;
+        readsize           = 256;
     ;
 
     memory "boot"
-        size            = 4096;
-        page_size       = 128;
-        offset          = 0x808000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 128;
+        offset             = 0x808000;
+        readsize           = 256;
     ;
 
     memory "usersig"
-        size            = 128;
-        page_size       = 128;
-        offset          = 0x8e0400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 128;
+        offset             = 0x8e0400;
+        readsize           = 256;
     ;
 ;
 
@@ -12543,19 +12507,19 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part
-    desc                = "AT32UC3A0512";
-    id                  = "uc3a0512";
-    signature           = 0xed 0xc0 0x3f;
-    has_jtag            = yes;
-    is_avr32            = yes;
+    desc                   = "AT32UC3A0512";
+    id                     = "uc3a0512";
+    signature              = 0xed 0xc0 0x3f;
+    has_jtag               = yes;
+    is_avr32               = yes;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x80000;    # could be set dynamicly
-        page_size       = 512;           # bytes
-        num_pages       = 1024;          # could be set dynamicly
-        offset          = 0x80000000;
-        readsize        = 512;           # bytes
+        paged              = yes;
+        size               = 0x80000;    # could be set dynamicly
+        page_size          = 512;           # bytes
+        num_pages          = 1024;          # could be set dynamicly
+        offset             = 0x80000000;
+        readsize           = 512;           # bytes
     ;
 ;
 
@@ -12564,8 +12528,8 @@ part
 #------------------------------------------------------------
 
 part parent "uc3a0512"
-    desc                = "deprecated, use 'uc3a0512'";
-    id                  = "ucr2";
+    desc                   = "deprecated, use 'uc3a0512'";
+    id                     = "ucr2";
 ;
 
 #------------------------------------------------------------
@@ -12573,122 +12537,122 @@ part parent "uc3a0512"
 #------------------------------------------------------------
 
 part
-    desc                = "ATtiny1634";
-    id                  = "t1634";
-    stk500_devcode      = 0x86;
-    chip_erase_delay    = 9000;
-    pagel               = 0xb3;
-    bs2                 = 0xb1;
-    # avr910_devcode = 0x;
-    signature           = 0x1e 0x94 0x12;
-    reset               = io;
-    has_debugwire       = yes;
-    timeout             = 200;
-    stabdelay           = 100;
-    cmdexedelay         = 25;
-    synchloops          = 32;
-    pollindex           = 3;
-    pollvalue           = 0x53;
-    predelay            = 1;
-    postdelay           = 1;
-    pollmethod          = 1;
-    pp_controlstack     =
+    desc                   = "ATtiny1634";
+    id                     = "t1634";
+    stk500_devcode         = 0x86;
+    chip_erase_delay       = 9000;
+    pagel                  = 0xb3;
+    bs2                    = 0xb1;
+#   avr910_devcode         = 0x??;
+    signature              = 0x1e 0x94 0x12;
+    reset                  = io;
+    has_debugwire          = yes;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 3;
+    pollvalue              = 0x53;
+    predelay               = 1;
+    postdelay              = 1;
+    pollmethod             = 1;
+    pp_controlstack        =
         0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
         0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
         0x26, 0x36, 0x66, 0x76, 0x2a, 0x3a, 0x6a, 0x7a,
         0x2e, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    flash_instr         =  0xb6, 0x01, 0x11;
-    eeprom_instr        =
+    flash_instr            =  0xb6, 0x01, 0x11;
+    eeprom_instr           =
         0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
         0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
         0x99, 0xf9, 0xbb, 0xaf;
-    hventerstabdelay    = 100;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepolltimeout = 10;
+    hventerstabdelay       = 100;
+    togglevtg              = 1;
+    poweroffdelay          = 15;
+    resetdelayms           = 1;
+    hvleavestabdelay       = 15;
+    resetdelay             = 15;
+    chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
-    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 4;
-        min_write_delay = 3600;
-        max_write_delay = 3600;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 5;
-        blocksize       = 4;
-        readsize        = 256;
-        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
-        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
-        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
-        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+        size               = 256;
+        page_size          = 4;
+        min_write_delay    = 3600;
+        max_write_delay    = 3600;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 5;
+        blocksize          = 4;
+        readsize           = 256;
+        read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write              = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo        = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage          = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0x4000;
-        page_size       = 32;
-        num_pages       = 512;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback        = 0xff 0xff;
-        mode            = 65;
-        delay           = 6;
-        blocksize       = 128;
-        readsize        = 256;
-        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
-        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
-        writepage       = "0100.1100--00aa.aaaa--aaaa.xxxx--xxxx.xxxx";
+        paged              = yes;
+        size               = 0x4000;
+        page_size          = 32;
+        num_pages          = 512;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 65;
+        delay              = 6;
+        blocksize          = 128;
+        readsize           = 256;
+        read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo        = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi        = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage          = "0100.1100--00aa.aaaa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxi.iiii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--xxxi.iiii";
     ;
 
     memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
-        write           = "1010.1100--111x.xxxx--xxxx.xxxx--1111.11ii";
+        size               = 1;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write              = "1010.1100--111x.xxxx--xxxx.xxxx--1111.11ii";
     ;
 
     memory "signature"
-        size            = 3;
-        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+        size               = 3;
+        read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
-        size            = 1;
-        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+        size               = 1;
+        read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -12697,8 +12661,8 @@ part
 #------------------------------------------------------------
 
 part parent "t1634"
-    desc                = "ATtiny1634R";
-    id                  = "t1634r";
+    desc                   = "ATtiny1634R";
+    id                     = "t1634r";
 ;
 
 #------------------------------------------------------------
@@ -12706,39 +12670,39 @@ part parent "t1634"
 #------------------------------------------------------------
 
 part
-    desc                = "Common values for reduced core tinys";
-    id                  = ".reduced_core_tiny";
-    has_tpi             = yes;
+    desc                   = "Common values for reduced core tinys";
+    id                     = ".reduced_core_tiny";
+    has_tpi                = yes;
 
     memory "fuse"
-        size            = 1;
-        page_size       = 16;
-        offset          = 0x3f40;
-        blocksize       = 4;
+        size               = 1;
+        page_size          = 16;
+        offset             = 0x3f40;
+        blocksize          = 4;
     ;
 
     memory "lockbits"
-        size            = 1;
-        page_size       = 16;
-        offset          = 0x3f00;
+        size               = 1;
+        page_size          = 16;
+        offset             = 0x3f00;
     ;
 
     memory "lockbits"
-        size            = 1;
-        page_size       = 16;
-        offset          = 0x3f00;
+        size               = 1;
+        page_size          = 16;
+        offset             = 0x3f00;
     ;
 
     memory "signature"
-        size            = 3;
-        page_size       = 16;
-        offset          = 0x3fc0;
+        size               = 3;
+        page_size          = 16;
+        offset             = 0x3fc0;
     ;
 
     memory "calibration"
-        size            = 1;
-        page_size       = 16;
-        offset          = 0x3f80;
+        size               = 1;
+        page_size          = 16;
+        offset             = 0x3f80;
     ;
 ;
 
@@ -12747,15 +12711,15 @@ part
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    desc                = "ATtiny4";
-    id                  = "t4";
-    signature           = 0x1e 0x8f 0x0a;
+    desc                   = "ATtiny4";
+    id                     = "t4";
+    signature              = 0x1e 0x8f 0x0a;
 
     memory "flash"
-        size            = 512;
-        page_size       = 16;
-        offset          = 0x4000;
-        blocksize       = 128;
+        size               = 512;
+        page_size          = 16;
+        offset             = 0x4000;
+        blocksize          = 128;
     ;
 ;
 
@@ -12764,9 +12728,9 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent "t4"
-    desc                = "ATtiny5";
-    id                  = "t5";
-    signature           = 0x1e 0x8f 0x09;
+    desc                   = "ATtiny5";
+    id                     = "t5";
+    signature              = 0x1e 0x8f 0x09;
 ;
 
 #------------------------------------------------------------
@@ -12774,15 +12738,15 @@ part parent "t4"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    desc                = "ATtiny9";
-    id                  = "t9";
-    signature           = 0x1e 0x90 0x08;
+    desc                   = "ATtiny9";
+    id                     = "t9";
+    signature              = 0x1e 0x90 0x08;
 
     memory "flash"
-        size            = 1024;
-        page_size       = 16;
-        offset          = 0x4000;
-        blocksize       = 128;
+        size               = 1024;
+        page_size          = 16;
+        offset             = 0x4000;
+        blocksize          = 128;
     ;
 ;
 
@@ -12791,9 +12755,9 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent "t9"
-    desc                = "ATtiny10";
-    id                  = "t10";
-    signature           = 0x1e 0x90 0x03;
+    desc                   = "ATtiny10";
+    id                     = "t10";
+    signature              = 0x1e 0x90 0x03;
 ;
 
 #------------------------------------------------------------
@@ -12801,15 +12765,15 @@ part parent "t9"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    desc                = "ATtiny20";
-    id                  = "t20";
-    signature           = 0x1e 0x91 0x0f;
+    desc                   = "ATtiny20";
+    id                     = "t20";
+    signature              = 0x1e 0x91 0x0f;
 
     memory "flash"
-        size            = 2048;
-        page_size       = 16;
-        offset          = 0x4000;
-        blocksize       = 128;
+        size               = 2048;
+        page_size          = 16;
+        offset             = 0x4000;
+        blocksize          = 128;
     ;
 ;
 
@@ -12818,15 +12782,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    desc                = "ATtiny40";
-    id                  = "t40";
-    signature           = 0x1e 0x92 0x0e;
+    desc                   = "ATtiny40";
+    id                     = "t40";
+    signature              = 0x1e 0x92 0x0e;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x4000;
-        blocksize       = 128;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x4000;
+        blocksize          = 128;
     ;
 ;
 
@@ -12835,15 +12799,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    desc                = "ATtiny102";
-    id                  = "t102";
-    signature           = 0x1e 0x90 0x0c;
+    desc                   = "ATtiny102";
+    id                     = "t102";
+    signature              = 0x1e 0x90 0x0c;
 
     memory "flash"
-        size            = 1024;
-        page_size       = 16;
-        offset          = 0x4000;
-        blocksize       = 128;
+        size               = 1024;
+        page_size          = 16;
+        offset             = 0x4000;
+        blocksize          = 128;
     ;
 ;
 
@@ -12852,15 +12816,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    desc                = "ATtiny104";
-    id                  = "t104";
-    signature           = 0x1e 0x90 0x0b;
+    desc                   = "ATtiny104";
+    id                     = "t104";
+    signature              = 0x1e 0x90 0x0b;
 
     memory "flash"
-        size            = 1024;
-        page_size       = 16;
-        offset          = 0x4000;
-        blocksize       = 128;
+        size               = 1024;
+        page_size          = 16;
+        offset             = 0x4000;
+        blocksize          = 128;
     ;
 ;
 
@@ -12869,60 +12833,60 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part
-    desc                = "ATmega406";
-    id                  = "m406";
+    desc                   = "ATmega406";
+    id                     = "m406";
     # STK500 parameters (parallel programming IO lines)
-    pagel               = 0xa7;
-    bs2                 = 0xa0;
-    signature           = 0x1e 0x95 0x07;
-    reset               = io;
-    has_jtag            = yes;
-    serial              = no;
+    pagel                  = 0xa7;
+    bs2                    = 0xa0;
+    signature              = 0x1e 0x95 0x07;
+    reset                  = io;
+    has_jtag               = yes;
+    serial                 = no;
     # STK500v2 HV programming parameters, from XML
-    pp_controlstack     =
+    pp_controlstack        =
         0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
         0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
         0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
         0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    idr                 = 0x51;
-    spmcr               = 0x57;
-    eecr                = 0x3f;
+    idr                    = 0x51;
+    spmcr                  = 0x57;
+    eecr                   = 0x3f;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 4;
-        num_pages       = 128;
-        blocksize       = 4;
-        readsize        = 4;
+        size               = 512;
+        page_size          = 4;
+        num_pages          = 128;
+        blocksize          = 4;
+        readsize           = 4;
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 0xa000;
-        page_size       = 128;
-        num_pages       = 320;
-        blocksize       = 128;
-        readsize        = 128;
+        paged              = yes;
+        size               = 0xa000;
+        page_size          = 128;
+        num_pages          = 320;
+        blocksize          = 128;
+        readsize           = 128;
     ;
 
     memory "lfuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "hfuse"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lockbits"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "lockbits"
-        size            = 1;
+        size               = 1;
     ;
 
     memory "signature"
-        size            = 3;
+        size               = 3;
     ;
 ;
 
@@ -12931,16 +12895,16 @@ part
 #------------------------------------------------------------
 
 part
-    desc                = "AVR8X family common values";
-    id                  = ".avr8x";
-    has_updi            = yes;
-    nvm_base            = 0x1000;
-    ocd_base            = 0x0f80;
+    desc                   = "AVR8X family common values";
+    id                     = ".avr8x";
+    has_updi               = yes;
+    nvm_base               = 0x1000;
+    ocd_base               = 0x0f80;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x1280;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1280;
+        readsize           = 1;
     ;
 
     memory "wdtcfg"
@@ -12948,9 +12912,9 @@ part
     ;
 
     memory "fuse1"
-        size            = 1;
-        offset          = 0x1281;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1281;
+        readsize           = 1;
     ;
 
     memory "bodcfg"
@@ -12958,9 +12922,9 @@ part
     ;
 
     memory "fuse2"
-        size            = 1;
-        offset          = 0x1282;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1282;
+        readsize           = 1;
     ;
 
     memory "osccfg"
@@ -12968,9 +12932,9 @@ part
     ;
 
     memory "fuse4"
-        size            = 1;
-        offset          = 0x1284;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1284;
+        readsize           = 1;
     ;
 
     memory "tcd0cfg"
@@ -12978,9 +12942,9 @@ part
     ;
 
     memory "fuse5"
-        size            = 1;
-        offset          = 0x1285;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1285;
+        readsize           = 1;
     ;
 
     memory "syscfg0"
@@ -12988,9 +12952,9 @@ part
     ;
 
     memory "fuse6"
-        size            = 1;
-        offset          = 0x1286;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1286;
+        readsize           = 1;
     ;
 
     memory "syscfg1"
@@ -12998,9 +12962,9 @@ part
     ;
 
     memory "fuse7"
-        size            = 1;
-        offset          = 0x1287;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1287;
+        readsize           = 1;
     ;
 
     memory "append"
@@ -13012,9 +12976,9 @@ part
     ;
 
     memory "fuse8"
-        size            = 1;
-        offset          = 0x1288;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1288;
+        readsize           = 1;
     ;
 
     memory "bootend"
@@ -13026,70 +12990,70 @@ part
     ;
 
     memory "fuses"
-        size            = 9;
-        page_size       = 10;
-        offset          = 0x1280;
-        readsize        = 10;
+        size               = 9;
+        page_size          = 10;
+        offset             = 0x1280;
+        readsize           = 10;
     ;
 
     memory "lock"
-        size            = 1;
-        offset          = 0x128a;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x128a;
+        readsize           = 1;
     ;
 
     memory "tempsense"
-        size            = 2;
-        offset          = 0x1120;
-        readsize        = 1;
+        size               = 2;
+        offset             = 0x1120;
+        readsize           = 1;
     ;
 
     memory "signature"
-        size            = 3;
-        offset          = 0x1100;
-        readsize        = 3;
+        size               = 3;
+        offset             = 0x1100;
+        readsize           = 3;
     ;
 
     memory "prodsig"
-        size            = 61;
-        page_size       = 61;
-        offset          = 0x1103;
-        readsize        = 61;
+        size               = 61;
+        page_size          = 61;
+        offset             = 0x1103;
+        readsize           = 61;
     ;
 
     memory "sernum"
-        size            = 10;
-        offset          = 0x1104;
-        readsize        = 1;
+        size               = 10;
+        offset             = 0x1104;
+        readsize           = 1;
     ;
 
     memory "osccal16"
-        size            = 2;
-        offset          = 0x1118;
-        readsize        = 1;
+        size               = 2;
+        offset             = 0x1118;
+        readsize           = 1;
     ;
 
     memory "osccal20"
-        size            = 2;
-        offset          = 0x111a;
-        readsize        = 1;
+        size               = 2;
+        offset             = 0x111a;
+        readsize           = 1;
     ;
 
     memory "osc16err"
-        size            = 2;
-        offset          = 0x1122;
-        readsize        = 1;
+        size               = 2;
+        offset             = 0x1122;
+        readsize           = 1;
     ;
 
     memory "osc20err"
-        size            = 2;
-        offset          = 0x1124;
-        readsize        = 1;
+        size               = 2;
+        offset             = 0x1124;
+        readsize           = 1;
     ;
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset          = 0x1000000;
+        offset             = 0x1000000;
     ;
 ;
 
@@ -13098,17 +13062,17 @@ part
 #------------------------------------------------------------
 
 part parent ".avr8x"
-    desc                = "AVR8X tiny family common values";
-    id                  = ".avr8x_tiny";
-    family_id           = "tinyAVR";
+    desc                   = "AVR8X tiny family common values";
+    id                     = ".avr8x_tiny";
+    family_id              = "tinyAVR";
     # Shared UPDI pin, HV on UPDI pin
-    hvupdi_variant      = 0;
+    hvupdi_variant         = 0;
 
     memory "userrow"
-        size            = 32;
-        page_size       = 32;
-        offset          = 0x1300;
-        readsize        = 256;
+        size               = 32;
+        page_size          = 32;
+        offset             = 0x1300;
+        readsize           = 256;
     ;
 
     memory "usersig"
@@ -13121,17 +13085,17 @@ part parent ".avr8x"
 #------------------------------------------------------------
 
 part parent ".avr8x"
-    desc                = "AVR8X mega family common values";
-    id                  = ".avr8x_mega";
-    family_id           = "megaAVR";
+    desc                   = "AVR8X mega family common values";
+    id                     = ".avr8x_mega";
+    family_id              = "megaAVR";
     # Dedicated UPDI pin, no HV
-    hvupdi_variant      = 1;
+    hvupdi_variant         = 1;
 
     memory "userrow"
-        size            = 64;
-        page_size       = 64;
-        offset          = 0x1300;
-        readsize        = 256;
+        size               = 64;
+        page_size          = 64;
+        offset             = 0x1300;
+        readsize           = 256;
     ;
 
     memory "usersig"
@@ -13144,22 +13108,22 @@ part parent ".avr8x"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny202";
-    id                  = "t202";
-    signature           = 0x1e 0x91 0x23;
+    desc                   = "ATtiny202";
+    id                     = "t202";
+    signature              = 0x1e 0x91 0x23;
 
     memory "eeprom"
-        size            = 64;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 64;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 2048;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13168,22 +13132,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny204";
-    id                  = "t204";
-    signature           = 0x1e 0x91 0x22;
+    desc                   = "ATtiny204";
+    id                     = "t204";
+    signature              = 0x1e 0x91 0x22;
 
     memory "eeprom"
-        size            = 64;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 64;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 2048;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13192,22 +13156,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny402";
-    id                  = "t402";
-    signature           = 0x1e 0x92 0x27;
+    desc                   = "ATtiny402";
+    id                     = "t402";
+    signature              = 0x1e 0x92 0x27;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13216,22 +13180,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny404";
-    id                  = "t404";
-    signature           = 0x1e 0x92 0x26;
+    desc                   = "ATtiny404";
+    id                     = "t404";
+    signature              = 0x1e 0x92 0x26;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13240,22 +13204,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny406";
-    id                  = "t406";
-    signature           = 0x1e 0x92 0x25;
+    desc                   = "ATtiny406";
+    id                     = "t406";
+    signature              = 0x1e 0x92 0x25;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13264,22 +13228,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny804";
-    id                  = "t804";
-    signature           = 0x1e 0x93 0x25;
+    desc                   = "ATtiny804";
+    id                     = "t804";
+    signature              = 0x1e 0x93 0x25;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13288,22 +13252,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny806";
-    id                  = "t806";
-    signature           = 0x1e 0x93 0x24;
+    desc                   = "ATtiny806";
+    id                     = "t806";
+    signature              = 0x1e 0x93 0x24;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13312,22 +13276,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny807";
-    id                  = "t807";
-    signature           = 0x1e 0x93 0x23;
+    desc                   = "ATtiny807";
+    id                     = "t807";
+    signature              = 0x1e 0x93 0x23;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13336,22 +13300,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1604";
-    id                  = "t1604";
-    signature           = 0x1e 0x94 0x25;
+    desc                   = "ATtiny1604";
+    id                     = "t1604";
+    signature              = 0x1e 0x94 0x25;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13360,22 +13324,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1606";
-    id                  = "t1606";
-    signature           = 0x1e 0x94 0x24;
+    desc                   = "ATtiny1606";
+    id                     = "t1606";
+    signature              = 0x1e 0x94 0x24;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13384,22 +13348,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1607";
-    id                  = "t1607";
-    signature           = 0x1e 0x94 0x23;
+    desc                   = "ATtiny1607";
+    id                     = "t1607";
+    signature              = 0x1e 0x94 0x23;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13408,22 +13372,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny212";
-    id                  = "t212";
-    signature           = 0x1e 0x91 0x21;
+    desc                   = "ATtiny212";
+    id                     = "t212";
+    signature              = 0x1e 0x91 0x21;
 
     memory "eeprom"
-        size            = 64;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 64;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 2048;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13432,22 +13396,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny214";
-    id                  = "t214";
-    signature           = 0x1e 0x91 0x20;
+    desc                   = "ATtiny214";
+    id                     = "t214";
+    signature              = 0x1e 0x91 0x20;
 
     memory "eeprom"
-        size            = 64;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 64;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 2048;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 2048;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13456,22 +13420,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny412";
-    id                  = "t412";
-    signature           = 0x1e 0x92 0x23;
+    desc                   = "ATtiny412";
+    id                     = "t412";
+    signature              = 0x1e 0x92 0x23;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13480,22 +13444,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny414";
-    id                  = "t414";
-    signature           = 0x1e 0x92 0x22;
+    desc                   = "ATtiny414";
+    id                     = "t414";
+    signature              = 0x1e 0x92 0x22;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13504,22 +13468,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny416";
-    id                  = "t416";
-    signature           = 0x1e 0x92 0x21;
+    desc                   = "ATtiny416";
+    id                     = "t416";
+    signature              = 0x1e 0x92 0x21;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13528,22 +13492,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny417";
-    id                  = "t417";
-    signature           = 0x1e 0x92 0x20;
+    desc                   = "ATtiny417";
+    id                     = "t417";
+    signature              = 0x1e 0x92 0x20;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13552,22 +13516,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny814";
-    id                  = "t814";
-    signature           = 0x1e 0x93 0x22;
+    desc                   = "ATtiny814";
+    id                     = "t814";
+    signature              = 0x1e 0x93 0x22;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13576,22 +13540,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny816";
-    id                  = "t816";
-    signature           = 0x1e 0x93 0x21;
+    desc                   = "ATtiny816";
+    id                     = "t816";
+    signature              = 0x1e 0x93 0x21;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13600,22 +13564,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny817";
-    id                  = "t817";
-    signature           = 0x1e 0x93 0x20;
+    desc                   = "ATtiny817";
+    id                     = "t817";
+    signature              = 0x1e 0x93 0x20;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13624,22 +13588,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1614";
-    id                  = "t1614";
-    signature           = 0x1e 0x94 0x22;
+    desc                   = "ATtiny1614";
+    id                     = "t1614";
+    signature              = 0x1e 0x94 0x22;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13648,22 +13612,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1616";
-    id                  = "t1616";
-    signature           = 0x1e 0x94 0x21;
+    desc                   = "ATtiny1616";
+    id                     = "t1616";
+    signature              = 0x1e 0x94 0x21;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13672,22 +13636,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1617";
-    id                  = "t1617";
-    signature           = 0x1e 0x94 0x20;
+    desc                   = "ATtiny1617";
+    id                     = "t1617";
+    signature              = 0x1e 0x94 0x20;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13696,22 +13660,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny3216";
-    id                  = "t3216";
-    signature           = 0x1e 0x95 0x21;
+    desc                   = "ATtiny3216";
+    id                     = "t3216";
+    signature              = 0x1e 0x95 0x21;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13720,22 +13684,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny3217";
-    id                  = "t3217";
-    signature           = 0x1e 0x95 0x22;
+    desc                   = "ATtiny3217";
+    id                     = "t3217";
+    signature              = 0x1e 0x95 0x22;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13744,22 +13708,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny424";
-    id                  = "t424";
-    signature           = 0x1e 0x92 0x2c;
+    desc                   = "ATtiny424";
+    id                     = "t424";
+    signature              = 0x1e 0x92 0x2c;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13768,22 +13732,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny426";
-    id                  = "t426";
-    signature           = 0x1e 0x92 0x2b;
+    desc                   = "ATtiny426";
+    id                     = "t426";
+    signature              = 0x1e 0x92 0x2b;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13792,22 +13756,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny427";
-    id                  = "t427";
-    signature           = 0x1e 0x92 0x2a;
+    desc                   = "ATtiny427";
+    id                     = "t427";
+    signature              = 0x1e 0x92 0x2a;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 4096;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 4096;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13816,22 +13780,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny824";
-    id                  = "t824";
-    signature           = 0x1e 0x93 0x29;
+    desc                   = "ATtiny824";
+    id                     = "t824";
+    signature              = 0x1e 0x93 0x29;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13840,22 +13804,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny826";
-    id                  = "t826";
-    signature           = 0x1e 0x93 0x28;
+    desc                   = "ATtiny826";
+    id                     = "t826";
+    signature              = 0x1e 0x93 0x28;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13864,22 +13828,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny827";
-    id                  = "t827";
-    signature           = 0x1e 0x93 0x27;
+    desc                   = "ATtiny827";
+    id                     = "t827";
+    signature              = 0x1e 0x93 0x27;
 
     memory "eeprom"
-        size            = 128;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 128;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13888,22 +13852,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1624";
-    id                  = "t1624";
-    signature           = 0x1e 0x94 0x2a;
+    desc                   = "ATtiny1624";
+    id                     = "t1624";
+    signature              = 0x1e 0x94 0x2a;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13912,22 +13876,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1626";
-    id                  = "t1626";
-    signature           = 0x1e 0x94 0x29;
+    desc                   = "ATtiny1626";
+    id                     = "t1626";
+    signature              = 0x1e 0x94 0x29;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13936,22 +13900,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny1627";
-    id                  = "t1627";
-    signature           = 0x1e 0x94 0x28;
+    desc                   = "ATtiny1627";
+    id                     = "t1627";
+    signature              = 0x1e 0x94 0x28;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13960,22 +13924,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny3224";
-    id                  = "t3224";
-    signature           = 0x1e 0x95 0x28;
+    desc                   = "ATtiny3224";
+    id                     = "t3224";
+    signature              = 0x1e 0x95 0x28;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -13984,22 +13948,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny3226";
-    id                  = "t3226";
-    signature           = 0x1e 0x95 0x27;
+    desc                   = "ATtiny3226";
+    id                     = "t3226";
+    signature              = 0x1e 0x95 0x27;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -14008,22 +13972,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATtiny3227";
-    id                  = "t3227";
-    signature           = 0x1e 0x95 0x26;
+    desc                   = "ATtiny3227";
+    id                     = "t3227";
+    signature              = 0x1e 0x95 0x26;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x8000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x8000;
+        readsize           = 256;
     ;
 ;
 
@@ -14032,22 +13996,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATmega808";
-    id                  = "m808";
-    signature           = 0x1e 0x93 0x26;
+    desc                   = "ATmega808";
+    id                     = "m808";
+    signature              = 0x1e 0x93 0x26;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14056,22 +14020,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATmega809";
-    id                  = "m809";
-    signature           = 0x1e 0x93 0x2a;
+    desc                   = "ATmega809";
+    id                     = "m809";
+    signature              = 0x1e 0x93 0x2a;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14080,22 +14044,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATmega1608";
-    id                  = "m1608";
-    signature           = 0x1e 0x94 0x27;
+    desc                   = "ATmega1608";
+    id                     = "m1608";
+    signature              = 0x1e 0x94 0x27;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14104,22 +14068,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_tiny"
-    desc                = "ATmega1609";
-    id                  = "m1609";
-    signature           = 0x1e 0x94 0x26;
+    desc                   = "ATmega1609";
+    id                     = "m1609";
+    signature              = 0x1e 0x94 0x26;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 32;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 32;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14128,22 +14092,22 @@ part parent ".avr8x_tiny"
 #------------------------------------------------------------
 
 part parent ".avr8x_mega"
-    desc                = "ATmega3208";
-    id                  = "m3208";
-    signature           = 0x1e 0x95 0x30;
+    desc                   = "ATmega3208";
+    id                     = "m3208";
+    signature              = 0x1e 0x95 0x30;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14152,22 +14116,22 @@ part parent ".avr8x_mega"
 #------------------------------------------------------------
 
 part parent ".avr8x_mega"
-    desc                = "ATmega3209";
-    id                  = "m3209";
-    signature           = 0x1e 0x95 0x31;
+    desc                   = "ATmega3209";
+    id                     = "m3209";
+    signature              = 0x1e 0x95 0x31;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 128;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 128;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14176,22 +14140,22 @@ part parent ".avr8x_mega"
 #------------------------------------------------------------
 
 part parent ".avr8x_mega"
-    desc                = "ATmega4808";
-    id                  = "m4808";
-    signature           = 0x1e 0x96 0x50;
+    desc                   = "ATmega4808";
+    id                     = "m4808";
+    signature              = 0x1e 0x96 0x50;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0xc000;
-        page_size       = 128;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 0xc000;
+        page_size          = 128;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14200,22 +14164,22 @@ part parent ".avr8x_mega"
 #------------------------------------------------------------
 
 part parent ".avr8x_mega"
-    desc                = "ATmega4809";
-    id                  = "m4809";
-    signature           = 0x1e 0x96 0x51;
+    desc                   = "ATmega4809";
+    id                     = "m4809";
+    signature              = 0x1e 0x96 0x51;
 
     memory "eeprom"
-        size            = 256;
-        page_size       = 64;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0xc000;
-        page_size       = 128;
-        offset          = 0x4000;
-        readsize        = 256;
+        size               = 0xc000;
+        page_size          = 128;
+        offset             = 0x4000;
+        readsize           = 256;
     ;
 ;
 
@@ -14224,18 +14188,18 @@ part parent ".avr8x_mega"
 #------------------------------------------------------------
 
 part
-    desc                = "AVR-Dx family common values";
-    id                  = ".avrdx";
+    desc                   = "AVR-Dx family common values";
+    id                     = ".avrdx";
     # Dedicated UPDI pin, no HV
-    hvupdi_variant      = 1;
-    has_updi            = yes;
-    nvm_base            = 0x1000;
-    ocd_base            = 0x0f80;
+    hvupdi_variant         = 1;
+    has_updi               = yes;
+    nvm_base               = 0x1000;
+    ocd_base               = 0x0f80;
 
     memory "fuse0"
-        size            = 1;
-        offset          = 0x1050;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1050;
+        readsize           = 1;
     ;
 
     memory "wdtcfg"
@@ -14243,9 +14207,9 @@ part
     ;
 
     memory "fuse1"
-        size            = 1;
-        offset          = 0x1051;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1051;
+        readsize           = 1;
     ;
 
     memory "bodcfg"
@@ -14253,9 +14217,9 @@ part
     ;
 
     memory "fuse2"
-        size            = 1;
-        offset          = 0x1052;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1052;
+        readsize           = 1;
     ;
 
     memory "osccfg"
@@ -14263,9 +14227,9 @@ part
     ;
 
     memory "fuse4"
-        size            = 1;
-        offset          = 0x1054;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1054;
+        readsize           = 1;
     ;
 
     memory "tcd0cfg"
@@ -14273,9 +14237,9 @@ part
     ;
 
     memory "fuse5"
-        size            = 1;
-        offset          = 0x1055;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1055;
+        readsize           = 1;
     ;
 
     memory "syscfg0"
@@ -14283,9 +14247,9 @@ part
     ;
 
     memory "fuse6"
-        size            = 1;
-        offset          = 0x1056;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1056;
+        readsize           = 1;
     ;
 
     memory "syscfg1"
@@ -14293,9 +14257,9 @@ part
     ;
 
     memory "fuse7"
-        size            = 1;
-        offset          = 0x1057;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1057;
+        readsize           = 1;
     ;
 
     memory "codesize"
@@ -14307,9 +14271,9 @@ part
     ;
 
     memory "fuse8"
-        size            = 1;
-        offset          = 0x1058;
-        readsize        = 1;
+        size               = 1;
+        offset             = 0x1058;
+        readsize           = 1;
     ;
 
     memory "bootsize"
@@ -14321,48 +14285,48 @@ part
     ;
 
     memory "fuses"
-        size            = 9;
-        page_size       = 16;
-        offset          = 0x1050;
-        readsize        = 16;
+        size               = 9;
+        page_size          = 16;
+        offset             = 0x1050;
+        readsize           = 16;
     ;
 
     memory "lock"
-        size            = 4;
-        offset          = 0x1040;
-        readsize        = 4;
+        size               = 4;
+        offset             = 0x1040;
+        readsize           = 4;
     ;
 
     memory "tempsense"
-        size            = 2;
-        offset          = 0x1104;
-        readsize        = 1;
+        size               = 2;
+        offset             = 0x1104;
+        readsize           = 1;
     ;
 
     memory "signature"
-        size            = 3;
-        offset          = 0x1100;
-        readsize        = 3;
+        size               = 3;
+        offset             = 0x1100;
+        readsize           = 3;
     ;
 
     memory "prodsig"
-        size            = 125;
-        page_size       = 125;
-        offset          = 0x1103;
-        readsize        = 125;
+        size               = 125;
+        page_size          = 125;
+        offset             = 0x1103;
+        readsize           = 125;
     ;
 
     memory "sernum"
-        size            = 16;
-        offset          = 0x1110;
-        readsize        = 1;
+        size               = 16;
+        offset             = 0x1110;
+        readsize           = 1;
     ;
 
     memory "userrow"
-        size            = 32;
-        page_size       = 32;
-        offset          = 0x1080;
-        readsize        = 32;
+        size               = 32;
+        page_size          = 32;
+        offset             = 0x1080;
+        readsize           = 32;
     ;
 
     memory "usersig"
@@ -14371,7 +14335,7 @@ part
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset          = 0x1000000;
+        offset             = 0x1000000;
     ;
 ;
 
@@ -14380,21 +14344,21 @@ part
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DA28";
-    id                  = "avr32da28";
-    signature           = 0x1e 0x95 0x34;
+    desc                   = "AVR32DA28";
+    id                     = "avr32da28";
+    signature              = 0x1e 0x95 0x34;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14403,21 +14367,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DA32";
-    id                  = "avr32da32";
-    signature           = 0x1e 0x95 0x33;
+    desc                   = "AVR32DA32";
+    id                     = "avr32da32";
+    signature              = 0x1e 0x95 0x33;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14426,21 +14390,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DA48";
-    id                  = "avr32da48";
-    signature           = 0x1e 0x95 0x32;
+    desc                   = "AVR32DA48";
+    id                     = "avr32da48";
+    signature              = 0x1e 0x95 0x32;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14449,21 +14413,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DA28";
-    id                  = "avr64da28";
-    signature           = 0x1e 0x96 0x15;
+    desc                   = "AVR64DA28";
+    id                     = "avr64da28";
+    signature              = 0x1e 0x96 0x15;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14472,21 +14436,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DA32";
-    id                  = "avr64da32";
-    signature           = 0x1e 0x96 0x14;
+    desc                   = "AVR64DA32";
+    id                     = "avr64da32";
+    signature              = 0x1e 0x96 0x14;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14495,21 +14459,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DA48";
-    id                  = "avr64da48";
-    signature           = 0x1e 0x96 0x13;
+    desc                   = "AVR64DA48";
+    id                     = "avr64da48";
+    signature              = 0x1e 0x96 0x13;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14518,21 +14482,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DA64";
-    id                  = "avr64da64";
-    signature           = 0x1e 0x96 0x12;
+    desc                   = "AVR64DA64";
+    id                     = "avr64da64";
+    signature              = 0x1e 0x96 0x12;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14541,21 +14505,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DA28";
-    id                  = "avr128da28";
-    signature           = 0x1e 0x97 0x0a;
+    desc                   = "AVR128DA28";
+    id                     = "avr128da28";
+    signature              = 0x1e 0x97 0x0a;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14564,21 +14528,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DA32";
-    id                  = "avr128da32";
-    signature           = 0x1e 0x97 0x09;
+    desc                   = "AVR128DA32";
+    id                     = "avr128da32";
+    signature              = 0x1e 0x97 0x09;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14587,21 +14551,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DA48";
-    id                  = "avr128da48";
-    signature           = 0x1e 0x97 0x08;
+    desc                   = "AVR128DA48";
+    id                     = "avr128da48";
+    signature              = 0x1e 0x97 0x08;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14610,21 +14574,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DA64";
-    id                  = "avr128da64";
-    signature           = 0x1e 0x97 0x07;
+    desc                   = "AVR128DA64";
+    id                     = "avr128da64";
+    signature              = 0x1e 0x97 0x07;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14633,21 +14597,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DB28";
-    id                  = "avr32db28";
-    signature           = 0x1e 0x95 0x37;
+    desc                   = "AVR32DB28";
+    id                     = "avr32db28";
+    signature              = 0x1e 0x95 0x37;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14656,21 +14620,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DB32";
-    id                  = "avr32db32";
-    signature           = 0x1e 0x95 0x36;
+    desc                   = "AVR32DB32";
+    id                     = "avr32db32";
+    signature              = 0x1e 0x95 0x36;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14679,21 +14643,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DB48";
-    id                  = "avr32db48";
-    signature           = 0x1e 0x95 0x35;
+    desc                   = "AVR32DB48";
+    id                     = "avr32db48";
+    signature              = 0x1e 0x95 0x35;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14702,21 +14666,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DB28";
-    id                  = "avr64db28";
-    signature           = 0x1e 0x96 0x19;
+    desc                   = "AVR64DB28";
+    id                     = "avr64db28";
+    signature              = 0x1e 0x96 0x19;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14725,21 +14689,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DB32";
-    id                  = "avr64db32";
-    signature           = 0x1e 0x96 0x18;
+    desc                   = "AVR64DB32";
+    id                     = "avr64db32";
+    signature              = 0x1e 0x96 0x18;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14748,21 +14712,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DB48";
-    id                  = "avr64db48";
-    signature           = 0x1e 0x96 0x17;
+    desc                   = "AVR64DB48";
+    id                     = "avr64db48";
+    signature              = 0x1e 0x96 0x17;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14771,21 +14735,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DB64";
-    id                  = "avr64db64";
-    signature           = 0x1e 0x96 0x16;
+    desc                   = "AVR64DB64";
+    id                     = "avr64db64";
+    signature              = 0x1e 0x96 0x16;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14794,21 +14758,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DB28";
-    id                  = "avr128db28";
-    signature           = 0x1e 0x97 0x0e;
+    desc                   = "AVR128DB28";
+    id                     = "avr128db28";
+    signature              = 0x1e 0x97 0x0e;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14817,21 +14781,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DB32";
-    id                  = "avr128db32";
-    signature           = 0x1e 0x97 0x0d;
+    desc                   = "AVR128DB32";
+    id                     = "avr128db32";
+    signature              = 0x1e 0x97 0x0d;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14840,21 +14804,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DB48";
-    id                  = "avr128db48";
-    signature           = 0x1e 0x97 0x0c;
+    desc                   = "AVR128DB48";
+    id                     = "avr128db48";
+    signature              = 0x1e 0x97 0x0c;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14863,21 +14827,21 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR128DB64";
-    id                  = "avr128db64";
-    signature           = 0x1e 0x97 0x0b;
+    desc                   = "AVR128DB64";
+    id                     = "avr128db64";
+    signature              = 0x1e 0x97 0x0b;
 
     memory "eeprom"
-        size            = 512;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x20000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x20000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14886,22 +14850,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR16DD14";
-    id                  = "avr16dd14";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x94 0x34;
+    desc                   = "AVR16DD14";
+    id                     = "avr16dd14";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x94 0x34;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14910,22 +14874,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR16DD20";
-    id                  = "avr16dd20";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x94 0x33;
+    desc                   = "AVR16DD20";
+    id                     = "avr16dd20";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x94 0x33;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14934,22 +14898,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR16DD28";
-    id                  = "avr16dd28";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x94 0x32;
+    desc                   = "AVR16DD28";
+    id                     = "avr16dd28";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x94 0x32;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14958,22 +14922,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR16DD32";
-    id                  = "avr16dd32";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x94 0x31;
+    desc                   = "AVR16DD32";
+    id                     = "avr16dd32";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x94 0x31;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -14982,22 +14946,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DD14";
-    id                  = "avr32dd14";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x95 0x3b;
+    desc                   = "AVR32DD14";
+    id                     = "avr32dd14";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x95 0x3b;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15006,22 +14970,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DD20";
-    id                  = "avr32dd20";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x95 0x3a;
+    desc                   = "AVR32DD20";
+    id                     = "avr32dd20";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x95 0x3a;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15030,22 +14994,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DD28";
-    id                  = "avr32dd28";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x95 0x39;
+    desc                   = "AVR32DD28";
+    id                     = "avr32dd28";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x95 0x39;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15054,22 +15018,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR32DD32";
-    id                  = "avr32dd32";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x95 0x38;
+    desc                   = "AVR32DD32";
+    id                     = "avr32dd32";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x95 0x38;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15078,22 +15042,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DD14";
-    id                  = "avr64dd14";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x96 0x1d;
+    desc                   = "AVR64DD14";
+    id                     = "avr64dd14";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x96 0x1d;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15102,22 +15066,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DD20";
-    id                  = "avr64dd20";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x96 0x1c;
+    desc                   = "AVR64DD20";
+    id                     = "avr64dd20";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x96 0x1c;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15126,22 +15090,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DD28";
-    id                  = "avr64dd28";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x96 0x1b;
+    desc                   = "AVR64DD28";
+    id                     = "avr64dd28";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x96 0x1b;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15150,22 +15114,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR64DD32";
-    id                  = "avr64dd32";
-    hvupdi_variant      = 2;
-    signature           = 0x1e 0x96 0x1a;
+    desc                   = "AVR64DD32";
+    id                     = "avr64dd32";
+    hvupdi_variant         = 2;
+    signature              = 0x1e 0x96 0x1a;
 
     memory "eeprom"
-        size            = 256;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 512;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15174,15 +15138,15 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    desc                = "AVR-Ex family common values";
-    id                  = ".avrex";
+    desc                   = "AVR-Ex family common values";
+    id                     = ".avrex";
     # Shared UPDI pin, HV on _RESET
-    hvupdi_variant      = 2;
+    hvupdi_variant         = 2;
 
     memory "userrow"
-        size            = 64;
-        page_size       = 64;
-        readsize        = 64;
+        size               = 64;
+        page_size          = 64;
+        readsize           = 64;
     ;
 
     memory "usersig"
@@ -15195,22 +15159,22 @@ part parent ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR8EA28";
-    id                  = "avr8ea28";
-    signature           = 0x1e 0x93 0x2c;
+    desc                   = "AVR8EA28";
+    id                     = "avr8ea28";
+    signature              = 0x1e 0x93 0x2c;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15219,22 +15183,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR8EA32";
-    id                  = "avr8ea32";
-    signature           = 0x1e 0x93 0x2b;
+    desc                   = "AVR8EA32";
+    id                     = "avr8ea32";
+    signature              = 0x1e 0x93 0x2b;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 8192;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 8192;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15243,22 +15207,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR16EA28";
-    id                  = "avr16ea28";
-    signature           = 0x1e 0x94 0x37;
+    desc                   = "AVR16EA28";
+    id                     = "avr16ea28";
+    signature              = 0x1e 0x94 0x37;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15267,22 +15231,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR16EA32";
-    id                  = "avr16ea32";
-    signature           = 0x1e 0x94 0x36;
+    desc                   = "AVR16EA32";
+    id                     = "avr16ea32";
+    signature              = 0x1e 0x94 0x36;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15291,22 +15255,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR16EA48";
-    id                  = "avr16ea48";
-    signature           = 0x1e 0x94 0x35;
+    desc                   = "AVR16EA48";
+    id                     = "avr16ea48";
+    signature              = 0x1e 0x94 0x35;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x4000;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x4000;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15315,22 +15279,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR32EA28";
-    id                  = "avr32ea28";
-    signature           = 0x1e 0x95 0x3e;
+    desc                   = "AVR32EA28";
+    id                     = "avr32ea28";
+    signature              = 0x1e 0x95 0x3e;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15339,22 +15303,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR32EA32";
-    id                  = "avr32ea32";
-    signature           = 0x1e 0x95 0x3d;
+    desc                   = "AVR32EA32";
+    id                     = "avr32ea32";
+    signature              = 0x1e 0x95 0x3d;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15363,22 +15327,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR32EA48";
-    id                  = "avr32ea48";
-    signature           = 0x1e 0x95 0x3c;
+    desc                   = "AVR32EA48";
+    id                     = "avr32ea48";
+    signature              = 0x1e 0x95 0x3c;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x8000;
-        page_size       = 64;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x8000;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15387,22 +15351,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR64EA28";
-    id                  = "avr64ea28";
-    signature           = 0x1e 0x96 0x20;
+    desc                   = "AVR64EA28";
+    id                     = "avr64ea28";
+    signature              = 0x1e 0x96 0x20;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15411,22 +15375,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR64EA32";
-    id                  = "avr64ea32";
-    signature           = 0x1e 0x96 0x1f;
+    desc                   = "AVR64EA32";
+    id                     = "avr64ea32";
+    signature              = 0x1e 0x96 0x1f;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15435,22 +15399,22 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent ".avrex"
-    desc                = "AVR64EA48";
-    id                  = "avr64ea48";
-    signature           = 0x1e 0x96 0x1e;
+    desc                   = "AVR64EA48";
+    id                     = "avr64ea48";
+    signature              = 0x1e 0x96 0x1e;
 
     memory "eeprom"
-        size            = 512;
-        page_size       = 8;
-        offset          = 0x1400;
-        readsize        = 256;
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
     ;
 
     memory "flash"
-        size            = 0x10000;
-        page_size       = 128;
-        offset          = 0x800000;
-        readsize        = 256;
+        size               = 0x10000;
+        page_size          = 128;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 
@@ -15459,9 +15423,9 @@ part parent ".avrex"
 #------------------------------------------------------------
 
 part parent "m88"
-    desc                = "LGT8F88P";
-    id                  = "lgt8f88p";
-    signature           = 0x1e 0x93 0x0f;
+    desc                   = "LGT8F88P";
+    id                     = "lgt8f88p";
+    signature              = 0x1e 0x93 0x0f;
 ;
 
 #------------------------------------------------------------
@@ -15469,9 +15433,9 @@ part parent "m88"
 #------------------------------------------------------------
 
 part parent "m168"
-    desc                = "LGT8F168P";
-    id                  = "lgt8f168p";
-    signature           = 0x1e 0x94 0x0b;
+    desc                   = "LGT8F168P";
+    id                     = "lgt8f168p";
+    signature              = 0x1e 0x94 0x0b;
 ;
 
 #------------------------------------------------------------
@@ -15479,7 +15443,7 @@ part parent "m168"
 #------------------------------------------------------------
 
 part parent "m328"
-    desc                = "LGT8F328P";
-    id                  = "lgt8f328p";
-    signature           = 0x1e 0x95 0x0f;
+    desc                   = "LGT8F328P";
+    id                     = "lgt8f328p";
+    signature              = 0x1e 0x95 0x0f;
 ;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1801,6 +1801,7 @@ part
     stk500_devcode      = 0x11;
     signature           = 0x1e 0x90 0x04;
     chip_erase_delay    = 20000;
+    serial			= no;
 
     timeout		= 200;
     hvsp_controlstack     =
@@ -7989,6 +7990,7 @@ part
     stk500_devcode      = 0x22;
     avr910_devcode      = 0x5c;
     signature           = 0x1e 0x91 0x07;
+    serial			= no;
 
     pp_controlstack     =
         0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
@@ -15533,7 +15535,7 @@ part parent "x16a4u"
     id		= "x16a4";
     desc	= "ATxmega16A4";
     signature	= 0x1e 0x94 0x41;
-    has_jtag	= yes;
+    has_jtag	= no;
 
     memory "fuse0"
         size		= 1;
@@ -15622,7 +15624,7 @@ part parent "x32a4u"
     id		= "x32a4";
     desc	= "ATxmega32A4";
     signature	= 0x1e 0x95 0x41;
-    has_jtag	= yes;
+    has_jtag	= no;
 
     memory "fuse0"
         size		= 1;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3501,6 +3501,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x96 0x02;
+    reset               = io;
     has_jtag            = yes;
     allowfullpagebitstream = yes;
     timeout             = 200;
@@ -3626,6 +3627,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x97 0x02;
+    reset               = io;
     has_jtag            = yes;
     allowfullpagebitstream = yes;
     timeout             = 200;
@@ -3752,6 +3754,7 @@ part
     bs2                 = 0xa0;
 #    avr910_devcode   = 0x43;
     signature           = 0x1e 0x97 0x81;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -3872,6 +3875,7 @@ part
     bs2                 = 0xa0;
 #    avr910_devcode   = 0x43;
     signature           = 0x1e 0x96 0x81;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -3992,6 +3996,7 @@ part
     bs2                 = 0xa0;
 #    avr910_devcode   = 0x43;
     signature           = 0x1e 0x95 0x81;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -4112,6 +4117,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x94 0x03;
+    reset               = io;
     has_jtag            = yes;
     allowfullpagebitstream = yes;
     timeout             = 200;
@@ -4233,6 +4239,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x95 0x08;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -4421,6 +4428,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x96 0x09;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -4567,6 +4575,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x97 0x06;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -4698,6 +4707,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x94 0x04;
+    reset               = io;
     has_jtag            = yes;
     allowfullpagebitstream = yes;
     timeout             = 200;
@@ -5031,6 +5041,7 @@ part parent "m169"
     desc                = "ATmega169A";
     id                  = "m169a";
     signature           = 0x1e 0x94 0x11;
+    reset               = io;
 ;
 
 #------------------------------------------------------------
@@ -5040,6 +5051,7 @@ part parent "m169"
 part parent "m169"
     desc                = "ATmega169P";
     id                  = "m169p";
+    reset               = io;
 ;
 
 #------------------------------------------------------------
@@ -5049,6 +5061,7 @@ part parent "m169"
 part parent "m169"
     desc                = "ATmega169PA";
     id                  = "m169pa";
+    reset               = io;
 ;
 
 #------------------------------------------------------------
@@ -5063,6 +5076,7 @@ part
     avr910_devcode      = 0x75;
     chip_erase_delay    = 9000;
     signature           = 0x1e 0x95 0x03;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -5252,6 +5266,7 @@ part
     avr910_devcode      = 0x75;
     chip_erase_delay    = 9000;
     signature           = 0x1e 0x96 0x03;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -5422,6 +5437,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x95 0x02;
+    reset               = io;
     has_jtag            = yes;
     allowfullpagebitstream = yes;
     timeout             = 200;
@@ -5629,6 +5645,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xc2;
     signature           = 0x1e 0x93 0x07;
+    reset               = io;
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
@@ -6500,6 +6517,7 @@ part
     bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
     signature           = 0x1e 0x92 0x05;
+    reset               = io;
     has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -6664,6 +6682,7 @@ part
     bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
     signature           = 0x1e 0x93 0x0a;
+    reset               = io;
     has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -6829,6 +6848,7 @@ part
     bs2                 = 0xc2;
     # avr910_devcode = 0x;
     signature           = 0x1e 0x94 0x06;
+    reset               = io;
     has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -6994,6 +7014,7 @@ part
     bs2                 = 0xc2;
     # avr910_devcode = 0x;
     signature           = 0x1e 0x93 0x14;
+    reset               = io;
     has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -7376,6 +7397,7 @@ part
     bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
     signature           = 0x1e 0x92 0x09;
+    reset               = io;
     has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -7501,6 +7523,7 @@ part
     bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
     signature           = 0x1e 0x93 0x11;
+    reset               = io;
     has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -7626,6 +7649,7 @@ part
     bs2                 = 0xc2;
     # avr910_devcode    = 0x;
     signature           = 0x1e 0x95 0x14;
+    reset               = io;
     has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -8671,6 +8695,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x96 0x08;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -8791,6 +8816,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x97 0x03;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -8922,6 +8948,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x98 0x01;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -9749,6 +9776,7 @@ part
     bs2                 = 0xa0;
     signature           = 0x1e 0x94 0x88;
     usbpid              = 0x2ff4;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -9870,6 +9898,7 @@ part
     bs2                 = 0xa0;
     signature           = 0x1e 0x95 0x87;
     usbpid              = 0x2ff4;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -9991,6 +10020,7 @@ part
     bs2                 = 0xa0;
     signature           = 0x1e 0x96 0x82;
     usbpid              = 0x2ff9;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -10122,6 +10152,7 @@ part
     bs2                 = 0xa0;
     signature           = 0x1e 0x97 0x82;
     usbpid              = 0x2ffb;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -11013,6 +11044,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x95 0x05;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -11164,6 +11196,7 @@ part
     pagel               = 0xd7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x96 0x05;
+    reset               = io;
     has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
@@ -12842,6 +12875,7 @@ part
     pagel               = 0xa7;
     bs2                 = 0xa0;
     signature           = 0x1e 0x95 0x07;
+    reset               = io;
     has_jtag            = yes;
     serial              = no;
     # STK500v2 HV programming parameters, from XML

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -356,15 +356,15 @@
 # in the Internet.  These add the following codes (only devices that
 # actually exist are listed):
 
-# ATmega8515	0x3A
-# ATmega128	0x43
-# ATmega64	0x45
-# ATtiny26	0x5E
-# ATmega8535	0x69
-# ATmega32	0x72
-# ATmega16	0x74
-# ATmega8	0x76
-# ATmega169	0x78
+# ATmega8515    0x3A
+# ATmega128     0x43
+# ATmega64      0x45
+# ATtiny26      0x5E
+# ATmega8535    0x69
+# ATmega32      0x72
+# ATmega16      0x74
+# ATmega8       0x76
+# ATmega169     0x78
 
 #
 # Overall avrdude defaults; suitable for ~/.avrduderc
@@ -7624,7 +7624,7 @@ part
     chip_erase_delay    = 9000;
     pagel               = 0xd7;
     bs2                 = 0xc2;
-    # avr910_devcode	= 0x;
+    # avr910_devcode    = 0x;
     signature           = 0x1e 0x95 0x14;
     has_debugwire       = yes;
     timeout             = 200;
@@ -7771,8 +7771,8 @@ part parent "m328"
     desc                = "ATmega32M1";
     id                  = "m32m1";
     bs2                 = 0xe2;
-    # stk500_devcode	= 0x;
-    # avr910_devcode	= 0x;
+    # stk500_devcode    = 0x;
+    # avr910_devcode    = 0x;
     signature           = 0x1e 0x95 0x84;
 
     memory "efuse"
@@ -7788,8 +7788,8 @@ part parent "m328"
     desc                = "ATmega64M1";
     id                  = "m64m1";
     bs2                 = 0xe2;
-    # stk500_devcode	= 0x;
-    # avr910_devcode	= 0x;
+    # stk500_devcode    = 0x;
+    # avr910_devcode    = 0x;
     signature           = 0x1e 0x96 0x84;
 
     memory "eeprom"
@@ -12074,7 +12074,7 @@ part parent ".xmega"
     desc                = "ATxmega192C3";
     id                  = "x192c3";
     signature           = 0x1e 0x97 0x51;
-    # usbpid	= 0x2f??;
+    # usbpid            = 0x2f??;
 
     memory "eeprom"
         size            = 2048;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -159,9 +159,9 @@
 # complain.
 #
 # Parts can also inherit parameters from previously defined parts
-# using the following syntax. In this case specified integer and 
-# string values override parameter values from the parent part. New 
-# memory definitions are added to the definitions inherited from the 
+# using the following syntax. In this case specified integer and
+# string values override parameter values from the parent part. New
+# memory definitions are added to the definitions inherited from the
 # parent. If, however, a new memory definition refers to an existing
 # one of the same name for that part then, from v7.1, the existing
 # memory definition is extended, and components overwritten with new
@@ -175,7 +175,7 @@
 #     ;
 #
 # NOTES:
-#   * 'devicecode' is the device code used by the STK500 (see codes 
+#   * 'devicecode' is the device code used by the STK500 (see codes
 #       listed below)
 #   * Not all memory types will implement all instructions.
 #   * AVR Fuse bits and Lock bits are implemented as a type of memory.
@@ -374,1075 +374,6 @@ default_serial     = "@DEFAULT_SER_PORT@";
 default_spi        = "@DEFAULT_SPI_PORT@";
 # default_bitclock = 2.5;
 
-#
-# PROGRAMMER DEFINITIONS
-#
-
-# http://wiring.org.co/
-# Basically STK500v2 protocol, with some glue to trigger the
-# bootloader.
-programmer
-  id    = "wiring";
-  desc  = "Wiring";
-  type  = "wiring";
-  connection_type = serial;
-;
-
-programmer
-  id    = "arduino";
-  desc  = "Arduino";
-  type  = "arduino";
-  connection_type = serial;
-;
-
-programmer
-  id    = "xbee";
-  desc  = "XBee Series 2 Over-The-Air (XBeeBoot)";
-  type  = "xbee";
-  connection_type = serial;
-;
-
-# this will interface with the chips on these programmers:
-#
-# http://real.kiev.ua/old/avreal/en/adapters
-# http://www.amontec.com/jtagkey.shtml, jtagkey-tiny.shtml
-# http://www.olimex.com/dev/arm-usb-ocd.html, arm-usb-tiny.html
-# http://www.ethernut.de/en/hardware/turtelizer/index.html
-# http://elk.informatik.fh-augsburg.de/hhweb/doc/openocd/usbjtag/usbjtag.html
-# http://dangerousprototypes.com/docs/FT2232_breakout_board
-# http://www.ftdichip.com/Products/Modules/DLPModules.htm,DLP-2232*,DLP-USB1232H
-# http://flashrom.org/FT2232SPI_Programmer
-# 
-# The drivers will look for a specific device and use the first one found.
-# If you have mulitple devices, then look for unique information (like SN)
-# And fill that in here.
-#
-# Note that the pin numbers for the main ISP signals (reset, sck,
-# mosi, miso) are fixed and cannot be changed, since they must match
-# the way the Multi-Protocol Synchronous Serial Engine (MPSSE) of
-# these FTDI ICs has been designed.
-
-programmer
-  id         = "avrftdi";
-  desc       = "FT2232D based generic programmer";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-  usbpid     = 0x6010;
-  usbvendor  = "";
-  usbproduct = "";
-  usbdev     = "A";
-  usbsn      = "";
-#ISP-signals - lower ADBUS-Nibble (default)
-  reset  = 3;
-  sck    = 0;
-  mosi   = 1;
-  miso   = 2;
-#LED SIGNALs - higher ADBUS-Nibble
-#  errled = 4;
-#  rdyled = 5;
-#  pgmled = 6;
-#  vfyled = 7;
-#Buffer Signal - ACBUS - Nibble
-#  buff   = 8;
-;
-# This is an implementation of the above with a buffer IC (74AC244) and
-# 4 LEDs directly attached, all active low.
-programmer
-  id         = "2232HIO";
-  desc       = "FT2232H based generic programmer";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-# Note: This PID is reserved for generic H devices and 
-# should be programmed into the EEPROM
-#  usbpid     = 0x8A48;
-  usbpid     = 0x6010;
-  usbdev     = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
-#ISP-signals 
-  reset  = 3;
-  sck    = 0;
-  mosi   = 1;
-  miso   = 2;
-  buff   = ~4;
-#LED SIGNALs 
-  errled = ~ 11;
-  rdyled = ~ 14;
-  pgmled = ~ 13;
-  vfyled = ~ 12;
-;
-
-#The FT4232H can be treated as FT2232H, but it has a different USB
-#device ID of 0x6011.
-programmer parent "avrftdi"
-  id         = "4232h";
-  desc       = "FT4232H based generic programmer";
-  usbpid     = 0x6011;
-;
-
-programmer
-  id         = "jtagkey";
-  desc       = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-# Note: This PID is used in all JTAGKey variants
-  usbpid     = 0xCFF8;
-  usbdev     = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
-#ISP-signals => 20 - Pin connector on JTAGKey
-  reset  = 3; # TMS 7 violet
-  sck    = 0; # TCK 9 white
-  mosi   = 1; # TDI 5 green
-  miso   = 2; # TDO 13 orange
-  buff   = ~4;
-# VTG           VREF 1 brown with red tip
-# GND           GND 20 black
-# The colors are on the 20 pin breakout cable
-# from Amontec
-;
-
-programmer
-  id         = "ft232h";
-  desc       = "FT232H in MPSSE mode";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-  usbpid     = 0x6014;
-  usbdev     = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
-#ISP-signals
-  sck    = 0; # AD0 (TCK)
-  mosi   = 1; # AD1 (TDI)
-  miso   = 2; # AD2 (TDO)
-  reset  = 3; # AD3 (TMS)
-;
-
-# Pin J2-7 (AD0) is SCK
-# Pin J2-8 (AD1) is MOSI
-# Pin J2-9 (AD2) is MISO
-# Pin J2-10 (AD3) is RESET
-# Pin J2-6 is GND
-# Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
-# a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
-programmer parent "ft232h"
-  id    = "um232h";
-  desc  = "UM232H module from FTDI";
-;
-
-# Orange (Pin 2) is SCK
-# Yellow (Pin 3) is MOSI
-# Green (Pin 4) is MISO
-# Brown (Pin 5) is RESET
-# Black (Pin 10) is GND
-# Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
-# a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
-programmer parent "ft232h"
-  id    = "c232hm";
-  desc  = "C232HM cable from FTDI";
-;
-
-# On the adapter you can read "O-Link". On the PCB is printed "OpenJTAG v3.1"
-# You can find it as "OpenJTAG ARM JTAG USB" in the internet. 
-# (But there are also several projects called Open JTAG, eg. 
-# http://www.openjtag.org, which are completely different.)
-#   http://www.100ask.net/shop/english.html (website seems to be outdated)
-#   http://item.taobao.com/item.htm?id=1559277013
-#   http://www.micro4you.com/store/openjtag-arm-jtag-usb.html (schematics!)
-# some other sources which call it O-Link
-#   http://www.andahammer.com/olink/
-#   http://www.developmentboard.net/31-o-link-debugger.html
-#   http://armwerks.com/catalog/o-link-debugger-copy/
-# or just have a look at ebay ...
-# It is basically the same entry as jtagkey with different usb ids.
-programmer parent "jtagkey"
-  id         = "o-link";
-  desc       = "O-Link, OpenJTAG from www.100ask.net";
-  usbvid     = 0x1457;
-  usbpid     = 0x5118;
-  usbvendor  = "www.100ask.net";
-  usbproduct = "USB<=>JTAG&RS232";
-;
-
-# http://wiki.openmoko.org/wiki/Debug_Board_v3
-programmer
-  id    = "openmoko";
-  desc  = "Openmoko debug board (v3)";
-  type  = "avrftdi";
-  usbvid     = 0x1457;
-  usbpid    = 0x5118;
-  usbdev = "A";
-  usbvendor  = "";
-  usbproduct = "";
-  usbsn      = "";
-  reset  = 3; # TMS 7
-  sck    = 0; # TCK 9
-  mosi   = 1; # TDI 5
-  miso   = 2; # TDO 13
-;
-
-# Only Rev. A boards.
-# Schematic and user manual: http://www.cs.put.poznan.pl/wswitala/download/pdf/811EVBK.pdf
-programmer
-  id         = "lm3s811";
-  desc       = "Luminary Micro LM3S811 Eval Board (Rev. A)";
-  type       = "avrftdi";
-  connection_type = usb;
-  usbvid     = 0x0403;
-  usbpid     = 0xbcd9;
-  usbvendor  = "LMI";
-  usbproduct = "LM3S811 Evaluation Board";
-  usbdev     = "A";
-  usbsn      = "";
-#ISP-signals - lower ACBUS-Nibble (default)
-  reset  = 3;
-  sck    = 0;
-  mosi   = 1;
-  miso   = 2;
-# Enable correct buffers
-  buff   = 7;
-;
-
-# submitted as bug #46020
-programmer
-  id     = "tumpa";
-  desc   = "TIAO USB Multi-Protocol Adapter";
-  type   = "avrftdi";
-  connection_type = usb;
-  usbvid = 0x0403;
-  usbpid = 0x8A98;
-  usbdev = "A";
-  usbvendor = "TIAO";
-  usbproduct = "";
-  usbsn  = "";
-  sck    = 0; # TCK 9
-  mosi   = 1; # TDI 5
-  miso   = 2; # TDO 13
-  reset  = 3; # TMS 7
-;
-
-# Kristech KT-LINK FT2232H interface with IO switching and voltage buffers.
-# Created on 20220410 by CeDeROM Tomasz CEDRO (www.cederom.io).
-# Interface DataSheet: https://kristech.pl/files/KT-LINK-UM-ENG.pdf
-# AVRDUDE FT2232H PIN NUMBER DECODE:
-#  | 0      | 1      | .. | 7      | 8      | 9      | .. | 15     |
-#  | ADBUS0 | ADBUS1 | .. | ADBUS7 | ACBUS0 | ACBUS1 | .. | ACBUS7 |
-# KT-LINK JTAG CONN:
-#  1=Vsense(->EXT13), 19=5V(EXT1->EXT3), 20=GND, 3=TPIRST, 9=TPICLK, 7=TPIDATA.
-# INTERNALS CONFIGURATION ("~" MEANS ACTIVE LOW):
-#  ~TRST_EN=10(ACBUS2), ~CLK_EN=14(ACBUS6), ~MOSI_EN=13(ACBUS5),
-#  TMS_SEL=5(ADBUS5), ~TMS_EN=12(ACBUS4), LED=~15(ACBUS7).
-# CONNECTION NOTES:
-#  * Connect EXT connector pin 1 with 3 to get 5V on JTAG connector pin 19.
-#  * Connect JTAG connector pin 1 to 5V (i.e. EXT pin 13 or JTAG pin 19).
-#  * For TPI connection use resistors: TDO --[470R]-- TPIDATA --[470R]-- TDI.
-#  * Powering target from JTAG pin 19 allows KT-LINK current measurement.
-programmer
-  id    = "ktlink";
-  desc  = "KT-LINK FT2232H interface with IO switching and voltage buffers.";
-  type  = "avrftdi";
-  connection_type = usb;
-  usbvid= 0x0403;
-  usbpid= 0xBBE2;
-  usbdev= "A";
-  reset = 8;
-  sck   = 0;
-  mosi  = 1;
-  miso  = 2;
-  buff  = ~10,~14,~13,5;
-  rdyled = ~15;
-;
-
-programmer
-  id    = "serialupdi";
-  desc  = "SerialUPDI";
-  type  = "serialupdi";
-  connection_type = serial;
-  hvupdi_support = 1;
-;
-
-programmer
-  id    = "avrisp";
-  desc  = "Atmel AVR ISP";
-  type  = "stk500";
-  connection_type = serial;
-;
-
-programmer
-  id    = "avrispv2";
-  desc  = "Atmel AVR ISP V2";
-  type  =  "stk500v2";
-  connection_type = serial;
-;
-
-programmer
-  id    = "avrispmkII";
-  desc  = "Atmel AVR ISP mkII";
-  type  =  "stk500v2";
-  connection_type = usb;
-;
-
-programmer parent "avrispmkII"
-  id    = "avrisp2";
-;
-
-programmer
-  id    = "buspirate";
-  desc  = "The Bus Pirate";
-  type  = "buspirate";
-  connection_type = serial;
-;
-
-programmer
-  id    = "buspirate_bb";
-  desc  = "The Bus Pirate (bitbang interface, supports TPI)";
-  type  = "buspirate_bb";
-  connection_type = serial;
-  # pins are bits in bitbang byte (numbers are 87654321)
-  # 1|POWER|PULLUP|AUX|MOSI|CLK|MISO|CS
-  reset  = 1;
-  sck    = 3;
-  mosi   = 4;
-  miso   = 2;
-  #vcc    = 7; This is internally set independent of this setting.
-;
-
-# This is supposed to be the "default" STK500 entry.
-# Attempts to select the correct firmware version
-# by probing for it.  Better use one of the entries
-# below instead.
-programmer
-  id    = "stk500";
-  desc  = "Atmel STK500";
-  type  = "stk500generic";
-  connection_type = serial;
-;
-
-programmer
-  id    = "stk500v1";
-  desc  = "Atmel STK500 Version 1.x firmware";
-  type  = "stk500";
-  connection_type = serial;
-;
-
-programmer
-  id    = "mib510";
-  desc  = "Crossbow MIB510 programming board";
-  type  = "stk500";
-  connection_type = serial;
-;
-
-programmer
-  id    = "stk500v2";
-  desc  = "Atmel STK500 Version 2.x firmware";
-  type  = "stk500v2";
-  connection_type = serial;
-;
-
-programmer
-  id    = "stk500pp";
-  desc  = "Atmel STK500 V2 in parallel programming mode";
-  type  = "stk500pp";
-  connection_type = serial;
-;
-
-programmer
-  id    = "stk500hvsp";
-  desc  = "Atmel STK500 V2 in high-voltage serial programming mode";
-  type  = "stk500hvsp";
-  connection_type = serial;
-;
-
-programmer
-  id    = "stk600";
-  desc  = "Atmel STK600";
-  type  = "stk600";
-  connection_type = usb;
-;
-
-programmer
-  id    = "stk600pp";
-  desc  = "Atmel STK600 in parallel programming mode";
-  type  = "stk600pp";
-  connection_type = usb;
-;
-
-programmer
-  id    = "stk600hvsp";
-  desc  = "Atmel STK600 in high-voltage serial programming mode";
-  type  = "stk600hvsp";
-  connection_type = usb;
-;
-
-programmer
-  id    = "avr910";
-  desc  = "Atmel Low Cost Serial Programmer";
-  type  = "avr910";
-  connection_type = serial;
-;
-
-programmer
-  id    = "ft245r";
-  desc  = "FT245R Synchronous BitBang";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 1; # D1
-  sck   = 0; # D0
-  mosi  = 2; # D2
-  reset = 4; # D4
-;
-
-programmer
-  id    = "ft232r";
-  desc  = "FT232R Synchronous BitBang";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 1;  # RxD
-  sck   = 0;  # TxD
-  mosi  = 2;  # RTS
-  reset = 4;  # DTR
-;
-
-# see http://www.bitwizard.nl/wiki/index.php/FTDI_ATmega
-programmer
-  id    = "bwmega";
-  desc  = "BitWizard ftdi_atmega builtin programmer";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 5;  # DSR
-  sck   = 6;  # DCD
-  mosi  = 3;  # CTS
-  reset = 7;  # RI
-;
-
-# see http://www.geocities.jp/arduino_diecimila/bootloader/index_en.html
-# Note: pins are numbered from 1!
-programmer
-  id    = "arduino-ft232r";
-  desc  = "Arduino: FT232R connected to ISP";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 3;  # CTS X3(1)
-  sck   = 5;  # DSR X3(2)
-  mosi  = 6;  # DCD X3(3)
-  reset = 7;  # RI  X3(4)
-;
-
-programmer
-  id    = "tc2030";
-  desc  = "Tag-Connect TC2030";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  #                      FOR TPI devices:
-  mosi  = 0;  # TxD = D0 (wire to TPIDATA via 1k resistor)
-  miso  = 1;  # RxD = D1 (wire to TPIDATA directly)
-  sck   = 2;  # RTS = D2 (wire to SCK)
-  reset = 3;  # CTS = D3 (wire to ~RESET)
-;
-
-# website mentioned above uses this id
-programmer parent "arduino-ft232r"
-  id    = "diecimila";
-  desc  = "alias for arduino-ft232r";
-;
-
-# There is a ATmega328P kit PCB called "uncompatino".
-# This board allows ISP via its on-board FT232R.
-# This is designed like Arduino Duemilanove but has no standard ICPS header.
-# Its 4 pairs of pins are shorted to enable ftdi_syncbb.
-# http://akizukidenshi.com/catalog/g/gP-07487/
-# http://akizukidenshi.com/download/ds/akizuki/k6096_manual_20130816.pdf
-programmer
-  id    = "uncompatino";
-  desc  = "uncompatino with all pairs of pins shorted";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 3; # cts
-  sck   = 5; # dsr
-  mosi  = 6; # dcd
-  reset = 7; # ri
-;
-
-# FTDI USB to serial cable TTL-232R-5V with a custom adapter for ICSP
-# http://www.ftdichip.com/Products/Cables/USBTTLSerial.htm
-# http://www.ftdichip.com/Support/Documents/DataSheets/Cables/DS_TTL-232R_CABLES.pdf
-# For ICSP pinout see for example http://www.atmel.com/images/doc2562.pdf
-# (Figure 1. ISP6PIN header pinout and Table 1. Connections required for ISP ...)
-# TTL-232R GND 1 Black  -> ICPS GND   (pin 6)
-# TTL-232R CTS 2 Brown  -> ICPS MOSI  (pin 4)
-# TTL-232R VCC 3 Red    -> ICPS VCC   (pin 2)
-# TTL-232R TXD 4 Orange -> ICPS RESET (pin 5)
-# TTL-232R RXD 5 Yellow -> ICPS SCK   (pin 3)
-# TTL-232R RTS 6 Green  -> ICPS MISO  (pin 1)
-# Except for VCC and GND, you can connect arbitual pairs as long as 
-# the following table is adjusted.
-programmer
-  id    = "ttl232r";
-  desc  = "FTDI TTL232R-5V with ICSP adapter";
-  type  = "ftdi_syncbb";
-  connection_type = usb;
-  miso  = 2; # rts
-  sck   = 1; # rxd
-  mosi  = 3; # cts
-  reset = 0; # txd
-;
-
-programmer
-  id    = "usbasp";
-  desc  = "USBasp, http://www.fischl.de/usbasp/";
-  type  = "usbasp";
-  connection_type = usb;
-  usbvid     = 0x16C0; # VOTI
-  usbpid     = 0x05DC; # Obdev's free shared PID
-  usbvendor  = "www.fischl.de";
-  usbproduct = "USBasp";
-
-  # following variants are autodetected for id "usbasp"
-
-  # original usbasp from fischl.de
-  # see above "usbasp"
-
-  # old usbasp from fischl.de
-  #usbvid     = 0x03EB; # ATMEL
-  #usbpid     = 0xC7B4; # (unoffical) USBasp
-  #usbvendor  = "www.fischl.de";
-  #usbproduct = "USBasp";
-
-  # NIBObee (only if -P nibobee is given on command line)
-  # see below "nibobee"
-;
-
-programmer
-  id    = "nibobee";
-  desc  = "NIBObee";
-  type  = "usbasp";
-  connection_type = usb;
-  usbvid     = 0x16C0; # VOTI
-  usbpid     = 0x092F; # NIBObee PID
-  usbvendor  = "www.nicai-systems.com";
-  usbproduct = "NIBObee";
-;
-
-programmer
-  id    = "usbasp-clone";
-  desc  = "Any usbasp clone with correct VID/PID";
-  type  = "usbasp";
-  connection_type = usb;
-  usbvid    = 0x16C0; # VOTI
-  usbpid    = 0x05DC; # Obdev's free shared PID
-  #usbvendor  = "";
-  #usbproduct = "";
-;
-
-# USBtiny can also be used for TPI programming.
-# In that case, a resistor of 1 kOhm is needed between MISO and MOSI
-# pins of the connector, and MISO (pin 1 of the 6-pin connector)
-# connects to TPIDATA.
-programmer
-  id    = "usbtiny";
-  desc  = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x1781;
-  usbpid     = 0x0c9f;
-;
-
-programmer
-  id    = "arduinoisp";
-  desc  = "Arduino ISP Programmer";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x2341;
-  usbpid     = 0x0049;
-;
-
-programmer
-  id    = "arduinoisporg";
-  desc  = "Arduino ISP Programmer";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x2A03;
-  usbpid     = 0x0049;
-;
-
-# commercial version of USBtiny, using a separate VID/PID
-programmer
-  id    = "ehajo-isp";
-  desc  = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x16D0;
-  usbpid     = 0x0BA5;
-;
-
-# commercial version of USBtiny, using a separate VID/PID
-# https://github.com/IowaScaledEngineering/ckt-avrprogrammer
-programmer
-  id    = "iseavrprog";
-  desc  = "USBtiny-based programmer, https://iascaled.com";
-  type  = "usbtiny";
-  connection_type = usb;
-  usbvid     = 0x1209;
-  usbpid     = 0x6570;
-;
-
-programmer
-  id = "micronucleus";
-  desc = "Micronucleus Bootloader";
-  type = "micronucleus";
-  connection_type = usb;
-  usbvid = 0x16D0;
-  usbpid = 0x0753;
-;
-
-programmer
-  id = "teensy";
-  desc = "Teensy Bootloader";
-  type = "teensy";
-  connection_type = usb;
-  usbvid = 0x16C0;
-  usbpid = 0x0478;
-;
-
-programmer
-  id    = "butterfly";
-  desc  = "Atmel Butterfly Development Board";
-  type  = "butterfly";
-  connection_type = serial;
-;
-
-programmer
-  id    = "avr109";
-  desc  = "Atmel AppNote AVR109 Boot Loader";
-  type  = "butterfly";
-  connection_type = serial;
-;
-
-programmer
-  id    = "avr911";
-  desc  = "Atmel AppNote AVR911 AVROSP";
-  type  = "butterfly";
-  connection_type = serial;
-;
- 
-# suggested in http://forum.mikrokopter.de/topic-post48317.html
-programmer
-  id    = "mkbutterfly";
-  desc  = "Mikrokopter.de Butterfly";
-  type  = "butterfly_mk";
-  connection_type = serial;
-;
-
-programmer parent "mkbutterfly"
-  id    = "butterfly_mk";
-;
-
-programmer
-  id    = "jtagmkI";
-  desc  = "Atmel JTAG ICE (mkI)";
-  baudrate = 115200;    # default is 115200
-  type  = "jtagmki";
-  connection_type = serial;
-;
-
-# easier to type
-programmer parent "jtagmkI"
-  id    = "jtag1";
-;
-
-# easier to type
-programmer parent "jtag1"
-  id    = "jtag1slow";
-  baudrate = 19200;
-;
-
-# The JTAG ICE mkII has both, serial and USB connectivity.  As it is
-# mostly used through USB these days (AVR Studio 5 only supporting it
-# that way), we make connection_type = usb the default.  Users are
-# still free to use a serial port with the -P option.
-
-programmer
-  id    = "jtagmkII";
-  desc  = "Atmel JTAG ICE mkII";
-  baudrate = 19200;    # default is 19200
-  type  = "jtagmkii";
-  connection_type = usb;
-;
-
-# easier to type
-programmer parent "jtagmkII"
-  id    = "jtag2slow";
-;
-
-# JTAG ICE mkII @ 115200 Bd
-programmer parent "jtag2slow"
-  id    = "jtag2fast";
-  baudrate = 115200;
-;
-
-# make the fast one the default, people will love that
-programmer parent "jtag2fast"
-  id    = "jtag2";
-;
-
-# JTAG ICE mkII in ISP mode
-programmer
-  id    = "jtag2isp";
-  desc  = "Atmel JTAG ICE mkII in ISP mode";
-  baudrate = 115200;
-  type  = "jtagmkii_isp";
-  connection_type = usb;
-;
-
-# JTAG ICE mkII in debugWire mode
-programmer
-  id    = "jtag2dw";
-  desc  = "Atmel JTAG ICE mkII in debugWire mode";
-  baudrate = 115200;
-  type  = "jtagmkii_dw";
-  connection_type = usb;
-;
-
-# JTAG ICE mkII in AVR32 mode
-programmer
-  id    = "jtagmkII_avr32";
-  desc  = "Atmel JTAG ICE mkII im AVR32 mode";
-  baudrate = 115200;
-  type  = "jtagmkii_avr32";
-  connection_type = usb;
-;
-
-# JTAG ICE mkII in AVR32 mode
-programmer
-  id    = "jtag2avr32";
-  desc  = "Atmel JTAG ICE mkII im AVR32 mode";
-  baudrate = 115200;
-  type  = "jtagmkii_avr32";
-  connection_type = usb;
-;
-
-# JTAG ICE mkII in PDI mode
-programmer
-  id    = "jtag2pdi";
-  desc  = "Atmel JTAG ICE mkII PDI mode";
-  baudrate = 115200;
-  type  = "jtagmkii_pdi";
-  connection_type = usb;
-;
-
-# AVR Dragon in JTAG mode
-programmer
-  id    = "dragon_jtag";
-  desc  = "Atmel AVR Dragon in JTAG mode";
-  baudrate = 115200;
-  type  = "dragon_jtag";
-  connection_type = usb;
-;
-
-# AVR Dragon in ISP mode
-programmer
-  id    = "dragon_isp";
-  desc  = "Atmel AVR Dragon in ISP mode";
-  baudrate = 115200;
-  type  = "dragon_isp";
-  connection_type = usb;
-;
-
-# AVR Dragon in PP mode
-programmer
-  id    = "dragon_pp";
-  desc  = "Atmel AVR Dragon in PP mode";
-  baudrate = 115200;
-  type  = "dragon_pp";
-  connection_type = usb;
-;
-
-# AVR Dragon in HVSP mode
-programmer
-  id    = "dragon_hvsp";
-  desc  = "Atmel AVR Dragon in HVSP mode";
-  baudrate = 115200;
-  type  = "dragon_hvsp";
-  connection_type = usb;
-;
-
-# AVR Dragon in debugWire mode
-programmer
-  id    = "dragon_dw";
-  desc  = "Atmel AVR Dragon in debugWire mode";
-  baudrate = 115200;
-  type  = "dragon_dw";
-  connection_type = usb;
-;
-
-# AVR Dragon in PDI mode
-programmer
-  id    = "dragon_pdi";
-  desc  = "Atmel AVR Dragon in PDI mode";
-  baudrate = 115200;
-  type  = "dragon_pdi";
-  connection_type = usb;
-;
-
-programmer
-  id    = "jtag3";
-  desc  = "Atmel AVR JTAGICE3 in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
-;
-
-programmer
-  id    = "jtag3pdi";
-  desc  = "Atmel AVR JTAGICE3 in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
-;
-
-programmer
-  id    = "jtag3updi";
-  desc  = "Atmel AVR JTAGICE3 in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
-  hvupdi_support = 1;
-;
-
-programmer
-  id    = "jtag3dw";
-  desc  = "Atmel AVR JTAGICE3 in debugWIRE mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
-;
-
-programmer
-  id    = "jtag3isp";
-  desc  = "Atmel AVR JTAGICE3 in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2110, 0x2140;
-;
-
-programmer
-  id    = "xplainedpro";
-  desc  = "Atmel AVR XplainedPro in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2111;
-;
-
-programmer
-  id    = "xplainedpro_updi";
-  desc  = "Atmel AVR XplainedPro in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2111;
-  hvupdi_support = 1;
-;
-
-programmer
-  id    = "xplainedmini";
-  desc  = "Atmel AVR XplainedMini in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2145;
-;
-
-programmer
-  id    = "xplainedmini_dw";
-  desc  = "Atmel AVR XplainedMini in debugWIRE mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2145;
-;
-
-programmer
-  id    = "xplainedmini_updi";
-  desc  = "Atmel AVR XplainedMini in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2145;
-  hvupdi_support = 1;
-;
-
-programmer
-  id    = "atmelice";
-  desc  = "Atmel-ICE (ARM/AVR) in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2141;
-;
-
-programmer
-  id    = "atmelice_pdi";
-  desc  = "Atmel-ICE (ARM/AVR) in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2141;
-;
-
-programmer
-  id    = "atmelice_updi";
-  desc  = "Atmel-ICE (ARM/AVR) in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2141;
-  hvupdi_support = 1;
-;
-
-programmer
-  id    = "atmelice_dw";
-  desc  = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2141;
-;
-
-programmer
-  id    = "atmelice_isp";
-  desc  = "Atmel-ICE (ARM/AVR) in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2141;
-;
-
-programmer
-  id    = "powerdebugger";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
-  type  = "jtagice3";
-  connection_type = usb;
-  usbpid = 0x2144;
-;
-
-programmer
-  id    = "powerdebugger_pdi";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2144;
-;
-
-programmer
-  id    = "powerdebugger_updi";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2144;
-  hvupdi_support = 0, 1;
-;
-
-programmer
-  id    = "powerdebugger_dw";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
-  type  = "jtagice3_dw";
-  connection_type = usb;
-  usbpid = 0x2144;
-;
-
-programmer
-  id    = "powerdebugger_isp";
-  desc  = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x2144;
-;
-
-programmer
-  id    = "pickit4_updi";
-  desc  = "MPLAB(R) PICkit 4 in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2177, 0x2178, 0x2179;
-  hvupdi_support = 0, 1, 2;
-;
-
-programmer
-  id    = "pickit4_pdi";
-  desc  = "MPLAB(R) PICkit 4 in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x2177, 0x2178, 0x2179;
-;
-
-programmer
-   id    = "pickit4_isp";
-   desc  = "MPLAB(R) PICkit 4 in ISP mode";
-   type  = "jtagice3_isp";
-   connection_type = usb;
-   usbpid = 0x2177, 0x2178, 0x2179;
-;
-
-programmer
-  id    = "snap_updi";
-  desc  = "MPLAB(R) SNAP in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x217F, 0x2180, 0x2181;
-  hvupdi_support = 1;
-;
-
-programmer
-  id    = "snap_pdi";
-  desc  = "MPLAB(R) SNAP in PDI mode";
-  type  = "jtagice3_pdi";
-  connection_type = usb;
-  usbpid = 0x217F, 0x2180, 0x2181;
-;
-
-programmer
-  id    = "snap_isp";
-  desc  = "MPLAB(R) SNAP in ISP mode";
-  type  = "jtagice3_isp";
-  connection_type = usb;
-  usbpid = 0x217F, 0x2180, 0x2181;
-;
-
-programmer
-  id    = "pkobn_updi";
-  desc  = "Curiosity nano (nEDBG) in UPDI mode";
-  type  = "jtagice3_updi";
-  connection_type = usb;
-  usbpid = 0x2175;
-  hvupdi_support = 1;
-;
-
-programmer
-  id    = "pavr";
-  desc  = "Jason Kyle's pAVR Serial Programmer";
-  type  = "avr910";
-  connection_type = serial;
-;
-
-programmer
-  id    = "pickit2";
-  desc  = "MicroChip's PICkit2 Programmer";
-  type  = "pickit2";
-  connection_type = usb;
-;
-
-programmer
-  id    = "flip1";
-  desc  = "FLIP USB DFU protocol version 1 (doc7618)";
-  type  = "flip1";
-  connection_type = usb;
-;
-
-programmer
-  id    = "flip2";
-  desc  = "FLIP USB DFU protocol version 2 (AVR4023)";
-  type  = "flip2";
-  connection_type = usb;
-;
-
 @HAVE_PARPORT_BEGIN@
 # Parallel port programmers.
 
@@ -1478,7 +409,7 @@ programmer
 programmer parent "stk200"
   id    = "pony-stk200";
   desc  = "Pony Prog STK200";
-  pgmled = 8; 
+  pgmled = 8;
 ;
 
 programmer
@@ -1563,7 +494,7 @@ programmer
 # From the contributor of the "xil" jtag cable:
 # The "vcc" definition isn't really vcc (the cable gets its power from
 # the programming circuit) but is necessary to switch one of the
-# buffer lines (trying to add it to the "buff" lines doesn't work in 
+# buffer lines (trying to add it to the "buff" lines doesn't work in
 # avrdude versions before 5.5j).
 # With this, TMS connects to RESET, TDI to MOSI, TDO to MISO and TCK
 # to SCK (plus vcc/gnd of course)
@@ -1691,8 +622,1513 @@ programmer
 ;
 @HAVE_LINUXSPI_END@
 
-# some ultra cheap programmers use bitbanging on the 
-# serialport.
+#
+# PROGRAMMER DEFINITIONS
+#
+
+#------------------------------------------------------------
+# wiring
+#------------------------------------------------------------
+
+# http://wiring.org.co/
+# Basically STK500v2 protocol, with some glue to trigger the
+# bootloader.
+programmer
+    id                  = "wiring";
+    desc                = "Wiring";
+    type                = "wiring";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# arduino
+#------------------------------------------------------------
+
+programmer
+    id                  = "arduino";
+    desc                = "Arduino";
+    type                = "arduino";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# xbee
+#------------------------------------------------------------
+
+programmer
+    id                  = "xbee";
+    desc                = "XBee Series 2 Over-The-Air (XBeeBoot)";
+    type                = "xbee";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# avrftdi
+#------------------------------------------------------------
+
+# this will interface with the chips on these programmers:
+#
+# http://real.kiev.ua/old/avreal/en/adapters
+# http://www.amontec.com/jtagkey.shtml, jtagkey-tiny.shtml
+# http://www.olimex.com/dev/arm-usb-ocd.html, arm-usb-tiny.html
+# http://www.ethernut.de/en/hardware/turtelizer/index.html
+# http://elk.informatik.fh-augsburg.de/hhweb/doc/openocd/usbjtag/usbjtag.html
+# http://dangerousprototypes.com/docs/FT2232_breakout_board
+# http://www.ftdichip.com/Products/Modules/DLPModules.htm,DLP-2232*,DLP-USB1232H
+# http://flashrom.org/FT2232SPI_Programmer
+#
+# The drivers will look for a specific device and use the first one found.
+# If you have mulitple devices, then look for unique information (like SN)
+# And fill that in here.
+#
+# Note that the pin numbers for the main ISP signals (reset, sck,
+# mosi, miso) are fixed and cannot be changed, since they must match
+# the way the Multi-Protocol Synchronous Serial Engine (MPSSE) of
+# these FTDI ICs has been designed.
+
+programmer
+    id                  = "avrftdi";
+    desc                = "FT2232D based generic programmer";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0x6010;
+    usbdev              = "A";
+#ISP-signals - lower ADBUS-Nibble (default)
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+#LED SIGNALs - higher ADBUS-Nibble
+#  errled = 4;
+#  rdyled = 5;
+#  pgmled = 6;
+#  vfyled = 7;
+#Buffer Signal - ACBUS - Nibble
+#  buff   = 8;
+;
+
+#------------------------------------------------------------
+# 2232HIO
+#------------------------------------------------------------
+
+# This is an implementation of the above with a buffer IC (74AC244) and
+# 4 LEDs directly attached, all active low.
+programmer
+    id                  = "2232HIO";
+    desc                = "FT2232H based generic programmer";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+# Note: This PID is reserved for generic H devices and
+# should be programmed into the EEPROM
+#  usbpid     = 0x8A48;
+    usbpid              = 0x6010;
+    usbdev              = "A";
+    buff                = ~4;
+#ISP-signals
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+#LED SIGNALs
+    errled              = ~11;
+    rdyled              = ~14;
+    pgmled              = ~13;
+    vfyled              = ~12;
+;
+
+#------------------------------------------------------------
+# 4232h
+#------------------------------------------------------------
+
+#The FT4232H can be treated as FT2232H, but it has a different USB
+#device ID of 0x6011.
+programmer parent "avrftdi"
+    id                  = "4232h";
+    desc                = "FT4232H based generic programmer";
+    type                = "avrftdi";
+    usbpid              = 0x6011;
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+;
+
+#------------------------------------------------------------
+# jtagkey
+#------------------------------------------------------------
+
+programmer
+    id                  = "jtagkey";
+    desc                = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+# Note: This PID is used in all JTAGKey variants
+    usbpid              = 0xcff8;
+    usbdev              = "A";
+    buff                = ~4;
+#ISP-signals => 20 - Pin connector on JTAGKey
+    reset               = 3; # TMS 7 violet
+    sck                 = 0; # TCK 9 white
+    mosi                = 1; # TDI 5 green
+    miso                = 2; # TDO 13 orange
+# VTG           VREF 1 brown with red tip
+# GND           GND 20 black
+# The colors are on the 20 pin breakout cable
+# from Amontec
+;
+
+#------------------------------------------------------------
+# ft232h
+#------------------------------------------------------------
+
+programmer
+    id                  = "ft232h";
+    desc                = "FT232H in MPSSE mode";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0x6014;
+    usbdev              = "A";
+    reset               = 3; # AD3 (TMS)
+#ISP-signals
+    sck                 = 0; # AD0 (TCK)
+    mosi                = 1; # AD1 (TDI)
+    miso                = 2; # AD2 (TDO)
+;
+
+#------------------------------------------------------------
+# um232h
+#------------------------------------------------------------
+
+# Pin J2-7 (AD0) is SCK
+# Pin J2-8 (AD1) is MOSI
+# Pin J2-9 (AD2) is MISO
+# Pin J2-10 (AD3) is RESET
+# Pin J2-6 is GND
+# Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
+# a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
+programmer parent "ft232h"
+    id                  = "um232h";
+    desc                = "UM232H module from FTDI";
+    type                = "avrftdi";
+    usbpid              = 0x6014;
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+;
+
+#------------------------------------------------------------
+# c232hm
+#------------------------------------------------------------
+
+# Orange (Pin 2) is SCK
+# Yellow (Pin 3) is MOSI
+# Green (Pin 4) is MISO
+# Brown (Pin 5) is RESET
+# Black (Pin 10) is GND
+# Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
+# a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
+programmer parent "ft232h"
+    id                  = "c232hm";
+    desc                = "C232HM cable from FTDI";
+    type                = "avrftdi";
+    usbpid              = 0x6014;
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+;
+
+#------------------------------------------------------------
+# o-link
+#------------------------------------------------------------
+
+# On the adapter you can read "O-Link". On the PCB is printed "OpenJTAG v3.1"
+# You can find it as "OpenJTAG ARM JTAG USB" in the internet.
+# (But there are also several projects called Open JTAG, eg.
+# http://www.openjtag.org, which are completely different.)
+#   http://www.100ask.net/shop/english.html (website seems to be outdated)
+#   http://item.taobao.com/item.htm?id=1559277013
+#   http://www.micro4you.com/store/openjtag-arm-jtag-usb.html (schematics!)
+# some other sources which call it O-Link
+#   http://www.andahammer.com/olink/
+#   http://www.developmentboard.net/31-o-link-debugger.html
+#   http://armwerks.com/catalog/o-link-debugger-copy/
+# or just have a look at ebay ...
+# It is basically the same entry as jtagkey with different usb ids.
+programmer parent "jtagkey"
+    id                  = "o-link";
+    desc                = "O-Link, OpenJTAG from www.100ask.net";
+    type                = "avrftdi";
+    usbvid              = 0x1457;
+    usbpid              = 0x5118;
+    usbvendor           = "www.100ask.net";
+    usbproduct          = "USB<=>JTAG&RS232";
+    buff                = ~4;
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+;
+
+#------------------------------------------------------------
+# openmoko
+#------------------------------------------------------------
+
+# http://wiki.openmoko.org/wiki/Debug_Board_v3
+programmer
+    id                  = "openmoko";
+    desc                = "Openmoko debug board (v3)";
+    type                = "avrftdi";
+    usbvid              = 0x1457;
+    usbpid              = 0x5118;
+    usbdev              = "A";
+    reset               = 3; # TMS 7
+    sck                 = 0; # TCK 9
+    mosi                = 1; # TDI 5
+    miso                = 2; # TDO 13
+;
+
+#------------------------------------------------------------
+# lm3s811
+#------------------------------------------------------------
+
+# Only Rev. A boards.
+# Schematic and user manual: http://www.cs.put.poznan.pl/wswitala/download/pdf/811EVBK.pdf
+programmer
+    id                  = "lm3s811";
+    desc                = "Luminary Micro LM3S811 Eval Board (Rev. A)";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0xbcd9;
+    usbdev              = "A";
+    usbvendor           = "LMI";
+    usbproduct          = "LM3S811 Evaluation Board";
+# Enable correct buffers
+    buff                = 7;
+#ISP-signals - lower ACBUS-Nibble (default)
+    reset               = 3;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+;
+
+#------------------------------------------------------------
+# tumpa
+#------------------------------------------------------------
+
+# submitted as bug #46020
+programmer
+    id                  = "tumpa";
+    desc                = "TIAO USB Multi-Protocol Adapter";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0x8a98;
+    usbdev              = "A";
+    usbvendor           = "TIAO";
+    reset               = 3; # TMS 7
+    sck                 = 0; # TCK 9
+    mosi                = 1; # TDI 5
+    miso                = 2; # TDO 13
+;
+
+#------------------------------------------------------------
+# ktlink
+#------------------------------------------------------------
+
+# Kristech KT-LINK FT2232H interface with IO switching and voltage buffers.
+# Created on 20220410 by CeDeROM Tomasz CEDRO (www.cederom.io).
+# Interface DataSheet: https://kristech.pl/files/KT-LINK-UM-ENG.pdf
+# AVRDUDE FT2232H PIN NUMBER DECODE:
+#  | 0      | 1      | .. | 7      | 8      | 9      | .. | 15     |
+#  | ADBUS0 | ADBUS1 | .. | ADBUS7 | ACBUS0 | ACBUS1 | .. | ACBUS7 |
+# KT-LINK JTAG CONN:
+#  1=Vsense(->EXT13), 19=5V(EXT1->EXT3), 20=GND, 3=TPIRST, 9=TPICLK, 7=TPIDATA.
+# INTERNALS CONFIGURATION ("~" MEANS ACTIVE LOW):
+#  ~TRST_EN=10(ACBUS2), ~CLK_EN=14(ACBUS6), ~MOSI_EN=13(ACBUS5),
+#  TMS_SEL=5(ADBUS5), ~TMS_EN=12(ACBUS4), LED=~15(ACBUS7).
+# CONNECTION NOTES:
+#  * Connect EXT connector pin 1 with 3 to get 5V on JTAG connector pin 19.
+#  * Connect JTAG connector pin 1 to 5V (i.e. EXT pin 13 or JTAG pin 19).
+#  * For TPI connection use resistors: TDO --[470R]-- TPIDATA --[470R]-- TDI.
+#  * Powering target from JTAG pin 19 allows KT-LINK current measurement.
+programmer
+    id                  = "ktlink";
+    desc                = "KT-LINK FT2232H interface with IO switching and voltage buffers.";
+    type                = "avrftdi";
+    connection_type     = usb;
+    usbvid              = 0x0403;
+    usbpid              = 0xbbe2;
+    usbdev              = "A";
+    buff                = 5, ~10, ~13, ~14;
+    reset               = 8;
+    sck                 = 0;
+    mosi                = 1;
+    miso                = 2;
+    rdyled              = ~15;
+;
+
+#------------------------------------------------------------
+# serialupdi
+#------------------------------------------------------------
+
+programmer
+    id                  = "serialupdi";
+    desc                = "SerialUPDI";
+    type                = "serialupdi";
+    connection_type     = serial;
+    hvupdi_support      = 1;
+;
+
+#------------------------------------------------------------
+# avrisp
+#------------------------------------------------------------
+
+programmer
+    id                  = "avrisp";
+    desc                = "Atmel AVR ISP";
+    type                = "stk500";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# avrispv2
+#------------------------------------------------------------
+
+programmer
+    id                  = "avrispv2";
+    desc                = "Atmel AVR ISP V2";
+    type                = "stk500v2";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# avrispmkII
+#------------------------------------------------------------
+
+programmer
+    id                  = "avrispmkII";
+    desc                = "Atmel AVR ISP mkII";
+    type                = "stk500v2";
+    connection_type     = usb;
+;
+
+#------------------------------------------------------------
+# avrisp2
+#------------------------------------------------------------
+
+programmer parent "avrispmkII"
+    id                  = "avrisp2";
+    type                = "stk500v2";
+;
+
+#------------------------------------------------------------
+# buspirate
+#------------------------------------------------------------
+
+programmer
+    id                  = "buspirate";
+    desc                = "The Bus Pirate";
+    type                = "buspirate";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# buspirate_bb
+#------------------------------------------------------------
+
+programmer
+    id                  = "buspirate_bb";
+    desc                = "The Bus Pirate (bitbang interface, supports TPI)";
+    type                = "buspirate_bb";
+    connection_type     = serial;
+  # pins are bits in bitbang byte (numbers are 87654321)
+  # 1|POWER|PULLUP|AUX|MOSI|CLK|MISO|CS
+    reset               = 1;
+    sck                 = 3;
+    mosi                = 4;
+    miso                = 2;
+  #vcc    = 7; This is internally set independent of this setting.
+;
+
+#------------------------------------------------------------
+# stk500
+#------------------------------------------------------------
+
+# This is supposed to be the "default" STK500 entry.
+# Attempts to select the correct firmware version
+# by probing for it.  Better use one of the entries
+# below instead.
+programmer
+    id                  = "stk500";
+    desc                = "Atmel STK500";
+    type                = "stk500generic";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# stk500v1
+#------------------------------------------------------------
+
+programmer
+    id                  = "stk500v1";
+    desc                = "Atmel STK500 Version 1.x firmware";
+    type                = "stk500";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# mib510
+#------------------------------------------------------------
+
+programmer
+    id                  = "mib510";
+    desc                = "Crossbow MIB510 programming board";
+    type                = "stk500";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# stk500v2
+#------------------------------------------------------------
+
+programmer
+    id                  = "stk500v2";
+    desc                = "Atmel STK500 Version 2.x firmware";
+    type                = "stk500v2";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# stk500pp
+#------------------------------------------------------------
+
+programmer
+    id                  = "stk500pp";
+    desc                = "Atmel STK500 V2 in parallel programming mode";
+    type                = "stk500pp";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# stk500hvsp
+#------------------------------------------------------------
+
+programmer
+    id                  = "stk500hvsp";
+    desc                = "Atmel STK500 V2 in high-voltage serial programming mode";
+    type                = "stk500hvsp";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# stk600
+#------------------------------------------------------------
+
+programmer
+    id                  = "stk600";
+    desc                = "Atmel STK600";
+    type                = "stk600";
+    connection_type     = usb;
+;
+
+#------------------------------------------------------------
+# stk600pp
+#------------------------------------------------------------
+
+programmer
+    id                  = "stk600pp";
+    desc                = "Atmel STK600 in parallel programming mode";
+    type                = "stk600pp";
+    connection_type     = usb;
+;
+
+#------------------------------------------------------------
+# stk600hvsp
+#------------------------------------------------------------
+
+programmer
+    id                  = "stk600hvsp";
+    desc                = "Atmel STK600 in high-voltage serial programming mode";
+    type                = "stk600hvsp";
+    connection_type     = usb;
+;
+
+#------------------------------------------------------------
+# avr910
+#------------------------------------------------------------
+
+programmer
+    id                  = "avr910";
+    desc                = "Atmel Low Cost Serial Programmer";
+    type                = "avr910";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# ft245r
+#------------------------------------------------------------
+
+programmer
+    id                  = "ft245r";
+    desc                = "FT245R Synchronous BitBang";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    reset               = 4; # D4
+    sck                 = 0; # D0
+    mosi                = 2; # D2
+    miso                = 1; # D1
+;
+
+#------------------------------------------------------------
+# ft232r
+#------------------------------------------------------------
+
+programmer
+    id                  = "ft232r";
+    desc                = "FT232R Synchronous BitBang";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    reset               = 4;  # DTR
+    sck                 = 0;  # TxD
+    mosi                = 2;  # RTS
+    miso                = 1;  # RxD
+;
+
+#------------------------------------------------------------
+# bwmega
+#------------------------------------------------------------
+
+# see http://www.bitwizard.nl/wiki/index.php/FTDI_ATmega
+programmer
+    id                  = "bwmega";
+    desc                = "BitWizard ftdi_atmega builtin programmer";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    reset               = 7;  # RI
+    sck                 = 6;  # DCD
+    mosi                = 3;  # CTS
+    miso                = 5;  # DSR
+;
+
+#------------------------------------------------------------
+# arduino-ft232r
+#------------------------------------------------------------
+
+# see http://www.geocities.jp/arduino_diecimila/bootloader/index_en.html
+# Note: pins are numbered from 1!
+programmer
+    id                  = "arduino-ft232r";
+    desc                = "Arduino: FT232R connected to ISP";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    reset               = 7;  # RI  X3(4)
+    sck                 = 5;  # DSR X3(2)
+    mosi                = 6;  # DCD X3(3)
+    miso                = 3;  # CTS X3(1)
+;
+
+#------------------------------------------------------------
+# tc2030
+#------------------------------------------------------------
+
+programmer
+    id                  = "tc2030";
+    desc                = "Tag-Connect TC2030";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    reset               = 3;  # CTS = D3 (wire to ~RESET)
+    sck                 = 2;  # RTS = D2 (wire to SCK)
+  #                      FOR TPI devices:
+    mosi                = 0;  # TxD = D0 (wire to TPIDATA via 1k resistor)
+    miso                = 1;  # RxD = D1 (wire to TPIDATA directly)
+;
+
+#------------------------------------------------------------
+# diecimila
+#------------------------------------------------------------
+
+# website mentioned above uses this id
+programmer parent "arduino-ft232r"
+    id                  = "diecimila";
+    desc                = "alias for arduino-ft232r";
+    type                = "ftdi_syncbb";
+    reset               = 7;
+    sck                 = 5;
+    mosi                = 6;
+    miso                = 3;
+;
+
+#------------------------------------------------------------
+# uncompatino
+#------------------------------------------------------------
+
+# There is a ATmega328P kit PCB called "uncompatino".
+# This board allows ISP via its on-board FT232R.
+# This is designed like Arduino Duemilanove but has no standard ICPS header.
+# Its 4 pairs of pins are shorted to enable ftdi_syncbb.
+# http://akizukidenshi.com/catalog/g/gP-07487/
+# http://akizukidenshi.com/download/ds/akizuki/k6096_manual_20130816.pdf
+programmer
+    id                  = "uncompatino";
+    desc                = "uncompatino with all pairs of pins shorted";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    reset               = 7; # ri
+    sck                 = 5; # dsr
+    mosi                = 6; # dcd
+    miso                = 3; # cts
+;
+
+#------------------------------------------------------------
+# ttl232r
+#------------------------------------------------------------
+
+# FTDI USB to serial cable TTL-232R-5V with a custom adapter for ICSP
+# http://www.ftdichip.com/Products/Cables/USBTTLSerial.htm
+# http://www.ftdichip.com/Support/Documents/DataSheets/Cables/DS_TTL-232R_CABLES.pdf
+# For ICSP pinout see for example http://www.atmel.com/images/doc2562.pdf
+# (Figure 1. ISP6PIN header pinout and Table 1. Connections required for ISP ...)
+# TTL-232R GND 1 Black  -> ICPS GND   (pin 6)
+# TTL-232R CTS 2 Brown  -> ICPS MOSI  (pin 4)
+# TTL-232R VCC 3 Red    -> ICPS VCC   (pin 2)
+# TTL-232R TXD 4 Orange -> ICPS RESET (pin 5)
+# TTL-232R RXD 5 Yellow -> ICPS SCK   (pin 3)
+# TTL-232R RTS 6 Green  -> ICPS MISO  (pin 1)
+# Except for VCC and GND, you can connect arbitual pairs as long as
+# the following table is adjusted.
+programmer
+    id                  = "ttl232r";
+    desc                = "FTDI TTL232R-5V with ICSP adapter";
+    type                = "ftdi_syncbb";
+    connection_type     = usb;
+    reset               = 0; # txd
+    sck                 = 1; # rxd
+    mosi                = 3; # cts
+    miso                = 2; # rts
+;
+
+#------------------------------------------------------------
+# usbasp
+#------------------------------------------------------------
+
+programmer
+    id                  = "usbasp";
+    desc                = "USBasp, http://www.fischl.de/usbasp/";
+    type                = "usbasp";
+    connection_type     = usb;
+    usbvid              = 0x16c0; # VOTI
+    usbpid              = 0x05dc; # Obdev's free shared PID
+    usbvendor           = "www.fischl.de";
+    usbproduct          = "USBasp";
+  # following variants are autodetected for id "usbasp"
+
+  # original usbasp from fischl.de
+  # see above "usbasp"
+
+  # old usbasp from fischl.de
+  #usbvid     = 0x03EB; # ATMEL
+  #usbpid     = 0xC7B4; # (unoffical) USBasp
+  #usbvendor  = "www.fischl.de";
+  #usbproduct = "USBasp";
+
+  # NIBObee (only if -P nibobee is given on command line)
+  # see below "nibobee"
+;
+
+#------------------------------------------------------------
+# nibobee
+#------------------------------------------------------------
+
+programmer
+    id                  = "nibobee";
+    desc                = "NIBObee";
+    type                = "usbasp";
+    connection_type     = usb;
+    usbvid              = 0x16c0; # VOTI
+    usbpid              = 0x092f; # NIBObee PID
+    usbvendor           = "www.nicai-systems.com";
+    usbproduct          = "NIBObee";
+;
+
+#------------------------------------------------------------
+# usbasp-clone
+#------------------------------------------------------------
+
+programmer
+    id                  = "usbasp-clone";
+    desc                = "Any usbasp clone with correct VID/PID";
+    type                = "usbasp";
+    connection_type     = usb;
+    usbvid              = 0x16c0; # VOTI
+    usbpid              = 0x05dc; # Obdev's free shared PID
+  #usbvendor  = "";
+  #usbproduct = "";
+;
+
+#------------------------------------------------------------
+# usbtiny
+#------------------------------------------------------------
+
+# USBtiny can also be used for TPI programming.
+# In that case, a resistor of 1 kOhm is needed between MISO and MOSI
+# pins of the connector, and MISO (pin 1 of the 6-pin connector)
+# connects to TPIDATA.
+programmer
+    id                  = "usbtiny";
+    desc                = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x1781;
+    usbpid              = 0x0c9f;
+;
+
+#------------------------------------------------------------
+# arduinoisp
+#------------------------------------------------------------
+
+programmer
+    id                  = "arduinoisp";
+    desc                = "Arduino ISP Programmer";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x2341;
+    usbpid              = 0x0049;
+;
+
+#------------------------------------------------------------
+# arduinoisporg
+#------------------------------------------------------------
+
+programmer
+    id                  = "arduinoisporg";
+    desc                = "Arduino ISP Programmer";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x2a03;
+    usbpid              = 0x0049;
+;
+
+#------------------------------------------------------------
+# ehajo-isp
+#------------------------------------------------------------
+
+# commercial version of USBtiny, using a separate VID/PID
+programmer
+    id                  = "ehajo-isp";
+    desc                = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x16d0;
+    usbpid              = 0x0ba5;
+;
+
+#------------------------------------------------------------
+# iseavrprog
+#------------------------------------------------------------
+
+# commercial version of USBtiny, using a separate VID/PID
+# https://github.com/IowaScaledEngineering/ckt-avrprogrammer
+programmer
+    id                  = "iseavrprog";
+    desc                = "USBtiny-based programmer, https://iascaled.com";
+    type                = "usbtiny";
+    connection_type     = usb;
+    usbvid              = 0x1209;
+    usbpid              = 0x6570;
+;
+
+#------------------------------------------------------------
+# micronucleus
+#------------------------------------------------------------
+
+programmer
+    id                  = "micronucleus";
+    desc                = "Micronucleus Bootloader";
+    type                = "micronucleus";
+    connection_type     = usb;
+    usbvid              = 0x16d0;
+    usbpid              = 0x0753;
+;
+
+#------------------------------------------------------------
+# teensy
+#------------------------------------------------------------
+
+programmer
+    id                  = "teensy";
+    desc                = "Teensy Bootloader";
+    type                = "teensy";
+    connection_type     = usb;
+    usbvid              = 0x16c0;
+    usbpid              = 0x0478;
+;
+
+#------------------------------------------------------------
+# butterfly
+#------------------------------------------------------------
+
+programmer
+    id                  = "butterfly";
+    desc                = "Atmel Butterfly Development Board";
+    type                = "butterfly";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# avr109
+#------------------------------------------------------------
+
+programmer
+    id                  = "avr109";
+    desc                = "Atmel AppNote AVR109 Boot Loader";
+    type                = "butterfly";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# avr911
+#------------------------------------------------------------
+
+programmer
+    id                  = "avr911";
+    desc                = "Atmel AppNote AVR911 AVROSP";
+    type                = "butterfly";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# mkbutterfly
+#------------------------------------------------------------
+
+# suggested in http://forum.mikrokopter.de/topic-post48317.html
+programmer
+    id                  = "mkbutterfly";
+    desc                = "Mikrokopter.de Butterfly";
+    type                = "butterfly_mk";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# butterfly_mk
+#------------------------------------------------------------
+
+programmer parent "mkbutterfly"
+    id                  = "butterfly_mk";
+    type                = "butterfly_mk";
+;
+
+#------------------------------------------------------------
+# jtagmkI
+#------------------------------------------------------------
+
+programmer
+    id                  = "jtagmkI";
+    desc                = "Atmel JTAG ICE (mkI)";
+    type                = "jtagmki";
+    connection_type     = serial;
+    baudrate            = 115200;    # default is 115200
+;
+
+#------------------------------------------------------------
+# jtag1
+#------------------------------------------------------------
+
+# easier to type
+programmer parent "jtagmkI"
+    id                  = "jtag1";
+    type                = "jtagmki";
+;
+
+#------------------------------------------------------------
+# jtag1slow
+#------------------------------------------------------------
+
+# easier to type
+programmer parent "jtag1"
+    id                  = "jtag1slow";
+    type                = "jtagmki";
+    baudrate            = 19200;
+;
+
+#------------------------------------------------------------
+# jtagmkII
+#------------------------------------------------------------
+
+# The JTAG ICE mkII has both, serial and USB connectivity.  As it is
+# mostly used through USB these days (AVR Studio 5 only supporting it
+# that way), we make connection_type = usb the default.  Users are
+# still free to use a serial port with the -P option.
+
+programmer
+    id                  = "jtagmkII";
+    desc                = "Atmel JTAG ICE mkII";
+    type                = "jtagmkii";
+    connection_type     = usb;
+    baudrate            = 19200;    # default is 19200
+;
+
+#------------------------------------------------------------
+# jtag2slow
+#------------------------------------------------------------
+
+# easier to type
+programmer parent "jtagmkII"
+    id                  = "jtag2slow";
+    type                = "jtagmkii";
+;
+
+#------------------------------------------------------------
+# jtag2fast
+#------------------------------------------------------------
+
+# JTAG ICE mkII @ 115200 Bd
+programmer parent "jtag2slow"
+    id                  = "jtag2fast";
+    type                = "jtagmkii";
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# jtag2
+#------------------------------------------------------------
+
+# make the fast one the default, people will love that
+programmer parent "jtag2fast"
+    id                  = "jtag2";
+    type                = "jtagmkii";
+;
+
+#------------------------------------------------------------
+# jtag2isp
+#------------------------------------------------------------
+
+# JTAG ICE mkII in ISP mode
+programmer
+    id                  = "jtag2isp";
+    desc                = "Atmel JTAG ICE mkII in ISP mode";
+    type                = "jtagmkii_isp";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# jtag2dw
+#------------------------------------------------------------
+
+# JTAG ICE mkII in debugWire mode
+programmer
+    id                  = "jtag2dw";
+    desc                = "Atmel JTAG ICE mkII in debugWire mode";
+    type                = "jtagmkii_dw";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# jtagmkII_avr32
+#------------------------------------------------------------
+
+# JTAG ICE mkII in AVR32 mode
+programmer
+    id                  = "jtagmkII_avr32";
+    desc                = "Atmel JTAG ICE mkII im AVR32 mode";
+    type                = "jtagmkii_avr32";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# jtag2avr32
+#------------------------------------------------------------
+
+# JTAG ICE mkII in AVR32 mode
+programmer
+    id                  = "jtag2avr32";
+    desc                = "Atmel JTAG ICE mkII im AVR32 mode";
+    type                = "jtagmkii_avr32";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# jtag2pdi
+#------------------------------------------------------------
+
+# JTAG ICE mkII in PDI mode
+programmer
+    id                  = "jtag2pdi";
+    desc                = "Atmel JTAG ICE mkII PDI mode";
+    type                = "jtagmkii_pdi";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# dragon_jtag
+#------------------------------------------------------------
+
+# AVR Dragon in JTAG mode
+programmer
+    id                  = "dragon_jtag";
+    desc                = "Atmel AVR Dragon in JTAG mode";
+    type                = "dragon_jtag";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# dragon_isp
+#------------------------------------------------------------
+
+# AVR Dragon in ISP mode
+programmer
+    id                  = "dragon_isp";
+    desc                = "Atmel AVR Dragon in ISP mode";
+    type                = "dragon_isp";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# dragon_pp
+#------------------------------------------------------------
+
+# AVR Dragon in PP mode
+programmer
+    id                  = "dragon_pp";
+    desc                = "Atmel AVR Dragon in PP mode";
+    type                = "dragon_pp";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# dragon_hvsp
+#------------------------------------------------------------
+
+# AVR Dragon in HVSP mode
+programmer
+    id                  = "dragon_hvsp";
+    desc                = "Atmel AVR Dragon in HVSP mode";
+    type                = "dragon_hvsp";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# dragon_dw
+#------------------------------------------------------------
+
+# AVR Dragon in debugWire mode
+programmer
+    id                  = "dragon_dw";
+    desc                = "Atmel AVR Dragon in debugWire mode";
+    type                = "dragon_dw";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# dragon_pdi
+#------------------------------------------------------------
+
+# AVR Dragon in PDI mode
+programmer
+    id                  = "dragon_pdi";
+    desc                = "Atmel AVR Dragon in PDI mode";
+    type                = "dragon_pdi";
+    connection_type     = usb;
+    baudrate            = 115200;
+;
+
+#------------------------------------------------------------
+# jtag3
+#------------------------------------------------------------
+
+programmer
+    id                  = "jtag3";
+    desc                = "Atmel AVR JTAGICE3 in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
+;
+
+#------------------------------------------------------------
+# jtag3pdi
+#------------------------------------------------------------
+
+programmer
+    id                  = "jtag3pdi";
+    desc                = "Atmel AVR JTAGICE3 in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
+;
+
+#------------------------------------------------------------
+# jtag3updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "jtag3updi";
+    desc                = "Atmel AVR JTAGICE3 in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
+    hvupdi_support      = 1;
+;
+
+#------------------------------------------------------------
+# jtag3dw
+#------------------------------------------------------------
+
+programmer
+    id                  = "jtag3dw";
+    desc                = "Atmel AVR JTAGICE3 in debugWIRE mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
+;
+
+#------------------------------------------------------------
+# jtag3isp
+#------------------------------------------------------------
+
+programmer
+    id                  = "jtag3isp";
+    desc                = "Atmel AVR JTAGICE3 in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2110, 0x2140;
+;
+
+#------------------------------------------------------------
+# xplainedpro
+#------------------------------------------------------------
+
+programmer
+    id                  = "xplainedpro";
+    desc                = "Atmel AVR XplainedPro in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2111;
+;
+
+#------------------------------------------------------------
+# xplainedpro_updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "xplainedpro_updi";
+    desc                = "Atmel AVR XplainedPro in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2111;
+    hvupdi_support      = 1;
+;
+
+#------------------------------------------------------------
+# xplainedmini
+#------------------------------------------------------------
+
+programmer
+    id                  = "xplainedmini";
+    desc                = "Atmel AVR XplainedMini in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2145;
+;
+
+#------------------------------------------------------------
+# xplainedmini_dw
+#------------------------------------------------------------
+
+programmer
+    id                  = "xplainedmini_dw";
+    desc                = "Atmel AVR XplainedMini in debugWIRE mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2145;
+;
+
+#------------------------------------------------------------
+# xplainedmini_updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "xplainedmini_updi";
+    desc                = "Atmel AVR XplainedMini in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2145;
+    hvupdi_support      = 1;
+;
+
+#------------------------------------------------------------
+# atmelice
+#------------------------------------------------------------
+
+programmer
+    id                  = "atmelice";
+    desc                = "Atmel-ICE (ARM/AVR) in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2141;
+;
+
+#------------------------------------------------------------
+# atmelice_pdi
+#------------------------------------------------------------
+
+programmer
+    id                  = "atmelice_pdi";
+    desc                = "Atmel-ICE (ARM/AVR) in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2141;
+;
+
+#------------------------------------------------------------
+# atmelice_updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "atmelice_updi";
+    desc                = "Atmel-ICE (ARM/AVR) in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2141;
+    hvupdi_support      = 1;
+;
+
+#------------------------------------------------------------
+# atmelice_dw
+#------------------------------------------------------------
+
+programmer
+    id                  = "atmelice_dw";
+    desc                = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2141;
+;
+
+#------------------------------------------------------------
+# atmelice_isp
+#------------------------------------------------------------
+
+programmer
+    id                  = "atmelice_isp";
+    desc                = "Atmel-ICE (ARM/AVR) in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2141;
+;
+
+#------------------------------------------------------------
+# powerdebugger
+#------------------------------------------------------------
+
+programmer
+    id                  = "powerdebugger";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
+    type                = "jtagice3";
+    connection_type     = usb;
+    usbpid              = 0x2144;
+;
+
+#------------------------------------------------------------
+# powerdebugger_pdi
+#------------------------------------------------------------
+
+programmer
+    id                  = "powerdebugger_pdi";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2144;
+;
+
+#------------------------------------------------------------
+# powerdebugger_updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "powerdebugger_updi";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2144;
+    hvupdi_support      = 0, 1;
+;
+
+#------------------------------------------------------------
+# powerdebugger_dw
+#------------------------------------------------------------
+
+programmer
+    id                  = "powerdebugger_dw";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
+    type                = "jtagice3_dw";
+    connection_type     = usb;
+    usbpid              = 0x2144;
+;
+
+#------------------------------------------------------------
+# powerdebugger_isp
+#------------------------------------------------------------
+
+programmer
+    id                  = "powerdebugger_isp";
+    desc                = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2144;
+;
+
+#------------------------------------------------------------
+# pickit4_updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "pickit4_updi";
+    desc                = "MPLAB(R) PICkit 4 in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2177, 0x2178, 0x2179;
+    hvupdi_support      = 0, 1, 2;
+;
+
+#------------------------------------------------------------
+# pickit4_pdi
+#------------------------------------------------------------
+
+programmer
+    id                  = "pickit4_pdi";
+    desc                = "MPLAB(R) PICkit 4 in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x2177, 0x2178, 0x2179;
+;
+
+#------------------------------------------------------------
+# pickit4_isp
+#------------------------------------------------------------
+
+programmer
+    id                  = "pickit4_isp";
+    desc                = "MPLAB(R) PICkit 4 in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x2177, 0x2178, 0x2179;
+;
+
+#------------------------------------------------------------
+# snap_updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "snap_updi";
+    desc                = "MPLAB(R) SNAP in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x217f, 0x2180, 0x2181;
+    hvupdi_support      = 1;
+;
+
+#------------------------------------------------------------
+# snap_pdi
+#------------------------------------------------------------
+
+programmer
+    id                  = "snap_pdi";
+    desc                = "MPLAB(R) SNAP in PDI mode";
+    type                = "jtagice3_pdi";
+    connection_type     = usb;
+    usbpid              = 0x217f, 0x2180, 0x2181;
+;
+
+#------------------------------------------------------------
+# snap_isp
+#------------------------------------------------------------
+
+programmer
+    id                  = "snap_isp";
+    desc                = "MPLAB(R) SNAP in ISP mode";
+    type                = "jtagice3_isp";
+    connection_type     = usb;
+    usbpid              = 0x217f, 0x2180, 0x2181;
+;
+
+#------------------------------------------------------------
+# pkobn_updi
+#------------------------------------------------------------
+
+programmer
+    id                  = "pkobn_updi";
+    desc                = "Curiosity nano (nEDBG) in UPDI mode";
+    type                = "jtagice3_updi";
+    connection_type     = usb;
+    usbpid              = 0x2175;
+    hvupdi_support      = 1;
+;
+
+#------------------------------------------------------------
+# pavr
+#------------------------------------------------------------
+
+programmer
+    id                  = "pavr";
+    desc                = "Jason Kyle's pAVR Serial Programmer";
+    type                = "avr910";
+    connection_type     = serial;
+;
+
+#------------------------------------------------------------
+# pickit2
+#------------------------------------------------------------
+
+programmer
+    id                  = "pickit2";
+    desc                = "MicroChip's PICkit2 Programmer";
+    type                = "pickit2";
+    connection_type     = usb;
+;
+
+#------------------------------------------------------------
+# flip1
+#------------------------------------------------------------
+
+programmer
+    id                  = "flip1";
+    desc                = "FLIP USB DFU protocol version 1 (doc7618)";
+    type                = "flip1";
+    connection_type     = usb;
+;
+
+#------------------------------------------------------------
+# flip2
+#------------------------------------------------------------
+
+programmer
+    id                  = "flip2";
+    desc                = "FLIP USB DFU protocol version 2 (AVR4023)";
+    type                = "flip2";
+    connection_type     = usb;
+;
+
+#------------------------------------------------------------
+# ponyser
+#------------------------------------------------------------
+
+# some ultra cheap programmers use bitbanging on the serialport
 #
 # PC - DB9 - Pins for RS232:
 #
@@ -1713,76 +2149,101 @@ programmer
 # reset=!txd sck=rts mosi=dtr miso=cts
 
 programmer
-  id    = "ponyser";
-  desc  = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = ~3;
-  sck   = 7;
-  mosi  = 4;
-  miso  = 8;
+    id                  = "ponyser";
+    desc                = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = ~3;
+    sck                 = 7;
+    mosi                = 4;
+    miso                = 8;
 ;
+
+#------------------------------------------------------------
+# siprog
+#------------------------------------------------------------
 
 # Same as above, different name
 # reset=!txd sck=rts mosi=dtr miso=cts
 
 programmer parent "ponyser"
-  id    = "siprog";
-  desc  = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
+    id                  = "siprog";
+    desc                = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
+    type                = "serbb";
+    reset               = ~3;
+    sck                 = 7;
+    mosi                = 4;
+    miso                = 8;
 ;
+
+#------------------------------------------------------------
+# dasa
+#------------------------------------------------------------
 
 # unknown (dasa in uisp)
 # reset=rts sck=dtr mosi=txd miso=cts
 
 programmer
-  id    = "dasa";
-  desc  = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = 7;
-  sck   = 4;
-  mosi  = 3;
-  miso  = 8;
+    id                  = "dasa";
+    desc                = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = 7;
+    sck                 = 4;
+    mosi                = 3;
+    miso                = 8;
 ;
+
+#------------------------------------------------------------
+# dasa3
+#------------------------------------------------------------
 
 # unknown (dasa3 in uisp)
 # reset=!dtr sck=rts mosi=txd miso=cts
 
 programmer
-  id    = "dasa3";
-  desc  = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = ~4;
-  sck   = 7;
-  mosi  = 3;
-  miso  = 8;
+    id                  = "dasa3";
+    desc                = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = ~4;
+    sck                 = 7;
+    mosi                = 3;
+    miso                = 8;
 ;
+
+#------------------------------------------------------------
+# c2n232i
+#------------------------------------------------------------
 
 # C2N232i (jumper configuration "auto")
 # reset=dtr sck=!rts mosi=!txd miso=!cts
 
 programmer
-  id    = "c2n232i";
-  desc  = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
-  type  = "serbb";
-  connection_type = serial;
-  reset = 4;
-  sck   = ~7;
-  mosi  = ~3;
-  miso  = ~8;
+    id                  = "c2n232i";
+    desc                = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
+    type                = "serbb";
+    connection_type     = serial;
+    reset               = 4;
+    sck                 = ~7;
+    mosi                = ~3;
+    miso                = ~8;
 ;
+
+#------------------------------------------------------------
+# jtag2updi
+#------------------------------------------------------------
 
 # JTAG2UPDI
 # https://github.com/ElTangas/jtag2updi
 
 programmer
-  id    = "jtag2updi";
-  desc  = "JTAGv2 to UPDI bridge";
-  type  = "jtagmkii_updi";
-  connection_type = serial;
-  baudrate = 115200;
-  hvupdi_support = 1;
+    id                  = "jtag2updi";
+    desc                = "JTAGv2 to UPDI bridge";
+    type                = "jtagmkii_updi";
+    connection_type     = serial;
+    baudrate            = 115200;
+    hvupdi_support      = 1;
 ;
 
 #
@@ -1796,62 +2257,57 @@ programmer
 # This is an HVSP-only device.
 
 part
-    id                  = "t11";
     desc                = "ATtiny11";
+    id                  = "t11";
     stk500_devcode      = 0x11;
-    signature           = 0x1e 0x90 0x04;
     chip_erase_delay    = 20000;
-    serial			= no;
-
-    timeout		= 200;
-    hvsp_controlstack     =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+    signature           = 0x1e 0x90 0x04;
+    serial              = no;
+    timeout             = 200;
+    hvsp_controlstack   =
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
-        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
     latchcycles         = 1;
     togglevtg           = 1;
     poweroffdelay       = 25;
-    resetdelayms        = 0;
     resetdelayus        = 50;
     hvleavestabdelay    = 100;
     resetdelay          = 25;
     chiperasepolltimeout = 40;
-    chiperasetime       = 0;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
+    synchcycles         = 6;
 
     memory "eeprom"
         size            = 64;
-	blocksize	= 64;
-	readsize	= 256;
-	delay		= 5;
+        delay           = 5;
+        blocksize       = 64;
+        readsize        = 256;
     ;
 
     memory "flash"
         size            = 1024;
-	blocksize	= 128;
-	readsize	= 256;
-	delay		= 3;
+        delay           = 3;
+        blocksize       = 128;
+        readsize        = 256;
     ;
 
-    memory "signature"
-        size            = 3;
+    memory "fuse"
+        size            = 1;
     ;
 
     memory "lock"
         size            = 1;
     ;
 
-    memory "calibration"
-        size            = 1;
+    memory "signature"
+        size            = 3;
     ;
 
-    memory "fuse"
+    memory "calibration"
         size            = 1;
     ;
 ;
@@ -1861,131 +2317,91 @@ part
 #------------------------------------------------------------
 
 part
-    id                  = "t12";
     desc                = "ATtiny12";
+    id                  = "t12";
     stk500_devcode      = 0x12;
     avr910_devcode      = 0x55;
-    signature           = 0x1e 0x90 0x05;
     chip_erase_delay    = 20000;
-    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    signature           = 0x1e 0x90 0x05;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
-        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
     hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
     latchcycles         = 1;
     togglevtg           = 1;
     poweroffdelay       = 25;
-    resetdelayms        = 0;
     resetdelayus        = 50;
     hvleavestabdelay    = 100;
     resetdelay          = 25;
     chiperasepolltimeout = 40;
-    chiperasetime       = 0;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
+    synchcycles         = 6;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 64;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
-
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 8;
-	blocksize	= 64;
-	readsize	= 256;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 8;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
         size            = 1024;
         min_write_delay = 4500;
         max_write_delay = 20000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        write_lo        = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        write_hi        = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-	mode		= 0x04;
-	delay		= 5;
-	blocksize	= 128;
-	readsize	= 256;
-    ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
-    ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x o o x";
-
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 i i 1",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-    ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 5;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
         size            = 1;
-        read            = "0  1  0  1   0  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    o o o o  o o o o";
-
-        write           = "1  0  1  0   1  1  0  0    1 0 1 x  x x x x",
-                          "x  x  x  x   x  x  x  x    i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
+        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--101x.xxxx--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -1994,83 +2410,60 @@ part
 #------------------------------------------------------------
 
 part
-    id                  = "t13";
     desc                = "ATtiny13";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x0E, 0x1E;
-     eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x0E, 0xB4, 0x0E, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+    id                  = "t13";
     stk500_devcode      = 0x14;
-    signature           = 0x1e 0x90 0x07;
     chip_erase_delay    = 4000;
-    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack     =
-	0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+    signature           = 0x1e 0x90 0x07;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    hvsp_controlstack   =
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
+        0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    flash_instr         =  0xb4, 0x0e, 0x1e;
+    eeprom_instr        =
+        0xbb, 0xfe, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x0e, 0xb4, 0x0e, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
     latchcycles         = 1;
     togglevtg           = 1;
     poweroffdelay       = 25;
-    resetdelayms        = 0;
     resetdelayus        = 90;
     hvleavestabdelay    = 100;
     resetdelay          = 25;
     chiperasepolltimeout = 40;
-    chiperasetime       = 0;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-
+    synchcycles         = 6;
     ocdrev              = 0;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 64;
         page_size       = 4;
         min_write_delay = 4000;
         max_write_delay = 4000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
-
-        write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x   x  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 5;
-	blocksize	= 4;
-	readsize	= 256;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--xxaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--xxaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
@@ -2080,86 +2473,51 @@ part
         num_pages       = 32;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  0  0  0  0   0  0  0 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  0  0  0  0   0  0  0 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  0  0  0  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  0  0  0  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  0  0  0  0   0  0  0 a8",
-                          " a7 a6 a5 a4   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-    ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0    0 0 0 x  x x x x",
-                          "x  x  x  x   x  x a1 a0    o o o o  o o o o";
-    ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-
-	read            = "0  1  0  1   1  0  0  0    0 0 0 0  0 0 0 0",
-                          "x  x  x  x   x  x  x  x    o o o o  o o o o";
-
-        write           = "1  0  1  0   1  1  0  0    1 1 1 x  x x x x",
-                          "x  x  x  x   x  x  x  x    1 1 i i  i i i i";
-    ;
-
-    memory "calibration"
-        size            = 2;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                          "0  0  0  0   0  0  0 a0    o o o o  o o o o";
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.000a--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.000a--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.000a--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-      ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 2;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
 ;
 
 #------------------------------------------------------------
@@ -2167,140 +2525,101 @@ part
 #------------------------------------------------------------
 
 part parent "t13"
-    id               = "t13a";
-    desc             = "ATtiny13A";
-  ;
+    desc                = "ATtiny13A";
+    id                  = "t13a";
+;
 
 #------------------------------------------------------------
 # ATtiny15
 #------------------------------------------------------------
 
 part
-    id                  = "t15";
     desc                = "ATtiny15";
+    id                  = "t15";
     stk500_devcode      = 0x13;
     avr910_devcode      = 0x56;
-    signature           = 0x1e 0x90 0x06;
     chip_erase_delay    = 8200;
-    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    signature           = 0x1e 0x90 0x06;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
-        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
     hventerstabdelay    = 100;
-    hvspcmdexedelay     = 5;
-    synchcycles         = 6;
     latchcycles         = 16;
     togglevtg           = 1;
     poweroffdelay       = 25;
-    resetdelayms        = 0;
     resetdelayus        = 50;
     hvleavestabdelay    = 100;
     resetdelay          = 25;
     chiperasepolltimeout = 40;
-    chiperasetime       = 0;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
+    synchcycles         = 6;
+    hvspcmdexedelay     = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 64;
         min_write_delay = 8200;
         max_write_delay = 8200;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    o o o o  o o o o";
-
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x  x a5 a4  a3 a2 a1 a0    i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
         size            = 1024;
         min_write_delay = 4100;
         max_write_delay = 4100;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        write_lo        = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        write_hi        = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-	mode		= 0x04;
-	delay		= 5;
-	blocksize	= 128;
-	readsize	= 256;
-    ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
-    ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x o o x";
-
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 i i 1",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-    ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 5;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "fuse"
         size            = 1;
-        read            = "0  1  0  1   0  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    o o o o  x x o o";
-
-        write           = "1  0  1  0   1  1  0  0    1 0 1 x  x x x x",
-                          "x  x  x  x   x  x  x  x    i i i i  1 1 i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
+        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.xxoo";
+        write           = "1010.1100--101x.xxxx--xxxx.xxxx--iiii.11ii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -2309,4517 +2628,2972 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "1200";
-    desc             = "AT90S1200";
-    is_at90s1200     = yes;
-    stk500_devcode   = 0x33;
-    avr910_devcode   = 0x13;
-    signature        = 0x1e 0x90 0x01;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 1;
-    bytedelay		= 0;
-    pollindex		= 0;
-    pollvalue		= 0xFF;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S1200";
+    id                  = "1200";
+    stk500_devcode      = 0x33;
+    avr910_devcode      = 0x13;
+    chip_erase_delay    = 20000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x90 0x01;
+    is_at90s1200        = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 1;
+    pollvalue           = 0xff;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 1;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 64;
         min_write_delay = 4000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0xff;
-        read            = "1 0  1  0   0  0  0  0   x x x x  x x x x", 
-                          "x x a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x00 0xff;
+        mode            = 4;
+        delay           = 20;
+        blocksize       = 32;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+    ;
 
-        write           = "1 1  0  0   0  0  0  0   x x x x  x x x x",
-                          "x x a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 32;
-	readsize	= 256;
-      ;
     memory "flash"
         size            = 1024;
         min_write_delay = 4000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 2;
+        delay           = 15;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x   x  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x02;
-	delay		= 15;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
         size            = 1;
-      ;
+    ;
+
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s4414
 #------------------------------------------------------------
 
 part
-    id               = "4414";
-    desc             = "AT90S4414";
-    stk500_devcode   = 0x50;
-    avr910_devcode   = 0x28;
-    signature        = 0x1e 0x92 0x01;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S4414";
+    id                  = "4414";
+    stk500_devcode      = 0x50;
+    avr910_devcode      = 0x28;
+    chip_erase_delay    = 20000;
+    signature           = 0x1e 0x92 0x01;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 1;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 256;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0x80;
-        readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
-                          "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x80 0x7f;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
     memory "flash"
         size            = 4096;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0x7f;
-        readback_p2     = 0x7f;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0x7f 0x7f;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
-	size		= 1;
-      ;
+        size            = 1;
+    ;
+
     memory "lock"
-	size		= 1;
-	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        size            = 1;
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-  ;
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s2313
 #------------------------------------------------------------
 
 part
-    id               = "2313";
-    desc             = "AT90S2313";
-    stk500_devcode   = 0x40;
-    avr910_devcode   = 0x20;
-    signature        = 0x1e 0x91 0x01;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S2313";
+    id                  = "2313";
+    stk500_devcode      = 0x40;
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 20000;
+    signature           = 0x1e 0x91 0x01;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 1;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 128;
         min_write_delay = 4000;
         max_write_delay = 9000;
-        readback_p1     = 0x80;
-        readback_p2     = 0x7f;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
-                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x80 0x7f;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+    ;
 
-        write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
     memory "flash"
         size            = 2048;
         min_write_delay = 4000;
         max_write_delay = 9000;
-        readback_p1     = 0x7f;
-        readback_p2     = 0x7f;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0x7f 0x7f;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
         size            = 1;
-      ;
+    ;
+
     memory "lock"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x i i x",
-                          "x x x x  x x x x  x x x x  x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-  ;
+        write           = "1010.1100--111x.xiix--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s2333
 #------------------------------------------------------------
 
 part
-    id               = "2333";
 ##### WARNING: No XML file for device 'AT90S2333'! #####
-    desc             = "AT90S2333";
-    stk500_devcode   = 0x42;
-    avr910_devcode   = 0x34;
-    signature        = 0x1e 0x91 0x05;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S2333";
+    id                  = "2333";
+    stk500_devcode      = 0x42;
+    avr910_devcode      = 0x34;
+    chip_erase_delay    = 20000;
+    signature           = 0x1e 0x91 0x05;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 1;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 128;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0x00;
-        readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   x x x x  x x x x", 
-                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-        write           = "1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        readback        = 0x00 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+    ;
 
     memory "flash"
         size            = 2048;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
         pwroff_after_write = yes;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x o o  o o o o";
+        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
+        write           = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
-
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s2343 (also AT90s2323 and ATtiny22)
 #------------------------------------------------------------
 
 part
-    id               = "2343";
-    desc             = "AT90S2343";
-    stk500_devcode   = 0x43;
-    avr910_devcode   = 0x4c;
-    signature        = 0x1e 0x91 0x03;
-    chip_erase_delay = 18000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S2343";
+    id                  = "2343";
+    stk500_devcode      = 0x43;
+    avr910_devcode      = 0x4c;
+    chip_erase_delay    = 18000;
+    signature           = 0x1e 0x91 0x03;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x00,
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x00,
         0x68, 0x78, 0x68, 0x68, 0x00, 0x00, 0x68, 0x78,
-        0x78, 0x00, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x78, 0x00, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
     hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
     latchcycles         = 1;
-    togglevtg           = 0;
     poweroffdelay       = 25;
-    resetdelayms        = 0;
     resetdelayus        = 50;
     hvleavestabdelay    = 100;
     resetdelay          = 25;
     chiperasepolltimeout = 40;
-    chiperasetime       = 0;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
+    synchcycles         = 6;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 128;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0x00;
-        readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0   0 0 0 0  0 0 0 0", 
-                          "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x00 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--0000.0000--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.0000--xaaa.aaaa--iiii.iiii";
+    ;
 
-        write           = "1  1  0  0   0  0  0  0   0 0 0 0  0 0 0 0",
-                          "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
     memory "flash"
         size            = 2048;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 128;
+        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x   x  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 128;
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   o o o x  x x x o";
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
+        write           = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 1  1 1 1 i",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   o o o x  x x x o";
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
-
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s4433
 #------------------------------------------------------------
 
 part
-    id               = "4433";
-    desc             = "AT90S4433";
-    stk500_devcode   = 0x51;
-    avr910_devcode   = 0x30;
-    signature        = 0x1e 0x92 0x03;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S4433";
+    id                  = "4433";
+    stk500_devcode      = 0x51;
+    avr910_devcode      = 0x30;
+    chip_erase_delay    = 20000;
+    signature           = 0x1e 0x92 0x03;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 1;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 256;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0x00;
-        readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
-                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x00 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
+    ;
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
     memory "flash"
         size            = 4096;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
         pwroff_after_write = yes;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x o o  o o o o";
+        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
+        write           = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s4434
 #------------------------------------------------------------
 
 part
-    id               = "4434";
 ##### WARNING: No XML file for device 'AT90S4434'! #####
-    desc             = "AT90S4434";
-    stk500_devcode   = 0x52;
-    avr910_devcode   = 0x6c;
-    signature        = 0x1e 0x92 0x02;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
+    desc                = "AT90S4434";
+    id                  = "4434";
+    stk500_devcode      = 0x52;
+    avr910_devcode      = 0x6c;
+    chip_erase_delay    = 20000;
+    signature           = 0x1e 0x92 0x02;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 256;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0x00;
-        readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x x", 
-                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x00 0xff;
+        read            = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
+    ;
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-      ;
     memory "flash"
         size            = 4096;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0xff 0xff;
+        read_lo         = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x    x a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x o o  o o o o";
+        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
+        write           = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 0 1 i  i i i i",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
     memory "lock"
         size            = 1;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-      ;
-  ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s8515
 #------------------------------------------------------------
 
 part
-    id               = "8515";
-    desc             = "AT90S8515";
-    stk500_devcode   = 0x60;
-    avr910_devcode   = 0x38;
-    signature        = 0x1e 0x93 0x01;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S8515";
+    id                  = "8515";
+    stk500_devcode      = 0x60;
+    avr910_devcode      = 0x38;
+    chip_erase_delay    = 20000;
+    signature           = 0x1e 0x93 0x01;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 512;
         min_write_delay = 4000;
         max_write_delay = 9000;
-        readback_p1     = 0x80;
-        readback_p2     = 0x7f;
-        read            = " 1  0  1  0   0  0  0  0  x x x x  x x x a8", 
-                          "a7 a6 a5 a4 a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x80 0x7f;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
     memory "flash"
         size            = 8192;
         min_write_delay = 4000;
         max_write_delay = 9000;
-        readback_p1     = 0x7f;
-        readback_p2     = 0x7f;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0x7f 0x7f;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
     memory "fuse"
-	size		= 1;
-      ;
+        size            = 1;
+    ;
+
     memory "lock"
-	size		= 1;
-	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
+        size            = 1;
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-  ;
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90s8535
 #------------------------------------------------------------
 
 part
-    id               = "8535";
-    desc             = "AT90S8535";
-    stk500_devcode   = 0x61;
-    avr910_devcode   = 0x68;
-    signature        = 0x1e 0x93 0x03;
-    chip_erase_delay = 20000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "AT90S8535";
+    id                  = "8535";
+    stk500_devcode      = 0x61;
+    avr910_devcode      = 0x68;
+    chip_erase_delay    = 20000;
+    signature           = 0x1e 0x93 0x03;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 1;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 512;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0x00;
-        readback_p2     = 0xff;
-        read            = " 1  0  1  0   0  0  0  0   x x x x  x x x a8", 
-                          "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        readback        = 0x00 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        write           = " 1  1  0  0   0  0  0  0   x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
     memory "flash"
         size            = 8192;
         min_write_delay = 9000;
         max_write_delay = 20000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write_lo        = "0100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        write_hi        = "0100.1000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
+    memory "fuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxxo";
+        write           = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write_lo        = "  0   1   0   0    0   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooxx.xxxx";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
 
-        write_hi        = "  0   1   0   0    1   0   0   0",
-                          "  x   x   x   x  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-    memory "fuse"
-	size		= 1;
-	read		= "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  o";
-	write		= "1  0  1  0   1  1  0  0   1  0  1  1   1  1  1  i",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-    memory "lock"
-	size		= 1;
-	read		= "0  1  0  1   1  0  0  0   x  x  x  x   x  x  x  x",
-			  "x  x  x  x   x  x  x  x   o  o  x  x   x  x  x  x";
-	write		= "1  0  1  0   1  1  0  0   1  1  1  1   1  i  i  1",
-			  "x  x  x  x   x  x  x  x   x  x  x  x   x  x  x  x";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega103
 #------------------------------------------------------------
 
 part
-    id               = "m103";
-    desc             = "ATmega103";
-    stk500_devcode   = 0xB1;
-    avr910_devcode   = 0x41;
-    signature        = 0x1e 0x97 0x01;
-    chip_erase_delay = 112000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "ATmega103";
+    id                  = "m103";
+    stk500_devcode      = 0xb1;
+    avr910_devcode      = 0x41;
+    chip_erase_delay    = 112000;
+    signature           = 0x1e 0x97 0x01;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x8E, 0x9E, 0x2E, 0x3E, 0xAE, 0xBE,
-        0x4E, 0x5E, 0xCE, 0xDE, 0x6E, 0x7E, 0xEE, 0xDE,
-        0x66, 0x76, 0xE6, 0xF6, 0x6A, 0x7A, 0xEA, 0x7A,
-        0x7F, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x8e, 0x9e, 0x2e, 0x3e, 0xae, 0xbe,
+        0x4e, 0x5e, 0xce, 0xde, 0x6e, 0x7e, 0xee, 0xde,
+        0x66, 0x76, 0xe6, 0xf6, 0x6a, 0x7a, 0xea, 0x7a,
+        0x7f, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     chiperasepulsewidth = 15;
-    chiperasepolltimeout = 0;
     programfusepulsewidth = 2;
-    programfusepolltimeout = 0;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 10;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 4096;
         min_write_delay = 4000;
         max_write_delay = 9000;
-        readback_p1     = 0x80;
-        readback_p2     = 0x7f;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0x80 0x7f;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 131072;
+        size            = 0x20000;
         page_size       = 256;
         num_pages       = 512;
         min_write_delay = 22000;
         max_write_delay = 56000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x11;
-	delay		= 70;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 17;
+        delay           = 70;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "fuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0  x x x x  x x x x",
-                          "x x x x  x x x x  x x o x  o 1 o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 1  i 1 i i",
-                          "x x x x  x x x x  x x x x  x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxox.o1oo";
+        write           = "1010.1100--1011.i1ii--xxxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x x x x  x o o x";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 1  1 i i 1",
-                          "x x x x  x x x x   x x x x  x x x x";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        write           = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
-
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega64
 #------------------------------------------------------------
 
 part
-    id               = "m64";
-    desc             = "ATmega64";
-    has_jtag         = yes;
-    stk500_devcode   = 0xA0;
-    avr910_devcode   = 0x45;
-    signature        = 0x1e 0x96 0x02;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "ATmega64";
+    id                  = "m64";
+    stk500_devcode      = 0xa0;
+    avr910_devcode      = 0x45;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x96 0x02;
+    has_jtag            = yes;
+    allowfullpagebitstream = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x22;
     spmcr               = 0x68;
-    allowfullpagebitstream = yes;
-
     ocdrev              = 2;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 2048;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 20;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 65536;
+        size            = 0x10000;
         page_size       = 256;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x x i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 4;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega64A
 #------------------------------------------------------------
 
 part parent "m64"
-    id               = "m64a";
-    desc             = "ATmega64A";
-  ;
+    desc                = "ATmega64A";
+    id                  = "m64a";
+;
 
 #------------------------------------------------------------
 # ATmega128
 #------------------------------------------------------------
 
 part
-    id               = "m128";
-    desc             = "ATmega128";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB2;
-    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x97 0x02;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    idr                 = 0x22;
-    spmcr               = 0x68;
-    rampz               = 0x3b;
+    desc                = "ATmega128";
+    id                  = "m128";
+    stk500_devcode      = 0xb2;
+    avr910_devcode      = 0x43;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x97 0x02;
+    has_jtag            = yes;
     allowfullpagebitstream = yes;
-
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 6;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x22;
+    rampz               = 0x3b;
+    spmcr               = 0x68;
     ocdrev              = 1;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 4096;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 12;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 12;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 131072;
+        size            = 0x20000;
         page_size       = 256;
         num_pages       = 512;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x x i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 4;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega128A
 #------------------------------------------------------------
 
 part parent "m128"
-    id               = "m128a";
-    desc             = "ATmega128A";
-  ;
+    desc                = "ATmega128A";
+    id                  = "m128a";
+;
 
 #------------------------------------------------------------
 # AT90CAN128
 #------------------------------------------------------------
 
 part
-    id               = "c128";
-    desc             = "AT90CAN128";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB3;
+    desc                = "AT90CAN128";
+    id                  = "c128";
+    stk500_devcode      = 0xb3;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
 #    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x97 0x81;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    signature           = 0x1e 0x97 0x81;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
-    spmcr               = 0x57;
     rampz               = 0x3b;
+    spmcr               = 0x57;
     eecr                = 0x3f;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 4096;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--000x.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 131072;
+        size            = 0x20000;
         page_size       = 256;
         num_pages       = 512;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90CAN64
 #------------------------------------------------------------
 
 part
-    id               = "c64";
-    desc             = "AT90CAN64";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB3;
+    desc                = "AT90CAN64";
+    id                  = "c64";
+    stk500_devcode      = 0xb3;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
 #    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x96 0x81;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    signature           = 0x1e 0x96 0x81;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
-    spmcr               = 0x57;
     rampz               = 0x3b;
+    spmcr               = 0x57;
     eecr                = 0x3f;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 2048;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--000x.xaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 65536;
+        size            = 0x10000;
         page_size       = 256;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90CAN32
 #------------------------------------------------------------
 
 part
-    id               = "c32";
-    desc             = "AT90CAN32";
-    has_jtag         = yes;
-    stk500_devcode   = 0xB3;
+    desc                = "AT90CAN32";
+    id                  = "c32";
+    stk500_devcode      = 0xb3;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
 #    avr910_devcode   = 0x43;
-    signature        = 0x1e 0x95 0x81;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    signature           = 0x1e 0x95 0x81;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
-    spmcr               = 0x57;
     rampz               = 0x3b;
+    spmcr               = 0x57;
     eecr                = 0x3f;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 1024;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 32768;
+        size            = 0x8000;
         page_size       = 256;
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0  0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega16
 #------------------------------------------------------------
 
 part
-    id               = "m16";
-    desc             = "ATmega16";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82;
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x94 0x03;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "ATmega16";
+    id                  = "m16";
+    stk500_devcode      = 0x82;
+    avr910_devcode      = 0x74;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x94 0x03;
+    has_jtag            = yes;
+    allowfullpagebitstream = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
     progmodedelay       = 100;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
     spmcr               = 0x57;
-    allowfullpagebitstream = yes;
-
     ocdrev              = 2;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 512;
+        page_size       = 4;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 128;
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
     memory "calibration"
         size            = 4;
-
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
-        ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.00aa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega16A
 #------------------------------------------------------------
 
 part parent "m16"
-    id               = "m16a";
-    desc             = "ATmega16A";
-  ;
+    desc                = "ATmega16A";
+    id                  = "m16a";
+;
 
 #------------------------------------------------------------
 # ATmega324P
 #------------------------------------------------------------
 
 part
-    id               = "m324p";
-    desc             = "ATmega324P";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x95 0x08;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 55000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "ATmega324P";
+    id                  = "m324p";
+    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode      = 0x74;
+    chip_erase_delay    = 55000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x95 0x08;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
     spmcr               = 0x57;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 1024;
+        page_size       = 4;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xaaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 32768;
+        size            = 0x8000;
         page_size       = 128;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0aaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega164P
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m164p";
-    desc             = "ATmega164P";
-    signature        = 0x1e 0x94 0x0a;
+    desc                = "ATmega164P";
+    id                  = "m164p";
+    signature           = 0x1e 0x94 0x0a;
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
         size            = 512;
-        page_size       = 4;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+    ;
 
     memory "flash"
-        paged           = yes;
-        size            = 16384;
-        page_size       = 128;
+        size            = 0x4000;
         num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-        ;
-
-  ;
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega164PA
 #------------------------------------------------------------
 
 part parent "m164p"
-    id               = "m164pa";
-    desc             = "ATmega164PA";
-  ;
+    desc                = "ATmega164PA";
+    id                  = "m164pa";
+;
 
 #------------------------------------------------------------
 # ATmega164A
 #------------------------------------------------------------
 
 part parent "m164p"
-    id               = "m164a";
-    desc             = "ATmega164A";
-    signature        = 0x1e 0x94 0x0f;
-  ;
+    desc                = "ATmega164A";
+    id                  = "m164a";
+    signature           = 0x1e 0x94 0x0f;
+;
 
 #------------------------------------------------------------
 # ATmega324PB
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m324pb";
-    desc             = "ATmega324PB";
-    signature        = 0x1e 0x95 0x17;
-  ;
+    desc                = "ATmega324PB";
+    id                  = "m324pb";
+    signature           = 0x1e 0x95 0x17;
+;
 
 #------------------------------------------------------------
 # ATmega324PA
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m324pa";
-    desc             = "ATmega324PA";
-    signature        = 0x1e 0x95 0x11;
-  ;
+    desc                = "ATmega324PA";
+    id                  = "m324pa";
+    signature           = 0x1e 0x95 0x11;
+;
 
 #------------------------------------------------------------
 # ATmega324A
 #------------------------------------------------------------
 
 part parent "m324p"
-    id               = "m324a";
-    desc             = "ATmega324A";
-    signature        = 0x1e 0x95 0x15;
-  ;
+    desc                = "ATmega324A";
+    id                  = "m324a";
+    signature           = 0x1e 0x95 0x15;
+;
 
 #------------------------------------------------------------
 # ATmega644
 #------------------------------------------------------------
 
 part
-    id               = "m644";
-    desc             = "ATmega644";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x96 0x09;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 55000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "ATmega644";
+    id                  = "m644";
+    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode      = 0x74;
+    chip_erase_delay    = 55000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x96 0x09;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
     spmcr               = 0x57;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 2048;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--00xx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 65536;
+        size            = 0x10000;
         page_size       = 256;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega644A
 #------------------------------------------------------------
 
 part parent "m644"
-    id               = "m644a";
-    desc             = "ATmega644A";
-  ;
+    desc                = "ATmega644A";
+    id                  = "m644a";
+;
 
 #------------------------------------------------------------
 # ATmega644P
 #------------------------------------------------------------
 
 part parent "m644"
-    id               = "m644p";
-    desc             = "ATmega644P";
-    signature        = 0x1e 0x96 0x0a;
-  ;
+    desc                = "ATmega644P";
+    id                  = "m644p";
+    signature           = 0x1e 0x96 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega644PA
 #------------------------------------------------------------
 
 part parent "m644"
-    id               = "m644pa";
-    desc             = "ATmega644PA";
-    signature        = 0x1e 0x96 0x0a;
-  ;
+    desc                = "ATmega644PA";
+    id                  = "m644pa";
+    signature           = 0x1e 0x96 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega1284
 #------------------------------------------------------------
 
 part
-    id               = "m1284";
-    desc             = "ATmega1284";
-    has_jtag         = yes;
-    stk500_devcode   = 0x82; # no STK500v1 support, use the ATmega16 one
-    avr910_devcode   = 0x74;
-    signature        = 0x1e 0x97 0x06;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 55000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    desc                = "ATmega1284";
+    id                  = "m1284";
+    stk500_devcode      = 0x82; # no STK500v1 support, use the ATmega16 one
+    avr910_devcode      = 0x74;
+    chip_erase_delay    = 55000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x97 0x06;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
     spmcr               = 0x57;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 4096;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--00xx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 131072;
+        size            = 0x20000;
         page_size       = 256;
         num_pages       = 512;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--00xx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega1284P
 #------------------------------------------------------------
 
 part parent "m1284"
-    id               = "m1284p";
-    desc             = "ATmega1284P";
-    signature        = 0x1e 0x97 0x05;
-  ;
+    desc                = "ATmega1284P";
+    id                  = "m1284p";
+    signature           = 0x1e 0x97 0x05;
+;
 
 #------------------------------------------------------------
 # ATmega162
 #------------------------------------------------------------
 
 part
-    id               = "m162";
-    desc             = "ATmega162";
-    has_jtag         = yes;
-    stk500_devcode   = 0x83;
-    avr910_devcode   = 0x63;
-    signature        = 0x1e 0x94 0x04;
-    chip_erase_delay = 9000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-
-    idr              = 0x04;
-    spmcr            = 0x57;
+    desc                = "ATmega162";
+    id                  = "m162";
+    stk500_devcode      = 0x83;
+    avr910_devcode      = 0x63;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x94 0x04;
+    has_jtag            = yes;
     allowfullpagebitstream = yes;
-
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    ocdrev              = 2;
-
-    memory "flash"
-        paged           = yes;
-        size            = 16384;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-       mode        = 0x41;
-    delay       = 10;
-    blocksize   = 128;
-    readsize    = 256;  
-
-        ;
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
-        size            = 512;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-                read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-                write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-        ;
-
-    memory "lfuse"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-        ;
-
-    memory "hfuse"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-        ;
-
-    memory "efuse"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  1 i i i";
-      ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        ;
-
-    memory "signature"
-        size            = 3;
-
-        read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-        ;
-
-    memory "calibration"
-        size            = 1;
-
-        read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-;
-
-
-
-#------------------------------------------------------------
-# ATmega163
-#------------------------------------------------------------
-
-part
-    id               = "m163";
-    desc             = "ATmega163";
-    stk500_devcode   = 0x81;
-    avr910_devcode   = 0x64;
-    signature        = 0x1e 0x94 0x02;
-    chip_erase_delay = 32000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
     synchloops          = 32;
-    bytedelay           = 0;
     pollindex           = 3;
     pollvalue           = 0x53;
     predelay            = 1;
     postdelay           = 1;
-    pollmethod          = 0;
-
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 30;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 2;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 2;
-
-
-   memory "eeprom"
-        size            = 512;
-        min_write_delay = 4000;
-        max_write_delay = 4000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-        mode            = 0x41;
-        delay           = 20;
-        blocksize       = 4;
-        readsize        = 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 16384;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 16000;
-        max_write_delay = 16000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x11;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o x x  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i 1 1  i i i i";
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   x x x x  1 o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   1 1 1 1  1 i i i";
-      ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  0 x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0   x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega169
-#------------------------------------------------------------
-
-part
-    id               = "m169";
-    desc             = "ATmega169";
-    has_jtag         = yes;
-    stk500_devcode   = 0x85;
-    avr910_devcode   = 0x78;
-    signature        = 0x1e 0x94 0x05;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    idr                 = 0x31;
-    spmcr               = 0x57;
-
-    ocdrev              = 2;
-
-   memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
-        size            = 512;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 16384;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "efuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-      ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega169A
-#------------------------------------------------------------
-
-part parent "m169"
-    id               = "m169a";
-    desc             = "ATmega169A";
-    signature        = 0x1E 0x94 0x11;
-  ;
-
-#------------------------------------------------------------
-# ATmega169P
-#------------------------------------------------------------
-
-part parent "m169"
-    id               = "m169p";
-    desc             = "ATmega169P";
-    signature        = 0x1E 0x94 0x05;
-  ;
-
-#------------------------------------------------------------
-# ATmega169PA
-#------------------------------------------------------------
-
-part parent "m169"
-    id               = "m169pa";
-    desc             = "ATmega169PA";
-    signature        = 0x1E 0x94 0x05;
-  ;
-
-#------------------------------------------------------------
-# ATmega329
-#------------------------------------------------------------
-
-part
-    id               = "m329";
-    desc             = "ATmega329";
-    has_jtag         = yes;
-#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
-#    avr910_devcode   = 0x?;  # try the ATmega169 one:
-    avr910_devcode   = 0x75;
-    signature        = 0x1e 0x95 0x03;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    idr                 = 0x31;
-    spmcr               = 0x57;
-
-    ocdrev              = 3;
-
-   memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
-        size            = 1024;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 32768;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x i i i";
-      ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega329A
-#------------------------------------------------------------
-
-part parent "m329"
-    id               = "m329a";
-    desc             = "ATmega329A";
-  ;
-
-#------------------------------------------------------------
-# ATmega329P
-#------------------------------------------------------------
-
-part parent "m329"
-    id               = "m329p";
-    desc             = "ATmega329P";
-    signature        = 0x1e 0x95 0x0b;
-  ;
-
-#------------------------------------------------------------
-# ATmega329PA
-#------------------------------------------------------------
-
-part parent "m329"
-    id               = "m329pa";
-    desc             = "ATmega329PA";
-    signature        = 0x1e 0x95 0x0b;
-  ;
-
-#------------------------------------------------------------
-# ATmega3290
-#------------------------------------------------------------
-
-part parent "m329"
-    id               = "m3290";
-    desc             = "ATmega3290";
-    signature        = 0x1e 0x95 0x04;
-  ;
-
-#------------------------------------------------------------
-# ATmega3290A
-#------------------------------------------------------------
-
-part parent "m329"
-    id               = "m3290a";
-    desc             = "ATmega3290A";
-    signature        = 0x1e 0x95 0x04;
-  ;
-
-#------------------------------------------------------------
-# ATmega3290P
-#------------------------------------------------------------
-
-part parent "m329"
-    id               = "m3290p";
-    desc             = "ATmega3290P";
-    signature        = 0x1e 0x95 0x0c;
-  ;
-
-#------------------------------------------------------------
-# ATmega3290PA
-#------------------------------------------------------------
-
-part parent "m329"
-    id               = "m3290pa";
-    desc             = "ATmega3290PA";
-    signature        = 0x1e 0x95 0x0c;
-  ;
-
-#------------------------------------------------------------
-# ATmega649
-#------------------------------------------------------------
-
-part
-    id               = "m649";
-    desc             = "ATmega649";
-    has_jtag         = yes;
-#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
-#    avr910_devcode   = 0x?;  # try the ATmega169 one:
-    avr910_devcode   = 0x75;
-    signature        = 0x1e 0x96 0x03;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    idr                 = 0x31;
-    spmcr               = 0x57;
-
-    ocdrev              = 3;
-
-   memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
-        size            = 2048;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 65536;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x i i i";
-      ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega649A
-#------------------------------------------------------------
-
-part parent "m649"
-    id               = "m649a";
-    desc             = "ATmega649A";
-  ;
-
-#------------------------------------------------------------
-# ATmega649P
-#------------------------------------------------------------
-
-part parent "m649"
-    id               = "m649p";
-    desc             = "ATmega649P";
-    signature        = 0x1e 0x96 0x0b;
-  ;
-
-#------------------------------------------------------------
-# ATmega6490
-#------------------------------------------------------------
-
-part parent "m649"
-    id               = "m6490";
-    desc             = "ATmega6490";
-    signature        = 0x1e 0x96 0x04;
-  ;
-
-#------------------------------------------------------------
-# ATmega6490A
-#------------------------------------------------------------
-
-part parent "m649"
-    id               = "m6490a";
-    desc             = "ATmega6490A";
-    signature        = 0x1e 0x96 0x04;
-  ;
-
-#------------------------------------------------------------
-# ATmega6490P
-#------------------------------------------------------------
-
-part parent "m649"
-    id               = "m6490p";
-    desc             = "ATmega6490P";
-    signature        = 0x1e 0x96 0x0C;
-  ;
-
-#------------------------------------------------------------
-# ATmega32
-#------------------------------------------------------------
-
-part
-    id               = "m32";
-    desc             = "ATmega32";
-    has_jtag         = yes;
-    stk500_devcode   = 0x91;
-    avr910_devcode   = 0x72;
-    signature        = 0x1e 0x95 0x02;
-    chip_erase_delay = 9000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
-    idr                 = 0x31;
+    idr                 = 0x04;
     spmcr               = 0x57;
-    allowfullpagebitstream = yes;
-
     ocdrev              = 2;
-
-   memory "eeprom"
-        paged           = no;   /* leave this "no" */
-        page_size       = 4;    /* for parallel programming */
-        size            = 1024;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 32768;
-        page_size       = 128;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o o";
-      ;
-
-    memory "calibration"
-        size            = 4;
-        read            = "0 0 1 1  1 0 0 0    0 0 x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0  o o o o  o o o o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega161
-#------------------------------------------------------------
-
-part
-    id               = "m161";
-    desc             = "ATmega161";
-    stk500_devcode   = 0x80;
-    avr910_devcode   = 0x60;
-    signature        = 0x1e 0x94 0x01;
-    chip_erase_delay = 28000;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 30;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 2;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 2;
-
-   memory "eeprom"
-        size            = 512;
-        min_write_delay = 3400;
-        max_write_delay = 3400;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 5;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 16384;
-        page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 14000;
-        max_write_delay = 14000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 16;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-
-    memory "fuse"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   x x x x  x x x x",
-                          "x x x x  x x x x   x o x o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 x  x x x x",
-                          "x x x x  x x x x   1 i 1 i  i i i i";
-      ;
-
-    memory "lock"
-        size            = 1;
-        min_write_delay = 2000;
-        max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega32A
-#------------------------------------------------------------
-
-part parent "m32"
-    id               = "m32a";
-    desc             = "ATmega32A";
-  ;
-
-#------------------------------------------------------------
-# ATmega8
-#------------------------------------------------------------
-
-part
-    id               = "m8";
-    desc             = "ATmega8";
-    stk500_devcode   = 0x70;
-    avr910_devcode   = 0x76;
-    signature        = 0x1e 0x93 0x07;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 10000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
-    pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 2;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 512;
         page_size       = 4;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
+    memory "flash"
+        paged           = yes;
+        size            = 0x4000;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--00xx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--00xx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega163
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega163";
+    id                  = "m163";
+    stk500_devcode      = 0x81;
+    avr910_devcode      = 0x64;
+    chip_erase_delay    = 32000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x94 0x02;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 30;
+    programfusepolltimeout = 2;
+    programlockpolltimeout = 2;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 512;
+        min_write_delay = 4000;
+        max_write_delay = 4000;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x4000;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 16000;
+        max_write_delay = 16000;
+        readback        = 0xff 0xff;
+        mode            = 17;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--ooxx.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--ii11.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--xxxx.1ooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--1111.1iii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.1000--0000.0000--xxxx.0xxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega169
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega169";
+    id                  = "m169";
+    stk500_devcode      = 0x85;
+    avr910_devcode      = 0x78;
+    chip_erase_delay    = 9000;
+    signature           = 0x1e 0x94 0x05;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    ocdrev              = 2;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 512;
+        page_size       = 4;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x4000;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega169A
+#------------------------------------------------------------
+
+part parent "m169"
+    desc                = "ATmega169A";
+    id                  = "m169a";
+    signature           = 0x1e 0x94 0x11;
+;
+
+#------------------------------------------------------------
+# ATmega169P
+#------------------------------------------------------------
+
+part parent "m169"
+    desc                = "ATmega169P";
+    id                  = "m169p";
+;
+
+#------------------------------------------------------------
+# ATmega169PA
+#------------------------------------------------------------
+
+part parent "m169"
+    desc                = "ATmega169PA";
+    id                  = "m169pa";
+;
+
+#------------------------------------------------------------
+# ATmega329
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega329";
+    id                  = "m329";
+#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
+#    avr910_devcode   = 0x?;  # try the ATmega169 one:
+    avr910_devcode      = 0x75;
+    chip_erase_delay    = 9000;
+    signature           = 0x1e 0x95 0x03;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 1024;
+        page_size       = 4;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x8000;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega329A
+#------------------------------------------------------------
+
+part parent "m329"
+    desc                = "ATmega329A";
+    id                  = "m329a";
+;
+
+#------------------------------------------------------------
+# ATmega329P
+#------------------------------------------------------------
+
+part parent "m329"
+    desc                = "ATmega329P";
+    id                  = "m329p";
+    signature           = 0x1e 0x95 0x0b;
+;
+
+#------------------------------------------------------------
+# ATmega329PA
+#------------------------------------------------------------
+
+part parent "m329"
+    desc                = "ATmega329PA";
+    id                  = "m329pa";
+    signature           = 0x1e 0x95 0x0b;
+;
+
+#------------------------------------------------------------
+# ATmega3290
+#------------------------------------------------------------
+
+part parent "m329"
+    desc                = "ATmega3290";
+    id                  = "m3290";
+    signature           = 0x1e 0x95 0x04;
+;
+
+#------------------------------------------------------------
+# ATmega3290A
+#------------------------------------------------------------
+
+part parent "m329"
+    desc                = "ATmega3290A";
+    id                  = "m3290a";
+    signature           = 0x1e 0x95 0x04;
+;
+
+#------------------------------------------------------------
+# ATmega3290P
+#------------------------------------------------------------
+
+part parent "m329"
+    desc                = "ATmega3290P";
+    id                  = "m3290p";
+    signature           = 0x1e 0x95 0x0c;
+;
+
+#------------------------------------------------------------
+# ATmega3290PA
+#------------------------------------------------------------
+
+part parent "m329"
+    desc                = "ATmega3290PA";
+    id                  = "m3290pa";
+    signature           = 0x1e 0x95 0x0c;
+;
+
+#------------------------------------------------------------
+# ATmega649
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega649";
+    id                  = "m649";
+#    stk500_devcode   = 0x85; # no STK500 support, only STK500v2
+#    avr910_devcode   = 0x?;  # try the ATmega169 one:
+    avr910_devcode      = 0x75;
+    chip_erase_delay    = 9000;
+    signature           = 0x1e 0x96 0x03;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 2048;
+        page_size       = 8;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x10000;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega649A
+#------------------------------------------------------------
+
+part parent "m649"
+    desc                = "ATmega649A";
+    id                  = "m649a";
+;
+
+#------------------------------------------------------------
+# ATmega649P
+#------------------------------------------------------------
+
+part parent "m649"
+    desc                = "ATmega649P";
+    id                  = "m649p";
+    signature           = 0x1e 0x96 0x0b;
+;
+
+#------------------------------------------------------------
+# ATmega6490
+#------------------------------------------------------------
+
+part parent "m649"
+    desc                = "ATmega6490";
+    id                  = "m6490";
+    signature           = 0x1e 0x96 0x04;
+;
+
+#------------------------------------------------------------
+# ATmega6490A
+#------------------------------------------------------------
+
+part parent "m649"
+    desc                = "ATmega6490A";
+    id                  = "m6490a";
+    signature           = 0x1e 0x96 0x04;
+;
+
+#------------------------------------------------------------
+# ATmega6490P
+#------------------------------------------------------------
+
+part parent "m649"
+    desc                = "ATmega6490P";
+    id                  = "m6490p";
+    signature           = 0x1e 0x96 0x0c;
+;
+
+#------------------------------------------------------------
+# ATmega32
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega32";
+    id                  = "m32";
+    stk500_devcode      = 0x91;
+    avr910_devcode      = 0x72;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x95 0x02;
+    has_jtag            = yes;
+    allowfullpagebitstream = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 6;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    ocdrev              = 2;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 1024;
+        page_size       = 4;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x8000;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 4;
+        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega161
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega161";
+    id                  = "m161";
+    stk500_devcode      = 0x80;
+    avr910_devcode      = 0x60;
+    chip_erase_delay    = 28000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x94 0x01;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 30;
+    programfusepolltimeout = 2;
+    programlockpolltimeout = 2;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 512;
+        min_write_delay = 3400;
+        max_write_delay = 3400;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 5;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x4000;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 14000;
+        max_write_delay = 14000;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 16;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "fuse"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.0000--xxxx.xxxx--xxxx.xxxx--xoxo.oooo";
+        write           = "1010.1100--101x.xxxx--xxxx.xxxx--1i1i.iiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 2000;
+        max_write_delay = 2000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega32A
+#------------------------------------------------------------
+
+part parent "m32"
+    desc                = "ATmega32A";
+    id                  = "m32a";
+;
+
+#------------------------------------------------------------
+# ATmega8
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega8";
+    id                  = "m8";
+    stk500_devcode      = 0x70;
+    avr910_devcode      = 0x76;
+    chip_erase_delay    = 10000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
+    signature           = 0x1e 0x93 0x07;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 2;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 512;
+        page_size       = 4;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
+
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -6827,165 +5601,108 @@ part
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0x00;
+        mode            = 33;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "calibration"
-        size            = 4;
-        read            = "0  0  1  1   1  0  0  0   0  0  x  x   x  x  x  x",
-                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
-
+    memory "calibration"
+        size            = 4;
+        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega8A
 #------------------------------------------------------------
 
 part parent "m8"
-    id               = "m8a";
-    desc             = "ATmega8A";
-    ;
+    desc                = "ATmega8A";
+    id                  = "m8a";
+;
 
 #------------------------------------------------------------
 # ATmega8515
 #------------------------------------------------------------
 
 part
-    id               = "m8515";
-    desc             = "ATmega8515";
-    stk500_devcode   = 0x63;
-    avr910_devcode   = 0x3A;
-    signature        = 0x1e 0x93 0x06;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "ATmega8515";
+    id                  = "m8515";
+    stk500_devcode      = 0x63;
+    avr910_devcode      = 0x3a;
+    chip_erase_delay    = 9000;
+    signature           = 0x1e 0x93 0x06;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 512;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
- read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
 
- write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -6993,159 +5710,101 @@ part
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "calibration"
-        size            = 4;
-        read            = "0 0 1 1  1 0 0 0     0 0 x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0   o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
-
-
+    memory "calibration"
+        size            = 4;
+        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega8535
 #------------------------------------------------------------
 
 part
-    id               = "m8535";
-    desc             = "ATmega8535";
-    stk500_devcode   = 0x64;
-    avr910_devcode   = 0x69;
-    signature        = 0x1e 0x93 0x08;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    desc                = "ATmega8535";
+    id                  = "m8535";
+    stk500_devcode      = 0x64;
+    avr910_devcode      = 0x69;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x93 0x08;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 6;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 512;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 20;
+        blocksize       = 128;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+    ;
 
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	mode		= 0x04;
-	delay		= 20;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -7153,152 +5812,102 @@ part
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--0000.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 2000;
         max_write_delay = 2000;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "calibration"
-        size            = 4;
-        read            = "0 0 1 1  1 0 0 0   0 0 x x  x x x x",
-                          "0 0 0 0  0 0 a1 a0 o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
+    memory "calibration"
+        size            = 4;
+        read            = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny26
 #------------------------------------------------------------
 
 part
-    id                  = "t26";
     desc                = "ATtiny26";
+    id                  = "t26";
     stk500_devcode      = 0x21;
     avr910_devcode      = 0x5e;
-    signature           = 0x1e 0x91 0x09;
+    chip_erase_delay    = 9000;
     pagel               = 0xb3;
     bs2                 = 0xb2;
-    chip_erase_delay    = 9000;
-    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    signature           = 0x1e 0x91 0x09;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
-        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
-        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
-        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+        0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
+        0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
+        0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
+        0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 2;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size            = 128;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
-
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
-
-	mode		= 0x04;
-	delay		= 10;
-	blocksize	= 64;
-	readsize	= 256;
+        readback        = 0xff 0xff;
+        mode            = 4;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
@@ -7308,82 +5917,50 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 16;
-	readsize	= 256;
-    ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
-    ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
-
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
+        readback        = 0xff 0xff;
+        mode            = 33;
+        delay           = 6;
+        blocksize       = 16;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxx.xxaa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  x x x i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--xxxi.iiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 4;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
+        read            = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 ;
 
@@ -7392,89 +5969,61 @@ part
 #------------------------------------------------------------
 
 part
-    id                  = "t261";
     desc                = "ATtiny261";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x00, 0x10;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+    id                  = "t261";
+    chip_erase_delay    = 4000;
+    pagel               = 0xb3;
+    bs2                 = 0xb2;
 #    stk500_devcode      = 0x21;
 #    avr910_devcode      = 0x5e;
     signature           = 0x1e 0x91 0x0c;
-    pagel               = 0xb3;
-    bs2                 = 0xb2;
-    chip_erase_delay    = 4000;
-
-    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
-        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
-        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
-        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+        0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
+        0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
+        0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
+        0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb4, 0x00, 0x10;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x00, 0xb4, 0x00, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 2;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
         size            = 128;
         page_size       = 4;
         num_pages       = 32;
         min_write_delay = 4000;
         max_write_delay = 4000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read            = "1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
-
-        write           = "1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "x a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 4;
-	readsize	= 256;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
@@ -7484,94 +6033,58 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read_lo         = "  0  0  1  0   0  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        read_hi         = "  0  0  1  0   1  0  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4  a3 a2 a1 a0",
-                          "  o  o  o  o   o  o  o  o";
-
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x  x  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  x  x  x  x   x  x a9 a8",
-                          " a7 a6 a5 a4   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-    ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
-    ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
-
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
-        min_write_delay = 4500;
-        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxx.xxaa--aaaa.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
-
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -7580,98 +6093,70 @@ part
 #------------------------------------------------------------
 
 part parent "t261"
-    id               = "t261a";
-    desc             = "ATtiny261A";
-  ;
+    desc                = "ATtiny261A";
+    id                  = "t261a";
+;
 
 #------------------------------------------------------------
 # ATtiny461
 #------------------------------------------------------------
 
 part
-    id                  = "t461";
     desc                = "ATtiny461";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x00, 0x10;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+    id                  = "t461";
+    chip_erase_delay    = 4000;
+    pagel               = 0xb3;
+    bs2                 = 0xb2;
 #    stk500_devcode      = 0x21;
 #    avr910_devcode      = 0x5e;
     signature           = 0x1e 0x92 0x08;
-    pagel               = 0xb3;
-    bs2                 = 0xb2;
-    chip_erase_delay    = 4000;
-
-    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
-        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
-        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
-        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+        0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
+        0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
+        0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
+        0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb4, 0x00, 0x10;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x00, 0xb4, 0x00, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 2;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
         size            = 256;
         page_size       = 4;
         num_pages       = 64;
         min_write_delay = 4000;
         max_write_delay = 4000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read            = " 1  0  1  0   0  0  0  0    x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
-
-        write           = " 1  1  0  0   0  0  0  0    x x x x  x x x x",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 4;
-	readsize	= 256;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
@@ -7681,94 +6166,58 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read_lo         = "  0  0  1  0   0   0  0  0",
-                          "  x  x  x  x   x a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
-
-        read_hi         = "  0  0  1  0   1   0  0  0",
-                          "  x  x  x  x   x a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
-
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        writepage       = "  0  1  0  0   1   1  0  0",
-                          "  x  x  x  x   x a10 a9 a8",
-                          " a7 a6 a5  x   x   x  x  x",
-                          "  x  x  x  x   x   x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-    ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
-    ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
-
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
-        min_write_delay = 4500;
-        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxx.xaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
-
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -7777,98 +6226,70 @@ part
 #------------------------------------------------------------
 
 part parent "t461"
-    id               = "t461a";
-    desc             = "ATtiny461A";
-  ;
+    desc                = "ATtiny461A";
+    id                  = "t461a";
+;
 
 #------------------------------------------------------------
 # ATtiny861
 #------------------------------------------------------------
 
 part
-    id                  = "t861";
     desc                = "ATtiny861";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x00, 0x10;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x00, 0xB4, 0x00, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+    id                  = "t861";
+    chip_erase_delay    = 4000;
+    pagel               = 0xb3;
+    bs2                 = 0xb2;
 #    stk500_devcode      = 0x21;
 #    avr910_devcode      = 0x5e;
     signature           = 0x1e 0x93 0x0d;
-    pagel               = 0xb3;
-    bs2                 = 0xb2;
-    chip_erase_delay    = 4000;
-
-    pgm_enable          = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase          = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                          "x x x x  x x x x   x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 0;
-
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0xC4, 0xE4, 0xC4, 0xE4, 0xCC, 0xEC, 0xCC, 0xEC,
-        0xD4, 0xF4, 0xD4, 0xF4, 0xDC, 0xFC, 0xDC, 0xFC,
-        0xC8, 0xE8, 0xD8, 0xF8, 0x4C, 0x6C, 0x5C, 0x7C,
-        0xEC, 0xBC, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+        0xc4, 0xe4, 0xc4, 0xe4, 0xcc, 0xec, 0xcc, 0xec,
+        0xd4, 0xf4, 0xd4, 0xf4, 0xdc, 0xfc, 0xdc, 0xfc,
+        0xc8, 0xe8, 0xd8, 0xf8, 0x4c, 0x6c, 0x5c, 0x7c,
+        0xec, 0xbc, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb4, 0x00, 0x10;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x00, 0xb4, 0x00, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 2;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
         size            = 512;
-        num_pages       = 128;
         page_size       = 4;
+        num_pages       = 128;
         min_write_delay = 4000;
         max_write_delay = 4000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read            = " 1  0  1  0   0  0  0  0    x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    o o o o  o o o  o";
-
-        write           = " 1  1  0  0   0  0  0  0    x x x x  x x x a8",
-                          "a7 a6 a5 a4  a3 a2 a1 a0    i i i i  i i i  i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 4;
-	readsize	= 256;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
@@ -7878,94 +6299,58 @@ part
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read_lo         = "  0  0  1  0   0   0  0  0",
-                          "  x  x  x  x a11 a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
-
-        read_hi         = "  0  0  1  0   1   0  0  0",
-                          "  x  x  x  x a11 a10 a9 a8",
-                          " a7 a6 a5 a4  a3  a2 a1 a0",
-                          "  o  o  o  o   o   o  o  o";
-
-        loadpage_lo     = "  0  1  0  0   0  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        loadpage_hi     = "  0  1  0  0   1  0  0  0",
-                          "  x  x  x  x   x  x  x  x",
-                          "  x  x  x a4  a3 a2 a1 a0",
-                          "  i  i  i  i   i  i  i  i";
-
-        writepage       = "  0  1  0  0   1   1  0  0",
-                          "  x  x  x  x a11 a10 a9 a8",
-                          " a7 a6 a5  x   x   x  x  x",
-                          "  x  x  x  x   x   x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-    ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0 a1 a0    o o o o  o o o o";
-    ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0  1  0  1   1  0  0  0    x x x x  x x x x",
-                          "x  x  x  x   x  x  x  x    x x x x  x x o o";
-
-        write           = "1  0  1  0   1  1  0  0    1 1 1 1  1 1 i i",
-                          "x  x  x  x   x  x  x  x    x x x x  x x x x";
-        min_write_delay = 4500;
-        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxx.aaaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
-
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
         min_write_delay = 4500;
         max_write_delay = 4500;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
+        write           = "1010.1100--1111.11ii--xxxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    x x x x  x x x x",
-                          "0  0  0  0   0  0  0  0    o o o o  o o o o";
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -7974,9 +6359,9 @@ part
 #------------------------------------------------------------
 
 part parent "t861"
-    id               = "t861a";
-    desc             = "ATtiny861A";
-  ;
+    desc                = "ATtiny861A";
+    id                  = "t861a";
+;
 
 #------------------------------------------------------------
 # ATtiny28
@@ -7985,151 +6370,111 @@ part parent "t861"
 # This is an HVPP-only device.
 
 part
-    id                  = "t28";
     desc                = "ATtiny28";
+    id                  = "t28";
     stk500_devcode      = 0x22;
     avr910_devcode      = 0x5c;
     signature           = 0x1e 0x91 0x07;
-    serial			= no;
-
+    serial              = no;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
-    togglevtg           = 0;
-    poweroffdelay       = 0;
-    resetdelayms        = 0;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
 
     memory "flash"
         size            = 2048;
         page_size       = 2;
-        readsize        = 256;
         delay           = 5;
+        readsize        = 256;
     ;
 
-    memory "signature"
-        size            = 3;
+    memory "fuse"
+        size            = 1;
     ;
 
     memory "lock"
         size            = 1;
     ;
 
+    memory "signature"
+        size            = 3;
+    ;
+
     memory "calibration"
         size            = 1;
     ;
-
-    memory "fuse"
-        size            = 1;
-    ;
 ;
-
-
 
 #------------------------------------------------------------
 # ATmega48
 #------------------------------------------------------------
 
 part
-    id               = "m48";
-    desc             = "ATmega48";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x59;
+    desc                = "ATmega48";
+    id                  = "m48";
+    stk500_devcode      = 0x59;
+    chip_erase_delay    = 45000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x92 0x05;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 45000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    signature           = 0x1e 0x92 0x05;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 256;
+        page_size       = 4;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+    ;
 
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
     memory "flash"
         paged           = yes;
         size            = 4096;
@@ -8137,227 +6482,163 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0    0 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0    0 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega48A
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48a";
-    desc             = "ATmega48A";
-  ;
+    desc                = "ATmega48A";
+    id                  = "m48a";
+;
 
 #------------------------------------------------------------
 # ATmega48P
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48p";
-    desc             = "ATmega48P";
-    signature        = 0x1e 0x92 0x0a;
-  ;
+    desc                = "ATmega48P";
+    id                  = "m48p";
+    signature           = 0x1e 0x92 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega48PA
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48pa";
-    desc             = "ATmega48PA";
-    signature        = 0x1e 0x92 0x0a;
-  ;
+    desc                = "ATmega48PA";
+    id                  = "m48pa";
+    signature           = 0x1e 0x92 0x0a;
+;
 
 #------------------------------------------------------------
 # ATmega48PB
 #------------------------------------------------------------
 
 part parent "m48"
-    id               = "m48pb";
-    desc             = "ATmega48PB";
-    signature        = 0x1e 0x92 0x10;
-    chip_erase_delay = 10500;
-  ;
+    desc                = "ATmega48PB";
+    id                  = "m48pb";
+    chip_erase_delay    = 10500;
+    signature           = 0x1e 0x92 0x10;
+;
 
 #------------------------------------------------------------
 # ATmega88
 #------------------------------------------------------------
 
 part
-    id               = "m88";
-    desc             = "ATmega88";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x73;
+    desc                = "ATmega88";
+    id                  = "m88";
+    stk500_devcode      = 0x73;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x93 0x0a;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    signature           = 0x1e 0x93 0x0a;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 512;
+        page_size       = 4;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -8365,324 +6646,224 @@ part
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x i i i";
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega88A
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88a";
-    desc             = "ATmega88A";
-  ;
+    desc                = "ATmega88A";
+    id                  = "m88a";
+;
 
 #------------------------------------------------------------
 # ATmega88P
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88p";
-    desc             = "ATmega88P";
-    signature        = 0x1e 0x93 0x0f;
-  ;
+    desc                = "ATmega88P";
+    id                  = "m88p";
+    signature           = 0x1e 0x93 0x0f;
+;
 
 #------------------------------------------------------------
 # ATmega88PA
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88pa";
-    desc             = "ATmega88PA";
-    signature        = 0x1e 0x93 0x0f;
-  ;
+    desc                = "ATmega88PA";
+    id                  = "m88pa";
+    signature           = 0x1e 0x93 0x0f;
+;
 
 #------------------------------------------------------------
 # ATmega88PB
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "m88pb";
-    desc             = "ATmega88PB";
-    signature        = 0x1e 0x93 0x16;
-    chip_erase_delay = 10500;
-  ;
+    desc                = "ATmega88PB";
+    id                  = "m88pb";
+    chip_erase_delay    = 10500;
+    signature           = 0x1e 0x93 0x16;
+;
 
 #------------------------------------------------------------
 # ATmega168
 #------------------------------------------------------------
 
 part
-    id              = "m168";
-    desc            = "ATmega168";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode  = 0x86;
+    desc                = "ATmega168";
+    id                  = "m168";
+    stk500_devcode      = 0x86;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
     # avr910_devcode = 0x;
-    signature       = 0x1e 0x94 0x06;
-    pagel           = 0xd7;
-    bs2             = 0xc2;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-                       "x x x x x x x x x x x x x x x x";
-
-    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-                       "x x x x x x x x x x x x x x x x";
-
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 1;
-
+    signature           = 0x1e 0x94 0x06;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 512;
+        page_size       = 4;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
-    
-        write           = " 1 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-        ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 128;
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                          " 0 0 0 a12 a11 a10 a9 a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
-        
-        read_hi          = " 0 0 1 0 1 0 0 0",
-                           " 0 0 0 a12 a11 a10 a9 a8",
-                           " a7 a6 a5 a4 a3 a2 a1 a0",
-                           " o o o o o o o o";
-        
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
-        
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
-        
-        writepage       = " 0 1 0 0 1 1 0 0",
-                          " 0 0 0 a12 a11 a10 a9 a8",
-                          " a7 a6 x x x x x x",
-                          " x x x x x x x x";
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--000a.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
-        mode        = 0x41;
-        delay       = 6;
-        blocksize   = 128;
-        readsize    = 256;
-
-        ;
-        
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-        
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
-        ;
-    
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-        
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
-        ;
-    
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-        
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x x x x i i i";
-        ;
-    
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+    ;
+
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-        
-        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-                          "x x x x x x x x 1 1 i i i i i i";
-        ;
-    
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-                          "0 0 0 0 0 0 0 0 o o o o o o o o";
-        ;
-    
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
     memory "signature"
         size            = 3;
-        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-                          "x x x x x x a1 a0 o o o o o o o o";
-        ;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
 ;
 
 #------------------------------------------------------------
@@ -8690,130 +6871,102 @@ part
 #------------------------------------------------------------
 
 part parent "m168"
-    id               = "m168a";
-    desc             = "ATmega168A";
-  ;
+    desc                = "ATmega168A";
+    id                  = "m168a";
+;
 
 #------------------------------------------------------------
 # ATmega168P
 #------------------------------------------------------------
 
 part parent "m168"
-    id              = "m168p";
-    desc            = "ATmega168P";
-    signature       = 0x1e 0x94 0x0b;
-  ;
+    desc                = "ATmega168P";
+    id                  = "m168p";
+    signature           = 0x1e 0x94 0x0b;
+;
 
 #------------------------------------------------------------
 # ATmega168PA
 #------------------------------------------------------------
 
 part parent "m168"
-    id              = "m168pa";
-    desc            = "ATmega168PA";
-    signature       = 0x1e 0x94 0x0b;
-  ;
+    desc                = "ATmega168PA";
+    id                  = "m168pa";
+    signature           = 0x1e 0x94 0x0b;
+;
 
 #------------------------------------------------------------
 # ATmega168PB
 #------------------------------------------------------------
 
 part parent "m168"
-    id              = "m168pb";
-    desc            = "ATmega168PB";
-    signature       = 0x1e 0x94 0x15;
-    chip_erase_delay = 10500;
-  ;
+    desc                = "ATmega168PB";
+    id                  = "m168pb";
+    chip_erase_delay    = 10500;
+    signature           = 0x1e 0x94 0x15;
+;
 
 #------------------------------------------------------------
 # ATtiny828
 #------------------------------------------------------------
 
 part
-    id              = "t828";
-    desc            = "ATtiny828";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-                0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-                0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode  = 0x86;
+    desc                = "ATtiny828";
+    id                  = "t828";
+    stk500_devcode      = 0x86;
+    chip_erase_delay    = 15000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
     # avr910_devcode = 0x;
-    signature       = 0x1e 0x93 0x14;
-    pagel           = 0xd7;
-    bs2             = 0xc2;
-    chip_erase_delay = 15000;
-    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-                       "x x x x x x x x x x x x x x x x";
-
-    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-                       "x x x x x x x x x x x x x x x x";
-
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 1;
-
+    signature           = 0x1e 0x93 0x14;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-   0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-   0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-   0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-   0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 256;
+        page_size       = 4;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
-
-        write           = " 1 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
-
-   loadpage_lo   = "  1   1   0   0      0   0   0   1",
-                   "  0   0   0   0      0   0   0   0",
-                   "  0   0   0   0      0   0  a1  a0",
-                   "  i   i   i   i      i   i   i   i";
-
-writepage   = "  1   1   0   0      0   0   1   0",
-              "  0   0   x   x      x   x   x  a8",
-              " a7  a6  a5  a4     a3  a2   0   0",
-              "  x   x   x   x      x   x   x   x";
-
-   mode      = 0x41;
-   delay      = 5;
-   blocksize   = 4;
-   readsize   = 256;
-        ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
@@ -8822,95 +6975,59 @@ writepage   = "  1   1   0   0      0   0   1   0",
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                          " 0 0 0 0 a11 a10 a9 a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
-
-        read_hi          = " 0 0 1 0 1 0 0 0",
-                           " 0 0 0 0 a11 a10 a9 a8",
-                           " a7 a6 a5 a4 a3 a2 a1 a0",
-                           " o o o o o o o o";
-
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x x a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
-
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x x a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
-
-        writepage       = " 0 1 0 0 1 1 0 0",
-                          " 0 0 0 0 a11 a10 a9 a8",
-                          " a7 a6 a5 x x x x x",
-                          " x x x x x x x x";
-
-        mode        = 0x41;
-        delay       = 6;
-        blocksize   = 128;
-        readsize    = 256;
-
-        ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
-        ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
-        ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x 1 1 1 i i i i i";
-        ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--111i.iiii";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-                          "x x x x x x x x 1 1 i i i i i i";
-        ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-                          "0 0 0 0 0 0 0 0 o o o o o o o o";
-        ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-                          "x x x x x x a1 a0 o o o o o o o o";
-        ;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
 ;
 
 #------------------------------------------------------------
@@ -8918,474 +7035,322 @@ writepage   = "  1   1   0   0      0   0   1   0",
 #------------------------------------------------------------
 
 part parent "t828"
-    id              = "t828r";
-    desc            = "ATtiny828R";
-  ;
+    desc                = "ATtiny828R";
+    id                  = "t828r";
+;
 
 #------------------------------------------------------------
 # ATtiny87
 #------------------------------------------------------------
 
 part
-     id            = "t87";
-     desc          = "ATtiny87";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4,
-               0x00, 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB,
-               0xBF, 0x99, 0xF9, 0xBB, 0xAF;
+    desc                = "ATtiny87";
+    id                  = "t87";
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x93 0x87;
-     reset            = io;
-     chip_erase_delay = 15000;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 0;
-
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 15000;
+    signature           = 0x1e 0x93 0x87;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
-        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
-        0x06, 0x16, 0x46, 0x56, 0x0A, 0x1A, 0x4A, 0x5A,
-        0x1E, 0x7C, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
+        0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
+        0x06, 0x16, 0x46, 0x56, 0x0a, 0x1a, 0x4a, 0x5a,
+        0x1e, 0x7c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 20;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
-    idr                 = 0x00;
     spmcr               = 0x57;
-    allowfullpagebitstream = no;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
-     memory "eeprom"
-         size            = 512;
-        paged           = no;
+    memory "eeprom"
+        size            = 512;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
-         write           = "1  1  0  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 128;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
-  loadpage_lo   = "  1   1   0   0      0   0   0   1",
-        "  0   0   0   0      0   0   0   0",
-        "  0   0   0   0      0   0  a1  a0",
-        "  i   i   i   i      i   i   i   i";
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
-  writepage = "  1   1   0   0      0   0   1   0",
-        "  0   0   x   x      x   x   x  a8",
-        " a7  a6  a5  a4     a3  a2   0   0",
-        "  x   x   x   x      x   x   x   x";
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 4;
-  readsize  = 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 128;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 64;
-  readsize  = 256;
-       ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+    ;
 #   ATtiny87 has Signature Bytes: 0x1E 0x93 0x87.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny167
 #------------------------------------------------------------
 
 part
-     id            = "t167";
-     desc          = "ATtiny167";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4,
-               0x00, 0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB,
-               0xBF, 0x99, 0xF9, 0xBB, 0xAF;
+    desc                = "ATtiny167";
+    id                  = "t167";
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x94 0x87;
-     reset            = io;
-     chip_erase_delay = 15000;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout     = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 0;
-
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 15000;
+    signature           = 0x1e 0x94 0x87;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
-        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
-        0x06, 0x16, 0x46, 0x56, 0x0A, 0x1A, 0x4A, 0x5A,
-        0x1E, 0x7C, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
+        0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
+        0x06, 0x16, 0x46, 0x56, 0x0a, 0x1a, 0x4a, 0x5a,
+        0x1e, 0x7c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 20;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
-    idr                 = 0x00;
     spmcr               = 0x57;
-    allowfullpagebitstream = no;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
-     memory "eeprom"
-         size            = 512;
-        paged           = no;
+    memory "eeprom"
+        size            = 512;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--00xx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--00xx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
-         write           = "1  1  0  0   0  0  0  0    0 0 x x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+    memory "flash"
+        paged           = yes;
+        size            = 0x4000;
+        page_size       = 128;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--000a.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
-  loadpage_lo   = "  1   1   0   0      0   0   0   1",
-        "  0   0   0   0      0   0   0   0",
-        "  0   0   0   0      0   0  a1  a0",
-        "  i   i   i   i      i   i   i   i";
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
-  writepage = "  1   1   0   0      0   0   1   0",
-        "  0   0   x   x      x   x   x  a8",
-        " a7  a6  a5  a4     a3  a2   0   0",
-        "  x   x   x   x      x   x   x   x";
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 4;
-  readsize  = 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 16384;
-         page_size       = 128;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0  a12  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2   a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x  a5  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-          writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  a12  a11 a10 a9 a8",
-                           " a7 a6 x  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-  mode      = 0x41;
-  delay     = 10;
-  blocksize = 64;
-  readsize  = 256;
-       ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+    ;
 #   ATtiny167 has Signature Bytes: 0x1E 0x94 0x87.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny48
 #------------------------------------------------------------
 
 part
-    id               = "t48";
-    desc             = "ATtiny48";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-                     0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-                     0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x73;
+    desc                = "ATtiny48";
+    id                  = "t48";
+    stk500_devcode      = 0x73;
+    chip_erase_delay    = 15000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x92 0x09;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 15000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
+    signature           = 0x1e 0x92 0x09;
+    has_debugwire       = yes;
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
     synchloops          = 32;
-    bytedelay           = 0;
     pollindex           = 3;
     pollvalue           = 0x53;
     predelay            = 1;
     postdelay           = 1;
     pollmethod          = 1;
-
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 64;
+        page_size       = 4;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
-
-        mode            = 0x41;
+        readback        = 0xff 0xff;
+        mode            = 65;
         delay           = 20;
         blocksize       = 4;
         readsize        = 64;
-      ;
+        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+    ;
+
     memory "flash"
         paged           = yes;
         size            = 4096;
@@ -9393,187 +7358,124 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-        mode            = 0x41;
+        readback        = 0xff 0xff;
+        mode            = 65;
         delay           = 6;
         blocksize       = 64;
         readsize        = 256;
-      ;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   1 1 1 1  1 1 1 i";
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.111i";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny88
 #------------------------------------------------------------
 
 part
-    id               = "t88";
-    desc             = "ATtiny88";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode   = 0x73;
+    desc                = "ATtiny88";
+    id                  = "t88";
+    stk500_devcode      = 0x73;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
 #    avr910_devcode   = 0x;
-    signature        = 0x1e 0x93 0x11;
-    pagel            = 0xd7;
-    bs2              = 0xc2;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    signature           = 0x1e 0x93 0x11;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 64;
+        page_size       = 4;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-	read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 64;
+        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+    ;
 
-	write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 64;
-      ;
     memory "flash"
         paged           = yes;
         size            = 8192;
@@ -9581,283 +7483,183 @@ part
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0  a11 a10  a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   x      x   x   x   x",
-                          "  x   x   x  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-      ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x   x x x x  x x x i";
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0  0  1  1   1  0  0  0   0  0  0  x   x  x  x  x",
-                          "0  0  0  0   0  0  0  0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega328
 #------------------------------------------------------------
 
 part
-    id			= "m328";
-    desc		= "ATmega328";
-    has_debugwire	= yes;
-    flash_instr		= 0xB6, 0x01, 0x11;
-    eeprom_instr	= 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-			  0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-			  0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode	= 0x86;
+    desc                = "ATmega328";
+    id                  = "m328";
+    stk500_devcode      = 0x86;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc2;
     # avr910_devcode	= 0x;
-    signature		= 0x1e 0x95 0x14;
-    pagel		= 0xd7;
-    bs2			= 0xc2;
-    chip_erase_delay	= 9000;
-    pgm_enable = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-		 "x x x x x x x x x x x x x x x x";
-
-    chip_erase = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-		 "x x x x x x x x x x x x x x x x";
-
-    timeout	= 200;
-    stabdelay	= 100;
-    cmdexedelay	= 25;
-    synchloops	= 32;
-    bytedelay	= 0;
-    pollindex	= 3;
-    pollvalue	= 0x53;
-    predelay	= 1;
-    postdelay	= 1;
-    pollmethod	= 1;
-
-    pp_controlstack =
-	0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay	= 100;
-    progmodedelay	= 0;
-    latchcycles		= 5;
-    togglevtg		= 1;
-    poweroffdelay	= 15;
-    resetdelayms	= 1;
-    resetdelayus	= 0;
-    hvleavestabdelay	= 15;
-    resetdelay		= 15;
-    chiperasepulsewidth	= 0;
+    signature           = 0x1e 0x95 0x14;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-	paged		= no;
-	page_size	= 4;
-	size		= 1024;
-	min_write_delay = 3600;
-	max_write_delay = 3600;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read = " 1 0 1 0 0 0 0 0",
-	       " 0 0 0 x x x a9 a8",
-	       " a7 a6 a5 a4 a3 a2 a1 a0",
-	       " o o o o o o o o";
-
-	write = " 1 1 0 0 0 0 0 0",
-	      	" 0 0 0 x x x a9 a8",
-		" a7 a6 a5 a4 a3 a2 a1 a0",
-		" i i i i i i i i";
-
-	loadpage_lo = " 1 1 0 0 0 0 0 1",
-		      " 0 0 0 0 0 0 0 0",
-		      " 0 0 0 0 0 0 a1 a0",
-		      " i i i i i i i i";
-
-	writepage = " 1 1 0 0 0 0 1 0",
-		    " 0 0 x x x x a9 a8",
-		    " a7 a6 a5 a4 a3 a2 0 0",
-		    " x x x x x x x x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
+        size            = 1024;
+        page_size       = 4;
+        min_write_delay = 3600;
+        max_write_delay = 3600;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxaa--aaaa.aa00--xxxx.xxxx";
     ;
 
     memory "flash"
-	paged		= yes;
-	size		= 32768;
-	page_size	= 128;
-	num_pages	= 256;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read_lo = " 0 0 1 0 0 0 0 0",
-		  " 0 0 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
-
-	read_hi = " 0 0 1 0 1 0 0 0",
-		  " 0 0 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
-
-	loadpage_lo = " 0 1 0 0 0 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x x a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
-
-	loadpage_hi = " 0 1 0 0 1 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x x a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
-
-	writepage = " 0 1 0 0 1 1 0 0",
-		    " 0 0 a13 a12 a11 a10 a9 a8",
-		    " a7 a6 x x x x x x",
-		    " x x x x x x x x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-
+        paged           = yes;
+        size            = 0x8000;
+        page_size       = 128;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
-
-	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-	      	"x x x x x x x x i i i i i i i i";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "hfuse"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
-
-	write = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-	      	"x x x x x x x x i i i i i i i i";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
 
     memory "efuse"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
-
-	write = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-	      	"x x x x x x x x x x x x x i i i";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
     ;
 
     memory "lock"
-	size = 1;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	read = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-	       "x x x x x x x x o o o o o o o o";
-
-	write = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-	      	"x x x x x x x x 1 1 i i i i i i";
-    ;
-
-    memory "calibration"
-	size = 1;
-	read = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-	       "0 0 0 0 0 0 0 0 o o o o o o o o";
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
 
     memory "signature"
-	size = 3;
-	read = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-	       "x x x x x x a1 a0 o o o o o o o o";
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 ;
 
@@ -9866,9 +7668,9 @@ part
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m328p";
-    desc            = "ATmega328P";
-    signature       = 0x1e 0x95 0x0f;
+    desc                = "ATmega328P";
+    id                  = "m328p";
+    signature           = 0x1e 0x95 0x0f;
 ;
 
 #------------------------------------------------------------
@@ -9876,20 +7678,13 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m328pb";
-    desc            = "ATmega328PB";
-    signature       = 0x1e 0x95 0x16;
-    chip_erase_delay = 10500;
+    desc                = "ATmega328PB";
+    id                  = "m328pb";
+    chip_erase_delay    = 10500;
+    signature           = 0x1e 0x95 0x16;
 
     memory "efuse"
-        size = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-               "x x x x x x x x o o o o o o o o";
-
-        write = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                "x x x x x x x x x x x x i i i i";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 ;
 
@@ -9898,21 +7693,15 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m32m1";
-    desc            = "ATmega32M1";
+    desc                = "ATmega32M1";
+    id                  = "m32m1";
+    bs2                 = 0xe2;
     # stk500_devcode	= 0x;
     # avr910_devcode	= 0x;
-    signature       = 0x1e 0x95 0x84;
-    bs2             = 0xe2;
+    signature           = 0x1e 0x95 0x84;
 
     memory "efuse"
-        size = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x i i i i i i";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxii.iiii";
     ;
 ;
 
@@ -9921,97 +7710,34 @@ part parent "m328"
 #------------------------------------------------------------
 
 part parent "m328"
-    id              = "m64m1";
-    desc            = "ATmega64M1";
+    desc                = "ATmega64M1";
+    id                  = "m64m1";
+    bs2                 = 0xe2;
     # stk500_devcode	= 0x;
     # avr910_devcode	= 0x;
-    signature       = 0x1e 0x96 0x84;
-    bs2             = 0xe2;
+    signature           = 0x1e 0x96 0x84;
 
     memory "eeprom"
-	paged		= no;
         size            = 2048;
         page_size       = 8;
-	min_write_delay = 3600;
-	max_write_delay = 3600;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read = " 1 0 1 0 0 0 0 0",
-	       " 0 0 0 x x a10 a9 a8",
-	       " a7 a6 a5 a4 a3 a2 a1 a0",
-	       " o o o o o o o o";
-
-	write = " 1 1 0 0 0 0 0 0",
-		" 0 0 0 x x a10 a9 a8",
-		" a7 a6 a5 a4 a3 a2 a1 a0",
-		" i i i i i i i i";
-
-	loadpage_lo = " 1 1 0 0 0 0 0 1",
-		      " 0 0 0 0 0 0 0 0",
-		      " 0 0 0 0 0 a2 a1 a0",
-		      " i i i i i i i i";
-
-	writepage = " 1 1 0 0 0 0 1 0",
-		    " 0 0 x x x a10 a9 a8",
-		    " a7 a6 a5 a4 a3 0 0 0",
-		    " x x x x x x x x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
+        read            = "1010.0000--000x.xaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        paged           = yes;
-        size            = 65536;
+        size            = 0x10000;
         page_size       = 256;
-        num_pages       = 256;
-	min_write_delay = 4500;
-	max_write_delay = 4500;
-	readback_p1	= 0xff;
-	readback_p2	= 0xff;
-	read_lo = " 0 0 1 0 0 0 0 0",
-		  " a15 a14 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
-
-	read_hi = " 0 0 1 0 1 0 0 0",
-		  " a15 a14 a13 a12 a11 a10 a9 a8",
-		  " a7 a6 a5 a4 a3 a2 a1 a0",
-		  " o o o o o o o o";
-
-	loadpage_lo = " 0 1 0 0 0 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x a6 a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
-
-	loadpage_hi = " 0 1 0 0 1 0 0 0",
-		      " 0 0 0 x x x x x",
-		      " x a6 a5 a4 a3 a2 a1 a0",
-		      " i i i i i i i i";
-
-	writepage = " 0 1 0 0 1 1 0 0",
-		    " a15 a14 a13 a12 a11 a10 a9 a8",
-		    " a7 x x x x x x x",
-		    " x x x x x x x x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
     ;
 
     memory "efuse"
-        size            = 1;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-        
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x i i i i i i";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxii.iiii";
     ;
 ;
 
@@ -10020,564 +7746,390 @@ part parent "m328"
 #------------------------------------------------------------
 
 part
-     id            = "t2313";
-     desc          = "ATtiny2313";
-     has_debugwire = yes;
-     flash_instr   = 0xB2, 0x0F, 0x1F;
-     eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-     stk500_devcode   = 0x23;
+    desc                = "ATtiny2313";
+    id                  = "t2313";
+    stk500_devcode      = 0x23;
 ##   Use the ATtiny26 devcode:
-     avr910_devcode   = 0x5e;
-     signature        = 0x1e 0x91 0x0a;
-     pagel            = 0xD4;
-     bs2              = 0xD6;
-     reset            = io;
-     chip_erase_delay = 9000;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    avr910_devcode      = 0x5e;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd4;
+    bs2                 = 0xd6;
+    signature           = 0x1e 0x91 0x0a;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
-        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
-        0x26, 0x36, 0x66, 0x76, 0x2A, 0x3A, 0x6A, 0x7A,
-        0x2E, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
+        0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
+        0x26, 0x36, 0x66, 0x76, 0x2a, 0x3a, 0x6a, 0x7a,
+        0x2e, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb2, 0x0f, 0x1f;
+    eeprom_instr        =
+        0xbb, 0xfe, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xba, 0x0f, 0xb2, 0x0f, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 0;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
-     memory "eeprom"
-         size            = 128;
-        paged           = no;
+    memory "eeprom"
+        size            = 128;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+    ;
 
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 2048;
-         page_size       = 32;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
 # The information in the data sheet of April/2004 is wrong, this works:
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
 # The information in the data sheet of April/2004 is wrong, this works:
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
 # The information in the data sheet of April/2004 is wrong, this works:
-         writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0  0 a9 a8",
-                           " a7 a6 a5 a4   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
+        writepage       = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
+    ;
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 #   ATtiny2313 has Signature Bytes: 0x1E 0x91 0x0A.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-         read           = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 # The Tiny2313 has calibration data for both 4 MHz and 8 MHz.
 # The information in the data sheet of April/2004 is wrong, this works:
 
-     memory "calibration"
-         size            = 2;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    memory "calibration"
+        size            = 2;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny2313A
 #------------------------------------------------------------
 
 part parent "t2313"
-    id              = "t2313a";
-    desc            = "ATtiny2313A";
-  ;
+    desc                = "ATtiny2313A";
+    id                  = "t2313a";
+;
 
 #------------------------------------------------------------
 # ATtiny4313
 #------------------------------------------------------------
 
 part
-     id            = "t4313";
-     desc          = "ATtiny4313";
-     has_debugwire = yes;
-     flash_instr   = 0xB2, 0x0F, 0x1F;
-     eeprom_instr  = 0xBB, 0xFE, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBA, 0x0F, 0xB2, 0x0F, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-     stk500_devcode   = 0x23;
+    desc                = "ATtiny4313";
+    id                  = "t4313";
+    stk500_devcode      = 0x23;
 ##   Use the ATtiny26 devcode:
-     avr910_devcode   = 0x5e;
-     signature        = 0x1e 0x92 0x0d;
-     pagel            = 0xD4;
-     bs2              = 0xD6;
-     reset            = io;
-     chip_erase_delay = 9000;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    avr910_devcode      = 0x5e;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd4;
+    bs2                 = 0xd6;
+    signature           = 0x1e 0x92 0x0d;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
-        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
-        0x26, 0x36, 0x66, 0x76, 0x2A, 0x3A, 0x6A, 0x7A,
-        0x2E, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
+        0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
+        0x26, 0x36, 0x66, 0x76, 0x2a, 0x3a, 0x6a, 0x7a,
+        0x2e, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb2, 0x0f, 0x1f;
+    eeprom_instr        =
+        0xbb, 0xfe, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xba, 0x0f, 0xb2, 0x0f, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 0;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
-     memory "eeprom"
-         size            = 256;
-        paged           = no;
+    memory "eeprom"
+        size            = 256;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1   0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+    ;
 
-         write           = "1   1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 64;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1  0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5  x   x   x  x  x",
-                           "  x  x  x  x   x   x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 #   ATtiny4313 has Signature Bytes: 0x1E 0x92 0x0D.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-         read           = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 2;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    memory "calibration"
+        size            = 2;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90PWM2
 #------------------------------------------------------------
 
 part
-     id            = "pwm2";
-     desc          = "AT90PWM2";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-	             0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-	             0x99, 0xF9, 0xBB, 0xAF;
-     stk500_devcode   = 0x65;
+    desc                = "AT90PWM2";
+    id                  = "pwm2";
+    stk500_devcode      = 0x65;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd8;
+    bs2                 = 0xe2;
 ##  avr910_devcode   = ?;
-     signature        = 0x1e 0x93 0x81;
-     pagel            = 0xD8;
-     bs2              = 0xE2;
-     reset            = io;
-     chip_erase_delay = 9000;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    signature           = 0x1e 0x93 0x81;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
-     memory "eeprom"
-         size            = 512;
-        paged           = no;
+    memory "eeprom"
+        size            = 512;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0  o o o o  o o o o";
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0  i i i i  i i i i";
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 64;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0   a11 a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0   a11 a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0   0",
-                           "  0  0  0  0   a11 a10 a9  a8",
-                           " a7 a6 a5  x   x   x   x   x",
-                           "  x  x  x  x   x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 64;
-	readsize	= 256;
-       ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 #   AT90PWM2 has Signature Bytes: 0x1E 0x93 0x81.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  x  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--00xx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  0    o o o o  o o o o";
-     ;
-  ;
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90PWM3
@@ -10586,9 +8138,9 @@ part
 # Completely identical to AT90PWM2 (including the signature!)
 
 part parent "pwm2"
-     id            = "pwm3";
-     desc          = "AT90PWM3";
-  ;
+    desc                = "AT90PWM3";
+    id                  = "pwm3";
+;
 
 #------------------------------------------------------------
 # AT90PWM2B
@@ -10596,12 +8148,11 @@ part parent "pwm2"
 # Same as AT90PWM2 but different signature.
 
 part parent "pwm2"
-     id            = "pwm2b";
-     desc          = "AT90PWM2B";
-     signature     = 0x1e 0x93 0x83;
-
+    desc                = "AT90PWM2B";
+    id                  = "pwm2b";
+    signature           = 0x1e 0x93 0x83;
     ocdrev              = 1;
-  ;
+;
 
 #------------------------------------------------------------
 # AT90PWM3B
@@ -10610,11 +8161,9 @@ part parent "pwm2"
 # Completely identical to AT90PWM2B (including the signature!)
 
 part parent "pwm2b"
-     id            = "pwm3b";
-     desc          = "AT90PWM3B";
-
-    ocdrev              = 1;
-  ;
+    desc                = "AT90PWM3B";
+    id                  = "pwm3b";
+;
 
 #------------------------------------------------------------
 # AT90PWM316
@@ -10623,52 +8172,22 @@ part parent "pwm2b"
 # Similar to AT90PWM3B, but with 16 kiB flash, 512 B EEPROM, and 1024 B SRAM.
 
 part parent "pwm3b"
-     id            = "pwm316";
-     desc          = "AT90PWM316";
-     signature     = 0x1e 0x94 0x83;
-
-    ocdrev              = 1;
+    desc                = "AT90PWM316";
+    id                  = "pwm316";
+    signature           = 0x1e 0x94 0x83;
 
     memory "flash"
-        paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 128;
-        num_pages       = 128;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0   0 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x21;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
-  ;
+        mode            = 33;
+        blocksize       = 128;
+        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90PWM216
@@ -10676,2188 +8195,203 @@ part parent "pwm3b"
 # Completely identical to AT90PWM316 (including the signature!)
 
 part parent "pwm316"
-     id = "pwm216";
-     desc = "AT90PWM216";
-  ; 
+    desc                = "AT90PWM216";
+    id                  = "pwm216";
+;
 
 #------------------------------------------------------------
 # ATtiny25
 #------------------------------------------------------------
 
 part
-     id            = "t25";
-     desc          = "ATtiny25";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x02, 0x12;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
+    desc                = "ATtiny25";
+    id                  = "t25";
 ## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x91 0x08;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 4500;
+    signature           = 0x1e 0x91 0x08;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
+        0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
         0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    flash_instr         =  0xb4, 0x02, 0x12;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x02, 0xb4, 0x02, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
     latchcycles         = 1;
     togglevtg           = 1;
     poweroffdelay       = 25;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 100;
     resetdelay          = 25;
     chiperasepolltimeout = 40;
-    chiperasetime       = 0;
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
-
+    synchcycles         = 6;
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
-     memory "eeprom"
-         size            = 128;
-        paged           = no;
+    memory "eeprom"
+        size            = 128;
         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+    ;
 
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
+    ;
 
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 2048;
-         page_size       = 32;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
 
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0  0 a9 a8",
-                           " a7 a6 a5 a4   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 #   ATtiny25 has Signature Bytes: 0x1E 0x91 0x08.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATtiny45
 #------------------------------------------------------------
 
 part
-     id            = "t45";
-     desc          = "ATtiny45";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x02, 0x12;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-     stk500_devcode   = 0x14;
+    desc                = "ATtiny45";
+    id                  = "t45";
+    stk500_devcode      = 0x14;
 ##  avr910_devcode   = ?;
 ##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x92 0x06;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack     =
-	0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 256;
-         page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 64;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny45 has Signature Bytes: 0x1E 0x92 0x08. (Data sheet 2586C-AVR-06/05 (doc2586.pdf) indicates otherwise!)
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATtiny85
-#------------------------------------------------------------
-
-part
-     id            = "t85";
-     desc          = "ATtiny85";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x02, 0x12;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x02, 0xB4, 0x02, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x93 0x0b;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
-    hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 512;
-        paged           = no;
-        page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 64;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny85 has Signature Bytes: 0x1E 0x93 0x08.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  1 1 i i  i i i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATmega640
-#------------------------------------------------------------
-# Almost same as ATmega1280, except for different memory sizes
-
-part
-    id               = "m640";
-    desc             = "ATmega640";
-    signature        = 0x1e 0x96 0x08;
-    has_jtag         = yes;
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    rampz               = 0x3b;
-    allowfullpagebitstream = no;
-
-    ocdrev              = 3;
-
-    memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
-        size            = 4096;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 65536;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "efuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega1280
-#------------------------------------------------------------
-
-part
-    id               = "m1280";
-    desc             = "ATmega1280";
-    signature        = 0x1e 0x97 0x03;
-    has_jtag         = yes;
-#    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    rampz               = 0x3b;
-    allowfullpagebitstream = no;
-
-    ocdrev              = 3;
-
-    memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
-        size            = 4096;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 131072;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "efuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega1281
-#------------------------------------------------------------
-# Identical to ATmega1280
-
-part parent "m1280"
-    id               = "m1281";
-    desc             = "ATmega1281";
-    signature        = 0x1e 0x97 0x04;
-
-    ocdrev              = 3;
-  ;
-
-#------------------------------------------------------------
-# ATmega2560
-#------------------------------------------------------------
-
-part
-    id               = "m2560";
-    desc             = "ATmega2560";
-    signature        = 0x1e 0x98 0x01;
-    has_jtag         = yes;
-    stk500_devcode   = 0xB2;
-#    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
-    hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 5;
-    togglevtg           = 1;
-    poweroffdelay       = 15;
-    resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
-
-    idr                 = 0x31;
-    spmcr               = 0x57;
-    rampz               = 0x3b;
-    allowfullpagebitstream = no;
-
-    ocdrev              = 4;
-
-    memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
-        size            = 4096;
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
-
-    memory "flash"
-        paged           = yes;
-        size            = 262144;
-        page_size       = 256;
-        num_pages       = 1024;
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-        load_ext_addr   = "  0   1   0   0      1   1   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   0 a16",
-                          "  0   0   0   0      0   0   0   0";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "lfuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "hfuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "efuse"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega2561
-#------------------------------------------------------------
-
-part parent "m2560"
-    id               = "m2561";
-    desc             = "ATmega2561";
-    signature        = 0x1e 0x98 0x02;
-
-    ocdrev              = 4;
-  ;
-
-#------------------------------------------------------------
-# ATmega128RFA1
-#------------------------------------------------------------
-# Identical to ATmega2561 but half the ROM
-
-part parent "m2561"
-    id               = "m128rfa1";
-    desc             = "ATmega128RFA1";
-    signature        = 0x1e 0xa7 0x01;
-    chip_erase_delay = 55000;
-    bs2              = 0xE2;
-
-    ocdrev              = 3;
-
-    memory "flash"
-        paged           = yes;
-        size            = 131072;
-        page_size       = 256;
-        num_pages       = 512;
-        min_write_delay = 50000;
-        max_write_delay = 50000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-        load_ext_addr   = NULL;
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-  ;
-
-#------------------------------------------------------------
-# ATmega256RFR2
-#------------------------------------------------------------
-
-part parent "m2561"
-    id               = "m256rfr2";
-    desc             = "ATmega256RFR2";
-    signature        = 0x1e 0xa8 0x02;
-    chip_erase_delay = 18500;
-    bs2              = 0xE2;
-
-    memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
-        size            = 8192;
-        min_write_delay = 13000;
-        max_write_delay = 13000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x a12    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
-
-
-    ocdrev              = 4;
-  ;
-
-#------------------------------------------------------------
-# ATmega128RFR2
-#------------------------------------------------------------
-
-part parent "m128rfa1"
-    id               = "m128rfr2";
-    desc             = "ATmega128RFR2";
-    signature        = 0x1e 0xa7 0x02;
-
-
-    ocdrev              = 3;
-  ;
-
-#------------------------------------------------------------
-# ATmega64RFR2
-#------------------------------------------------------------
-
-part parent "m128rfa1"
-    id               = "m64rfr2";
-    desc             = "ATmega64RFR2";
-    signature        = 0x1e 0xa6 0x02;
-
-
-    ocdrev              = 3;
-
-    memory "flash"
-        paged           = yes;
-        size            = 65536;
-        page_size       = 256;
-        num_pages       = 256;
-        min_write_delay = 50000;
-        max_write_delay = 50000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
-
-    memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
-        size            = 2048;
-        min_write_delay = 13000;
-        max_write_delay = 13000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
-
-
-  ;
-
-#------------------------------------------------------------
-# ATmega2564RFR2
-#------------------------------------------------------------
-
-part parent "m256rfr2"
-    id               = "m2564rfr2";
-    desc             = "ATmega2564RFR2";
-    signature        = 0x1e 0xa8 0x03;
-  ;
-
-#------------------------------------------------------------
-# ATmega1284RFR2
-#------------------------------------------------------------
-
-part parent "m128rfr2"
-    id               = "m1284rfr2";
-    desc             = "ATmega1284RFR2";
-    signature        = 0x1e 0xa7 0x03;
-  ;
-
-#------------------------------------------------------------
-# ATmega644RFR2
-#------------------------------------------------------------
-
-part parent "m64rfr2"
-    id               = "m644rfr2";
-    desc             = "ATmega644RFR2";
-    signature        = 0x1e 0xa6 0x03;
-  ;
-
-#------------------------------------------------------------
-# ATtiny24
-#------------------------------------------------------------
-
-part
-     id            = "t24";
-     desc          = "ATtiny24";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x07, 0x17;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x91 0x0b;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
-    hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 0;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 128;
-        paged           = no;
-        page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0   0 0 0 x  x x x x",
-                           "x a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  "  x  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 2048;
-         page_size       = 32;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0   0  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0  0 a9 a8",
-                           " a7 a6 a5 a4   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATtiny24A
-#------------------------------------------------------------
-
-part parent "t24"
-    id               = "t24a";
-    desc             = "ATtiny24A";
-  ;
-
-#------------------------------------------------------------
-# ATtiny44
-#------------------------------------------------------------
-
-part
-     id            = "t44";
-     desc          = "ATtiny44";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x07, 0x17;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-                     0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
-                     0x99, 0xE1, 0xBB, 0xAC;
-## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x92 0x07;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
-    hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 0;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 256;
-        paged           = no;
-        page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x   x",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 64;
-         num_pages       = 64;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0  a10 a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1  1  0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATtiny44A
-#------------------------------------------------------------
-
-part parent "t44"
-    id               = "t44a";
-    desc             = "ATtiny44A";
-  ;
-
-#------------------------------------------------------------
-# ATtiny84
-#------------------------------------------------------------
-
-part
-     id            = "t84";
-     desc          = "ATtiny84";
-     has_debugwire = yes;
-     flash_instr   = 0xB4, 0x07, 0x17;
-     eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-	             0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
-	             0x99, 0xE1, 0xBB, 0xAC;
-## no STK500 devcode in XML file, use the ATtiny45 one
-     stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-     avr910_devcode   = 0x20;
-     signature        = 0x1e 0x93 0x0c;
-     reset            = io;
-     chip_erase_delay = 4500;
-
-     pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-     chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
-    hvsp_controlstack   =
-        0x4C, 0x0C, 0x1C, 0x2C, 0x3C, 0x64, 0x74, 0x66,
-        0x68, 0x78, 0x68, 0x68, 0x7A, 0x6A, 0x68, 0x78,
-        0x78, 0x7D, 0x6D, 0x0C, 0x80, 0x40, 0x20, 0x10,
-        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0F;
-    hventerstabdelay    = 100;
-    hvspcmdexedelay     = 0;
-    synchcycles         = 6;
-    latchcycles         = 1;
-    togglevtg           = 1;
-    poweroffdelay       = 25;
-    resetdelayms        = 0;
-    resetdelayus        = 70;
-    hvleavestabdelay    = 100;
-    resetdelay          = 25;
-    chiperasepolltimeout = 40;
-    chiperasetime       = 0;
-    programfusepolltimeout = 25;
-    programlockpolltimeout = 25;
-
-    ocdrev              = 1;
-
-     memory "eeprom"
-         size            = 512;
-        paged           = no;
-        page_size       = 4;
-         min_write_delay = 4000;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   o o o o  o o o o";
-
-         write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x a8",
-                           "a7 a6 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 4;
-	readsize	= 256;
-       ;
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 64;
-         num_pages       = 128;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x  a4   a3  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5  x   x  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 32;
-	readsize	= 256;
-       ;
-#   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
-     memory "signature"
-         size            = 3;
-         read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                           "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-       ;
-
-     memory "lock"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                           "x x x x  x x x x  x x x x  x x i i";
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                           "0 0 0 0  0 0 0 0  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "lfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "hfuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-       ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  x x x x  x x x i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-
-     memory "calibration"
-         size            = 1;
-         read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                           "0  0  0  0   0  0  0  a0   o o o o  o o o o";
-     ;
-  ;
-
-#------------------------------------------------------------
-# ATtiny84A
-#------------------------------------------------------------
-
-part parent "t84"
-    id               = "t84a";
-    desc             = "ATtiny84A";
-  ;
-
-#------------------------------------------------------------
-# ATtiny441
-#------------------------------------------------------------
-
-part parent "t44"
-     id            = "t441";
-     desc          = "ATtiny441";
-     signature     = 0x1e 0x92 0x15;
-
-     memory "flash"
-         paged           = yes;
-         size            = 4096;
-         page_size       = 16;
-         num_pages       = 256;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0    0 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0   0 a10 a9 a8",
-                           " a7 a6 a5 a4  a3  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 16;
-	readsize	= 256;
-     ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-;
-
-#------------------------------------------------------------
-# ATtiny841
-#------------------------------------------------------------
-
-part parent "t84"
-     id            = "t841";
-     desc          = "ATtiny841";
-     signature     = 0x1e 0x93 0x15;
-
-     memory "flash"
-         paged           = yes;
-         size            = 8192;
-         page_size       = 16;
-         num_pages       = 512;
-         min_write_delay = 4500;
-         max_write_delay = 4500;
-         readback_p1     = 0xff;
-         readback_p2     = 0xff;
-         read_lo         = "  0   0   1   0    0   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         read_hi         = "  0   0   1   0    1   0   0   0",
-                           "  0   0   0   0  a11 a10  a9  a8",
-                           " a7  a6  a5  a4   a3  a2  a1  a0",
-                           "  o   o   o   o    o   o   o   o";
-
-         loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                           "  0   0   0   x    x   x   x   x",
-                           "  x   x   x   x    x  a2  a1  a0",
-                           "  i   i   i   i    i   i   i   i";
-
-         writepage       = "  0  1  0  0   1   1   0  0",
-                           "  0  0  0  0  a11 a10 a9 a8",
-                           " a7 a6 a5 a4  a3  x  x  x",
-                           "  x  x  x  x   x  x  x  x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 16;
-	readsize	= 256;
-     ;
-
-     memory "efuse"
-         size            = 1;
-         write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                           "x x x x  x x x x  i i i i  i i i i";
-
-         read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                           "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-     ;
-;
-
-#------------------------------------------------------------
-# ATtiny43U
-#------------------------------------------------------------
-
-part
-    id            = "t43u";
-    desc          = "ATtiny43U";
-    has_debugwire = yes;
-    flash_instr   = 0xB4, 0x07, 0x17;
-    eeprom_instr  = 0xBB, 0xFF, 0xBB, 0xEE, 0xBB, 0xCC, 0xB2, 0x0D,
-                         0xBC, 0x07, 0xB4, 0x07, 0xBA, 0x0D, 0xBB, 0xBC,
-                         0x99, 0xE1, 0xBB, 0xAC;
-    stk500_devcode   = 0x14;
-##  avr910_devcode   = ?;
-##  Try the AT90S2313 devcode:
-    avr910_devcode   = 0x20;
-    signature        = 0x1e 0x92 0x0C;
-    reset            = io;
-    chip_erase_delay = 1000;
-
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                        "x x x x  x x x x    x x x x  x x x x";
-
-    timeout                     = 200;
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 4500;
+    signature           = 0x1e 0x92 0x06;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
     synchloops          = 32;
-    bytedelay           = 0;
     pollindex           = 3;
     pollvalue           = 0x53;
     predelay            = 1;
     postdelay           = 1;
     pollmethod          = 1;
-        pp_controlstack = 0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E, 0x4E, 0x5E,
-                                         0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E, 0x06, 0x16, 0x46, 0x56,
-                                         0x0A, 0x1A, 0x4A, 0x5A, 0x1E, 0x7C, 0x00, 0x01, 0x00, 0x00,
-                                         0x00, 0x00;
+    hvsp_controlstack   =
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
+        0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    flash_instr         =  0xb4, 0x02, 0x12;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x02, 0xb4, 0x02, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    hvspcmdexedelay     = 0;
-    latchcycles         = 5;
+    latchcycles         = 1;
     togglevtg           = 1;
-    poweroffdelay       = 20;
+    poweroffdelay       = 25;
     resetdelayms        = 1;
-    resetdelayus        = 0;
-    hvleavestabdelay    = 15;
-    resetdelay          = 15;
-    chiperasepulsewidth = 0;
-    chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
-    programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
-    programlockpolltimeout = 5;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+    synchcycles         = 6;
+    ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
     memory "eeprom"
-                size            = 64;
-                paged                   = yes;
-                page_size       = 4;
-                num_pages               = 16;
-                min_write_delay = 4000;
-                max_write_delay = 4500;
-                readback_p1     = 0xff;
-                readback_p2     = 0xff;
-                read            = "1  0  1  0   0  0  0  0    0 0 0 x  x x x x",
-                                  "0  0 a5 a4  a3 a2 a1 a0    o o o o  o o o o";
+        size            = 256;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+    ;
 
-                write           = "1  1  0  0   0  0  0  0    0 0 0 x  x x x x",
-                                   "0  0 a5 a4  a3 a2 a1 a0   i i i i  i i i i";
-
-                loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                                  "  0   0   0   0      0   0   0   0",
-                                  "  0   0   0   0      0   0  a1  a0",
-                                  "  i   i   i   i      i   i   i   i";
-
-                writepage       = "  1   1   0   0      0   0   1   0",
-                                  "  0   0   x   x      x   x   x   x",
-                                  "  0   0  a5  a4     a3  a2   0   0",
-                                  "  x   x   x   x      x   x   x   x";
-
-                mode            = 0x41;
-                delay           = 5;
-                blocksize       = 4;
-                readsize        = 256;
-        ;
     memory "flash"
         paged           = yes;
         size            = 4096;
@@ -12865,91 +8399,1264 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-
-        read_lo         = "  0   0   1   0    0   0   0   0",
-                          "  0   0   0   0    0  a10 a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        read_hi         = "  0   0   1   0    1   0   0   0",
-                          "  0   0   0   0    0  a10 a9  a8",
-                          " a7  a6  a5  a4   a3  a2  a1  a0",
-                          "  o   o   o   o    o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0    0   0   0   0",
-                          "  0   0   0   x    x   x   x   x",
-                          "  x   x   x  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0    1   0   0   0",
-                          "  0   0   0   x    x   x   x   x",
-                          "  x   x   x  a4   a3  a2  a1  a0",
-                          "  i   i   i   i    i   i   i   i";
-
-        writepage       = "  0  1  0  0   1  1  0  0",
-                          "  0  0  0  0   0 a10 a9 a8",
-                          " a7 a6 a5  x   x  x  x  x",
-                          "  x  x  x  x   x  x  x  x";
-
-                mode            = 0x41;
-                delay           = 10;
-                blocksize       = 64;
-                readsize        = 256;
-       ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-    ;
-    memory "lock"
-        size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 1 1 x  x x x x",
-                          "x x x x  x x x x  1 1 i i  i i i i";
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 4500;
-        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
     ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        ;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 4500;
-        max_write_delay = 4500;
-        ;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  x x x i";
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
 
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-        min_write_delay = 4500;
-        max_write_delay = 4500;
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+#   ATtiny45 has Signature Bytes: 0x1E 0x92 0x08. (Data sheet 2586C-AVR-06/05 (doc2586.pdf) indicates otherwise!)
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
 
     memory "calibration"
         size            = 1;
-        read            = "0  0  1  1   1  0  0  0    0 0 0 x  x x x x",
-                          "0  0  0  0   0  0  0  a0   o o o o  o o o o";
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny85
+#------------------------------------------------------------
+
+part
+    desc                = "ATtiny85";
+    id                  = "t85";
+## no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 4500;
+    signature           = 0x1e 0x93 0x0b;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    hvsp_controlstack   =
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
+        0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x00;
+    flash_instr         =  0xb4, 0x02, 0x12;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x02, 0xb4, 0x02, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
+    hventerstabdelay    = 100;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+    synchcycles         = 6;
+    ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 512;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+#   ATtiny85 has Signature Bytes: 0x1E 0x93 0x08.
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega640
+#------------------------------------------------------------
+# Almost same as ATmega1280, except for different memory sizes
+
+part
+    desc                = "ATmega640";
+    id                  = "m640";
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x96 0x08;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x31;
+    rampz               = 0x3b;
+    spmcr               = 0x57;
+    ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 4096;
+        page_size       = 8;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x10000;
+        page_size       = 256;
+        num_pages       = 256;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega1280
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega1280";
+    id                  = "m1280";
+#    stk500_devcode   = 0xB2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x97 0x03;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x31;
+    rampz               = 0x3b;
+    spmcr               = 0x57;
+    ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 4096;
+        page_size       = 8;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x20000;
+        page_size       = 256;
+        num_pages       = 512;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega1281
+#------------------------------------------------------------
+# Identical to ATmega1280
+
+part parent "m1280"
+    desc                = "ATmega1281";
+    id                  = "m1281";
+    signature           = 0x1e 0x97 0x04;
+;
+
+#------------------------------------------------------------
+# ATmega2560
+#------------------------------------------------------------
+
+part
+    desc                = "ATmega2560";
+    id                  = "m2560";
+    stk500_devcode      = 0xb2;
+#    avr910_devcode   = 0x43;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x98 0x01;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 15;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    idr                 = 0x31;
+    rampz               = 0x3b;
+    spmcr               = 0x57;
+    ocdrev              = 4;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 4096;
+        page_size       = 8;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 0x40000;
+        page_size       = 256;
+        num_pages       = 1024;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        load_ext_addr   = "0100.1101--0000.0000--0000.000a--0000.0000";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xiii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega2561
+#------------------------------------------------------------
+
+part parent "m2560"
+    desc                = "ATmega2561";
+    id                  = "m2561";
+    signature           = 0x1e 0x98 0x02;
+;
+
+#------------------------------------------------------------
+# ATmega128RFA1
+#------------------------------------------------------------
+# Identical to ATmega2561 but half the ROM
+
+part parent "m2561"
+    desc                = "ATmega128RFA1";
+    id                  = "m128rfa1";
+    chip_erase_delay    = 55000;
+    bs2                 = 0xe2;
+    signature           = 0x1e 0xa7 0x01;
+    ocdrev              = 3;
+
+    memory "flash"
+        size            = 0x20000;
+        num_pages       = 512;
+        min_write_delay = 50000;
+        max_write_delay = 50000;
+        delay           = 20;
+        load_ext_addr   = NULL;
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega256RFR2
+#------------------------------------------------------------
+
+part parent "m2561"
+    desc                = "ATmega256RFR2";
+    id                  = "m256rfr2";
+    chip_erase_delay    = 18500;
+    bs2                 = 0xe2;
+    signature           = 0x1e 0xa8 0x02;
+
+    memory "eeprom"
+        size            = 8192;
+        min_write_delay = 13000;
+        max_write_delay = 13000;
+        read            = "1010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxa.aaaa--aaaa.aaaa--iiii.iiii";
+        writepage       = "1100.0010--00xa.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega128RFR2
+#------------------------------------------------------------
+
+part parent "m128rfa1"
+    desc                = "ATmega128RFR2";
+    id                  = "m128rfr2";
+    signature           = 0x1e 0xa7 0x02;
+;
+
+#------------------------------------------------------------
+# ATmega64RFR2
+#------------------------------------------------------------
+
+part parent "m128rfa1"
+    desc                = "ATmega64RFR2";
+    id                  = "m64rfr2";
+    signature           = 0x1e 0xa6 0x02;
+
+    memory "eeprom"
+        size            = 2048;
+        min_write_delay = 13000;
+        max_write_delay = 13000;
+        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        num_pages       = 256;
+        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        writepage       = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
+;
+
+#------------------------------------------------------------
+# ATmega2564RFR2
+#------------------------------------------------------------
+
+part parent "m256rfr2"
+    desc                = "ATmega2564RFR2";
+    id                  = "m2564rfr2";
+    signature           = 0x1e 0xa8 0x03;
+;
+
+#------------------------------------------------------------
+# ATmega1284RFR2
+#------------------------------------------------------------
+
+part parent "m128rfr2"
+    desc                = "ATmega1284RFR2";
+    id                  = "m1284rfr2";
+    signature           = 0x1e 0xa7 0x03;
+;
+
+#------------------------------------------------------------
+# ATmega644RFR2
+#------------------------------------------------------------
+
+part parent "m64rfr2"
+    desc                = "ATmega644RFR2";
+    id                  = "m644rfr2";
+    signature           = 0x1e 0xa6 0x03;
+;
+
+#------------------------------------------------------------
+# ATtiny24
+#------------------------------------------------------------
+
+part
+    desc                = "ATtiny24";
+    id                  = "t24";
+## no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 4500;
+    signature           = 0x1e 0x91 0x0b;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    hvsp_controlstack   =
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
+        0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0f;
+    flash_instr         =  0xb4, 0x07, 0x17;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
+    hventerstabdelay    = 100;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+    synchcycles         = 6;
+    ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 128;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--xaaa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 2048;
+        page_size       = 32;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.00aa--aaaa.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+    ;
+#   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny24A
+#------------------------------------------------------------
+
+part parent "t24"
+    desc                = "ATtiny24A";
+    id                  = "t24a";
+;
+
+#------------------------------------------------------------
+# ATtiny44
+#------------------------------------------------------------
+
+part
+    desc                = "ATtiny44";
+    id                  = "t44";
+## no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 4500;
+    signature           = 0x1e 0x92 0x07;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    hvsp_controlstack   =
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
+        0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0f;
+    flash_instr         =  0xb4, 0x07, 0x17;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
+    hventerstabdelay    = 100;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+    synchcycles         = 6;
+    ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 256;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--aaaa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+    ;
+#   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny44A
+#------------------------------------------------------------
+
+part parent "t44"
+    desc                = "ATtiny44A";
+    id                  = "t44a";
+;
+
+#------------------------------------------------------------
+# ATtiny84
+#------------------------------------------------------------
+
+part
+    desc                = "ATtiny84";
+    id                  = "t84";
+## no STK500 devcode in XML file, use the ATtiny45 one
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 4500;
+    signature           = 0x1e 0x93 0x0c;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    hvsp_controlstack   =
+        0x4c, 0x0c, 0x1c, 0x2c, 0x3c, 0x64, 0x74, 0x66,
+        0x68, 0x78, 0x68, 0x68, 0x7a, 0x6a, 0x68, 0x78,
+        0x78, 0x7d, 0x6d, 0x0c, 0x80, 0x40, 0x20, 0x10,
+        0x11, 0x08, 0x04, 0x02, 0x03, 0x08, 0x04, 0x0f;
+    flash_instr         =  0xb4, 0x07, 0x17;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
+    hventerstabdelay    = 100;
+    latchcycles         = 1;
+    togglevtg           = 1;
+    poweroffdelay       = 25;
+    resetdelayus        = 70;
+    hvleavestabdelay    = 100;
+    resetdelay          = 25;
+    chiperasepolltimeout = 40;
+    programfusepolltimeout = 25;
+    programlockpolltimeout = 25;
+    synchcycles         = 6;
+    ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        size            = 512;
+        page_size       = 4;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 8192;
+        page_size       = 64;
+        num_pages       = 128;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 32;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaax.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
+    ;
+#   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny84A
+#------------------------------------------------------------
+
+part parent "t84"
+    desc                = "ATtiny84A";
+    id                  = "t84a";
+;
+
+#------------------------------------------------------------
+# ATtiny441
+#------------------------------------------------------------
+
+part parent "t44"
+    desc                = "ATtiny441";
+    id                  = "t441";
+    signature           = 0x1e 0x92 0x15;
+
+    memory "flash"
+        page_size       = 16;
+        num_pages       = 256;
+        blocksize       = 16;
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.0aaa--aaaa.axxx--xxxx.xxxx";
+    ;
+
+    memory "efuse"
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny841
+#------------------------------------------------------------
+
+part parent "t84"
+    desc                = "ATtiny841";
+    id                  = "t841";
+    signature           = 0x1e 0x93 0x15;
+
+    memory "flash"
+        page_size       = 16;
+        num_pages       = 512;
+        blocksize       = 16;
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.xaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.aaaa--aaaa.axxx--xxxx.xxxx";
+    ;
+
+    memory "efuse"
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny43U
+#------------------------------------------------------------
+
+part
+    desc                = "ATtiny43U";
+    id                  = "t43u";
+    stk500_devcode      = 0x14;
+##  avr910_devcode   = ?;
+##  Try the AT90S2313 devcode:
+    avr910_devcode      = 0x20;
+    chip_erase_delay    = 1000;
+    signature           = 0x1e 0x92 0x0c;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
+        0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
+        0x06, 0x16, 0x46, 0x56, 0x0a, 0x1a, 0x4a, 0x5a,
+        0x1e, 0x7c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb4, 0x07, 0x17;
+    eeprom_instr        =
+        0xbb, 0xff, 0xbb, 0xee, 0xbb, 0xcc, 0xb2, 0x0d,
+        0xbc, 0x07, 0xb4, 0x07, 0xba, 0x0d, 0xbb, 0xbc,
+        0x99, 0xe1, 0xbb, 0xac;
+    hventerstabdelay    = 100;
+    latchcycles         = 5;
+    togglevtg           = 1;
+    poweroffdelay       = 20;
+    resetdelayms        = 1;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepolltimeout = 10;
+    programfusepolltimeout = 5;
+    programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "eeprom"
+        paged           = yes;
+        size            = 64;
+        page_size       = 4;
+        num_pages       = 16;
+        min_write_delay = 4000;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxx--00aa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxx--00aa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxx--00aa.aa00--xxxx.xxxx";
+    ;
+
+    memory "flash"
+        paged           = yes;
+        size            = 4096;
+        page_size       = 64;
+        num_pages       = 64;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 64;
+        readsize        = 256;
+        read_lo         = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0000.0aaa--aaax.xxxx--xxxx.xxxx";
+    ;
+
+    memory "lfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "hfuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "efuse"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxxi";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 ;
 
@@ -12958,573 +9665,363 @@ part
 #------------------------------------------------------------
 
 part
-    id               = "m16u4";
-    desc             = "ATmega16U4";
-    signature        = 0x1e 0x94 0x88;
-    usbpid           = 0x2ff4;
-    has_jtag         = yes;
+    desc                = "ATmega16U4";
+    id                  = "m16u4";
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x94 0x88;
+    usbpid              = 0x2ff4;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
-    spmcr               = 0x57;
     rampz               = 0x3b;
-    allowfullpagebitstream = no;
-
+    spmcr               = 0x57;
     ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 512;
+        page_size       = 4;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x   x   x  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 128;
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   0 0 o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--00oo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega32u4
 #------------------------------------------------------------
 
 part
-    id               = "m32u4";
-    desc             = "ATmega32U4";
-    signature        = 0x1e 0x95 0x87;
-    usbpid           = 0x2ff4;
-    has_jtag         = yes;
+    desc                = "ATmega32U4";
+    id                  = "m32u4";
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x95 0x87;
+    usbpid              = 0x2ff4;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
-    spmcr               = 0x57;
     rampz               = 0x3b;
-    allowfullpagebitstream = no;
-
+    spmcr               = 0x57;
     ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 1024;
+        page_size       = 4;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xaaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 32768;
+        size            = 0x8000;
         page_size       = 128;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  1 1 1 1  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB646
 #------------------------------------------------------------
 
 part
-    id               = "usb646";
-    desc             = "AT90USB646";
-    signature        = 0x1e 0x96 0x82;
-    usbpid           = 0x2ff9;
-    has_jtag         = yes;
+    desc                = "AT90USB646";
+    id                  = "usb646";
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x96 0x82;
+    usbpid              = 0x2ff9;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
-    spmcr               = 0x57;
     rampz               = 0x3b;
-    allowfullpagebitstream = no;
-
+    spmcr               = 0x57;
     ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 2048;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x      x a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 65536;
+        size            = 0x10000;
         page_size       = 256;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB647
@@ -13532,203 +10029,130 @@ part
 # identical to AT90USB646
 
 part parent "usb646"
-    id               = "usb647";
-    desc             = "AT90USB647";
-    signature        = 0x1e 0x96 0x82;
-
-    ocdrev              = 3;
-  ;
+    desc                = "AT90USB647";
+    id                  = "usb647";
+;
 
 #------------------------------------------------------------
 # AT90USB1286
 #------------------------------------------------------------
 
 part
-    id               = "usb1286";
-    desc             = "AT90USB1286";
-    signature        = 0x1e 0x97 0x82;
-    usbpid           = 0x2ffb;
-    has_jtag         = yes;
+    desc                = "AT90USB1286";
+    id                  = "usb1286";
 #    stk500_devcode   = 0xB2;
 #    avr910_devcode   = 0x43;
-    chip_erase_delay = 9000;
-    pagel            = 0xD7;
-    bs2              = 0xA0;
-    reset            = dedicated;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "x x x x  x x x x    x x x x  x x x x";
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
-
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x97 0x82;
+    usbpid              = 0x2ffb;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
-    spmcr               = 0x57;
     rampz               = 0x3b;
-    allowfullpagebitstream = no;
-
+    spmcr               = 0x57;
     ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 4096;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  x   x   x   x    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0", 
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0  a2  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-			  "  0   0   x   x    a11 a10  a9  a8",
-			  " a7  a6  a5  a4     a3   0   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 10;
-	blocksize	= 8;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 10;
+        blocksize       = 8;
+        readsize        = 256;
+        read            = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--xxxx.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--00xx.aaaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 131072;
+        size            = 0x20000;
         page_size       = 256;
         num_pages       = 512;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7   x   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 256;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 256;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1  1 0 0 0    x x x x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   x  x  x  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB1287
@@ -13736,195 +10160,127 @@ part
 # identical to AT90USB1286
 
 part parent "usb1286"
-    id               = "usb1287";
-    desc             = "AT90USB1287";
-    signature        = 0x1e 0x97 0x82;
-
-    ocdrev              = 3;
-  ;
+    desc                = "AT90USB1287";
+    id                  = "usb1287";
+;
 
 #------------------------------------------------------------
 # AT90USB162
 #------------------------------------------------------------
 
 part
-    id               = "usb162";
-    desc             = "AT90USB162";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x94 0x82;
-    usbpid           = 0x2ffa;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    desc                = "AT90USB162";
+    id                  = "usb162";
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc6;
+    signature           = 0x1e 0x94 0x82;
+    usbpid              = 0x2ffa;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 512;
+        page_size       = 4;
         num_pages       = 128;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 128;
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # AT90USB82
@@ -13935,87 +10291,57 @@ part
 #        num_pages       = 64;
 
 part
-    id               = "usb82";
-    desc             = "AT90USB82";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x93 0x82;
-    usbpid           = 0x2ff7;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    desc                = "AT90USB82";
+    id                  = "usb82";
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc6;
+    signature           = 0x1e 0x93 0x82;
+    usbpid              = 0x2ff7;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 512;
+        page_size       = 4;
         num_pages       = 128;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
@@ -14024,94 +10350,59 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega32U2
@@ -14124,183 +10415,119 @@ part
 #        size            = 1024;
 #        num_pages       = 256;
 part
-    id               = "m32u2";
-    desc             = "ATmega32U2";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x95 0x8a;
-    usbpid           = 0x2ff0;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    desc                = "ATmega32U2";
+    id                  = "m32u2";
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc6;
+    signature           = 0x1e 0x95 0x8a;
+    usbpid              = 0x2ff0;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 1024;
+        page_size       = 4;
         num_pages       = 256;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 32768;
+        size            = 0x8000;
         page_size       = 128;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
+
 #------------------------------------------------------------
 # ATmega16U2
 #------------------------------------------------------------
@@ -14312,183 +10539,118 @@ part
 #        size            = 512;
 #        num_pages       = 128;
 part
-    id               = "m16u2";
-    desc             = "ATmega16U2";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x94 0x89;
-    usbpid           = 0x2fef;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    desc                = "ATmega16U2";
+    id                  = "m16u2";
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc6;
+    signature           = 0x1e 0x94 0x89;
+    usbpid              = 0x2fef;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 512;
+        page_size       = 4;
         num_pages       = 128;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 128;
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega8U2
@@ -14500,87 +10662,57 @@ part
 #        blocksize       = 64;
 
 part
-    id               = "m8u2";
-    desc             = "ATmega8U2";
-    has_jtag         = no;
-    has_debugwire    = yes;
-    signature        = 0x1e 0x93 0x89;
-    usbpid           = 0x2fee;
-    chip_erase_delay = 9000;
-    reset            = io;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x    x x x x  x x x x";
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 x  x x x x",
-                       "x x x x  x x x x    x x x x  x x x x";
-    pagel            = 0xD7;
-    bs2              = 0xC6;
-
-    timeout		= 200;
-    stabdelay		= 100;
-    cmdexedelay		= 25;
-    synchloops		= 32;
-    bytedelay		= 0;
-    pollindex		= 3;
-    pollvalue		= 0x53;
-    predelay		= 1;
-    postdelay		= 1;
-    pollmethod		= 1;
+    desc                = "ATmega8U2";
+    id                  = "m8u2";
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xc6;
+    signature           = 0x1e 0x93 0x89;
+    usbpid              = 0x2fee;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     ocdrev              = 1;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 512;
+        page_size       = 4;
         num_pages       = 128;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-	loadpage_lo	= "  1   1   0   0      0   0   0   1",
-			  "  0   0   0   0      0   0   0   0",
-			  "  0   0   0   0      0   0  a1  a0",
-			  "  i   i   i   i      i   i   i   i";
-
-	writepage	= "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-			  "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 20;
-	blocksize	= 4;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 20;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.aaaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--0000.aaaa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
@@ -14589,868 +10721,622 @@ part
         num_pages       = 64;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  x   x   x   x      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "a15 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-	mode		= 0x41;
-	delay		= 6;
-	blocksize	= 128;
-	readsize	= 256;
-      ;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--xxxx.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  1 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  i i i i  i i i i";
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "lock"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
+
+    memory "signature"
+        size            = 3;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0    0 0 0 x  x x x x",
-                          "0 0 0 0  0 0 0 0    o o o o  o o o o";
-      ;
-    memory "signature"
-        size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  x   x  x  x  x",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
-  ;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega165
 #------------------------------------------------------------
 
 part
-    id               = "m165";
-    desc             = "ATmega165";
-    signature        = 0x1e 0x94 0x10;
-    has_jtag         = yes;
+    desc                = "ATmega165";
+    id                  = "m165";
 #   stk500_devcode   = 0x??;
 #   avr910_devcode   = 0x??;
-    chip_erase_delay = 9000;
-    reset            =  io;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    pgm_enable       = "1 0 1 0  1 1 0 0   0 1 0 1  0 0 1 1",
-                       "x x x x  x x x x   x x x x  x x x x";
-
-    chip_erase       = "1 0 1 0  1 1 0 0   1 0 0 x  x x x x",
-                       "x x x x  x x x x   x x x x  x x x x";
-
-    timeout                = 200;
-    stabdelay              = 100;
-    cmdexedelay            = 25;
-    synchloops             = 32;
-    bytedelay              = 0;
-    pollindex              = 3;
-    pollvalue              = 0x53;
-    predelay               = 1;
-    postdelay              = 1;
-    pollmethod             = 1;
-
-    pp_controlstack        =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-	      0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-	      0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-	      0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay       = 100;
-    progmodedelay          = 0;
-    latchcycles            = 6;
-    togglevtg              = 0;
-    poweroffdelay          = 0;
-    resetdelayms           = 0;
-    resetdelayus           = 0;
-    hvleavestabdelay       = 15;
-    chiperasepulsewidth    = 0;
-    resetdelay             = 15;
-    chiperasepolltimeout   = 10;
-    programfusepulsewidth  = 0;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x94 0x10;
+    reset               = io;
+    has_jtag            = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    hventerstabdelay    = 100;
+    latchcycles         = 6;
+    hvleavestabdelay    = 15;
+    resetdelay          = 15;
+    chiperasepolltimeout = 10;
     programfusepolltimeout = 5;
-    programlockpulsewidth  = 0;
     programlockpolltimeout = 5;
-
-    idr                    = 0x31;
-    spmcr                  = 0x57;
-    eecr                   = 0x3f;
-    allowfullpagebitstream = no;
-
-    ocdrev                 = 3;
+    idr                 = 0x31;
+    spmcr               = 0x57;
+    eecr                = 0x3f;
+    ocdrev              = 3;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 512;
+        page_size       = 4;
         num_pages       = 128;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0      0   0   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   x  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0      0   0   x  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
-
-        mode            = 0x41;
+        mode            = 65;
         delay           = 20;
         blocksize       = 4;
         readsize        = 256;
-      ;
+        read            = "1010.0000--0000.00xa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.00xa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--0000.00xa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 128;
         num_pages       = 128;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0x00;
-        readback_p2     = 0x00;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      x   x   x   x",
-                          "  x   x  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  x   x   x a12    a11 a10  a9  a8",
-                          " a7  a6   x   x      x   x   x   x",
-                          "  x   x   x   x      x   x   x   x";
-
-        mode            = 0x41;
+        mode            = 65;
         delay           = 10;
         blocksize       = 128;
         readsize        = 256;
-      ;
+        read_lo         = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--0000.xxxx--xxaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--0000.xxxx--xxaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--xxxa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "x x x x  x x x x   i i i i  i i i i";
-      ;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "x x x x  x x x x  o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "x x x x  x x x x  x x x x  i i i i";
-     ;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
 
     memory "lock"
-        size   = 1;
-        min_write_delay   = 4500;
-        max_write_delay   = 4500;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 x  x x x x",
-                          "x x x x  x x x x   1 1 i i  i i i i";
-      ;
+        size            = 1;
+        min_write_delay = 4500;
+        max_write_delay = 4500;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
-                          "x  x  x  x   x  x a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0011.0000--0000.0000--xxxx.xxaa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-      ;
-  ;
+        read            = "0011.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega165A
 #------------------------------------------------------------
 
 part parent "m165"
-    id               = "m165a";
-    desc             = "ATmega165A";
-    signature        = 0x1e 0x94 0x10;
-  ;
+    desc                = "ATmega165A";
+    id                  = "m165a";
+;
 
 #------------------------------------------------------------
 # ATmega165P
 #------------------------------------------------------------
 
 part parent "m165"
-    id               = "m165p";
-    desc             = "ATmega165P";
-    signature        = 0x1e 0x94 0x07;
-  ;
+    desc                = "ATmega165P";
+    id                  = "m165p";
+    signature           = 0x1e 0x94 0x07;
+;
 
 #------------------------------------------------------------
 # ATmega165PA
 #------------------------------------------------------------
 
 part parent "m165"
-    id               = "m165pa";
-    desc             = "ATmega165PA";
-    signature        = 0x1e 0x94 0x07;
-  ;
+    desc                = "ATmega165PA";
+    id                  = "m165pa";
+    signature           = 0x1e 0x94 0x07;
+;
 
 #------------------------------------------------------------
 # ATmega325
 #------------------------------------------------------------
 
 part
-    id               = "m325";
-    desc             = "ATmega325";
-    signature        = 0x1e 0x95 0x05;
-    has_jtag         = yes;
+    desc                = "ATmega325";
+    id                  = "m325";
 #   stk500_devcode   = 0x??; # No STK500v1 support?
 #   avr910_devcode   = 0x??; # Try the ATmega16 one
-    avr910_devcode   = 0x74;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
-
+    avr910_devcode      = 0x74;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x95 0x05;
+    has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
     synchloops          = 32;
-    bytedelay           = 0;
     pollindex           = 3;
     pollvalue           = 0x53;
     predelay            = 1;
     postdelay           = 1;
     pollmethod          = 1;
-
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
     spmcr               = 0x57;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--0000.0000--0000.0000";
+    pgm_enable          = "1010.1100--0101.0011--0000.0000--0000.0000";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 4;  /* for parallel programming */
         size            = 1024;
+        page_size       = 4;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0      0   0  a9  a8",
-                          " a7  a6  a5  a4     a3  a2   0   0",
-                          "  x   x   x   x      x   x   x   x";
-
-        mode            = 0x41;
+        readback        = 0xff 0xff;
+        mode            = 65;
         delay           = 10;
         blocksize       = 4;
         readsize        = 256;
-      ;
+        read            = "1010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.00aa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--0000.00aa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 32768;
+        size            = 0x8000;
         page_size       = 128;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "  0   0   1   0      0   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        read_hi         = "  0   0   1   0      1   0   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  0   1   0   0      1   1   0   0",
-                          "  0 a14 a13 a12    a11 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  x   x   x   x      x   x   x   x";
-
-        mode            = 0x41;
+        readback        = 0xff 0xff;
+        mode            = 65;
         delay           = 10;
         blocksize       = 128;
         readsize        = 256;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
+        read_lo         = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--0000.0000--aaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--0000.0000--aaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--0aaa.aaaa--aaaa.aaaa--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--1010.0000--0000.0000--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--0000.0000--oooo.oooo";
+        write           = "1010.1100--1010.1000--0000.0000--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--0000.0000--oooo.oooo";
+        write           = "1010.1100--1010.0100--0000.0000--1111.1iii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1110.0000--0000.0000--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
-                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0011.0000--0000.0000--0000.00aa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-
-        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+        read            = "0011.1000--0000.0000--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega325A
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m325a";
-    desc             = "ATmega325A";
-  ;
+    desc                = "ATmega325A";
+    id                  = "m325a";
+;
 
 #------------------------------------------------------------
 # ATmega325P
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m325p";
-    desc             = "ATmega325P";
-    signature        = 0x1e 0x95 0x0d;
-  ;
+    desc                = "ATmega325P";
+    id                  = "m325p";
+    signature           = 0x1e 0x95 0x0d;
+;
 
 #------------------------------------------------------------
 # ATmega325PA
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m325pa";
-    desc             = "ATmega325PA";
-    signature        = 0x1e 0x95 0x0d;
-  ;
+    desc                = "ATmega325PA";
+    id                  = "m325pa";
+    signature           = 0x1e 0x95 0x0d;
+;
 
 #------------------------------------------------------------
 # ATmega645
 #------------------------------------------------------------
 
 part
-    id               = "m645";
-    desc             = "ATmega645";
-    signature        = 0x1E 0x96 0x05;
-    has_jtag         = yes;
+    desc                = "ATmega645";
+    id                  = "m645";
 #   stk500_devcode   = 0x??; # No STK500v1 support?
 #   avr910_devcode   = 0x??; # Try the ATmega16 one
-    avr910_devcode   = 0x74;
-    pagel            = 0xd7;
-    bs2              = 0xa0;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
-
-    chip_erase       = "1 0 1 0  1 1 0 0    1 0 0 0  0 0 0 0",
-                       "0 0 0 0  0 0 0 0    0 0 0 0  0 0 0 0";
-
+    avr910_devcode      = 0x74;
+    chip_erase_delay    = 9000;
+    pagel               = 0xd7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x96 0x05;
+    has_jtag            = yes;
     timeout             = 200;
     stabdelay           = 100;
     cmdexedelay         = 25;
     synchloops          = 32;
-    bytedelay           = 0;
     pollindex           = 3;
     pollvalue           = 0x53;
     predelay            = 1;
     postdelay           = 1;
     pollmethod          = 1;
-
     pp_controlstack     =
-        0x0E, 0x1E, 0x0F, 0x1F, 0x2E, 0x3E, 0x2F, 0x3F,
-        0x4E, 0x5E, 0x4F, 0x5F, 0x6E, 0x7E, 0x6F, 0x7F,
-        0x66, 0x76, 0x67, 0x77, 0x6A, 0x7A, 0x6B, 0x7B,
-        0xBE, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
     latchcycles         = 5;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
-
     idr                 = 0x31;
     spmcr               = 0x57;
-    allowfullpagebitstream = no;
-
     ocdrev              = 3;
+    chip_erase          = "1010.1100--1000.0000--0000.0000--0000.0000";
+    pgm_enable          = "1010.1100--0101.0011--0000.0000--0000.0000";
 
     memory "eeprom"
-        paged           = no; /* leave this "no" */
-        page_size       = 8;  /* for parallel programming */
         size            = 2048;
+        page_size       = 8;
         min_write_delay = 9000;
         max_write_delay = 9000;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = "  1   0   1   0      0   0   0   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  o   o   o   o      o   o   o   o";
-
-        write           = "  1   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_lo     = "  1   1   0   0      0   0   0   1",
-                          "  0   0   0   0      0   0   0   0",
-                          "  0   0   0   0      0  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "  1   1   0   0      0   0   1   0",
-                          "  0   0   0   0      0 a10  a9  a8",
-                          " a7  a6  a5  a4     a3   0   0   0",
-                          "  x   x   x   x      x   x   x   x";
-
-        mode            = 0x41;
+        readback        = 0xff 0xff;
+        mode            = 65;
         delay           = 10;
         blocksize       = 8;
         readsize        = 256;
-      ;
+        read            = "1010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--0000.0aaa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
+        writepage       = "1100.0010--0000.0aaa--aaaa.a000--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 65536;
+        size            = 0x10000;
         page_size       = 256;
         num_pages       = 256;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = "   0   0   1   0      0   0   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          "  a7  a6  a5  a4     a3  a2  a1  a0",
-                          "   o   o   o   o      o   o   o   o";
-
-        read_hi         = "   0   0   1   0      1   0   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          "  a7  a6  a5  a4     a3  a2  a1  a0",
-                          "   o   o   o   o      o   o   o   o";
-
-        loadpage_lo     = "  0   1   0   0      0   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          "  a7 a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        loadpage_hi     = "  0   1   0   0      1   0   0   0",
-                          "  0   0   0   0      0   0   0   0",
-                          "  a7 a6  a5  a4     a3  a2  a1  a0",
-                          "  i   i   i   i      i   i   i   i";
-
-        writepage       = "   0   1   0   0      1   1   0   0",
-                          " a15 a14 a13 a12    a11 a10  a9  a8",
-                          "  a7  a6  a5  a4     a3  a2  a1  a0",
-                          "   0   0   0   0      0   0   0   0";
-
-        mode            = 0x41;
+        readback        = 0xff 0xff;
+        mode            = 65;
         delay           = 10;
         blocksize       = 128;
         readsize        = 256;
-      ;
-
-    memory "lock"
-        size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "x x x x  x x x x   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 1 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   1 1 i i  i i i i";
-        min_write_delay = 9000;
-        max_write_delay = 9000;
-      ;
+        read_lo         = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--0000.0000--aaaa.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--0000.0000--aaaa.aaaa--iiii.iiii";
+        writepage       = "0100.1100--aaaa.aaaa--aaaa.aaaa--0000.0000";
+    ;
 
     memory "lfuse"
         size            = 1;
-        read            = "0 1 0 1  0 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.0000--0000.0000--oooo.oooo";
+        write           = "1010.1100--1010.0000--0000.0000--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
-        read            = "0 1 0 1  1 0 0 0   0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0   1 0 1 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0   i i i i  i i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.1000--0000.1000--0000.0000--oooo.oooo";
+        write           = "1010.1100--1010.1000--0000.0000--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
-
-        read            = "0 1 0 1  0 0 0 0  0 0 0 0  1 0 0 0",
-                          "0 0 0 0  0 0 0 0  o o o o  o o o o";
-
-        write           = "1 0 1 0  1 1 0 0  1 0 1 0  0 1 0 0",
-                          "0 0 0 0  0 0 0 0  1 1 1 1  1 i i i";
         min_write_delay = 9000;
         max_write_delay = 9000;
-      ;
+        read            = "0101.0000--0000.1000--0000.0000--oooo.oooo";
+        write           = "1010.1100--1010.0100--0000.0000--1111.1iii";
+    ;
+
+    memory "lock"
+        size            = 1;
+        min_write_delay = 9000;
+        max_write_delay = 9000;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1110.0000--0000.0000--11ii.iiii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0  0  1  1   0  0  0  0   0  0  0  0   0  0  0  0",
-                          "0  0  0  0   0  0 a1 a0   o  o  o  o   o  o  o  o";
-      ;
+        read            = "0011.0000--0000.0000--0000.00aa--oooo.oooo";
+    ;
 
     memory "calibration"
         size            = 1;
-
-        read            = "0 0 1 1  1 0 0 0   0 0 0 0  0 0 0 0",
-                          "0 0 0 0  0 0 0 0   o o o o  o o o o";
-        ;
-  ;
+        read            = "0011.1000--0000.0000--0000.0000--oooo.oooo";
+    ;
+;
 
 #------------------------------------------------------------
 # ATmega645A
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m645a";
-    desc             = "ATmega645A";
-  ;
+    desc                = "ATmega645A";
+    id                  = "m645a";
+;
 
 #------------------------------------------------------------
 # ATmega645P
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m645p";
-    desc             = "ATmega645P";
-    signature        = 0x1e 0x96 0x0d;
-  ;
+    desc                = "ATmega645P";
+    id                  = "m645p";
+    signature           = 0x1e 0x96 0x0d;
+;
 
 #------------------------------------------------------------
 # ATmega3250
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250";
-    desc             = "ATmega3250";
-    signature        = 0x1E 0x95 0x06;
-  ;
+    desc                = "ATmega3250";
+    id                  = "m3250";
+    signature           = 0x1e 0x95 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega3250A
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250a";
-    desc             = "ATmega3250A";
-    signature        = 0x1E 0x95 0x06;
-  ;
+    desc                = "ATmega3250A";
+    id                  = "m3250a";
+    signature           = 0x1e 0x95 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega3250P
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250p";
-    desc             = "ATmega3250P";
-    signature        = 0x1E 0x95 0x0e;
-  ;
+    desc                = "ATmega3250P";
+    id                  = "m3250p";
+    signature           = 0x1e 0x95 0x0e;
+;
 
 #------------------------------------------------------------
 # ATmega3250PA
 #------------------------------------------------------------
 
 part parent "m325"
-    id               = "m3250pa";
-    desc             = "ATmega3250PA";
-    signature        = 0x1E 0x95 0x0e;
-  ;
+    desc                = "ATmega3250PA";
+    id                  = "m3250pa";
+    signature           = 0x1e 0x95 0x0e;
+;
 
 #------------------------------------------------------------
 # ATmega6450
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m6450";
-    desc             = "ATmega6450";
-    signature        = 0x1E 0x96 0x06;
-  ;
+    desc                = "ATmega6450";
+    id                  = "m6450";
+    signature           = 0x1e 0x96 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega6450A
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m6450a";
-    desc             = "ATmega6450A";
-    signature        = 0x1E 0x96 0x06;
-  ;
+    desc                = "ATmega6450A";
+    id                  = "m6450a";
+    signature           = 0x1e 0x96 0x06;
+;
 
 #------------------------------------------------------------
 # ATmega6450P
 #------------------------------------------------------------
 
 part parent "m645"
-    id               = "m6450p";
-    desc             = "ATmega6450P";
-    signature        = 0x1E 0x96 0x0e;
-  ;
+    desc                = "ATmega6450P";
+    id                  = "m6450p";
+    signature           = 0x1e 0x96 0x0e;
+;
 
 #------------------------------------------------------------
 # AVR XMEGA family common values
 #------------------------------------------------------------
 
 part
-    id		= ".xmega";
-    desc	= "AVR XMEGA family common values";
-    has_pdi	= yes;
-    nvm_base	= 0x01c0;
-    mcu_base	= 0x0090;
-
-    memory "signature"
-        size		= 3;
-        offset		= 0x1000090;
-    ;
-
-    memory "prodsig"
-        size		= 0x32;
-        offset		= 0x8e0200;
-        page_size	= 0x32;
-        readsize	= 0x32;
-    ;
+    desc                = "AVR XMEGA family common values";
+    id                  = ".xmega";
+    has_pdi             = yes;
+    mcu_base            = 0x0090;
+    nvm_base            = 0x01c0;
 
     memory "fuse1"
-        size		= 1;
-        offset		= 0x8f0021;
+        size            = 1;
+        offset          = 0x8f0021;
     ;
 
     memory "fuse2"
-        size		= 1;
-        offset		= 0x8f0022;
+        size            = 1;
+        offset          = 0x8f0022;
     ;
 
     memory "fuse4"
-        size		= 1;
-        offset		= 0x8f0024;
+        size            = 1;
+        offset          = 0x8f0024;
     ;
 
     memory "fuse5"
-        size		= 1;
-        offset		= 0x8f0025;
+        size            = 1;
+        offset          = 0x8f0025;
     ;
 
     memory "lock"
-        size		= 1;
-        offset		= 0x8f0027;
+        size            = 1;
+        offset          = 0x8f0027;
+    ;
+
+    memory "signature"
+        size            = 3;
+        offset          = 0x1000090;
+    ;
+
+    memory "prodsig"
+        size            = 50;
+        page_size       = 50;
+        offset          = 0x8e0200;
+        readsize        = 50;
     ;
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset		= 0x1000000;
+        offset          = 0x1000000;
     ;
 ;
 
@@ -15459,51 +11345,51 @@ part
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x16a4u";
-    desc	= "ATxmega16A4U";
-    signature	= 0x1e 0x94 0x41;
-    usbpid	= 0x2fe3;
+    desc                = "ATxmega16A4U";
+    id                  = "x16a4u";
+    signature           = 0x1e 0x94 0x41;
+    usbpid              = 0x2fe3;
 
     memory "eeprom"
-        size		= 0x400;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x4000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x1000;
-        offset		= 0x803000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x1000;
-        offset		= 0x804000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 1024;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x5000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x5000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x4000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 4096;
+        page_size       = 256;
+        offset          = 0x803000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 4096;
+        page_size       = 256;
+        offset          = 0x804000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 256;
+        page_size       = 256;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -15512,9 +11398,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    id		= "x16c4";
-    desc	= "ATxmega16C4";
-    signature	= 0x1e 0x94 0x43;
+    desc                = "ATxmega16C4";
+    id                  = "x16c4";
+    signature           = 0x1e 0x94 0x43;
 ;
 
 #------------------------------------------------------------
@@ -15522,9 +11408,9 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    id		= "x16d4";
-    desc	= "ATxmega16D4";
-    signature	= 0x1e 0x94 0x42;
+    desc                = "ATxmega16D4";
+    id                  = "x16d4";
+    signature           = 0x1e 0x94 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15532,14 +11418,12 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent "x16a4u"
-    id		= "x16a4";
-    desc	= "ATxmega16A4";
-    signature	= 0x1e 0x94 0x41;
-    has_jtag	= no;
+    desc                = "ATxmega16A4";
+    id                  = "x16a4";
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15548,51 +11432,51 @@ part parent "x16a4u"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x32a4u";
-    desc	= "ATxmega32A4U";
-    signature	= 0x1e 0x95 0x41;
-    usbpid	= 0x2fe4;
+    desc                = "ATxmega32A4U";
+    id                  = "x32a4u";
+    signature           = 0x1e 0x95 0x41;
+    usbpid              = 0x2fe4;
 
     memory "eeprom"
-        size		= 0x400;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x8000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x1000;
-        offset		= 0x807000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x1000;
-        offset		= 0x808000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 1024;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x9000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x9000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x8000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 4096;
+        page_size       = 256;
+        offset          = 0x807000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 4096;
+        page_size       = 256;
+        offset          = 0x808000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 256;
+        page_size       = 256;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -15601,9 +11485,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    id		= "x32c4";
-    desc	= "ATxmega32C4";
-    signature	= 0x1e 0x95 0x44;
+    desc                = "ATxmega32C4";
+    id                  = "x32c4";
+    signature           = 0x1e 0x95 0x44;
 ;
 
 #------------------------------------------------------------
@@ -15611,9 +11495,9 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    id		= "x32d4";
-    desc	= "ATxmega32D4";
-    signature	= 0x1e 0x95 0x42;
+    desc                = "ATxmega32D4";
+    id                  = "x32d4";
+    signature           = 0x1e 0x95 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15621,14 +11505,12 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent "x32a4u"
-    id		= "x32a4";
-    desc	= "ATxmega32A4";
-    signature	= 0x1e 0x95 0x41;
-    has_jtag	= no;
+    desc                = "ATxmega32A4";
+    id                  = "x32a4";
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15637,51 +11519,51 @@ part parent "x32a4u"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x64a4u";
-    desc	= "ATxmega64A4U";
-    signature	= 0x1e 0x96 0x46;
-    usbpid	= 0x2fe5;
+    desc                = "ATxmega64A4U";
+    id                  = "x64a4u";
+    signature           = 0x1e 0x96 0x46;
+    usbpid              = 0x2fe5;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x10000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x1000;
-        offset		= 0x80f000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x1000;
-        offset		= 0x810000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 2048;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x11000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x11000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x10000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 4096;
+        page_size       = 256;
+        offset          = 0x80f000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 4096;
+        page_size       = 256;
+        offset          = 0x810000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 256;
+        page_size       = 256;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -15690,10 +11572,10 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64c3";
-    desc	= "ATxmega64C3";
-    signature	= 0x1e 0x96 0x49;
-    usbpid	= 0x2fd6;
+    desc                = "ATxmega64C3";
+    id                  = "x64c3";
+    signature           = 0x1e 0x96 0x49;
+    usbpid              = 0x2fd6;
 ;
 
 #------------------------------------------------------------
@@ -15701,9 +11583,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64d3";
-    desc	= "ATxmega64D3";
-    signature	= 0x1e 0x96 0x4a;
+    desc                = "ATxmega64D3";
+    id                  = "x64d3";
+    signature           = 0x1e 0x96 0x4a;
 ;
 
 #------------------------------------------------------------
@@ -15711,9 +11593,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64d4";
-    desc	= "ATxmega64D4";
-    signature	= 0x1e 0x96 0x47;
+    desc                = "ATxmega64D4";
+    id                  = "x64d4";
+    signature           = 0x1e 0x96 0x47;
 ;
 
 #------------------------------------------------------------
@@ -15721,14 +11603,14 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a4u"
-    id		= "x64a1";
-    desc	= "ATxmega64A1";
-    signature	= 0x1e 0x96 0x4e;
-    has_jtag	= yes;
+    desc                = "ATxmega64A1";
+    id                  = "x64a1";
+    signature           = 0x1e 0x96 0x4e;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15737,10 +11619,9 @@ part parent "x64a4u"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a1u";
-    desc	= "ATxmega64A1U";
-    signature	= 0x1e 0x96 0x4e;
-    usbpid	= 0x2fe8;
+    desc                = "ATxmega64A1U";
+    id                  = "x64a1u";
+    usbpid              = 0x2fe8;
 ;
 
 #------------------------------------------------------------
@@ -15748,9 +11629,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a3";
-    desc	= "ATxmega64A3";
-    signature	= 0x1e 0x96 0x42;
+    desc                = "ATxmega64A3";
+    id                  = "x64a3";
+    signature           = 0x1e 0x96 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15758,10 +11639,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a3u";
-    desc	= "ATxmega64A3U";
-    signature	= 0x1e 0x96 0x42;
-    usbpid	= 0x2fe5;
+    desc                = "ATxmega64A3U";
+    id                  = "x64a3u";
+    signature           = 0x1e 0x96 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15769,9 +11649,9 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64a4";
-    desc	= "ATxmega64A4";
-    signature	= 0x1e 0x96 0x46;
+    desc                = "ATxmega64A4";
+    id                  = "x64a4";
+    signature           = 0x1e 0x96 0x46;
 ;
 
 #------------------------------------------------------------
@@ -15779,10 +11659,10 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64b1";
-    desc	= "ATxmega64B1";
-    signature	= 0x1e 0x96 0x52;
-    usbpid	= 0x2fe1;
+    desc                = "ATxmega64B1";
+    id                  = "x64b1";
+    signature           = 0x1e 0x96 0x52;
+    usbpid              = 0x2fe1;
 ;
 
 #------------------------------------------------------------
@@ -15790,10 +11670,10 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent "x64a1"
-    id		= "x64b3";
-    desc	= "ATxmega64B3";
-    signature	= 0x1e 0x96 0x51;
-    usbpid	= 0x2fdf;
+    desc                = "ATxmega64B3";
+    id                  = "x64b3";
+    signature           = 0x1e 0x96 0x51;
+    usbpid              = 0x2fdf;
 ;
 
 #------------------------------------------------------------
@@ -15801,51 +11681,51 @@ part parent "x64a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128c3";
-    desc	= "ATxmega128C3";
-    signature	= 0x1e 0x97 0x52;
-    usbpid	= 0x2fd7;
+    desc                = "ATxmega128C3";
+    id                  = "x128c3";
+    signature           = 0x1e 0x97 0x52;
+    usbpid              = 0x2fd7;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x2000;
-        offset		= 0x81e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 2048;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x22000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x81e000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x820000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 512;
+        page_size       = 512;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -15854,9 +11734,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    id		= "x128d3";
-    desc	= "ATxmega128D3";
-    signature	= 0x1e 0x97 0x48;
+    desc                = "ATxmega128D3";
+    id                  = "x128d3";
+    signature           = 0x1e 0x97 0x48;
 ;
 
 #------------------------------------------------------------
@@ -15864,15 +11744,12 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    id		= "x128d4";
-    desc	= "ATxmega128D4";
-    signature	= 0x1e 0x97 0x47;
+    desc                = "ATxmega128D4";
+    id                  = "x128d4";
+    signature           = 0x1e 0x97 0x47;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        page_size       = 256;
     ;
 ;
 
@@ -15881,14 +11758,14 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128c3"
-    id		= "x128a1";
-    desc	= "ATxmega128A1";
-    signature	= 0x1e 0x97 0x4c;
-    has_jtag	= yes;
+    desc                = "ATxmega128A1";
+    id                  = "x128a1";
+    signature           = 0x1e 0x97 0x4c;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -15897,9 +11774,9 @@ part parent "x128c3"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a1d";
-    desc	= "ATxmega128A1revD";
-    signature	= 0x1e 0x97 0x41;
+    desc                = "ATxmega128A1revD";
+    id                  = "x128a1d";
+    signature           = 0x1e 0x97 0x41;
 ;
 
 #------------------------------------------------------------
@@ -15907,10 +11784,9 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a1u";
-    desc	= "ATxmega128A1U";
-    signature	= 0x1e 0x97 0x4c;
-    usbpid	= 0x2fed;
+    desc                = "ATxmega128A1U";
+    id                  = "x128a1u";
+    usbpid              = 0x2fed;
 ;
 
 #------------------------------------------------------------
@@ -15918,9 +11794,9 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a3";
-    desc	= "ATxmega128A3";
-    signature	= 0x1e 0x97 0x42;
+    desc                = "ATxmega128A3";
+    id                  = "x128a3";
+    signature           = 0x1e 0x97 0x42;
 ;
 
 #------------------------------------------------------------
@@ -15928,10 +11804,10 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent "x128a1"
-    id		= "x128a3u";
-    desc	= "ATxmega128A3U";
-    signature	= 0x1e 0x97 0x42;
-    usbpid	= 0x2fe6;
+    desc                = "ATxmega128A3U";
+    id                  = "x128a3u";
+    signature           = 0x1e 0x97 0x42;
+    usbpid              = 0x2fe6;
 ;
 
 #------------------------------------------------------------
@@ -15939,56 +11815,56 @@ part parent "x128a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128a4";
-    desc	= "ATxmega128A4";
-    signature	= 0x1e 0x97 0x46;
-    has_jtag	= yes;
+    desc                = "ATxmega128A4";
+    id                  = "x128a4";
+    signature           = 0x1e 0x97 0x46;
+    has_jtag            = yes;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x1000;
-        offset		= 0x81f000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 2048;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x22000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 
-    memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+    memory "application"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 4096;
+        page_size       = 512;
+        offset          = 0x81f000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x820000;
+        readsize        = 256;
     ;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
+    ;
+
+    memory "usersig"
+        size            = 512;
+        page_size       = 512;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -15997,51 +11873,51 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128a4u";
-    desc	= "ATxmega128A4U";
-    signature	= 0x1e 0x97 0x46;
-    usbpid	= 0x2fde;
+    desc                = "ATxmega128A4U";
+    id                  = "x128a4u";
+    signature           = 0x1e 0x97 0x46;
+    usbpid              = 0x2fde;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x1000;
-        offset		= 0x81f000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 2048;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x22000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x20000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 4096;
+        page_size       = 256;
+        offset          = 0x81f000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 8192;
+        page_size       = 256;
+        offset          = 0x820000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 256;
+        page_size       = 256;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -16050,57 +11926,57 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x128b1";
-    desc	= "ATxmega128B1";
-    signature	= 0x1e 0x97 0x4d;
-    usbpid	= 0x2fea;
-    has_jtag	= yes;
+    desc                = "ATxmega128B1";
+    id                  = "x128b1";
+    signature           = 0x1e 0x97 0x4d;
+    usbpid              = 0x2fea;
+    has_jtag            = yes;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x20000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x2000;
-        offset		= 0x81e000;
-        page_size	= 0x100;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x2000;
-        offset		= 0x820000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 2048;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x22000;
-        offset		= 0x800000;
-        page_size	= 0x100;
-        readsize	= 0x100;
+        size            = 0x22000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 
-    memory "usersig"
-        size		= 0x100;
-        offset		= 0x8e0400;
-        page_size	= 0x100;
-        readsize	= 0x100;
+    memory "application"
+        size            = 0x20000;
+        page_size       = 256;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 8192;
+        page_size       = 256;
+        offset          = 0x81e000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 8192;
+        page_size       = 256;
+        offset          = 0x820000;
+        readsize        = 256;
     ;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
+    ;
+
+    memory "usersig"
+        size            = 256;
+        page_size       = 256;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -16109,10 +11985,10 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x128b1"
-    id		= "x128b3";
-    desc	= "ATxmega128B3";
-    signature	= 0x1e 0x97 0x4b;
-    usbpid	= 0x2fe0;
+    desc                = "ATxmega128B3";
+    id                  = "x128b3";
+    signature           = 0x1e 0x97 0x4b;
+    usbpid              = 0x2fe0;
 ;
 
 #------------------------------------------------------------
@@ -16120,51 +11996,51 @@ part parent "x128b1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x192c3";
-    desc	= "ATxmega192C3";
-    signature	= 0x1e 0x97 0x51;
+    desc                = "ATxmega192C3";
+    id                  = "x192c3";
+    signature           = 0x1e 0x97 0x51;
     # usbpid	= 0x2f??;
 
     memory "eeprom"
-        size		= 0x800;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x30000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x2000;
-        offset		= 0x82e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x2000;
-        offset		= 0x830000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 2048;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x32000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x32000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x30000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x82e000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x830000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 512;
+        page_size       = 512;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -16173,9 +12049,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x192c3"
-    id		= "x192d3";
-    desc	= "ATxmega192D3";
-    signature	= 0x1e 0x97 0x49;
+    desc                = "ATxmega192D3";
+    id                  = "x192d3";
+    signature           = 0x1e 0x97 0x49;
 ;
 
 #------------------------------------------------------------
@@ -16183,14 +12059,14 @@ part parent "x192c3"
 #------------------------------------------------------------
 
 part parent "x192c3"
-    id		= "x192a1";
-    desc	= "ATxmega192A1";
-    signature	= 0x1e 0x97 0x4e;
-    has_jtag	= yes;
+    desc                = "ATxmega192A1";
+    id                  = "x192a1";
+    signature           = 0x1e 0x97 0x4e;
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -16199,9 +12075,9 @@ part parent "x192c3"
 #------------------------------------------------------------
 
 part parent "x192a1"
-    id		= "x192a3";
-    desc	= "ATxmega192A3";
-    signature	= 0x1e 0x97 0x44;
+    desc                = "ATxmega192A3";
+    id                  = "x192a3";
+    signature           = 0x1e 0x97 0x44;
 ;
 
 #------------------------------------------------------------
@@ -16209,10 +12085,10 @@ part parent "x192a1"
 #------------------------------------------------------------
 
 part parent "x192a1"
-    id		= "x192a3u";
-    desc	= "ATxmega192A3U";
-    signature	= 0x1e 0x97 0x44;
-    usbpid	= 0x2fe7;
+    desc                = "ATxmega192A3U";
+    id                  = "x192a3u";
+    signature           = 0x1e 0x97 0x44;
+    usbpid              = 0x2fe7;
 ;
 
 #------------------------------------------------------------
@@ -16220,51 +12096,51 @@ part parent "x192a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x256c3";
-    desc	= "ATxmega256C3";
-    signature	= 0x1e 0x98 0x46;
-    usbpid	= 0x2fda;
+    desc                = "ATxmega256C3";
+    id                  = "x256c3";
+    signature           = 0x1e 0x98 0x46;
+    usbpid              = 0x2fda;
 
     memory "eeprom"
-        size		= 0x1000;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x40000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x2000;
-        offset		= 0x83e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x2000;
-        offset		= 0x840000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 4096;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x42000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x42000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x40000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x83e000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x840000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 512;
+        page_size       = 512;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -16273,9 +12149,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x256c3"
-    id		= "x256d3";
-    desc	= "ATxmega256D3";
-    signature	= 0x1e 0x98 0x44;
+    desc                = "ATxmega256D3";
+    id                  = "x256d3";
+    signature           = 0x1e 0x98 0x44;
 ;
 
 #------------------------------------------------------------
@@ -16283,14 +12159,13 @@ part parent "x256c3"
 #------------------------------------------------------------
 
 part parent "x256c3"
-    id		= "x256a1";
-    desc	= "ATxmega256A1";
-    signature	= 0x1e 0x98 0x46;
-    has_jtag	= yes;
+    desc                = "ATxmega256A1";
+    id                  = "x256a1";
+    has_jtag            = yes;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x8f0020;
+        size            = 1;
+        offset          = 0x8f0020;
     ;
 ;
 
@@ -16299,9 +12174,9 @@ part parent "x256c3"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3";
-    desc	= "ATxmega256A3";
-    signature	= 0x1e 0x98 0x42;
+    desc                = "ATxmega256A3";
+    id                  = "x256a3";
+    signature           = 0x1e 0x98 0x42;
 ;
 
 #------------------------------------------------------------
@@ -16309,10 +12184,10 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3u";
-    desc	= "ATxmega256A3U";
-    signature	= 0x1e 0x98 0x42;
-    usbpid	= 0x2fec;
+    desc                = "ATxmega256A3U";
+    id                  = "x256a3u";
+    signature           = 0x1e 0x98 0x42;
+    usbpid              = 0x2fec;
 ;
 
 #------------------------------------------------------------
@@ -16320,9 +12195,9 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3b";
-    desc	= "ATxmega256A3B";
-    signature	= 0x1e 0x98 0x43;
+    desc                = "ATxmega256A3B";
+    id                  = "x256a3b";
+    signature           = 0x1e 0x98 0x43;
 ;
 
 #------------------------------------------------------------
@@ -16330,10 +12205,10 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent "x256a1"
-    id		= "x256a3bu";
-    desc	= "ATxmega256A3BU";
-    signature	= 0x1e 0x98 0x43;
-    usbpid	= 0x2fe2;
+    desc                = "ATxmega256A3BU";
+    id                  = "x256a3bu";
+    signature           = 0x1e 0x98 0x43;
+    usbpid              = 0x2fe2;
 ;
 
 #------------------------------------------------------------
@@ -16341,51 +12216,51 @@ part parent "x256a1"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x384c3";
-    desc	= "ATxmega384C3";
-    signature	= 0x1e 0x98 0x45;
-    usbpid	= 0x2fdb;
+    desc                = "ATxmega384C3";
+    id                  = "x384c3";
+    signature           = 0x1e 0x98 0x45;
+    usbpid              = 0x2fdb;
 
     memory "eeprom"
-        size		= 0x1000;
-        offset		= 0x8c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x60000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x2000;
-        offset		= 0x85e000;
-        page_size	= 0x200;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x2000;
-        offset		= 0x860000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 4096;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x62000;
-        offset		= 0x800000;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 0x62000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x60000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x85e000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 8192;
+        page_size       = 512;
+        offset          = 0x860000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size		= 0x200;
-        offset		= 0x8e0400;
-        page_size	= 0x200;
-        readsize	= 0x100;
+        size            = 512;
+        page_size       = 512;
+        offset          = 0x8e0400;
+        readsize        = 256;
     ;
 ;
 
@@ -16394,9 +12269,9 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent "x384c3"
-    id		= "x384d3";
-    desc	= "ATxmega384D3";
-    signature	= 0x1e 0x98 0x47;
+    desc                = "ATxmega384D3";
+    id                  = "x384d3";
+    signature           = 0x1e 0x98 0x47;
 ;
 
 #------------------------------------------------------------
@@ -16404,50 +12279,50 @@ part parent "x384c3"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x8e5";
-    desc	= "ATxmega8E5";
-    signature	= 0x1e 0x93 0x41;
+    desc                = "ATxmega8E5";
+    id                  = "x8e5";
+    signature           = 0x1e 0x93 0x41;
 
     memory "eeprom"
-        size		= 0x0200;
-        offset		= 0x08c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x2000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x800;
-        offset		= 0x00801800;
-        page_size	= 0x80;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x800;
-        offset		= 0x00802000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 512;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x2800;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x2800;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 8192;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 2048;
+        page_size       = 128;
+        offset          = 0x801800;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 2048;
+        page_size       = 128;
+        offset          = 0x802000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size            = 0x80;
+        size            = 128;
+        page_size       = 128;
         offset          = 0x8e0400;
-        page_size       = 0x80;
-        readsize	= 0x100;
+        readsize        = 256;
     ;
 ;
 
@@ -16456,50 +12331,50 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x16e5";
-    desc	= "ATxmega16E5";
-    signature	= 0x1e 0x94 0x45;
+    desc                = "ATxmega16E5";
+    id                  = "x16e5";
+    signature           = 0x1e 0x94 0x45;
 
     memory "eeprom"
-        size		= 0x0200;
-        offset		= 0x08c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x4000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x1000;
-        offset		= 0x00803000;
-        page_size	= 0x80;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x1000;
-        offset		= 0x00804000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 512;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x5000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x5000;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x4000;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 4096;
+        page_size       = 128;
+        offset          = 0x803000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 4096;
+        page_size       = 128;
+        offset          = 0x804000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size            = 0x80;
+        size            = 128;
+        page_size       = 128;
         offset          = 0x8e0400;
-        page_size       = 0x80;
-        readsize	= 0x100;
+        readsize        = 256;
     ;
 ;
 
@@ -16508,50 +12383,50 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part parent ".xmega"
-    id		= "x32e5";
-    desc	= "ATxmega32E5";
-    signature	= 0x1e 0x95 0x4c;
+    desc                = "ATxmega32E5";
+    id                  = "x32e5";
+    signature           = 0x1e 0x95 0x4c;
 
     memory "eeprom"
-        size		= 0x0400;
-        offset		= 0x08c0000;
-        page_size	= 0x20;
-        readsize	= 0x100;
-    ;
-
-    memory "application"
-        size		= 0x8000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
-    ;
-
-    memory "apptable"
-        size		= 0x1000;
-        offset		= 0x00807000;
-        page_size	= 0x80;
-        readsize	= 0x100;
-    ;
-
-    memory "boot"
-        size		= 0x1000;
-        offset		= 0x00808000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 1024;
+        page_size       = 32;
+        offset          = 0x8c0000;
+        readsize        = 256;
     ;
 
     memory "flash"
-        size		= 0x9000;
-        offset		= 0x0800000;
-        page_size	= 0x80;
-        readsize	= 0x100;
+        size            = 0x9000;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "application"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
+    ;
+
+    memory "apptable"
+        size            = 4096;
+        page_size       = 128;
+        offset          = 0x807000;
+        readsize        = 256;
+    ;
+
+    memory "boot"
+        size            = 4096;
+        page_size       = 128;
+        offset          = 0x808000;
+        readsize        = 256;
     ;
 
     memory "usersig"
-        size            = 0x80;
+        size            = 128;
+        page_size       = 128;
         offset          = 0x8e0400;
-        page_size       = 0x80;
-        readsize	= 0x100;
+        readsize        = 256;
     ;
 ;
 
@@ -16560,25 +12435,29 @@ part parent ".xmega"
 #------------------------------------------------------------
 
 part
-    id		= "uc3a0512";
-    desc	= "AT32UC3A0512";
-    signature	= 0xED 0xC0 0x3F;
-    has_jtag	= yes;
-    is_avr32	= yes;
+    desc                = "AT32UC3A0512";
+    id                  = "uc3a0512";
+    signature           = 0xed 0xc0 0x3f;
+    has_jtag            = yes;
+    is_avr32            = yes;
 
     memory "flash"
         paged           = yes;
+        size            = 0x80000;    # could be set dynamicly
         page_size       = 512;           # bytes
-        readsize        = 512;           # bytes
         num_pages       = 1024;          # could be set dynamicly
-        size            = 0x00080000;    # could be set dynamicly
         offset          = 0x80000000;
+        readsize        = 512;           # bytes
     ;
 ;
 
+#------------------------------------------------------------
+# deprecated, use 'uc3a0512'
+#------------------------------------------------------------
+
 part parent "uc3a0512"
-    id		= "ucr2";
-    desc	= "deprecated, use 'uc3a0512'";
+    desc                = "deprecated, use 'uc3a0512'";
+    id                  = "ucr2";
 ;
 
 #------------------------------------------------------------
@@ -16586,188 +12465,123 @@ part parent "uc3a0512"
 #------------------------------------------------------------
 
 part
-    id              = "t1634";
-    desc            = "ATtiny1634";
-     has_debugwire = yes;
-     flash_instr   = 0xB6, 0x01, 0x11;
-     eeprom_instr  = 0xBD, 0xF2, 0xBD, 0xE1, 0xBB, 0xCF, 0xB4, 0x00,
-                0xBE, 0x01, 0xB6, 0x01, 0xBC, 0x00, 0xBB, 0xBF,
-                0x99, 0xF9, 0xBB, 0xAF;
-    stk500_devcode  = 0x86;
+    desc                = "ATtiny1634";
+    id                  = "t1634";
+    stk500_devcode      = 0x86;
+    chip_erase_delay    = 9000;
+    pagel               = 0xb3;
+    bs2                 = 0xb1;
     # avr910_devcode = 0x;
-    signature       = 0x1e 0x94 0x12;
-    pagel           = 0xB3;
-    bs2             = 0xB1;
-    reset	    = io;
-    chip_erase_delay = 9000;
-    pgm_enable       = "1 0 1 0 1 1 0 0 0 1 0 1 0 0 1 1",
-                       "x x x x x x x x x x x x x x x x";
-
-    chip_erase       = "1 0 1 0 1 1 0 0 1 0 0 x x x x x",
-                       "x x x x x x x x x x x x x x x x";
-
-    timeout         = 200;
-    stabdelay       = 100;
-    cmdexedelay     = 25;
-    synchloops      = 32;
-    bytedelay       = 0;
-    pollindex       = 3;
-    pollvalue       = 0x53;
-    predelay        = 1;
-    postdelay       = 1;
-    pollmethod      = 1;
-
+    signature           = 0x1e 0x94 0x12;
+    reset               = io;
+    has_debugwire       = yes;
+    timeout             = 200;
+    stabdelay           = 100;
+    cmdexedelay         = 25;
+    synchloops          = 32;
+    pollindex           = 3;
+    pollvalue           = 0x53;
+    predelay            = 1;
+    postdelay           = 1;
+    pollmethod          = 1;
     pp_controlstack     =
-        0x0E, 0x1E, 0x0E, 0x1E, 0x2E, 0x3E, 0x2E, 0x3E,
-        0x4E, 0x5E, 0x4E, 0x5E, 0x6E, 0x7E, 0x6E, 0x7E,
-        0x26, 0x36, 0x66, 0x76, 0x2A, 0x3A, 0x6A, 0x7A,
-        0x2E, 0xFD, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+        0x0e, 0x1e, 0x0e, 0x1e, 0x2e, 0x3e, 0x2e, 0x3e,
+        0x4e, 0x5e, 0x4e, 0x5e, 0x6e, 0x7e, 0x6e, 0x7e,
+        0x26, 0x36, 0x66, 0x76, 0x2a, 0x3a, 0x6a, 0x7a,
+        0x2e, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    flash_instr         =  0xb6, 0x01, 0x11;
+    eeprom_instr        =
+        0xbd, 0xf2, 0xbd, 0xe1, 0xbb, 0xcf, 0xb4, 0x00,
+        0xbe, 0x01, 0xb6, 0x01, 0xbc, 0x00, 0xbb, 0xbf,
+        0x99, 0xf9, 0xbb, 0xaf;
     hventerstabdelay    = 100;
-    progmodedelay       = 0;
-    latchcycles         = 0;
     togglevtg           = 1;
     poweroffdelay       = 15;
     resetdelayms        = 1;
-    resetdelayus        = 0;
     hvleavestabdelay    = 15;
     resetdelay          = 15;
-    chiperasepulsewidth = 0;
     chiperasepolltimeout = 10;
-    programfusepulsewidth = 0;
     programfusepolltimeout = 5;
-    programlockpulsewidth = 0;
     programlockpolltimeout = 5;
+    chip_erase          = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable          = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged           = no;
-        page_size       = 4;
         size            = 256;
+        page_size       = 4;
         min_write_delay = 3600;
         max_write_delay = 3600;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read            = " 1 0 1 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
-
-        write           = " 1 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " i i i i i i i i";
-
-   loadpage_lo   = "  1   1   0   0      0   0   0   1",
-           "  0   0   0   0      0   0   0   0",
-           "  0   0   0   0      0   0  a1  a0",
-           "  i   i   i   i      i   i   i   i";
-
-   writepage   = "  1   1   0   0      0   0   1   0",
-           "  0   0   x   x      x   x   x  a8",
-           " a7  a6  a5  a4     a3  a2   0   0",
-           "  x   x   x   x      x   x   x   x";
-
-   mode      = 0x41;
-   delay      = 5;
-   blocksize   = 4;
-   readsize   = 256;
-        ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 5;
+        blocksize       = 4;
+        readsize        = 256;
+        read            = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
+        write           = "1100.0000--000x.xxxa--aaaa.aaaa--iiii.iiii";
+        loadpage_lo     = "1100.0001--0000.0000--0000.00aa--iiii.iiii";
+        writepage       = "1100.0010--00xx.xxxa--aaaa.aa00--xxxx.xxxx";
+    ;
 
     memory "flash"
         paged           = yes;
-        size            = 16384;
+        size            = 0x4000;
         page_size       = 32;
         num_pages       = 512;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        readback_p1     = 0xff;
-        readback_p2     = 0xff;
-        read_lo         = " 0 0 1 0 0 0 0 0",
-                          " 0 0 a13 a12 a11 a10 a9 a8",
-                          " a7 a6 a5 a4 a3 a2 a1 a0",
-                          " o o o o o o o o";
-
-        read_hi          = " 0 0 1 0 1 0 0 0",
-                           " 0 0 a13 a12 a11 a10 a9 a8",
-                           " a7 a6 a5 a4 a3 a2 a1 a0",
-                           " o o o o o o o o";
-
-        loadpage_lo     = " 0 1 0 0 0 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x x x a3 a2 a1 a0",
-                          " i i i i i i i i";
-
-        loadpage_hi     = " 0 1 0 0 1 0 0 0",
-                          " 0 0 0 x x x x x",
-                          " x x x x a3 a2 a1 a0",
-                          " i i i i i i i i";
-
-        writepage       = " 0 1 0 0 1 1 0 0",
-                          " 0 0 a13 a12 a11 a10 a9 a8",
-                          " a7 a6 a5 a4 x x x x",
-                          " x x x x x x x x";
-
-        mode        = 0x41;
-        delay       = 6;
-        blocksize   = 128;
-        readsize    = 256;
-
-        ;
+        readback        = 0xff 0xff;
+        mode            = 65;
+        delay           = 6;
+        blocksize       = 128;
+        readsize        = 256;
+        read_lo         = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        read_hi         = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
+        loadpage_lo     = "0100.0000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        loadpage_hi     = "0100.1000--000x.xxxx--xxxx.aaaa--iiii.iiii";
+        writepage       = "0100.1100--00aa.aaaa--aaaa.xxxx--xxxx.xxxx";
+    ;
 
     memory "lfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
-        ;
+        read            = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "hfuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 1 0 0 0",
-                          "x x x x x x x x i i i i i i i i";
-        ;
+        read            = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
+    ;
 
     memory "efuse"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 0 1 0 0 1 0 0",
-                          "x x x x x x x x x x x i i i i i";
-        ;
+        read            = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--1010.0100--xxxx.xxxx--xxxi.iiii";
+    ;
 
     memory "lock"
         size            = 1;
         min_write_delay = 4500;
         max_write_delay = 4500;
-        read            = "0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0",
-                          "x x x x x x x x o o o o o o o o";
-
-        write           = "1 0 1 0 1 1 0 0 1 1 1 x x x x x",
-                          "x x x x x x x x 1 1 1 1 1 1 i i";
-        ;
-
-    memory "calibration"
-        size            = 1;
-        read            = "0 0 1 1 1 0 0 0 0 0 0 x x x x x",
-                          "0 0 0 0 0 0 0 0 o o o o o o o o";
-        ;
+        read            = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+        write           = "1010.1100--111x.xxxx--xxxx.xxxx--1111.11ii";
+    ;
 
     memory "signature"
         size            = 3;
-        read            = "0 0 1 1 0 0 0 0 0 0 0 x x x x x",
-                          "x x x x x x a1 a0 o o o o o o o o";
-        ;
+        read            = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "calibration"
+        size            = 1;
+        read            = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16775,42 +12589,48 @@ part
 #------------------------------------------------------------
 
 part parent "t1634"
-    id              = "t1634r";
-    desc            = "ATtiny1634R";
-  ;
+    desc                = "ATtiny1634R";
+    id                  = "t1634r";
+;
 
 #------------------------------------------------------------
 # Common values for reduced core tinys (4/5/9/10/20/40)
 #------------------------------------------------------------
 
 part
-    id		= ".reduced_core_tiny";
-    desc	= "Common values for reduced core tinys";
-    has_tpi	= yes;
-
-    memory "signature"
-        size		= 3;
-        offset		= 0x3fc0;
-        page_size	= 16;
-    ;
+    desc                = "Common values for reduced core tinys";
+    id                  = ".reduced_core_tiny";
+    has_tpi             = yes;
 
     memory "fuse"
-        size		= 1;
-        offset		= 0x3f40;
-        page_size	= 16;
-	blocksize	= 4;
-    ;
-
-    memory "calibration"
-        size		= 1;
-        offset		= 0x3f80;
-        page_size	= 16;
+        size            = 1;
+        page_size       = 16;
+        offset          = 0x3f40;
+        blocksize       = 4;
     ;
 
     memory "lockbits"
-        size		= 1;
-        offset		= 0x3f00;
-        page_size	= 16;
+        size            = 1;
+        page_size       = 16;
+        offset          = 0x3f00;
+    ;
+
+    memory "lockbits"
+        size            = 1;
+        page_size       = 16;
+        offset          = 0x3f00;
+    ;
+
+    memory "signature"
+        size            = 3;
+        page_size       = 16;
+        offset          = 0x3fc0;
+    ;
+
+    memory "calibration"
+        size            = 1;
+        page_size       = 16;
+        offset          = 0x3f80;
     ;
 ;
 
@@ -16819,15 +12639,15 @@ part
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id		= "t4";
-    desc	= "ATtiny4";
-    signature	= 0x1e 0x8f 0x0a;
+    desc                = "ATtiny4";
+    id                  = "t4";
+    signature           = 0x1e 0x8f 0x0a;
 
     memory "flash"
-        size		= 512;
-        offset		= 0x4000;
-        page_size	= 16;
-        blocksize	= 128;
+        size            = 512;
+        page_size       = 16;
+        offset          = 0x4000;
+        blocksize       = 128;
     ;
 ;
 
@@ -16836,9 +12656,9 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent "t4"
-    id		= "t5";
-    desc	= "ATtiny5";
-    signature	= 0x1e 0x8f 0x09;
+    desc                = "ATtiny5";
+    id                  = "t5";
+    signature           = 0x1e 0x8f 0x09;
 ;
 
 #------------------------------------------------------------
@@ -16846,15 +12666,15 @@ part parent "t4"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id		= "t9";
-    desc	= "ATtiny9";
-    signature	= 0x1e 0x90 0x08;
+    desc                = "ATtiny9";
+    id                  = "t9";
+    signature           = 0x1e 0x90 0x08;
 
     memory "flash"
-        size		= 1024;
-        offset		= 0x4000;
-        page_size	= 16;
-        blocksize	= 128;
+        size            = 1024;
+        page_size       = 16;
+        offset          = 0x4000;
+        blocksize       = 128;
     ;
 ;
 
@@ -16863,9 +12683,9 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent "t9"
-    id		= "t10";
-    desc	= "ATtiny10";
-    signature	= 0x1e 0x90 0x03;
+    desc                = "ATtiny10";
+    id                  = "t10";
+    signature           = 0x1e 0x90 0x03;
 ;
 
 #------------------------------------------------------------
@@ -16873,14 +12693,14 @@ part parent "t9"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id          = "t20";
-    desc        = "ATtiny20";
-    signature   = 0x1e 0x91 0x0F;
+    desc                = "ATtiny20";
+    id                  = "t20";
+    signature           = 0x1e 0x91 0x0f;
 
     memory "flash"
         size            = 2048;
-        offset          = 0x4000;
         page_size       = 16;
+        offset          = 0x4000;
         blocksize       = 128;
     ;
 ;
@@ -16890,15 +12710,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id		= "t40";
-    desc	= "ATtiny40";
-    signature	= 0x1e 0x92 0x0E;
+    desc                = "ATtiny40";
+    id                  = "t40";
+    signature           = 0x1e 0x92 0x0e;
 
     memory "flash"
-        size		= 4096;
-        offset		= 0x4000;
-        page_size	= 64;
-        blocksize	= 128;
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x4000;
+        blocksize       = 128;
     ;
 ;
 
@@ -16907,15 +12727,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id    = "t102";
-    desc  = "ATtiny102";
-    signature = 0x1e 0x90 0x0C;
+    desc                = "ATtiny102";
+    id                  = "t102";
+    signature           = 0x1e 0x90 0x0c;
 
     memory "flash"
-        size    = 1024;
-        offset    = 0x4000;
-        page_size = 16;
-        blocksize = 128;
+        size            = 1024;
+        page_size       = 16;
+        offset          = 0x4000;
+        blocksize       = 128;
     ;
 ;
 
@@ -16924,15 +12744,15 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part parent ".reduced_core_tiny"
-    id    = "t104";
-    desc  = "ATtiny104";
-    signature = 0x1e 0x90 0x0B;
+    desc                = "ATtiny104";
+    id                  = "t104";
+    signature           = 0x1e 0x90 0x0b;
 
     memory "flash"
-        size    = 1024;
-        offset    = 0x4000;
-        page_size = 16;
-        blocksize = 128;
+        size            = 1024;
+        page_size       = 16;
+        offset          = 0x4000;
+        blocksize       = 128;
     ;
 ;
 
@@ -16941,59 +12761,55 @@ part parent ".reduced_core_tiny"
 #------------------------------------------------------------
 
 part
-    id				= "m406";
-    desc			= "ATmega406";
-    has_jtag			= yes;
-    signature			= 0x1e 0x95 0x07;
-
+    desc                = "ATmega406";
+    id                  = "m406";
     # STK500 parameters (parallel programming IO lines)
-    pagel			= 0xa7;
-    bs2				= 0xa0;
-    serial			= no;
-    parallel			= yes;
-
+    pagel               = 0xa7;
+    bs2                 = 0xa0;
+    signature           = 0x1e 0x95 0x07;
+    has_jtag            = yes;
+    serial              = no;
     # STK500v2 HV programming parameters, from XML
-    pp_controlstack		= 0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
-				  0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
-				  0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
-				  0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-
-    # JTAG ICE mkII parameters, also from XML files
-    allowfullpagebitstream	= no;
-    enablepageprogramming	= yes;
-    idr				= 0x51;
-    rampz			= 0x00;
-    spmcr			= 0x57;
-    eecr			= 0x3f;
+    pp_controlstack     =
+        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
+        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
+        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
+        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
+    idr                 = 0x51;
+    spmcr               = 0x57;
+    eecr                = 0x3f;
 
     memory "eeprom"
-        paged		= no;
-        size		= 512;
-        page_size	= 4;
-        blocksize	= 4;
-	readsize	= 4;
-        num_pages	= 128;
+        size            = 512;
+        page_size       = 4;
+        num_pages       = 128;
+        blocksize       = 4;
+        readsize        = 4;
     ;
 
     memory "flash"
-        paged		= yes;
-        size		= 40960;
-        page_size	= 128;
-        blocksize	= 128;
-	readsize	= 128;
-        num_pages	= 320;
-    ;
-
-    memory "hfuse"
-        size            = 1;
+        paged           = yes;
+        size            = 0xa000;
+        page_size       = 128;
+        num_pages       = 320;
+        blocksize       = 128;
+        readsize        = 128;
     ;
 
     memory "lfuse"
         size            = 1;
     ;
 
+    memory "hfuse"
+        size            = 1;
+    ;
+
     memory "lockbits"
-        size		= 1;
+        size            = 1;
+    ;
+
+    memory "lockbits"
+        size            = 1;
     ;
 
     memory "signature"
@@ -17006,72 +12822,16 @@ part
 #------------------------------------------------------------
 
 part
-    id		= ".avr8x";
-    desc	= "AVR8X family common values";
-    has_updi	= yes;
-    nvm_base	= 0x1000;
-    ocd_base	= 0x0F80;
-
-    memory "signature"
-        size		= 3;
-        offset		= 0x1100;
-        readsize	= 0x3;
-    ;
-
-    memory "prodsig"
-        size		= 0x3D;
-        offset		= 0x1103;
-        page_size	= 0x3D;
-        readsize	= 0x3D;
-    ;
-
-    memory "sernum"
-        size		= 10;
-        offset		= 0x1104;
-        readsize	= 1;
-    ;
-
-    memory "osccal16"
-        size		= 2;
-        offset		= 0x1118;
-        readsize	= 1;
-    ;
-
-    memory "osccal20"
-        size		= 2;
-        offset		= 0x111A;
-        readsize	= 1;
-    ;
-
-    memory "tempsense"
-        size		= 2;
-        offset		= 0x1120;
-        readsize	= 1;
-    ;
-
-    memory "osc16err"
-        size		= 2;
-        offset		= 0x1122;
-        readsize	= 1;
-    ;
-
-    memory "osc20err"
-        size		= 2;
-        offset		= 0x1124;
-        readsize	= 1;
-    ;
-
-    memory "fuses"
-        size		= 9;
-        offset		= 0x1280;
-        page_size = 0x0A;
-        readsize  = 0x0A;
-    ;
+    desc                = "AVR8X family common values";
+    id                  = ".avr8x";
+    has_updi            = yes;
+    nvm_base            = 0x1000;
+    ocd_base            = 0x0f80;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x1280;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1280;
+        readsize        = 1;
     ;
 
     memory "wdtcfg"
@@ -17079,9 +12839,9 @@ part
     ;
 
     memory "fuse1"
-        size		= 1;
-        offset		= 0x1281;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1281;
+        readsize        = 1;
     ;
 
     memory "bodcfg"
@@ -17089,9 +12849,9 @@ part
     ;
 
     memory "fuse2"
-        size		= 1;
-        offset		= 0x1282;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1282;
+        readsize        = 1;
     ;
 
     memory "osccfg"
@@ -17099,9 +12859,9 @@ part
     ;
 
     memory "fuse4"
-        size		= 1;
-        offset		= 0x1284;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1284;
+        readsize        = 1;
     ;
 
     memory "tcd0cfg"
@@ -17109,9 +12869,9 @@ part
     ;
 
     memory "fuse5"
-        size		= 1;
-        offset		= 0x1285;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1285;
+        readsize        = 1;
     ;
 
     memory "syscfg0"
@@ -17119,9 +12879,9 @@ part
     ;
 
     memory "fuse6"
-        size		= 1;
-        offset		= 0x1286;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1286;
+        readsize        = 1;
     ;
 
     memory "syscfg1"
@@ -17129,9 +12889,9 @@ part
     ;
 
     memory "fuse7"
-        size		= 1;
-        offset		= 0x1287;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1287;
+        readsize        = 1;
     ;
 
     memory "append"
@@ -17143,9 +12903,9 @@ part
     ;
 
     memory "fuse8"
-        size		= 1;
-        offset		= 0x1288;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1288;
+        readsize        = 1;
     ;
 
     memory "bootend"
@@ -17156,15 +12916,71 @@ part
         alias "fuse8";
     ;
 
+    memory "fuses"
+        size            = 9;
+        page_size       = 10;
+        offset          = 0x1280;
+        readsize        = 10;
+    ;
+
     memory "lock"
-        size		= 1;
-        offset		= 0x128a;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x128a;
+        readsize        = 1;
+    ;
+
+    memory "tempsense"
+        size            = 2;
+        offset          = 0x1120;
+        readsize        = 1;
+    ;
+
+    memory "signature"
+        size            = 3;
+        offset          = 0x1100;
+        readsize        = 3;
+    ;
+
+    memory "prodsig"
+        size            = 61;
+        page_size       = 61;
+        offset          = 0x1103;
+        readsize        = 61;
+    ;
+
+    memory "sernum"
+        size            = 10;
+        offset          = 0x1104;
+        readsize        = 1;
+    ;
+
+    memory "osccal16"
+        size            = 2;
+        offset          = 0x1118;
+        readsize        = 1;
+    ;
+
+    memory "osccal20"
+        size            = 2;
+        offset          = 0x111a;
+        readsize        = 1;
+    ;
+
+    memory "osc16err"
+        size            = 2;
+        offset          = 0x1122;
+        readsize        = 1;
+    ;
+
+    memory "osc20err"
+        size            = 2;
+        offset          = 0x1124;
+        readsize        = 1;
     ;
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset		= 0x1000000;
+        offset          = 0x1000000;
     ;
 ;
 
@@ -17173,17 +12989,17 @@ part
 #------------------------------------------------------------
 
 part parent ".avr8x"
-    id			       = ".avr8x_tiny";
-    desc		       = "AVR8X tiny family common values";
-    family_id      = "tinyAVR";
+    desc                = "AVR8X tiny family common values";
+    id                  = ".avr8x_tiny";
+    family_id           = "tinyAVR";
     # Shared UPDI pin, HV on UPDI pin
-    hvupdi_variant = 0;
+    hvupdi_variant      = 0;
 
     memory "userrow"
-        size	  	= 0x20;
-        offset		= 0x1300;
-        page_size	= 0x20;
-        readsize	= 0x100;
+        size            = 32;
+        page_size       = 32;
+        offset          = 0x1300;
+        readsize        = 256;
     ;
 
     memory "usersig"
@@ -17196,17 +13012,17 @@ part parent ".avr8x"
 #------------------------------------------------------------
 
 part parent ".avr8x"
-    id			       = ".avr8x_mega";
-    desc		       = "AVR8X mega family common values";
-    family_id	     = "megaAVR";
+    desc                = "AVR8X mega family common values";
+    id                  = ".avr8x_mega";
+    family_id           = "megaAVR";
     # Dedicated UPDI pin, no HV
-    hvupdi_variant = 1;
+    hvupdi_variant      = 1;
 
     memory "userrow"
-        size		  = 0x40;
-        offset		= 0x1300;
-        page_size	= 0x40;
-        readsize	= 0x100;
+        size            = 64;
+        page_size       = 64;
+        offset          = 0x1300;
+        readsize        = 256;
     ;
 
     memory "usersig"
@@ -17218,23 +13034,23 @@ part parent ".avr8x"
 # ATtiny202
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t202";
-    desc      = "ATtiny202";
-    signature = 0x1E 0x91 0x23;
-
-    memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny202";
+    id                  = "t202";
+    signature           = 0x1e 0x91 0x23;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 64;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 2048;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17242,23 +13058,23 @@ part parent    ".avr8x_tiny"
 # ATtiny204
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t204";
-    desc      = "ATtiny204";
-    signature = 0x1E 0x91 0x22;
-
-    memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny204";
+    id                  = "t204";
+    signature           = 0x1e 0x91 0x22;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 64;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 2048;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17266,23 +13082,23 @@ part parent    ".avr8x_tiny"
 # ATtiny402
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t402";
-    desc      = "ATtiny402";
-    signature = 0x1E 0x92 0x27;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny402";
+    id                  = "t402";
+    signature           = 0x1e 0x92 0x27;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17290,23 +13106,23 @@ part parent    ".avr8x_tiny"
 # ATtiny404
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t404";
-    desc      = "ATtiny404";
-    signature = 0x1E 0x92 0x26;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny404";
+    id                  = "t404";
+    signature           = 0x1e 0x92 0x26;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17314,23 +13130,23 @@ part parent    ".avr8x_tiny"
 # ATtiny406
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t406";
-    desc      = "ATtiny406";
-    signature = 0x1E 0x92 0x25;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny406";
+    id                  = "t406";
+    signature           = 0x1e 0x92 0x25;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17338,23 +13154,23 @@ part parent    ".avr8x_tiny"
 # ATtiny804
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t804";
-    desc      = "ATtiny804";
-    signature = 0x1E 0x93 0x25;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny804";
+    id                  = "t804";
+    signature           = 0x1e 0x93 0x25;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17362,23 +13178,23 @@ part parent    ".avr8x_tiny"
 # ATtiny806
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t806";
-    desc      = "ATtiny806";
-    signature = 0x1E 0x93 0x24;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny806";
+    id                  = "t806";
+    signature           = 0x1e 0x93 0x24;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17386,23 +13202,23 @@ part parent    ".avr8x_tiny"
 # ATtiny807
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t807";
-    desc      = "ATtiny807";
-    signature = 0x1E 0x93 0x23;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny807";
+    id                  = "t807";
+    signature           = 0x1e 0x93 0x23;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17410,23 +13226,23 @@ part parent    ".avr8x_tiny"
 # ATtiny1604
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1604";
-    desc      = "ATtiny1604";
-    signature = 0x1E 0x94 0x25;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1604";
+    id                  = "t1604";
+    signature           = 0x1e 0x94 0x25;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17434,23 +13250,23 @@ part parent    ".avr8x_tiny"
 # ATtiny1606
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1606";
-    desc      = "ATtiny1606";
-    signature = 0x1E 0x94 0x24;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1606";
+    id                  = "t1606";
+    signature           = 0x1e 0x94 0x24;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17458,23 +13274,23 @@ part parent    ".avr8x_tiny"
 # ATtiny1607
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1607";
-    desc      = "ATtiny1607";
-    signature = 0x1E 0x94 0x23;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1607";
+    id                  = "t1607";
+    signature           = 0x1e 0x94 0x23;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17482,23 +13298,23 @@ part parent    ".avr8x_tiny"
 # ATtiny212
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t212";
-    desc      = "ATtiny212";
-    signature = 0x1E 0x91 0x21;
-
-    memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny212";
+    id                  = "t212";
+    signature           = 0x1e 0x91 0x21;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 64;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 2048;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17506,23 +13322,23 @@ part parent    ".avr8x_tiny"
 # ATtiny214
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t214";
-    desc      = "ATtiny214";
-    signature = 0x1E 0x91 0x20;
-
-    memory "flash"
-        size      = 0x800;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny214";
+    id                  = "t214";
+    signature           = 0x1e 0x91 0x20;
 
     memory "eeprom"
-        size      = 0x40;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 64;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 2048;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17530,48 +13346,47 @@ part parent    ".avr8x_tiny"
 # ATtiny412
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t412";
-    desc      = "ATtiny412";
-    signature = 0x1E 0x92 0x23;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny412";
+    id                  = "t412";
+    signature           = 0x1e 0x92 0x23;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
-
 
 #------------------------------------------------------------
 # ATtiny414
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t414";
-    desc      = "ATtiny414";
-    signature = 0x1E 0x92 0x22;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny414";
+    id                  = "t414";
+    signature           = 0x1e 0x92 0x22;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17579,98 +13394,95 @@ part parent    ".avr8x_tiny"
 # ATtiny416
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t416";
-    desc      = "ATtiny416";
-    signature = 0x1E 0x92 0x21;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny416";
+    id                  = "t416";
+    signature           = 0x1e 0x92 0x21;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
-
 
 #------------------------------------------------------------
 # ATtiny417
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t417";
-    desc      = "ATtiny417";
-    signature = 0x1E 0x92 0x20;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny417";
+    id                  = "t417";
+    signature           = 0x1e 0x92 0x20;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
-
 
 #------------------------------------------------------------
 # ATtiny814
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t814";
-    desc      = "ATtiny814";
-    signature = 0x1E 0x93 0x22;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny814";
+    id                  = "t814";
+    signature           = 0x1e 0x93 0x22;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
-
 
 #------------------------------------------------------------
 # ATtiny816
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t816";
-    desc      = "ATtiny816";
-    signature = 0x1E 0x93 0x21;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny816";
+    id                  = "t816";
+    signature           = 0x1e 0x93 0x21;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17678,23 +13490,23 @@ part parent    ".avr8x_tiny"
 # ATtiny817
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t817";
-    desc      = "ATtiny817";
-    signature = 0x1E 0x93 0x20;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny817";
+    id                  = "t817";
+    signature           = 0x1e 0x93 0x20;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17702,23 +13514,23 @@ part parent    ".avr8x_tiny"
 # ATtiny1614
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1614";
-    desc      = "ATtiny1614";
-    signature = 0x1E 0x94 0x22;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1614";
+    id                  = "t1614";
+    signature           = 0x1e 0x94 0x22;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17726,23 +13538,23 @@ part parent    ".avr8x_tiny"
 # ATtiny1616
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1616";
-    desc      = "ATtiny1616";
-    signature = 0x1E 0x94 0x21;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1616";
+    id                  = "t1616";
+    signature           = 0x1e 0x94 0x21;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17750,23 +13562,23 @@ part parent    ".avr8x_tiny"
 # ATtiny1617
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1617";
-    desc      = "ATtiny1617";
-    signature = 0x1E 0x94 0x20;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1617";
+    id                  = "t1617";
+    signature           = 0x1e 0x94 0x20;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17774,23 +13586,23 @@ part parent    ".avr8x_tiny"
 # ATtiny3216
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t3216";
-    desc      = "ATtiny3216";
-    signature = 0x1E 0x95 0x21;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny3216";
+    id                  = "t3216";
+    signature           = 0x1e 0x95 0x21;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17798,23 +13610,23 @@ part parent    ".avr8x_tiny"
 # ATtiny3217
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t3217";
-    desc      = "ATtiny3217";
-    signature = 0x1E 0x95 0x22;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny3217";
+    id                  = "t3217";
+    signature           = 0x1e 0x95 0x22;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17822,23 +13634,23 @@ part parent    ".avr8x_tiny"
 # ATtiny424
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t424";
-    desc      = "ATtiny424";
-    signature = 0x1E 0x92 0x2C;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny424";
+    id                  = "t424";
+    signature           = 0x1e 0x92 0x2c;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17846,23 +13658,23 @@ part parent    ".avr8x_tiny"
 # ATtiny426
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t426";
-    desc      = "ATtiny426";
-    signature = 0x1E 0x92 0x2B;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny426";
+    id                  = "t426";
+    signature           = 0x1e 0x92 0x2b;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17870,23 +13682,23 @@ part parent    ".avr8x_tiny"
 # ATtiny427
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t427";
-    desc      = "ATtiny427";
-    signature = 0x1E 0x92 0x2A;
-
-    memory "flash"
-        size      = 0x1000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny427";
+    id                  = "t427";
+    signature           = 0x1e 0x92 0x2a;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 4096;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17894,23 +13706,23 @@ part parent    ".avr8x_tiny"
 # ATtiny824
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t824";
-    desc      = "ATtiny824";
-    signature = 0x1E 0x93 0x29;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny824";
+    id                  = "t824";
+    signature           = 0x1e 0x93 0x29;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17918,23 +13730,23 @@ part parent    ".avr8x_tiny"
 # ATtiny826
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t826";
-    desc      = "ATtiny826";
-    signature = 0x1E 0x93 0x28;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny826";
+    id                  = "t826";
+    signature           = 0x1e 0x93 0x28;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17942,23 +13754,23 @@ part parent    ".avr8x_tiny"
 # ATtiny827
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t827";
-    desc      = "ATtiny827";
-    signature = 0x1E 0x93 0x27;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny827";
+    id                  = "t827";
+    signature           = 0x1e 0x93 0x27;
 
     memory "eeprom"
-        size      = 0x80;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 128;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -17966,46 +13778,47 @@ part parent    ".avr8x_tiny"
 # ATtiny1624
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1624";
-    desc      = "ATtiny1624";
-    signature = 0x1E 0x94 0x2A;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1624";
+    id                  = "t1624";
+    signature           = 0x1e 0x94 0x2a;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
+
 #------------------------------------------------------------
 # ATtiny1626
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1626";
-    desc      = "ATtiny1626";
-    signature = 0x1E 0x94 0x29;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1626";
+    id                  = "t1626";
+    signature           = 0x1e 0x94 0x29;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -18013,23 +13826,23 @@ part parent    ".avr8x_tiny"
 # ATtiny1627
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t1627";
-    desc      = "ATtiny1627";
-    signature = 0x1E 0x94 0x28;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x8000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny1627";
+    id                  = "t1627";
+    signature           = 0x1e 0x94 0x28;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -18037,23 +13850,23 @@ part parent    ".avr8x_tiny"
 # ATtiny3224
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t3224";
-    desc      = "ATtiny3224";
-    signature = 0x1E 0x95 0x28;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny3224";
+    id                  = "t3224";
+    signature           = 0x1e 0x95 0x28;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -18061,23 +13874,23 @@ part parent    ".avr8x_tiny"
 # ATtiny3226
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t3226";
-    desc      = "ATtiny3226";
-    signature = 0x1E 0x95 0x27;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny3226";
+    id                  = "t3226";
+    signature           = 0x1e 0x95 0x27;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -18085,23 +13898,23 @@ part parent    ".avr8x_tiny"
 # ATtiny3227
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "t3227";
-    desc      = "ATtiny3227";
-    signature = 0x1E 0x95 0x26;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x8000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATtiny3227";
+    id                  = "t3227";
+    signature           = 0x1e 0x95 0x26;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x8000;
+        readsize        = 256;
     ;
 ;
 
@@ -18109,23 +13922,23 @@ part parent    ".avr8x_tiny"
 # ATmega808
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "m808";
-    desc      = "ATmega808";
-    signature = 0x1E 0x93 0x26;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATmega808";
+    id                  = "m808";
+    signature           = 0x1e 0x93 0x26;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18133,23 +13946,23 @@ part parent    ".avr8x_tiny"
 # ATmega809
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "m809";
-    desc      = "ATmega809";
-    signature = 0x1E 0x93 0x2A;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATmega809";
+    id                  = "m809";
+    signature           = 0x1e 0x93 0x2a;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18157,23 +13970,23 @@ part parent    ".avr8x_tiny"
 # ATmega1608
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "m1608";
-    desc      = "ATmega1608";
-    signature = 0x1E 0x94 0x27;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATmega1608";
+    id                  = "m1608";
+    signature           = 0x1e 0x94 0x27;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18181,23 +13994,23 @@ part parent    ".avr8x_tiny"
 # ATmega1609
 #------------------------------------------------------------
 
-part parent    ".avr8x_tiny"
-    id        = "m1609";
-    desc      = "ATmega1609";
-    signature = 0x1E 0x94 0x26;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x4000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_tiny"
+    desc                = "ATmega1609";
+    id                  = "m1609";
+    signature           = 0x1e 0x94 0x26;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x20;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 32;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18205,23 +14018,23 @@ part parent    ".avr8x_tiny"
 # ATmega3208
 #------------------------------------------------------------
 
-part parent    ".avr8x_mega"
-    id        = "m3208";
-    desc      = "ATmega3208";
-    signature = 0x1E 0x95 0x30;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_mega"
+    desc                = "ATmega3208";
+    id                  = "m3208";
+    signature           = 0x1e 0x95 0x30;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18229,23 +14042,23 @@ part parent    ".avr8x_mega"
 # ATmega3209
 #------------------------------------------------------------
 
-part parent    ".avr8x_mega"
-    id        = "m3209";
-    desc      = "ATmega3209";
-    signature = 0x1E 0x95 0x31;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_mega"
+    desc                = "ATmega3209";
+    id                  = "m3209";
+    signature           = 0x1e 0x95 0x31;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 128;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18253,23 +14066,23 @@ part parent    ".avr8x_mega"
 # ATmega4808
 #------------------------------------------------------------
 
-part parent    ".avr8x_mega"
-    id        = "m4808";
-    desc      = "ATmega4808";
-    signature = 0x1E 0x96 0x50;
-
-    memory "flash"
-        size      = 0xC000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_mega"
+    desc                = "ATmega4808";
+    id                  = "m4808";
+    signature           = 0x1e 0x96 0x50;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0xc000;
+        page_size       = 128;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18277,23 +14090,23 @@ part parent    ".avr8x_mega"
 # ATmega4809
 #------------------------------------------------------------
 
-part parent    ".avr8x_mega"
-    id        = "m4809";
-    desc      = "ATmega4809";
-    signature = 0x1E 0x96 0x51;
-
-    memory "flash"
-        size      = 0xC000;
-        offset    = 0x4000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avr8x_mega"
+    desc                = "ATmega4809";
+    id                  = "m4809";
+    signature           = 0x1e 0x96 0x51;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x40;
-        readsize  = 0x100;
+        size            = 256;
+        page_size       = 64;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0xc000;
+        page_size       = 128;
+        offset          = 0x4000;
+        readsize        = 256;
     ;
 ;
 
@@ -18302,50 +14115,18 @@ part parent    ".avr8x_mega"
 #------------------------------------------------------------
 
 part
-    id             = ".avrdx";
-    desc           = "AVR-Dx family common values";
-    has_updi       = yes;
-    nvm_base       = 0x1000;
-    ocd_base       = 0x0F80;
+    desc                = "AVR-Dx family common values";
+    id                  = ".avrdx";
     # Dedicated UPDI pin, no HV
-    hvupdi_variant = 1;
-
-    memory "signature"
-        size		= 3;
-        offset		= 0x1100;
-        readsize	= 0x3;
-    ;
-
-    memory "prodsig"
-        size		= 0x7D;
-        offset		= 0x1103;
-        page_size	= 0x7D;
-        readsize	= 0x7D;
-    ;
-
-    memory "tempsense"
-        size		= 2;
-        offset		= 0x1104;
-        readsize	= 1;
-    ;
-
-    memory "sernum"
-        size		= 16;
-        offset		= 0x1110;
-        readsize	= 1;
-    ;
-
-    memory "fuses"
-        size		= 9;
-        offset		= 0x1050;
-        page_size = 0x10;
-        readsize  = 0x10;
-    ;
+    hvupdi_variant      = 1;
+    has_updi            = yes;
+    nvm_base            = 0x1000;
+    ocd_base            = 0x0f80;
 
     memory "fuse0"
-        size		= 1;
-        offset		= 0x1050;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1050;
+        readsize        = 1;
     ;
 
     memory "wdtcfg"
@@ -18353,9 +14134,9 @@ part
     ;
 
     memory "fuse1"
-        size		= 1;
-        offset		= 0x1051;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1051;
+        readsize        = 1;
     ;
 
     memory "bodcfg"
@@ -18363,9 +14144,9 @@ part
     ;
 
     memory "fuse2"
-        size		= 1;
-        offset		= 0x1052;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1052;
+        readsize        = 1;
     ;
 
     memory "osccfg"
@@ -18373,9 +14154,9 @@ part
     ;
 
     memory "fuse4"
-        size		= 1;
-        offset		= 0x1054;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1054;
+        readsize        = 1;
     ;
 
     memory "tcd0cfg"
@@ -18383,9 +14164,9 @@ part
     ;
 
     memory "fuse5"
-        size		= 1;
-        offset		= 0x1055;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1055;
+        readsize        = 1;
     ;
 
     memory "syscfg0"
@@ -18393,9 +14174,9 @@ part
     ;
 
     memory "fuse6"
-        size		= 1;
-        offset		= 0x1056;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1056;
+        readsize        = 1;
     ;
 
     memory "syscfg1"
@@ -18403,9 +14184,9 @@ part
     ;
 
     memory "fuse7"
-        size		= 1;
-        offset		= 0x1057;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1057;
+        readsize        = 1;
     ;
 
     memory "codesize"
@@ -18417,9 +14198,9 @@ part
     ;
 
     memory "fuse8"
-        size		= 1;
-        offset		= 0x1058;
-        readsize  = 1;
+        size            = 1;
+        offset          = 0x1058;
+        readsize        = 1;
     ;
 
     memory "bootsize"
@@ -18430,18 +14211,49 @@ part
         alias "fuse8";
     ;
 
+    memory "fuses"
+        size            = 9;
+        page_size       = 16;
+        offset          = 0x1050;
+        readsize        = 16;
+    ;
+
     memory "lock"
-        size		= 4;
-        offset		= 0x1040;
-        page_size = 0x1;
-        readsize  = 0x4;
+        size            = 4;
+        offset          = 0x1040;
+        readsize        = 4;
+    ;
+
+    memory "tempsense"
+        size            = 2;
+        offset          = 0x1104;
+        readsize        = 1;
+    ;
+
+    memory "signature"
+        size            = 3;
+        offset          = 0x1100;
+        readsize        = 3;
+    ;
+
+    memory "prodsig"
+        size            = 125;
+        page_size       = 125;
+        offset          = 0x1103;
+        readsize        = 125;
+    ;
+
+    memory "sernum"
+        size            = 16;
+        offset          = 0x1110;
+        readsize        = 1;
     ;
 
     memory "userrow"
-        size      = 0x20;
-        offset    = 0x1080;
-        page_size = 0x20;
-        readsize  = 0x20;
+        size            = 32;
+        page_size       = 32;
+        offset          = 0x1080;
+        readsize        = 32;
     ;
 
     memory "usersig"
@@ -18450,7 +14262,7 @@ part
 
     memory "data"
         # SRAM, only used to supply the offset
-        offset		= 0x1000000;
+        offset          = 0x1000000;
     ;
 ;
 
@@ -18458,23 +14270,22 @@ part
 # AVR32DA28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32da28";
-    desc      = "AVR32DA28";
-    signature = 0x1E 0x95 0x34;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DA28";
+    id                  = "avr32da28";
+    signature           = 0x1e 0x95 0x34;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18482,23 +14293,22 @@ part parent    ".avrdx"
 # AVR32DA32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32da32";
-    desc      = "AVR32DA32";
-    signature = 0x1E 0x95 0x33;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DA32";
+    id                  = "avr32da32";
+    signature           = 0x1e 0x95 0x33;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18506,23 +14316,22 @@ part parent    ".avrdx"
 # AVR32DA48
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32da48";
-    desc      = "AVR32DA48";
-    signature = 0x1E 0x95 0x32;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DA48";
+    id                  = "avr32da48";
+    signature           = 0x1e 0x95 0x32;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18530,23 +14339,22 @@ part parent    ".avrdx"
 # AVR64DA28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64da28";
-    desc      = "AVR64DA28";
-    signature = 0x1E 0x96 0x15;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DA28";
+    id                  = "avr64da28";
+    signature           = 0x1e 0x96 0x15;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18554,23 +14362,22 @@ part parent    ".avrdx"
 # AVR64DA32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64da32";
-    desc      = "AVR64DA32";
-    signature = 0x1E 0x96 0x14;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DA32";
+    id                  = "avr64da32";
+    signature           = 0x1e 0x96 0x14;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18578,23 +14385,22 @@ part parent    ".avrdx"
 # AVR64DA48
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64da48";
-    desc      = "AVR64DA48";
-    signature = 0x1E 0x96 0x13;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DA48";
+    id                  = "avr64da48";
+    signature           = 0x1e 0x96 0x13;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18602,23 +14408,22 @@ part parent    ".avrdx"
 # AVR64DA64
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64da64";
-    desc      = "AVR64DA64";
-    signature = 0x1E 0x96 0x12;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DA64";
+    id                  = "avr64da64";
+    signature           = 0x1e 0x96 0x12;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18626,23 +14431,22 @@ part parent    ".avrdx"
 # AVR128DA28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128da28";
-    desc      = "AVR128DA28";
-    signature = 0x1E 0x97 0x0A;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DA28";
+    id                  = "avr128da28";
+    signature           = 0x1e 0x97 0x0a;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18650,23 +14454,22 @@ part parent    ".avrdx"
 # AVR128DA32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128da32";
-    desc      = "AVR128DA32";
-    signature = 0x1E 0x97 0x09;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DA32";
+    id                  = "avr128da32";
+    signature           = 0x1e 0x97 0x09;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18674,23 +14477,22 @@ part parent    ".avrdx"
 # AVR128DA48
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128da48";
-    desc      = "AVR128DA48";
-    signature = 0x1E 0x97 0x08;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DA48";
+    id                  = "avr128da48";
+    signature           = 0x1e 0x97 0x08;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18698,23 +14500,22 @@ part parent    ".avrdx"
 # AVR128DA64
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128da64";
-    desc      = "AVR128DA64";
-    signature = 0x1E 0x97 0x07;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DA64";
+    id                  = "avr128da64";
+    signature           = 0x1e 0x97 0x07;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18722,23 +14523,22 @@ part parent    ".avrdx"
 # AVR32DB28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32db28";
-    desc      = "AVR32DB28";
-    signature = 0x1E 0x95 0x37;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DB28";
+    id                  = "avr32db28";
+    signature           = 0x1e 0x95 0x37;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18746,23 +14546,22 @@ part parent    ".avrdx"
 # AVR32DB32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32db32";
-    desc      = "AVR32DB32";
-    signature = 0x1E 0x95 0x36;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DB32";
+    id                  = "avr32db32";
+    signature           = 0x1e 0x95 0x36;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18770,23 +14569,22 @@ part parent    ".avrdx"
 # AVR32DB48
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32db48";
-    desc      = "AVR32DB48";
-    signature = 0x1E 0x95 0x35;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DB48";
+    id                  = "avr32db48";
+    signature           = 0x1e 0x95 0x35;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18794,23 +14592,22 @@ part parent    ".avrdx"
 # AVR64DB28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64db28";
-    desc      = "AVR64DB28";
-    signature = 0x1E 0x96 0x19;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DB28";
+    id                  = "avr64db28";
+    signature           = 0x1e 0x96 0x19;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18818,23 +14615,22 @@ part parent    ".avrdx"
 # AVR64DB32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64db32";
-    desc      = "AVR64DB32";
-    signature = 0x1E 0x96 0x18;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DB32";
+    id                  = "avr64db32";
+    signature           = 0x1e 0x96 0x18;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18842,23 +14638,22 @@ part parent    ".avrdx"
 # AVR64DB48
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64db48";
-    desc      = "AVR64DB48";
-    signature = 0x1E 0x96 0x17;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DB48";
+    id                  = "avr64db48";
+    signature           = 0x1e 0x96 0x17;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18866,23 +14661,22 @@ part parent    ".avrdx"
 # AVR64DB64
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64db64";
-    desc      = "AVR64DB64";
-    signature = 0x1E 0x96 0x16;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DB64";
+    id                  = "avr64db64";
+    signature           = 0x1e 0x96 0x16;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18890,23 +14684,22 @@ part parent    ".avrdx"
 # AVR128DB28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128db28";
-    desc      = "AVR128DB28";
-    signature = 0x1E 0x97 0x0E;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DB28";
+    id                  = "avr128db28";
+    signature           = 0x1e 0x97 0x0e;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18914,23 +14707,22 @@ part parent    ".avrdx"
 # AVR128DB32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128db32";
-    desc      = "AVR128DB32";
-    signature = 0x1E 0x97 0x0D;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DB32";
+    id                  = "avr128db32";
+    signature           = 0x1e 0x97 0x0d;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18938,23 +14730,22 @@ part parent    ".avrdx"
 # AVR128DB48
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128db48";
-    desc      = "AVR128DB48";
-    signature = 0x1E 0x97 0x0C;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DB48";
+    id                  = "avr128db48";
+    signature           = 0x1e 0x97 0x0c;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18962,23 +14753,22 @@ part parent    ".avrdx"
 # AVR128DB64
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr128db64";
-    desc      = "AVR128DB64";
-    signature = 0x1E 0x97 0x0B;
-
-    memory "flash"
-        size      = 0x20000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR128DB64";
+    id                  = "avr128db64";
+    signature           = 0x1e 0x97 0x0b;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 512;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x20000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -18986,24 +14776,23 @@ part parent    ".avrdx"
 # AVR16DD14
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr16dd14";
-    desc      = "AVR16DD14";
-    signature = 0x1E 0x94 0x34;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR16DD14";
+    id                  = "avr16dd14";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x94 0x34;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19011,24 +14800,23 @@ part parent    ".avrdx"
 # AVR16DD20
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr16dd20";
-    desc      = "AVR16DD20";
-    signature = 0x1E 0x94 0x33;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR16DD20";
+    id                  = "avr16dd20";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x94 0x33;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19036,24 +14824,23 @@ part parent    ".avrdx"
 # AVR16DD28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr16dd28";
-    desc      = "AVR16DD28";
-    signature = 0x1E 0x94 0x32;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR16DD28";
+    id                  = "avr16dd28";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x94 0x32;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19061,24 +14848,23 @@ part parent    ".avrdx"
 # AVR16DD32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr16dd32";
-    desc      = "AVR16DD32";
-    signature = 0x1E 0x94 0x31;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR16DD32";
+    id                  = "avr16dd32";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x94 0x31;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19086,24 +14872,23 @@ part parent    ".avrdx"
 # AVR32DD14
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32dd14";
-    desc      = "AVR32DD14";
-    signature = 0x1E 0x95 0x3B;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DD14";
+    id                  = "avr32dd14";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x95 0x3b;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19111,24 +14896,23 @@ part parent    ".avrdx"
 # AVR32DD20
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32dd20";
-    desc      = "AVR32DD20";
-    signature = 0x1E 0x95 0x3A;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DD20";
+    id                  = "avr32dd20";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x95 0x3a;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19136,24 +14920,23 @@ part parent    ".avrdx"
 # AVR32DD28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32dd28";
-    desc      = "AVR32DD28";
-    signature = 0x1E 0x95 0x39;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DD28";
+    id                  = "avr32dd28";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x95 0x39;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19161,24 +14944,23 @@ part parent    ".avrdx"
 # AVR32DD32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr32dd32";
-    desc      = "AVR32DD32";
-    signature = 0x1E 0x95 0x38;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR32DD32";
+    id                  = "avr32dd32";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x95 0x38;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19186,24 +14968,23 @@ part parent    ".avrdx"
 # AVR64DD14
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64dd14";
-    desc      = "AVR64DD14";
-    signature = 0x1E 0x96 0x1D;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DD14";
+    id                  = "avr64dd14";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x96 0x1d;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19211,24 +14992,23 @@ part parent    ".avrdx"
 # AVR64DD20
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64dd20";
-    desc      = "AVR64DD20";
-    signature = 0x1E 0x96 0x1C;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DD20";
+    id                  = "avr64dd20";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x96 0x1c;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19236,24 +15016,23 @@ part parent    ".avrdx"
 # AVR64DD28
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64dd28";
-    desc      = "AVR64DD28";
-    signature = 0x1E 0x96 0x1B;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DD28";
+    id                  = "avr64dd28";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x96 0x1b;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19261,24 +15040,23 @@ part parent    ".avrdx"
 # AVR64DD32
 #------------------------------------------------------------
 
-part parent    ".avrdx"
-    id        = "avr64dd32";
-    desc      = "AVR64DD32";
-    signature = 0x1E 0x96 0x1A;
-    hvupdi_variant = 2;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x200;
-        readsize  = 0x100;
-    ;
+part parent ".avrdx"
+    desc                = "AVR64DD32";
+    id                  = "avr64dd32";
+    hvupdi_variant      = 2;
+    signature           = 0x1e 0x96 0x1a;
 
     memory "eeprom"
-        size      = 0x100;
-        offset    = 0x1400;
-        page_size = 0x1;
-        readsize  = 0x100;
+        size            = 256;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 512;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19287,16 +15065,15 @@ part parent    ".avrdx"
 #------------------------------------------------------------
 
 part parent ".avrdx"
-    id			       = ".avrex";
-    desc		       = "AVR-Ex family common values";
+    desc                = "AVR-Ex family common values";
+    id                  = ".avrex";
     # Shared UPDI pin, HV on _RESET
-    hvupdi_variant = 2;
+    hvupdi_variant      = 2;
 
     memory "userrow"
-        size      = 0x40;
-        offset    = 0x1080;
-        page_size = 0x40;
-        readsize  = 0x40;
+        size            = 64;
+        page_size       = 64;
+        readsize        = 64;
     ;
 
     memory "usersig"
@@ -19308,23 +15085,23 @@ part parent ".avrdx"
 # AVR8EA28
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr8ea28";
-    desc      = "AVR8EA28";
-    signature = 0x1E 0x93 0x2C;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR8EA28";
+    id                  = "avr8ea28";
+    signature           = 0x1e 0x93 0x2c;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19332,23 +15109,23 @@ part parent    ".avrex"
 # AVR8EA32
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr8ea32";
-    desc      = "AVR8EA32";
-    signature = 0x1E 0x93 0x2B;
-
-    memory "flash"
-        size      = 0x2000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR8EA32";
+    id                  = "avr8ea32";
+    signature           = 0x1e 0x93 0x2b;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 8192;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19356,23 +15133,23 @@ part parent    ".avrex"
 # AVR16EA28
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr16ea28";
-    desc      = "AVR16EA28";
-    signature = 0x1E 0x94 0x37;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR16EA28";
+    id                  = "avr16ea28";
+    signature           = 0x1e 0x94 0x37;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19380,23 +15157,23 @@ part parent    ".avrex"
 # AVR16EA32
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr16ea32";
-    desc      = "AVR16EA32";
-    signature = 0x1E 0x94 0x36;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR16EA32";
+    id                  = "avr16ea32";
+    signature           = 0x1e 0x94 0x36;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19404,23 +15181,23 @@ part parent    ".avrex"
 # AVR16EA48
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr16ea48";
-    desc      = "AVR16EA48";
-    signature = 0x1E 0x94 0x35;
-
-    memory "flash"
-        size      = 0x4000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR16EA48";
+    id                  = "avr16ea48";
+    signature           = 0x1e 0x94 0x35;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x4000;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19428,23 +15205,23 @@ part parent    ".avrex"
 # AVR32EA28
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr32ea28";
-    desc      = "AVR32EA28";
-    signature = 0x1E 0x95 0x3E;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR32EA28";
+    id                  = "avr32ea28";
+    signature           = 0x1e 0x95 0x3e;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19452,23 +15229,23 @@ part parent    ".avrex"
 # AVR32EA32
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr32ea32";
-    desc      = "AVR32EA32";
-    signature = 0x1E 0x95 0x3D;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR32EA32";
+    id                  = "avr32ea32";
+    signature           = 0x1e 0x95 0x3d;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19476,23 +15253,23 @@ part parent    ".avrex"
 # AVR32EA48
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr32ea48";
-    desc      = "AVR32EA48";
-    signature = 0x1E 0x95 0x3C;
-
-    memory "flash"
-        size      = 0x8000;
-        offset    = 0x800000;
-        page_size = 0x40;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR32EA48";
+    id                  = "avr32ea48";
+    signature           = 0x1e 0x95 0x3c;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x8000;
+        page_size       = 64;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19500,23 +15277,23 @@ part parent    ".avrex"
 # AVR64EA28
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr64ea28";
-    desc      = "AVR64EA28";
-    signature = 0x1E 0x96 0x20;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR64EA28";
+    id                  = "avr64ea28";
+    signature           = 0x1e 0x96 0x20;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19524,23 +15301,23 @@ part parent    ".avrex"
 # AVR64EA32
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr64ea32";
-    desc      = "AVR64EA32";
-    signature = 0x1E 0x96 0x1F;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR64EA32";
+    id                  = "avr64ea32";
+    signature           = 0x1e 0x96 0x1f;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19548,23 +15325,23 @@ part parent    ".avrex"
 # AVR64EA48
 #------------------------------------------------------------
 
-part parent    ".avrex"
-    id        = "avr64ea48";
-    desc      = "AVR64EA48";
-    signature = 0x1E 0x96 0x1E;
-
-    memory "flash"
-        size      = 0x10000;
-        offset    = 0x800000;
-        page_size = 0x80;
-        readsize  = 0x100;
-    ;
+part parent ".avrex"
+    desc                = "AVR64EA48";
+    id                  = "avr64ea48";
+    signature           = 0x1e 0x96 0x1e;
 
     memory "eeprom"
-        size      = 0x200;
-        offset    = 0x1400;
-        page_size = 0x8;
-        readsize  = 0x100;
+        size            = 512;
+        page_size       = 8;
+        offset          = 0x1400;
+        readsize        = 256;
+    ;
+
+    memory "flash"
+        size            = 0x10000;
+        page_size       = 128;
+        offset          = 0x800000;
+        readsize        = 256;
     ;
 ;
 
@@ -19573,25 +15350,27 @@ part parent    ".avrex"
 #------------------------------------------------------------
 
 part parent "m88"
-    id               = "lgt8f88p";
-    desc             = "LGT8F88P";
-    signature        = 0x1e 0x93 0x0f;
-
-    ocdrev              = 1;
-  ;
-
-part parent "m168"
-    id              = "lgt8f168p";
-    desc            = "LGT8F168P";
-    signature       = 0x1e 0x94 0x0b;
-
-    ocdrev              = 1;
+    desc                = "LGT8F88P";
+    id                  = "lgt8f88p";
+    signature           = 0x1e 0x93 0x0f;
 ;
 
-part parent "m328"
-    id      = "lgt8f328p";
-    desc    = "LGT8F328P";
-    signature   = 0x1e 0x95 0x0F;
+#------------------------------------------------------------
+# LGT8F168P
+#------------------------------------------------------------
 
-    ocdrev              = 1;
+part parent "m168"
+    desc                = "LGT8F168P";
+    id                  = "lgt8f168p";
+    signature           = 0x1e 0x94 0x0b;
+;
+
+#------------------------------------------------------------
+# LGT8F328P
+#------------------------------------------------------------
+
+part parent "m328"
+    desc                = "LGT8F328P";
+    id                  = "lgt8f328p";
+    signature           = 0x1e 0x95 0x0f;
 ;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -375,31 +375,41 @@ default_spi        = "@DEFAULT_SPI_PORT@";
 # default_bitclock = 2.5;
 
 @HAVE_PARPORT_BEGIN@
-# Parallel port programmers.
+# Parallel port programmers
+
+#------------------------------------------------------------
+# bsd
+#------------------------------------------------------------
 
 programmer
-  id    = "bsd";
-  desc  = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
-  type  = "par";
-  connection_type = parallel;
-  vcc   = 2, 3, 4, 5;
-  reset = 7;
-  sck   = 8;
-  mosi  = 9;
-  miso  = 10;
+    id                  = "bsd";
+    desc                = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
+    type                = "par";
+    vcc                 = 2, 3, 4, 5;
+    reset               = 7;
+    sck                 = 8;
+    mosi                = 9;
+    miso                = 10;
 ;
 
+#------------------------------------------------------------
+# stk200
+#------------------------------------------------------------
+
 programmer
-  id    = "stk200";
-  desc  = "STK200";
-  type  = "par";
-  connection_type = parallel;
-  buff  = 4, 5;
-  sck   = 6;
-  mosi  = 7;
-  reset = 9;
-  miso  = 10;
+    id                  = "stk200";
+    desc                = "STK200";
+    type                = "par";
+    buff                = 4, 5;
+    reset               = 9;
+    sck                 = 6;
+    mosi                = 7;
+    miso                = 10;
 ;
+
+#------------------------------------------------------------
+# pony-stk200
+#------------------------------------------------------------
 
 # The programming dongle used by the popular Ponyprog
 # utility.  It is almost similar to the STK200 one,
@@ -407,89 +417,116 @@ programmer
 # programming is currently in progress.
 
 programmer parent "stk200"
-  id    = "pony-stk200";
-  desc  = "Pony Prog STK200";
-  pgmled = 8;
+    id                  = "pony-stk200";
+    desc                = "Pony Prog STK200";
+    type                = "par";
+    pgmled              = 8;
 ;
 
+#------------------------------------------------------------
+# dt006
+#------------------------------------------------------------
+
 programmer
-  id    = "dt006";
-  desc  = "Dontronics DT006";
-  type  = "par";
-  connection_type = parallel;
-  reset = 4;
-  sck   = 5;
-  mosi  = 2;
-  miso  = 11;
+    id                  = "dt006";
+    desc                = "Dontronics DT006";
+    type                = "par";
+    reset               = 4;
+    sck                 = 5;
+    mosi                = 2;
+    miso                = 11;
 ;
+
+#------------------------------------------------------------
+# bascom
+#------------------------------------------------------------
 
 programmer parent "dt006"
-  id    = "bascom";
-  desc  = "Bascom SAMPLE programming cable";
+    id                  = "bascom";
+    desc                = "Bascom SAMPLE programming cable";
+    type                = "par";
 ;
+
+#------------------------------------------------------------
+# alf
+#------------------------------------------------------------
 
 programmer
-  id     = "alf";
-  desc   = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
-  type   = "par";
-  connection_type = parallel;
-  vcc    = 2, 3, 4, 5;
-  buff   = 6;
-  reset  = 7;
-  sck    = 8;
-  mosi   = 9;
-  miso   = 10;
-  errled = 1;
-  rdyled = 14;
-  pgmled = 16;
-  vfyled = 17;
+    id                  = "alf";
+    desc                = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
+    type                = "par";
+    vcc                 = 2, 3, 4, 5;
+    buff                = 6;
+    reset               = 7;
+    sck                 = 8;
+    mosi                = 9;
+    miso                = 10;
+    errled              = 1;
+    rdyled              = 14;
+    pgmled              = 16;
+    vfyled              = 17;
 ;
+
+#------------------------------------------------------------
+# sp12
+#------------------------------------------------------------
 
 programmer
-  id    = "sp12";
-  desc  = "Steve Bolt's Programmer";
-  type  = "par";
-  connection_type = parallel;
-  vcc   = 4,5,6,7,8;
-  reset = 3;
-  sck   = 2;
-  mosi  = 9;
-  miso  = 11;
+    id                  = "sp12";
+    desc                = "Steve Bolt's Programmer";
+    type                = "par";
+    vcc                 = 4, 5, 6, 7, 8;
+    reset               = 3;
+    sck                 = 2;
+    mosi                = 9;
+    miso                = 11;
 ;
+
+#------------------------------------------------------------
+# picoweb
+#------------------------------------------------------------
 
 programmer
-  id     = "picoweb";
-  desc   = "Picoweb Programming Cable, http://www.picoweb.net/";
-  type   = "par";
-  connection_type = parallel;
-  reset  = 2;
-  sck    = 3;
-  mosi   = 4;
-  miso   = 13;
+    id                  = "picoweb";
+    desc                = "Picoweb Programming Cable, http://www.picoweb.net/";
+    type                = "par";
+    reset               = 2;
+    sck                 = 3;
+    mosi                = 4;
+    miso                = 13;
 ;
+
+#------------------------------------------------------------
+# abcmini
+#------------------------------------------------------------
 
 programmer
-  id    = "abcmini";
-  desc  = "ABCmini Board, aka Dick Smith HOTCHIP";
-  type  = "par";
-  connection_type = parallel;
-  reset = 4;
-  sck   = 3;
-  mosi  = 2;
-  miso  = 10;
+    id                  = "abcmini";
+    desc                = "ABCmini Board, aka Dick Smith HOTCHIP";
+    type                = "par";
+    reset               = 4;
+    sck                 = 3;
+    mosi                = 2;
+    miso                = 10;
 ;
+
+#------------------------------------------------------------
+# futurlec
+#------------------------------------------------------------
 
 programmer
-  id    = "futurlec";
-  desc  = "Futurlec.com programming cable.";
-  type  = "par";
-  connection_type = parallel;
-  reset = 3;
-  sck   = 2;
-  mosi  = 1;
-  miso  = 10;
+    id                  = "futurlec";
+    desc                = "Futurlec.com programming cable.";
+    type                = "par";
+    reset               = 3;
+    sck                 = 2;
+    mosi                = 1;
+    miso                = 10;
 ;
 
+#------------------------------------------------------------
+# xil
+#------------------------------------------------------------
 
 # From the contributor of the "xil" jtag cable:
 # The "vcc" definition isn't really vcc (the cable gets its power from
@@ -498,91 +535,115 @@ programmer
 # avrdude versions before 5.5j).
 # With this, TMS connects to RESET, TDI to MOSI, TDO to MISO and TCK
 # to SCK (plus vcc/gnd of course)
-programmer
-  id    = "xil";
-  desc  = "Xilinx JTAG cable";
-  type  = "par";
-  connection_type = parallel;
-  mosi  = 2;
-  sck   = 3;
-  reset = 4;
-  buff  = 5;
-  miso  = 13;
-  vcc   = 6;
-;
-
 
 programmer
-  id = "dapa";
-  desc = "Direct AVR Parallel Access cable";
-  type = "par";
-  connection_type = parallel;
-  vcc   = 3;
-  reset = 16;
-  sck = 1;
-  mosi = 2;
-  miso = 11;
+    id                  = "xil";
+    desc                = "Xilinx JTAG cable";
+    type                = "par";
+    vcc                 = 6;
+    buff                = 5;
+    reset               = 4;
+    sck                 = 3;
+    mosi                = 2;
+    miso                = 13;
 ;
 
-programmer
-  id    = "atisp";
-  desc  = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
-  type  = "par";
-  connection_type = parallel;
-  reset = ~6;
-  sck   = ~8;
-  mosi  = ~7;
-  miso  = ~10;
-;
+#------------------------------------------------------------
+# dapa
+#------------------------------------------------------------
 
 programmer
-  id    = "ere-isp-avr";
-  desc  = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
-  type  = "par";
-  connection_type = parallel;
-  reset = ~4;
-  sck   = 3;
-  mosi  = 2;
-  miso  = 10;
+    id                  = "dapa";
+    desc                = "Direct AVR Parallel Access cable";
+    type                = "par";
+    vcc                 = 3;
+    reset               = 16;
+    sck                 = 1;
+    mosi                = 2;
+    miso                = 11;
 ;
 
+#------------------------------------------------------------
+# atisp
+#------------------------------------------------------------
+
 programmer
-  id    = "blaster";
-  desc  = "Altera ByteBlaster";
-  type  = "par";
-  connection_type = parallel;
-  sck   = 2;
-  miso  = 11;
-  reset = 3;
-  mosi  = 8;
-  buff  = 14;
+    id                  = "atisp";
+    desc                = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
+    type                = "par";
+    reset               = ~6;
+    sck                 = ~8;
+    mosi                = ~7;
+    miso                = ~10;
 ;
+
+#------------------------------------------------------------
+# ere-isp-avr
+#------------------------------------------------------------
+
+programmer
+    id                  = "ere-isp-avr";
+    desc                = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
+    type                = "par";
+    reset               = ~4;
+    sck                 = 3;
+    mosi                = 2;
+    miso                = 10;
+;
+
+#------------------------------------------------------------
+# blaster
+#------------------------------------------------------------
+
+programmer
+    id                  = "blaster";
+    desc                = "Altera ByteBlaster";
+    type                = "par";
+    buff                = 14;
+    reset               = 3;
+    sck                 = 2;
+    mosi                = 8;
+    miso                = 11;
+;
+
+#------------------------------------------------------------
+# frank-stk200
+#------------------------------------------------------------
 
 # It is almost same as pony-stk200, except vcc on pin 5 to auto
 # disconnect port (download on http://electropol.free.fr/spip/spip.php?article27)
+
 programmer parent "pony-stk200"
-  id    = "frank-stk200";
-  desc  = "Frank STK200";
-  buff  = ; # delete buff pin assignment
-  vcc   = 5;
+    id                  = "frank-stk200";
+    desc                = "Frank STK200";
+    type                = "par";
+    vcc                 = 5;
+    buff                = ; # delete buff pin assignment
 ;
+
+#------------------------------------------------------------
+# 89isp
+#------------------------------------------------------------
 
 # The AT98ISP Cable is a simple parallel dongle for AT89 family.
 # http://www.atmel.com/dyn/products/tools_card.asp?tool_id=2877
-programmer
-  id = "89isp";
-  desc = "Atmel at89isp cable";
-  type = "par";
-  connection_type = parallel;
-  reset = 17;
-  sck = 1;
-  mosi = 2;
-  miso = 10;
-;
 
+programmer
+    id                  = "89isp";
+    desc                = "Atmel at89isp cable";
+    type                = "par";
+    reset               = 17;
+    sck                 = 1;
+    mosi                = 2;
+    miso                = 10;
+;
 @HAVE_PARPORT_END@
 
 @HAVE_LINUXGPIO_BEGIN@
+#------------------------------------------------------------
+# linuxgpio
+#------------------------------------------------------------
+
 #This programmer bitbangs GPIO lines using the Linux sysfs GPIO interface
 #
 #To enable it set the configuration below to match the GPIO lines connected to the
@@ -606,19 +667,23 @@ programmer
 #;
 @HAVE_LINUXGPIO_END@
 
-
 @HAVE_LINUXSPI_BEGIN@
+#------------------------------------------------------------
+# linuxspi
+#------------------------------------------------------------
+
 # This programmer uses the built in linux SPI bus devices to program an
 # attached AVR. The reset pin must be attached to a GPIO pin that
 # is otherwise unused (see gpioinfo(1)); the SPI bus CE pins are not
 # suitable since they would release /RESET too early.
 #
+
 programmer
-   id = "linuxspi";
-   desc = "Use Linux SPI device in /dev/spidev*";
-   type = "linuxspi";
-   connection_type = spi;
-   reset = 25;    # Pi GPIO number - this is J8:22
+    id                  = "linuxspi";
+    desc                = "Use Linux SPI device in /dev/spidev*";
+    type                = "linuxspi";
+    connection_type     = spi;
+    reset               = 25;    # Pi GPIO number - this is J8:22
 ;
 @HAVE_LINUXSPI_END@
 
@@ -631,8 +696,8 @@ programmer
 #------------------------------------------------------------
 
 # http://wiring.org.co/
-# Basically STK500v2 protocol, with some glue to trigger the
-# bootloader.
+# Basically STK500v2 protocol, with some glue to trigger the bootloader
+
 programmer
     id                  = "wiring";
     desc                = "Wiring";
@@ -714,6 +779,7 @@ programmer
 
 # This is an implementation of the above with a buffer IC (74AC244) and
 # 4 LEDs directly attached, all active low.
+
 programmer
     id                  = "2232HIO";
     desc                = "FT2232H based generic programmer";
@@ -744,15 +810,12 @@ programmer
 
 #The FT4232H can be treated as FT2232H, but it has a different USB
 #device ID of 0x6011.
+
 programmer parent "avrftdi"
     id                  = "4232h";
     desc                = "FT4232H based generic programmer";
     type                = "avrftdi";
     usbpid              = 0x6011;
-    reset               = 3;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
 ;
 
 #------------------------------------------------------------
@@ -792,8 +855,8 @@ programmer
     usbvid              = 0x0403;
     usbpid              = 0x6014;
     usbdev              = "A";
-    reset               = 3; # AD3 (TMS)
 #ISP-signals
+    reset               = 3; # AD3 (TMS)
     sck                 = 0; # AD0 (TCK)
     mosi                = 1; # AD1 (TDI)
     miso                = 2; # AD2 (TDO)
@@ -810,15 +873,12 @@ programmer
 # Pin J2-6 is GND
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
+
 programmer parent "ft232h"
     id                  = "um232h";
     desc                = "UM232H module from FTDI";
     type                = "avrftdi";
     usbpid              = 0x6014;
-    reset               = 3;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
 ;
 
 #------------------------------------------------------------
@@ -832,15 +892,12 @@ programmer parent "ft232h"
 # Black (Pin 10) is GND
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
+
 programmer parent "ft232h"
     id                  = "c232hm";
     desc                = "C232HM cable from FTDI";
     type                = "avrftdi";
     usbpid              = 0x6014;
-    reset               = 3;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
 ;
 
 #------------------------------------------------------------
@@ -860,6 +917,7 @@ programmer parent "ft232h"
 #   http://armwerks.com/catalog/o-link-debugger-copy/
 # or just have a look at ebay ...
 # It is basically the same entry as jtagkey with different usb ids.
+
 programmer parent "jtagkey"
     id                  = "o-link";
     desc                = "O-Link, OpenJTAG from www.100ask.net";
@@ -868,11 +926,6 @@ programmer parent "jtagkey"
     usbpid              = 0x5118;
     usbvendor           = "www.100ask.net";
     usbproduct          = "USB<=>JTAG&RS232";
-    buff                = ~4;
-    reset               = 3;
-    sck                 = 0;
-    mosi                = 1;
-    miso                = 2;
 ;
 
 #------------------------------------------------------------
@@ -880,6 +933,7 @@ programmer parent "jtagkey"
 #------------------------------------------------------------
 
 # http://wiki.openmoko.org/wiki/Debug_Board_v3
+
 programmer
     id                  = "openmoko";
     desc                = "Openmoko debug board (v3)";
@@ -899,6 +953,7 @@ programmer
 
 # Only Rev. A boards.
 # Schematic and user manual: http://www.cs.put.poznan.pl/wswitala/download/pdf/811EVBK.pdf
+
 programmer
     id                  = "lm3s811";
     desc                = "Luminary Micro LM3S811 Eval Board (Rev. A)";
@@ -923,6 +978,7 @@ programmer
 #------------------------------------------------------------
 
 # submitted as bug #46020
+
 programmer
     id                  = "tumpa";
     desc                = "TIAO USB Multi-Protocol Adapter";
@@ -958,6 +1014,7 @@ programmer
 #  * Connect JTAG connector pin 1 to 5V (i.e. EXT pin 13 or JTAG pin 19).
 #  * For TPI connection use resistors: TDO --[470R]-- TPIDATA --[470R]-- TDI.
 #  * Powering target from JTAG pin 19 allows KT-LINK current measurement.
+
 programmer
     id                  = "ktlink";
     desc                = "KT-LINK FT2232H interface with IO switching and voltage buffers.";
@@ -1065,6 +1122,7 @@ programmer
 # Attempts to select the correct firmware version
 # by probing for it.  Better use one of the entries
 # below instead.
+
 programmer
     id                  = "stk500";
     desc                = "Atmel STK500";
@@ -1206,6 +1264,7 @@ programmer
 #------------------------------------------------------------
 
 # see http://www.bitwizard.nl/wiki/index.php/FTDI_ATmega
+
 programmer
     id                  = "bwmega";
     desc                = "BitWizard ftdi_atmega builtin programmer";
@@ -1223,6 +1282,7 @@ programmer
 
 # see http://www.geocities.jp/arduino_diecimila/bootloader/index_en.html
 # Note: pins are numbered from 1!
+
 programmer
     id                  = "arduino-ft232r";
     desc                = "Arduino: FT232R connected to ISP";
@@ -1243,9 +1303,9 @@ programmer
     desc                = "Tag-Connect TC2030";
     type                = "ftdi_syncbb";
     connection_type     = usb;
+  #                      FOR TPI devices:
     reset               = 3;  # CTS = D3 (wire to ~RESET)
     sck                 = 2;  # RTS = D2 (wire to SCK)
-  #                      FOR TPI devices:
     mosi                = 0;  # TxD = D0 (wire to TPIDATA via 1k resistor)
     miso                = 1;  # RxD = D1 (wire to TPIDATA directly)
 ;
@@ -1255,14 +1315,11 @@ programmer
 #------------------------------------------------------------
 
 # website mentioned above uses this id
+
 programmer parent "arduino-ft232r"
     id                  = "diecimila";
     desc                = "alias for arduino-ft232r";
     type                = "ftdi_syncbb";
-    reset               = 7;
-    sck                 = 5;
-    mosi                = 6;
-    miso                = 3;
 ;
 
 #------------------------------------------------------------
@@ -1275,6 +1332,7 @@ programmer parent "arduino-ft232r"
 # Its 4 pairs of pins are shorted to enable ftdi_syncbb.
 # http://akizukidenshi.com/catalog/g/gP-07487/
 # http://akizukidenshi.com/download/ds/akizuki/k6096_manual_20130816.pdf
+
 programmer
     id                  = "uncompatino";
     desc                = "uncompatino with all pairs of pins shorted";
@@ -1303,6 +1361,7 @@ programmer
 # TTL-232R RTS 6 Green  -> ICPS MISO  (pin 1)
 # Except for VCC and GND, you can connect arbitual pairs as long as
 # the following table is adjusted.
+
 programmer
     id                  = "ttl232r";
     desc                = "FTDI TTL232R-5V with ICSP adapter";
@@ -1380,6 +1439,7 @@ programmer
 # In that case, a resistor of 1 kOhm is needed between MISO and MOSI
 # pins of the connector, and MISO (pin 1 of the 6-pin connector)
 # connects to TPIDATA.
+
 programmer
     id                  = "usbtiny";
     desc                = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
@@ -1420,6 +1480,7 @@ programmer
 #------------------------------------------------------------
 
 # commercial version of USBtiny, using a separate VID/PID
+
 programmer
     id                  = "ehajo-isp";
     desc                = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
@@ -1435,6 +1496,7 @@ programmer
 
 # commercial version of USBtiny, using a separate VID/PID
 # https://github.com/IowaScaledEngineering/ckt-avrprogrammer
+
 programmer
     id                  = "iseavrprog";
     desc                = "USBtiny-based programmer, https://iascaled.com";
@@ -1508,6 +1570,7 @@ programmer
 #------------------------------------------------------------
 
 # suggested in http://forum.mikrokopter.de/topic-post48317.html
+
 programmer
     id                  = "mkbutterfly";
     desc                = "Mikrokopter.de Butterfly";
@@ -1541,6 +1604,7 @@ programmer
 #------------------------------------------------------------
 
 # easier to type
+
 programmer parent "jtagmkI"
     id                  = "jtag1";
     type                = "jtagmki";
@@ -1551,6 +1615,7 @@ programmer parent "jtagmkI"
 #------------------------------------------------------------
 
 # easier to type
+
 programmer parent "jtag1"
     id                  = "jtag1slow";
     type                = "jtagmki";
@@ -1579,6 +1644,7 @@ programmer
 #------------------------------------------------------------
 
 # easier to type
+
 programmer parent "jtagmkII"
     id                  = "jtag2slow";
     type                = "jtagmkii";
@@ -1589,6 +1655,7 @@ programmer parent "jtagmkII"
 #------------------------------------------------------------
 
 # JTAG ICE mkII @ 115200 Bd
+
 programmer parent "jtag2slow"
     id                  = "jtag2fast";
     type                = "jtagmkii";
@@ -1600,6 +1667,7 @@ programmer parent "jtag2slow"
 #------------------------------------------------------------
 
 # make the fast one the default, people will love that
+
 programmer parent "jtag2fast"
     id                  = "jtag2";
     type                = "jtagmkii";
@@ -1610,6 +1678,7 @@ programmer parent "jtag2fast"
 #------------------------------------------------------------
 
 # JTAG ICE mkII in ISP mode
+
 programmer
     id                  = "jtag2isp";
     desc                = "Atmel JTAG ICE mkII in ISP mode";
@@ -1623,6 +1692,7 @@ programmer
 #------------------------------------------------------------
 
 # JTAG ICE mkII in debugWire mode
+
 programmer
     id                  = "jtag2dw";
     desc                = "Atmel JTAG ICE mkII in debugWire mode";
@@ -1636,6 +1706,7 @@ programmer
 #------------------------------------------------------------
 
 # JTAG ICE mkII in AVR32 mode
+
 programmer
     id                  = "jtagmkII_avr32";
     desc                = "Atmel JTAG ICE mkII im AVR32 mode";
@@ -1649,6 +1720,7 @@ programmer
 #------------------------------------------------------------
 
 # JTAG ICE mkII in AVR32 mode
+
 programmer
     id                  = "jtag2avr32";
     desc                = "Atmel JTAG ICE mkII im AVR32 mode";
@@ -1662,6 +1734,7 @@ programmer
 #------------------------------------------------------------
 
 # JTAG ICE mkII in PDI mode
+
 programmer
     id                  = "jtag2pdi";
     desc                = "Atmel JTAG ICE mkII PDI mode";
@@ -1675,6 +1748,7 @@ programmer
 #------------------------------------------------------------
 
 # AVR Dragon in JTAG mode
+
 programmer
     id                  = "dragon_jtag";
     desc                = "Atmel AVR Dragon in JTAG mode";
@@ -1688,6 +1762,7 @@ programmer
 #------------------------------------------------------------
 
 # AVR Dragon in ISP mode
+
 programmer
     id                  = "dragon_isp";
     desc                = "Atmel AVR Dragon in ISP mode";
@@ -1701,6 +1776,7 @@ programmer
 #------------------------------------------------------------
 
 # AVR Dragon in PP mode
+
 programmer
     id                  = "dragon_pp";
     desc                = "Atmel AVR Dragon in PP mode";
@@ -1714,6 +1790,7 @@ programmer
 #------------------------------------------------------------
 
 # AVR Dragon in HVSP mode
+
 programmer
     id                  = "dragon_hvsp";
     desc                = "Atmel AVR Dragon in HVSP mode";
@@ -1727,6 +1804,7 @@ programmer
 #------------------------------------------------------------
 
 # AVR Dragon in debugWire mode
+
 programmer
     id                  = "dragon_dw";
     desc                = "Atmel AVR Dragon in debugWire mode";
@@ -1740,6 +1818,7 @@ programmer
 #------------------------------------------------------------
 
 # AVR Dragon in PDI mode
+
 programmer
     id                  = "dragon_pdi";
     desc                = "Atmel AVR Dragon in PDI mode";
@@ -2170,10 +2249,6 @@ programmer parent "ponyser"
     id                  = "siprog";
     desc                = "Lancos SI-Prog <http://www.lancos.com/siprogsch.html>";
     type                = "serbb";
-    reset               = ~3;
-    sck                 = 7;
-    mosi                = 4;
-    miso                = 8;
 ;
 
 #------------------------------------------------------------

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1147,7 +1147,8 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
   }
 
   _if_pgmout_str(strcmp, cfg_escape(pgm->desc), desc);
-  _pgmout_fmt("type", "\"%s\"", locate_programmer_type_id(pgm->initpgm));
+  if(!base || base->initpgm != pgm->initpgm)
+    _pgmout_fmt("type", "\"%s\"", locate_programmer_type_id(pgm->initpgm));
   if(!base || base->conntype != pgm->conntype)
     _pgmout_fmt("connection_type", "%s", connstr(pgm->conntype));
   _if_pgmout(intcmp, "%d", baudrate);
@@ -1182,10 +1183,13 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
 
   for(int i=0; i<N_PINS; i++) {
     char *str = pins_to_strdup(pgm->pin+i);
-    if(str && *str)
+    char *bstr = base? pins_to_strdup(base->pin+i): NULL;
+    if(!base || strcmp(bstr, str))
       _pgmout_fmt(avr_pin_lcname(i), "%s", str);
-    if(str)
-      free(str);
+
+    free(str);
+    if(bstr)
+      free(bstr);
   }
 
   if(pgm->hvupdi_support && lfirst(pgm->hvupdi_support)) {

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -331,7 +331,7 @@ static int dev_part_strct_entry(bool tsv,               // Print as spreadsheet?
   } else {                      // Grammar conform
     int indent = col2 && strcmp(col2, "part");
     dev_cout(comms, n, 0, 0); // Print comments before the line
-    dev_info("%*s%-*s = %s;", indent? 8: 4, "", indent? 15: 19, n, c);
+    dev_info("%*s%-*s = %s;", indent? 8: 4, "", indent? 18: 22, n, c);
     dev_cout(comms, n, 1, 1);  // Print comments on rhs
   }
 
@@ -361,7 +361,7 @@ static void dev_stack_out(bool tsv, const AVRPART *p, const char *name, const un
     dev_info(".pt\t%s\t%s\t", p->desc, name);
   else {
     dev_cout(p->comments, name, 0, 0);
-    dev_info("    %-19s =%s", name, ns <=8? " ": "");
+    dev_info("    %-22s =%s", name, ns <=8? " ": "");
   }
 
   if(ns <= 0)
@@ -1169,7 +1169,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
     dev_info(".prog\t%s\tid\t", id);
   else {
     dev_cout(pgm->comments, "id", 0, 0);
-    dev_info("    %-19s = ", "id");
+    dev_info("    %-22s = ", "id");
   }
   for(firstid=1, ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
     if(!firstid)
@@ -1200,7 +1200,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
       dev_info(".prog\t%s\tusbpid\t", id);
     else {
       dev_cout(pgm->comments, "usbpid", 0, 0);
-      dev_info("    %-19s = ", "usbpid");
+      dev_info("    %-22s = ", "usbpid");
     }
     for(firstid=1, ln=lfirst(pgm->usbpid); ln; ln=lnext(ln)) {
       if(!firstid)
@@ -1237,7 +1237,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
       dev_info(".prog\t%s\thvupdu_support\t", id);
     else {
       dev_cout(pgm->comments, "hvupdi_support", 0, 0);
-      dev_info("    %-19s = ", "hvupdi_support");
+      dev_info("    %-22s = ", "hvupdi_support");
     }
     for(firstid=1, ln=lfirst(pgm->hvupdi_support); ln; ln=lnext(ln)) {
       if(!firstid)

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -345,7 +345,7 @@ static void dev_stack_out(bool tsv, const AVRPART *p, const char *name, const un
     dev_info(tsv? "NULL\n": "NULL;");
   else
     for(int i=0; i<ns; i++)
-      dev_info("%s0x%02x%s", !tsv && ns > 8 && i%8 == 0? "\n        ": "", stack[i], i+1<ns? ", ": tsv? "\n": ";");
+      dev_info("%s0x%02x%s", !tsv && ns > 8 && i%8 == 0? "\n        ": " ", stack[i], i+1<ns? ",": tsv? "\n": ";");
 
   dev_cout(p->comments, name, 1, 1);
 }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -63,12 +63,14 @@ static struct {
   const char *mcu, *var, *value;
 } ptinj[] = {
   // Add triples here, eg, {"ATmega328P", "mcuid", "999"},
+ {NULL, NULL, NULL},
 };
 
 static struct {
   const char *mcu, *mem, *var, *value;
 } meminj[] = {
   // Add quadruples here, eg, {"ATmega328P", "flash", "page_size", "128"},
+  {NULL, NULL, NULL, NULL},
 };
 
 
@@ -713,9 +715,10 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
 
     if(injct)
       for(size_t i=0; i<sizeof meminj/sizeof*meminj; i++)
-        if(strcmp(meminj[i].mcu, p->desc) == 0 && strcmp(meminj[i].mem, m->desc) == 0)
-          dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc,
-            meminj[i].var, cfg_strdup("meminj", meminj[i].value), NULL);
+        if(meminj[i].mcu)
+          if(strcmp(meminj[i].mcu, p->desc) == 0 && strcmp(meminj[i].mem, m->desc) == 0)
+            dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc,
+              meminj[i].var, cfg_strdup("meminj", meminj[i].value), NULL);
 
     if(!tsv) {
       dev_cout(m->comments, ";", 0, 0);
@@ -735,9 +738,10 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
 
   if(injct)
     for(size_t i=0; i<sizeof ptinj/sizeof*ptinj; i++)
-      if(strcmp(ptinj[i].mcu, p->desc) == 0)
-        dev_part_strct_entry(tsv, ".pt", p->desc, NULL,
-          ptinj[i].var, cfg_strdup("ptinj", ptinj[i].value), NULL);
+      if(ptinj[i].mcu)
+        if(strcmp(ptinj[i].mcu, p->desc) == 0)
+          dev_part_strct_entry(tsv, ".pt", p->desc, NULL,
+            ptinj[i].var, cfg_strdup("ptinj", ptinj[i].value), NULL);
 
   if(!tsv) {
     dev_cout(p->comments, ";", 0, 0);

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -350,7 +350,7 @@ const char * pins_to_str(const struct pindef_t * const pindef) {
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation
- * @returns a pointer to a string, which was created by strdup
+ * @returns a pointer to a string, which was created by cfg_strdup()
  */
 char *pins_to_strdup(const struct pindef_t * const pindef) {
   char buf[6*(PIN_MAX+1)], *p = buf;


### PR DESCRIPTION
and fix Issue #1085 

This is the first application of semi-automated rewrites for avrdude.conf part descriptions. (For good measure this PR also rewrites the programmer descriptions). I have tested this method locally for a while, as has, I believe, @mcuee. 

Because this is the first rewrite of the `avrdude.conf.in` file almost all of the file differs, so is hard to review. I recommend checking commit by commit. When it comes to the single one commit that changes `avrdude.conf.in` radically, please make a raw dump of the avrdude.conf.in file before the change and compare afterwards:
``` sh
$ avrdude -c*/r -p*/r -C avrdude.conf-BEFORE > /tmp/avrdude.raw
$ avrdude -c*/r -p*/r -C avrdude.conf-AFTER | diff - /tmp/avrdude.raw
```

Here is how the semi-automated rewrites work: Add in `developer_opts.c` tables with part or memory parameter assignments. These tables will typically be generated by an external program that, eg, scrapes ATDF files for the right parameters. In this example the output looks like
```
  {"ATtiny24", "reset", "io"},
  {"ATtiny24A", "reset", "io"},
  {"ATtiny25", "reset", "io"},
  {"ATtiny43U", "reset", "io"},
  {"ATtiny44", "reset", "io"},
  {"ATtiny44A", "reset", "io"},
  {"ATtiny45", "reset", "io"},
  {"ATtiny48", "reset", "io"},
  {"ATtiny84", "reset", "io"},
  ...
```
  - Then output the parts description with -p*/i and use the output in a new `avrdude.conf`
  - Output again with -p* (no /i) and use that for final `avrdude.conf`
  - Remove table entries

With this technique it is possible to inject a lot of the parameters, perhaps even all, from the [parameters.txt](https://github.com/avrdudes/avrdude/files/9387791/parameters.txt) file discussed in #1077. And, as a side effect, all those decades of adding of entries in different formats now all look shiny, well-formatted and systematic.

Looking towards merging in the next few days as there are more, and more significant, parameters to add/fix.

Also note Issue #1035 is still unfixed, so remember when you change avrdude.conf.in to
```
$ rm -rf build_linux
$ cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -B build_linux
$ cmake --build build_linux
$ sudo cmake --build build_linux --target install
```
if you want any changed `avrdude.conf.in` to overwrite the system `avrdude.conf` file, which is used by `avrdude -p* ...`