### PR TITLE
CMake: Build docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,13 @@ jobs:
           libusb-1.0-0-dev
           libhidapi-dev
           libftdi1-dev
+          texinfo
+          texlive
+          texi2html
       - name: Configure
         run: >-
           cmake
+          -D BUILD_DOC=1
           -D DEBUG_CMAKE=1
           -D HAVE_LINUXGPIO=1
           -D HAVE_LINUXSPI=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,27 +282,6 @@ endif()
 add_subdirectory(src)
 
 # =====================================
-# Setup default port names
-# =====================================
-
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(DEFAULT_PAR_PORT "/dev/parport0")
-    set(DEFAULT_SER_PORT "/dev/ttyS0")
-elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    set(DEFAULT_PAR_PORT "/dev/ppi0")
-    set(DEFAULT_SER_PORT "/dev/cuad0")
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Solaris")
-    set(DEFAULT_PAR_PORT "/dev/printers/0")
-    set(DEFAULT_SER_PORT "/dev/term/a")
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(DEFAULT_PAR_PORT "lpt1")
-    set(DEFAULT_SER_PORT "com1")
-else()
-    set(DEFAULT_PAR_PORT "unknown")
-    set(DEFAULT_SER_PORT "unknown")
-endif()
-
-# =====================================
 # Configuration
 # =====================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,10 @@ endif()
 
 add_subdirectory(src)
 
+if(BUILD_DOC)
+    add_subdirectory(src/doc)
+endif()
+
 # =====================================
 # Configuration
 # =====================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,29 +82,51 @@ else()
 endif()
 
 # =====================================
+# Setup default port names
+# =====================================
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(DEFAULT_PAR_PORT "/dev/parport0")
+    set(DEFAULT_SER_PORT "/dev/ttyS0")
+elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(DEFAULT_PAR_PORT "/dev/ppi0")
+    set(DEFAULT_SER_PORT "/dev/cuad0")
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Solaris")
+    set(DEFAULT_PAR_PORT "/dev/printers/0")
+    set(DEFAULT_SER_PORT "/dev/term/a")
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(DEFAULT_PAR_PORT "lpt1")
+    set(DEFAULT_SER_PORT "com1")
+else()
+    set(DEFAULT_PAR_PORT "unknown")
+    set(DEFAULT_SER_PORT "unknown")
+endif()
+
+# =====================================
 # Configure files
 # =====================================
 
-macro(configure_option option)
-    if(${${option}})
-        string(REGEX REPLACE "(.*)@${option}_BEGIN@(.*)@${option}_END@(.*)" "\\1\\2\\3" conf_file "${conf_file}")
-    else()
-        string(REGEX REPLACE "(.*)@${option}_BEGIN@(.*)@${option}_END@(.*)" "\\1\\3" conf_file "${conf_file}")
-    endif()
-endmacro()
-
-file(READ avrdude.conf.in conf_file)
-configure_option(HAVE_PARPORT)
-configure_option(HAVE_LINUXGPIO)
-configure_option(HAVE_LINUXSPI)
-file(WRITE "${PROJECT_BINARY_DIR}/avrdude.conf.in" "${conf_file}")
-
 configure_file(cmake_config.h.in ac_cfg.h)
-configure_file("${PROJECT_BINARY_DIR}/avrdude.conf.in" avrdude.conf)
 configure_file(avrdude.spec.in avrdude.spec)
 if(WIN32)
     configure_file(windows.rc.in windows.rc)
 endif()
+
+add_custom_command(
+    OUTPUT avrdude.conf
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/avrdude.conf.in" avrdude.conf.in
+    COMMAND ${CMAKE_COMMAND}
+        -D HAVE_PARPORT=${HAVE_PARPORT}
+        -D HAVE_LINUXSPI=${HAVE_LINUXSPI}
+        -D HAVE_LINUXGPIO=${HAVE_LINUXGPIO}
+        -D DEFAULT_PAR_PORT=${DEFAULT_PAR_PORT}
+        -D DEFAULT_SER_PORT=${DEFAULT_SER_PORT}
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/configure.cmake"
+    DEPENDS avrdude.conf.in
+    VERBATIM
+    )
+
+add_custom_target(conf ALL DEPENDS avrdude.conf)
 
 # =====================================
 # Project

