### PR TITLE
avrdude.conf.in: Adds digilent-hs2 dongle

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1044,6 +1044,28 @@ programmer
     rdyled                 = ~15;
 ;
 
+#
+# Digilent JTAG HS2 programmer. FT232H-based dongle with
+# buffers.
+#
+programmer
+  id                       = "digilent-hs2";
+  desc                     = "Digilient JTAG HS2 (MPSSE)";
+  type                     = "avrftdi";
+  connection_type          = usb;
+  usbvid                   = 0x0403;
+  usbpid                   = 0x6014;
+  usbdev                   = "A";
+  usbvendor                = "";
+  usbproduct               = "";
+  usbsn                    = "";
+  reset                    = 3;
+  sck                      = 0;
+  mosi                     = 1;
+  miso                     = 2;
+  buff                     = 5,6,7;
+;
+
 #------------------------------------------------------------
 # serialupdi
 #------------------------------------------------------------

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1044,26 +1044,30 @@ programmer
     rdyled                 = ~15;
 ;
 
+#------------------------------------------------------------
+# digilent-hs2
+#------------------------------------------------------------
+
 #
 # Digilent JTAG HS2 programmer. FT232H-based dongle with
 # buffers.
 #
+# The reference manual can be found at https://digilent.com/reference/_media/reference/programmers/jtag-hs2/jtag-hs2_rm.pdf
+#
+
 programmer
-  id                       = "digilent-hs2";
-  desc                     = "Digilient JTAG HS2 (MPSSE)";
-  type                     = "avrftdi";
-  connection_type          = usb;
-  usbvid                   = 0x0403;
-  usbpid                   = 0x6014;
-  usbdev                   = "A";
-  usbvendor                = "";
-  usbproduct               = "";
-  usbsn                    = "";
-  reset                    = 3;
-  sck                      = 0;
-  mosi                     = 1;
-  miso                     = 2;
-  buff                     = 5,6,7;
+    id                     = "digilent-hs2";
+    desc                   = "Digilient JTAG HS2 (MPSSE)";
+    type                   = "avrftdi";
+    connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6014;
+    usbdev                 = "A";
+    buff                   = 5, 6, 7;
+    reset                  = 3;
+    sck                    = 0;
+    mosi                   = 1;
+    miso                   = 2;
 ;
 
 #------------------------------------------------------------

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1048,12 +1048,8 @@ programmer
 # digilent-hs2
 #------------------------------------------------------------
 
-#
-# Digilent JTAG HS2 programmer. FT232H-based dongle with
-# buffers.
-#
-# The reference manual can be found at https://digilent.com/reference/_media/reference/programmers/jtag-hs2/jtag-hs2_rm.pdf
-#
+# Digilent JTAG HS2 programmer. FT232H-based dongle with buffers.
+# https://digilent.com/reference/_media/reference/programmers/jtag-hs2/jtag-hs2_rm.pdf
 
 programmer
     id                     = "digilent-hs2";


### PR DESCRIPTION
Adds support for Digilint JTAG HS2 in MPSSE mode.