--- a/src/configure.cmake
+++ b/src/configure.cmake
@@ -1,0 +1,35 @@
+#
+# configure.cmake - autoconf like multi-line configure
+# Copyright (C) 2022 Marius Greuel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Do a multi-line replace based on @<OPTION>_BEGIN@ and @<OPTION>_END@ tags.
+macro(configure_option option)
+    if(${${option}})
+        string(REGEX REPLACE "(.*)@${option}_BEGIN@(.*)@${option}_END@(.*)" "\\1\\2\\3" CONTENTS "${CONTENTS}")
+    else()
+        string(REGEX REPLACE "(.*)@${option}_BEGIN@(.*)@${option}_END@(.*)" "\\1\\3" CONTENTS "${CONTENTS}")
+    endif()
+endmacro()
+
+# Perform autoconf like multi-line configure
+file(READ avrdude.conf.in CONTENTS)
+configure_option(HAVE_PARPORT)
+configure_option(HAVE_LINUXSPI)
+configure_option(HAVE_LINUXGPIO)
+file(WRITE avrdude.conf.in "${CONTENTS}")
+
+configure_file(avrdude.conf.in avrdude.conf)

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -167,3 +167,13 @@ add_custom_target(dvi ALL DEPENDS avrdude.dvi)
 add_custom_target(pdf ALL DEPENDS avrdude.pdf)
 add_custom_target(ps ALL DEPENDS avrdude.ps)
 add_custom_target(html ALL DEPENDS avrdude-html/avrdude.html)
+
+# =====================================
+# Install
+# =====================================
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.info" DESTINATION ${CMAKE_INSTALL_INFODIR})
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.dvi" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.pdf" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.ps" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/avrdude-html" DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -1,0 +1,169 @@
+#
+# CMakeLists.txt - CMake project for AVRDUDE documentation
+# Copyright (C) 2022 Marius Greuel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+set(AVRDUDE_CONF "${PROJECT_BINARY_DIR}/src/avrdude.conf")
+
+set(TEXINFOS "${CMAKE_CURRENT_SOURCE_DIR}/avrdude.texi")
+set(GENERATED_TEXINFOS
+    programmers.texi
+    programmer_types.texi
+    parts.texi
+    version.texi
+    )
+
+string(TIMESTAMP TODAY "%d %B %Y")
+set(DOCS_VERSION ${PROJECT_VERSION})
+set(DOCS_UPDATED ${TODAY})
+
+find_program(MAKEINFO_EXECUTABLE NAMES makeinfo)
+find_program(TEXI2HTML_EXECUTABLE NAMES texi2html)
+
+# =====================================
+# Custom rules for auto-generated texi
+# =====================================
+
+add_custom_target(avrdude_binaries DEPENDS avrdude conf)
+
+add_custom_command(
+    OUTPUT programmers.txt
+    DEPENDS avrdude_binaries
+    COMMAND $<TARGET_FILE:avrdude> -C ${AVRDUDE_CONF} -c ? 2>&1 | more > programmers.txt
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT programmer_types.txt
+    DEPENDS avrdude_binaries
+    COMMAND $<TARGET_FILE:avrdude> -C ${AVRDUDE_CONF} -c ?type 2>&1 | more > programmer_types.txt
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT parts.txt
+    DEPENDS avrdude_binaries
+    COMMAND $<TARGET_FILE:avrdude> -C ${AVRDUDE_CONF} -p ? 2>&1 | more > parts.txt
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT programmers.texi
+    DEPENDS programmers.txt
+    COMMAND ${CMAKE_COMMAND}
+        -D TXT_FILE=programmers.txt
+        -D TEXI_FILE=programmers.texi
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/programmers.cmake"
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT programmer_types.texi
+    DEPENDS programmer_types.txt
+    COMMAND ${CMAKE_COMMAND}
+        -D TXT_FILE=programmer_types.txt
+        -D TEXI_FILE=programmer_types.texi
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/programmer_types.cmake"
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT parts.texi
+    DEPENDS parts.txt
+    COMMAND ${CMAKE_COMMAND}
+        -D TXT_FILE=parts.txt
+        -D TEXI_FILE=parts.texi
+        -D COMMENTS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/parts_comments.txt
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/parts.cmake"
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT version.texi
+    COMMAND ${CMAKE_COMMAND} -E echo "@set EDITION ${DOCS_VERSION}" > version.texi
+    COMMAND ${CMAKE_COMMAND} -E echo "@set VERSION ${DOCS_VERSION}" >> version.texi
+    COMMAND ${CMAKE_COMMAND} -E echo "@set UPDATED ${DOCS_UPDATED}" >> version.texi
+    VERBATIM
+    )
+
+# =====================================
+# Custom rules for output files
+# =====================================
+
+add_custom_command(
+    OUTPUT avrdude.info
+    COMMAND ${MAKEINFO_EXECUTABLE} -o avrdude.info ${TEXINFOS}
+    DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS}
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT avrdude.dvi
+    COMMAND ${MAKEINFO_EXECUTABLE}
+        --dvi
+        --Xopt=--quiet
+        --Xopt=--build-dir=dvi
+        -o avrdude.dvi
+        ${TEXINFOS}
+    DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS}
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT avrdude.pdf
+    COMMAND ${MAKEINFO_EXECUTABLE}
+        --pdf
+        --Xopt=--quiet
+        --Xopt=--build-dir=pdf
+        -o avrdude.pdf
+        ${TEXINFOS}
+    DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS}
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT avrdude.ps
+    COMMAND ${MAKEINFO_EXECUTABLE}
+        --ps
+        --Xopt=--quiet
+        --Xopt=--build-dir=ps
+        -o avrdude.ps
+        ${TEXINFOS}
+    DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS}
+    VERBATIM
+    )
+
+add_custom_command(
+    OUTPUT avrdude-html/avrdude.html
+    COMMAND ${TEXI2HTML_EXECUTABLE}
+        --split=node
+        --css-include=avrdude.css
+        --output=avrdude-html
+        -I ${CMAKE_CURRENT_BINARY_DIR}
+        ${TEXINFOS}
+    DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS} avrdude.css
+    VERBATIM
+    )
+
+# =====================================
+# Custom targets for output files
+# =====================================
+
+add_custom_target(info ALL DEPENDS avrdude.info)
+add_custom_target(dvi ALL DEPENDS avrdude.dvi)
+add_custom_target(pdf ALL DEPENDS avrdude.pdf)
+add_custom_target(ps ALL DEPENDS avrdude.ps)
+add_custom_target(html ALL DEPENDS avrdude-html/avrdude.html)

--- a/src/doc/parts.cmake
+++ b/src/doc/parts.cmake
@@ -1,0 +1,37 @@
+#
+# programmers.cmake - create parts.texi from parts.txt
+# Copyright (C) 2022 Marius Greuel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+file(STRINGS ${COMMENTS_FILE} COMMENTS_CONTENTS)
+
+file(STRINGS ${TXT_FILE} TXT_CONTENTS REGEX "=")
+
+set(TEXI_CONTENTS "")
+foreach(TXT_LINE IN LISTS TXT_CONTENTS)
+    string(REGEX REPLACE "^[ \t]*([^ \t]+)[ \t]*=[ \t]*(.*)$" "@item @code{\\1} @tab \\2" TEXI_LINE "${TXT_LINE}")
+
+    foreach(COMMENTS_LINE IN LISTS COMMENTS_CONTENTS)
+        string(REGEX MATCH "^([^ \t]*)(.*)$" DUMMY "${COMMENTS_LINE}")
+        set(PART_REGEX "${CMAKE_MATCH_1}")
+        set(COMMENT "${CMAKE_MATCH_2}")
+        string(REGEX REPLACE "(${PART_REGEX})" "\\1${COMMENT}" TEXI_LINE "${TEXI_LINE}")
+    endforeach()
+
+    set(TEXI_CONTENTS "${TEXI_CONTENTS}${TEXI_LINE}\n")
+endforeach()
+
+file(WRITE ${TEXI_FILE} "${TEXI_CONTENTS}")

--- a/src/doc/programmer_types.cmake
+++ b/src/doc/programmer_types.cmake
@@ -1,0 +1,28 @@
+#
+# programmer_types.cmake - create programmer_types.texi from programmer_types.txt
+# Copyright (C) 2022 Marius Greuel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+file(STRINGS ${TXT_FILE} TXT_CONTENTS REGEX "=")
+
+SET(TEXI_CONTENTS "")
+foreach(TXT_LINE IN LISTS TXT_CONTENTS)
+    string(REGEX REPLACE "^[ \t]*([^ \t]+)[ \t]*=[ \t]*(.*)$" "@item @code{\\1} @tab \\2" TEXI_LINE "${TXT_LINE}")
+    string(REGEX REPLACE "<?(http[s]?://[^ \t,>]+)>?" "@url{\\1}" TEXI_LINE "${TEXI_LINE}")
+    set(TEXI_CONTENTS "${TEXI_CONTENTS}${TEXI_LINE}\n")
+endforeach()
+
+file(WRITE ${TEXI_FILE} "${TEXI_CONTENTS}")

--- a/src/doc/programmers.cmake
+++ b/src/doc/programmers.cmake
@@ -1,0 +1,28 @@
+#
+# programmers.cmake - create programmers.texi from programmers.txt
+# Copyright (C) 2022 Marius Greuel
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+file(STRINGS ${TXT_FILE} TXT_CONTENTS REGEX "=")
+
+SET(TEXI_CONTENTS "")
+foreach(TXT_LINE IN LISTS TXT_CONTENTS)
+    string(REGEX REPLACE "^[ \t]*([^ \t]+)[ \t]*=[ \t]*(.*)$" "@item @code{\\1} @tab \\2" TEXI_LINE "${TXT_LINE}")
+    string(REGEX REPLACE "[ \t>]*,?[ \t>]*<?(http[s]?://[^ \t>]+)>?" ",@*\n@url{\\1}" TEXI_LINE "${TEXI_LINE}")
+    set(TEXI_CONTENTS "${TEXI_CONTENTS}${TEXI_LINE}\n")
+endforeach()
+
+file(WRITE ${TEXI_FILE} "${TEXI_CONTENTS}")


### PR DESCRIPTION
Closes #947

This PR is a work in progress.

It currently has been tested working on Linux only, though it should work on most UN*Xes, as reported by @mcuee in PR https://github.com/avrdudes/avrdude/pull/1066#issuecomment-1231650850.

Regarding MSYS2:

The doc build fails on MSYS2 due to an issue with the CMake generators: In all variants of Make and Ninja, the generator emits a Windows like path such as `C:\Bla` instead of `/c/Bla`.

For make, texinfo chokes on the input DOS path and reports something like this:

```
/usr/bin/texi2dvi: texinfo.tex appears to be broken.
This may be due to the environment variable TEX set to something
other than (plain) tex, a corrupt texinfo.tex file, or
to tex itself simply not working.
This is pdfTeX, Version 3.141592653-2.6-1.40.24 (TeX Live 2022/Built by MSYS2 project) (preloaded format=etex)
 restricted \write18 enabled.
entering extended mode
! I can't find file `txiversion.tex'.
<*> txiversion.tex
```

For Ninja, the makeinfo path is a Windows path (without the extension). As makeinfo is a Perl script and not an exe, it fails like this:

```
[73/77] Generating avrdude.info
FAILED: src/doc/avrdude.info D:/Work/avrdude/build_mingw64/src/doc/avrdude.info
cmd.exe /C "cd /D D:\Work\avrdude\build_mingw64\src\doc && D:\Work\msys64\usr\bin\makeinfo -o avrdude.info D:/Work/avrdude/src/doc/avrdude.texi"
'D:\Work\msys64\usr\bin\makeinfo' is not recognized as an internal or external command,
operable program or batch file.
```

For MSYS2/Make, I was able to fix the Windows path problem by making it a relative path:

```
file(RELATIVE_PATH TEXINFOS ${CMAKE_CURRENT_BINARY_DIR} ${TEXINFOS})
```

Probably need to report this to CMake, not sure if there is a better workaround.

Unfortunately, texi2html does not seem to be available as a MSYS2 package. Not sure if this is worth the trouble.

Regarding Linux & co.: You will need the packages texinfo, texlive, and texi2html. I used the makeinfo toolset instead of the texi2xxx binaries, however, for HTML generation I stuck to texi2html, as the `makeinfo --html` output drops the contents page. 

```
git clean -xdf
cmake -D BUILD_DOC=1 -B build_linux
cmake --build build_linux
```