### PR TITLE
Print compatible parts for programmer and vice versa using -c? or -p?

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -301,10 +301,16 @@ need to be specified to
 .Nm avrdude .
 .Bl -tag -offset indent -width indent
 .It Fl p Ar partno
-This is the only option that is mandatory for every invocation of
-.Nm avrdude .
-It specifies the type of the MCU connected to the programmer.  These are read from the config file.
-For currently supported MCU types use ? as partno, this will print a list of partno ids and official part names on the terminal. (Both can be used with the -p option.)
+This option specifies the MCU connected to the programmer. The MCU
+descriptions are read from the config file. For currently supported MCUs use
+? as partno, which will print a list of partno ids and official part names.
+Both can be used with the -p option. If -p ? is specified with a specific
+programmer, see -c below, then only those parts are output that the
+programmer expects to be able to handle, together with the programming
+interface(s) that can be used in that combination. In reality there can be
+deviations from this list, particularly if programming is directly via a
+bootloader.
+
 .Pp
 Following parts need special attention:
 .Bl -tag -width "ATmega1234"
@@ -357,6 +363,11 @@ file to assign a default programmer to keep from having to specify
 this option on every invocation.
 A full list of all supported programmers is output to the terminal 
 by using ? as programmer-id.
+If -c ? is specified with a specific part, see
+-p above, then only those programmers are output that expect
+to be able to handle this part, together with the programming interface(s) that can be
+used in that combination. In reality there can be deviations from this list,
+particularly if programming is directly via a bootloader.
 .It Fl C Ar config-file
 Use the specified config file to load configuration data.  This file
 contains all programmer and part definitions that

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1709,7 +1709,7 @@ programmer
     id                     = "jtagmkII";
     desc                   = "Atmel JTAG ICE mkII";
     type                   = "jtagmkii";
-    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
+    prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     baudrate               = 19200;    # default is 19200
 ;
@@ -1830,7 +1830,7 @@ programmer
     id                     = "dragon_jtag";
     desc                   = "Atmel AVR Dragon in JTAG mode";
     type                   = "dragon_jtag";
-    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
+    prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1918,7 +1918,7 @@ programmer
     id                     = "jtag3";
     desc                   = "Atmel AVR JTAGICE3 in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
+    prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2110, 0x2140;
 ;
@@ -1984,7 +1984,7 @@ programmer
     id                     = "xplainedpro";
     desc                   = "Atmel AVR XplainedPro in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
+    prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2111;
 ;
@@ -2051,7 +2051,7 @@ programmer
     id                     = "atmelice";
     desc                   = "Atmel-ICE (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
+    prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2141;
 ;
@@ -2091,7 +2091,7 @@ programmer
     id                     = "atmelice_dw";
     desc                   = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
     type                   = "jtagice3_dw";
-    prog_modes             = PM_PDI | PM_debugWIRE;
+    prog_modes             = PM_debugWIRE;
     connection_type        = usb;
     usbpid                 = 0x2141;
 ;
@@ -2117,7 +2117,7 @@ programmer
     id                     = "powerdebugger";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
+    prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2144;
 ;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -595,7 +595,7 @@ programmer
 
 programmer
     id                     = "atisp";
-    desc                   = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
+    desc                   = "AT-ISP v1.1 programming cable for AVR-SDK1 from <https://micro-research.co.th>";
     type                   = "par";
     prog_modes             = PM_TPI | PM_ISP;
     reset                  = ~6;
@@ -1102,7 +1102,7 @@ programmer
 
 programmer
     id                     = "avrispv2";
-    desc                   = "Atmel AVR ISP V2";
+    desc                   = "Atmel AVR ISP v2";
     type                   = "stk500v2";
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
     connection_type        = serial;
@@ -1182,7 +1182,7 @@ programmer
 
 programmer
     id                     = "stk500v1";
-    desc                   = "Atmel STK500 Version 1.x firmware";
+    desc                   = "Atmel STK500 version 1.x firmware";
     type                   = "stk500";
     prog_modes             = PM_ISP;
     connection_type        = serial;
@@ -1206,7 +1206,7 @@ programmer
 
 programmer
     id                     = "stk500v2";
-    desc                   = "Atmel STK500 Version 2.x firmware";
+    desc                   = "Atmel STK500 version 2.x firmware";
     type                   = "stk500v2";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
@@ -1218,7 +1218,7 @@ programmer
 
 programmer
     id                     = "stk500pp";
-    desc                   = "Atmel STK500 V2 in parallel programming mode";
+    desc                   = "Atmel STK500 v2 in parallel programming mode";
     type                   = "stk500pp";
     prog_modes             = PM_HVPP;
     connection_type        = serial;
@@ -1230,7 +1230,7 @@ programmer
 
 programmer
     id                     = "stk500hvsp";
-    desc                   = "Atmel STK500 V2 in high-voltage serial programming mode";
+    desc                   = "Atmel STK500 v2 in high-voltage serial programming mode";
     type                   = "stk500hvsp";
     prog_modes             = PM_HVSP;
     connection_type        = serial;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -734,7 +734,7 @@ programmer
 
 programmer
     id                     = "wiring";
-    desc                   = "Wiring";
+    desc                   = "Wiring for bootloader using STK500 v2 protocol";
     type                   = "wiring";
     prog_modes             = PM_SPM;
     connection_type        = serial;
@@ -746,7 +746,7 @@ programmer
 
 programmer
     id                     = "arduino";
-    desc                   = "Arduino";
+    desc                   = "Arduino for bootloader using STK500 v1 protocol";
     type                   = "arduino";
     prog_modes             = PM_SPM;
     connection_type        = serial;
@@ -758,7 +758,7 @@ programmer
 
 programmer
     id                     = "xbee";
-    desc                   = "XBee Series 2 Over-The-Air (XBeeBoot)";
+    desc                   = "XBee for Series 2 Over-The-Air (XBeeBoot) bootloader using STK500 v1 protocol";
     type                   = "xbee";
     prog_modes             = PM_SPM;
     connection_type        = serial;
@@ -1579,7 +1579,7 @@ programmer
 
 programmer
     id                     = "micronucleus";
-    desc                   = "Micronucleus Bootloader";
+    desc                   = "Micronucleus for bootloader";
     type                   = "micronucleus";
     prog_modes             = PM_SPM;
     connection_type        = usb;
@@ -1593,7 +1593,7 @@ programmer
 
 programmer
     id                     = "teensy";
-    desc                   = "Teensy Bootloader";
+    desc                   = "Teensy for bootloader";
     type                   = "teensy";
     prog_modes             = PM_SPM;
     connection_type        = usb;
@@ -1607,7 +1607,7 @@ programmer
 
 programmer
     id                     = "butterfly";
-    desc                   = "Atmel Butterfly Development Board";
+    desc                   = "Atmel for bootloader (Butterfly Development Board)";
     type                   = "butterfly";
     prog_modes             = PM_SPM;
     connection_type        = serial;
@@ -1619,7 +1619,7 @@ programmer
 
 programmer
     id                     = "avr109";
-    desc                   = "Atmel AppNote AVR109 Boot Loader";
+    desc                   = "Atmel for bootloader using AppNote AVR109";
     type                   = "butterfly";
     prog_modes             = PM_SPM;
     connection_type        = serial;
@@ -1631,7 +1631,7 @@ programmer
 
 programmer
     id                     = "avr911";
-    desc                   = "Atmel AppNote AVR911 AVROSP";
+    desc                   = "Atmel for bootloader using AppNote AVR911 AVROSP";
     type                   = "butterfly";
     prog_modes             = PM_SPM;
     connection_type        = serial;
@@ -1645,7 +1645,7 @@ programmer
 
 programmer
     id                     = "mkbutterfly";
-    desc                   = "Mikrokopter.de Butterfly";
+    desc                   = "Mikrokopter.de Butterfly for bootloader";
     type                   = "butterfly_mk";
     prog_modes             = PM_SPM;
     connection_type        = serial;
@@ -2296,7 +2296,7 @@ programmer
 
 programmer
     id                     = "flip1";
-    desc                   = "FLIP USB DFU protocol version 1 (doc7618)";
+    desc                   = "FLIP for bootloader using USB DFU protocol version 1 (doc7618)";
     type                   = "flip1";
     prog_modes             = PM_SPM;
     connection_type        = usb;
@@ -2308,7 +2308,7 @@ programmer
 
 programmer
     id                     = "flip2";
-    desc                   = "FLIP USB DFU protocol version 2 (AVR4023)";
+    desc                   = "FLIP for bootloader using USB DFU protocol version 2 (AVR4023)";
     type                   = "flip2";
     prog_modes             = PM_SPM;
     connection_type        = usb;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -56,7 +56,10 @@
 #   #  - PM_HVSP: High Voltage Serial Programming (some classic parts)
 #   #  - PM_HVPP: High Voltage Parallel Programming (most non-HVSP classic parts)
 #   #  - PM_debugWIRE: Simpler alternative to JTAG (a subset of HVPP/HVSP parts)
-#   #  - PM_JTAG: Joint Test Action Group standard (some classic parts, some xmega)
+#   #  - PM_JTAG: Joint Test Action Group standard (some classic parts)
+#   #  - PM_JTAGmkI: Subset of PM_JTAG, older parts, Atmel ICE mkI
+#   #  - PM_XMEGAJTAG: JTAG, some XMEGA parts
+#   #  - PM_AVR32JTAG: JTAG for 32-bit AVRs
 #   #  - PM_aWire: AVR32 parts
 #   #
 #   # (2) Not all programmer types can process a list of PIDs
@@ -1667,7 +1670,7 @@ programmer
     id                     = "jtagmkI";
     desc                   = "Atmel JTAG ICE (mkI)";
     type                   = "jtagmki";
-    prog_modes             = PM_JTAG;
+    prog_modes             = PM_JTAGmkI;
     connection_type        = serial;
     baudrate               = 115200;    # default is 115200
 ;
@@ -1706,7 +1709,7 @@ programmer
     id                     = "jtagmkII";
     desc                   = "Atmel JTAG ICE mkII";
     type                   = "jtagmkii";
-    prog_modes             = PM_JTAG;
+    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     baudrate               = 19200;    # default is 19200
 ;
@@ -1795,7 +1798,7 @@ programmer
 
 programmer
     id                     = "jtag2avr32";
-    desc                   = "Atmel JTAG ICE mkII im AVR32 mode";
+    desc                   = "Atmel JTAG ICE mkII in AVR32 mode";
     type                   = "jtagmkii_avr32";
     prog_modes             = PM_aWire;
     connection_type        = usb;
@@ -1827,7 +1830,7 @@ programmer
     id                     = "dragon_jtag";
     desc                   = "Atmel AVR Dragon in JTAG mode";
     type                   = "dragon_jtag";
-    prog_modes             = PM_JTAG;
+    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1915,7 +1918,7 @@ programmer
     id                     = "jtag3";
     desc                   = "Atmel AVR JTAGICE3 in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG;
+    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2110, 0x2140;
 ;
@@ -1981,7 +1984,7 @@ programmer
     id                     = "xplainedpro";
     desc                   = "Atmel AVR XplainedPro in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG;
+    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2111;
 ;
@@ -2048,7 +2051,7 @@ programmer
     id                     = "atmelice";
     desc                   = "Atmel-ICE (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG;
+    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2141;
 ;
@@ -2114,7 +2117,7 @@ programmer
     id                     = "powerdebugger";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
-    prog_modes             = PM_JTAG;
+    prog_modes             = PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG;
     connection_type        = usb;
     usbpid                 = 0x2144;
 ;
@@ -3652,7 +3655,7 @@ part
 part
     desc                   = "ATmega64";
     id                     = "m64";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 72;
     n_interrupts           = 35;
     stk500_devcode         = 0xa0;
@@ -3771,6 +3774,7 @@ part
 part parent "m64"
     desc                   = "ATmega64A";
     id                     = "m64a";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 73;
 ;
 
@@ -3781,7 +3785,7 @@ part parent "m64"
 part
     desc                   = "ATmega128";
     id                     = "m128";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 85;
     n_interrupts           = 35;
     stk500_devcode         = 0xb2;
@@ -3901,6 +3905,7 @@ part
 part parent "m128"
     desc                   = "ATmega128A";
     id                     = "m128a";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 86;
 ;
 
@@ -3911,7 +3916,7 @@ part parent "m128"
 part
     desc                   = "AT90CAN128";
     id                     = "c128";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 176;
     n_interrupts           = 37;
     stk500_devcode         = 0xb3;
@@ -4280,7 +4285,7 @@ part
 part
     desc                   = "ATmega16";
     id                     = "m16";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 49;
     n_interrupts           = 21;
     stk500_devcode         = 0x82;
@@ -4395,6 +4400,7 @@ part
 part parent "m16"
     desc                   = "ATmega16A";
     id                     = "m16a";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 50;
 ;
 
@@ -4892,7 +4898,7 @@ part parent "m1284"
 part
     desc                   = "ATmega162";
     id                     = "m162";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 90;
     n_interrupts           = 28;
     stk500_devcode         = 0x83;
@@ -5117,7 +5123,7 @@ part
 part
     desc                   = "ATmega169";
     id                     = "m169";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 104;
     n_interrupts           = 23;
     stk500_devcode         = 0x85;
@@ -5238,6 +5244,7 @@ part
 part parent "m169"
     desc                   = "ATmega169A";
     id                     = "m169a";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 105;
     signature              = 0x1e 0x94 0x11;
     reset                  = io;
@@ -5250,6 +5257,7 @@ part parent "m169"
 part parent "m169"
     desc                   = "ATmega169P";
     id                     = "m169p";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 106;
     reset                  = io;
 ;
@@ -5261,6 +5269,7 @@ part parent "m169"
 part parent "m169"
     desc                   = "ATmega169PA";
     id                     = "m169pa";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 107;
     reset                  = io;
 ;
@@ -5655,7 +5664,7 @@ part parent "m649"
 part
     desc                   = "ATmega32";
     id                     = "m32";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 58;
     n_interrupts           = 21;
     stk500_devcode         = 0x91;
@@ -5859,6 +5868,7 @@ part
 part parent "m32"
     desc                   = "ATmega32A";
     id                     = "m32a";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 59;
 ;
 
@@ -11240,7 +11250,7 @@ part
 part
     desc                   = "ATmega165";
     id                     = "m165";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI;
     mcuid                  = 95;
     n_interrupts           = 22;
 #   stk500_devcode         = 0x??;
@@ -11362,6 +11372,7 @@ part
 part parent "m165"
     desc                   = "ATmega165A";
     id                     = "m165a";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 96;
 ;
 
@@ -11372,6 +11383,7 @@ part parent "m165"
 part parent "m165"
     desc                   = "ATmega165P";
     id                     = "m165p";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 97;
     signature              = 0x1e 0x94 0x07;
 ;
@@ -11383,6 +11395,7 @@ part parent "m165"
 part parent "m165"
     desc                   = "ATmega165PA";
     id                     = "m165pa";
+    prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 98;
     signature              = 0x1e 0x94 0x07;
 ;
@@ -12115,7 +12128,7 @@ part parent "x64a4u"
 part parent "x64a4u"
     desc                   = "ATxmega64A1";
     id                     = "x64a1";
-    prog_modes             = PM_SPM | PM_PDI | PM_JTAG;
+    prog_modes             = PM_SPM | PM_PDI | PM_XMEGAJTAG;
     mcuid                  = 243;
     n_interrupts           = 125;
     signature              = 0x1e 0x96 0x4e;
@@ -12289,7 +12302,7 @@ part parent "x128c3"
 part parent "x128c3"
     desc                   = "ATxmega128A1";
     id                     = "x128a1";
-    prog_modes             = PM_SPM | PM_PDI | PM_JTAG;
+    prog_modes             = PM_SPM | PM_PDI | PM_XMEGAJTAG;
     mcuid                  = 254;
     n_interrupts           = 125;
     signature              = 0x1e 0x97 0x4c;
@@ -12355,7 +12368,7 @@ part parent "x128a1"
 part parent ".xmega"
     desc                   = "ATxmega128A4";
     id                     = "x128a4";
-    prog_modes             = PM_SPM | PM_PDI | PM_JTAG;
+    prog_modes             = PM_SPM | PM_PDI | PM_XMEGAJTAG;
     mcuid                  = 263;
     signature              = 0x1e 0x97 0x46;
 
@@ -12469,7 +12482,7 @@ part parent ".xmega"
 part parent ".xmega"
     desc                   = "ATxmega128B1";
     id                     = "x128b1";
-    prog_modes             = PM_SPM | PM_PDI | PM_JTAG;
+    prog_modes             = PM_SPM | PM_PDI | PM_XMEGAJTAG;
     mcuid                  = 257;
     n_interrupts           = 81;
     signature              = 0x1e 0x97 0x4d;
@@ -12610,7 +12623,7 @@ part parent "x192c3"
 part parent "x192c3"
     desc                   = "ATxmega192A1";
     id                     = "x192a1";
-    prog_modes             = PM_SPM | PM_PDI | PM_JTAG;
+    prog_modes             = PM_SPM | PM_PDI | PM_XMEGAJTAG;
     mcuid                  = 266;
     signature              = 0x1e 0x97 0x4e;
 
@@ -12718,7 +12731,7 @@ part parent "x256c3"
 part parent "x256c3"
     desc                   = "ATxmega256A1";
     id                     = "x256a1";
-    prog_modes             = PM_SPM | PM_PDI | PM_JTAG;
+    prog_modes             = PM_SPM | PM_PDI | PM_XMEGAJTAG;
     mcuid                  = 271;
 
     memory "fuse0"
@@ -13011,7 +13024,7 @@ part parent ".xmega"
 part
     desc                   = "AT32UC3A0512";
     id                     = "uc3a0512";
-    prog_modes             = PM_JTAG | PM_aWire;
+    prog_modes             = PM_AVR32JTAG | PM_aWire;
     signature              = 0xed 0xc0 0x3f;
 
     memory "flash"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1783,7 +1783,7 @@ programmer
 
 programmer
     id                     = "jtagmkII_avr32";
-    desc                   = "Atmel JTAG ICE mkII im AVR32 mode";
+    desc                   = "Atmel JTAG ICE mkII in AVR32 mode";
     type                   = "jtagmkii_avr32";
     prog_modes             = PM_aWire;
     connection_type        = usb;
@@ -1813,7 +1813,7 @@ programmer
 
 programmer
     id                     = "jtag2pdi";
-    desc                   = "Atmel JTAG ICE mkII PDI mode";
+    desc                   = "Atmel JTAG ICE mkII in PDI mode";
     type                   = "jtagmkii_pdi";
     prog_modes             = PM_PDI;
     connection_type        = usb;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -678,6 +678,7 @@ programmer
 #     id                   = "linuxgpio";
 #     desc                 = "Use the Linux sysfs interface to bitbang GPIO lines";
 #     type                 = "linuxgpio";
+#     prog_modes           = PM_ISP;
 #     reset                = ?;
 #     sck                  = ?;
 #     mosi                 = ?;
@@ -700,6 +701,7 @@ programmer
     id                     = "linuxspi";
     desc                   = "Use Linux SPI device in /dev/spidev*";
     type                   = "linuxspi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = spi;
     reset                  = 25;    # Pi GPIO number - this is J8:22
 ;
@@ -720,6 +722,7 @@ programmer
     id                     = "wiring";
     desc                   = "Wiring";
     type                   = "wiring";
+    prog_modes             = PM_SPM;
     connection_type        = serial;
 ;
 
@@ -731,6 +734,7 @@ programmer
     id                     = "arduino";
     desc                   = "Arduino";
     type                   = "arduino";
+    prog_modes             = PM_SPM;
     connection_type        = serial;
 ;
 
@@ -742,6 +746,7 @@ programmer
     id                     = "xbee";
     desc                   = "XBee Series 2 Over-The-Air (XBeeBoot)";
     type                   = "xbee";
+    prog_modes             = PM_SPM;
     connection_type        = serial;
 ;
 
@@ -773,6 +778,7 @@ programmer
     id                     = "avrftdi";
     desc                   = "FT2232D based generic programmer";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6010;
@@ -802,6 +808,7 @@ programmer
     id                     = "2232HIO";
     desc                   = "FT2232H based generic programmer";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
 # Note: This PID is reserved for generic H devices and
@@ -843,6 +850,7 @@ programmer
     id                     = "jtagkey";
     desc                   = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
 #   Note: This PID is used in all JTAGKey variants
@@ -867,6 +875,7 @@ programmer
     id                     = "ft232h";
     desc                   = "FT232H in MPSSE mode";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6014;
@@ -951,6 +960,7 @@ programmer
     id                     = "openmoko";
     desc                   = "Openmoko debug board (v3)";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     usbvid                 = 0x1457;
     usbpid                 = 0x5118;
     usbdev                 = "A";
@@ -971,6 +981,7 @@ programmer
     id                     = "lm3s811";
     desc                   = "Luminary Micro LM3S811 Eval Board (Rev. A)";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0xbcd9;
@@ -996,6 +1007,7 @@ programmer
     id                     = "tumpa";
     desc                   = "TIAO USB Multi-Protocol Adapter";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x8a98;
@@ -1032,6 +1044,7 @@ programmer
     id                     = "ktlink";
     desc                   = "KT-LINK FT2232H interface with IO switching and voltage buffers.";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0xbbe2;
@@ -1052,6 +1065,7 @@ programmer
     id                     = "serialupdi";
     desc                   = "SerialUPDI";
     type                   = "serialupdi";
+    prog_modes             = PM_UPDI;
     connection_type        = serial;
     hvupdi_support         = 1;
 ;
@@ -1064,6 +1078,7 @@ programmer
     id                     = "avrisp";
     desc                   = "Atmel AVR ISP";
     type                   = "stk500";
+    prog_modes             = PM_ISP;
     connection_type        = serial;
 ;
 
@@ -1075,6 +1090,7 @@ programmer
     id                     = "avrispv2";
     desc                   = "Atmel AVR ISP V2";
     type                   = "stk500v2";
+    prog_modes             = PM_TPI | PM_ISP | PM_PDI;
     connection_type        = serial;
 ;
 
@@ -1086,6 +1102,7 @@ programmer
     id                     = "avrispmkII";
     desc                   = "Atmel AVR ISP mkII";
     type                   = "stk500v2";
+    prog_modes             = PM_TPI | PM_ISP | PM_PDI;
     connection_type        = usb;
 ;
 
@@ -1105,6 +1122,7 @@ programmer
     id                     = "buspirate";
     desc                   = "The Bus Pirate";
     type                   = "buspirate";
+    prog_modes             = PM_ISP;
     connection_type        = serial;
 ;
 
@@ -1116,6 +1134,7 @@ programmer
     id                     = "buspirate_bb";
     desc                   = "The Bus Pirate (bitbang interface, supports TPI)";
     type                   = "buspirate_bb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
   # pins are bits in bitbang byte (numbers are 87654321)
   # 1|POWER|PULLUP|AUX|MOSI|CLK|MISO|CS
@@ -1139,6 +1158,7 @@ programmer
     id                     = "stk500";
     desc                   = "Atmel STK500";
     type                   = "stk500generic";
+    prog_modes             = PM_ISP;
     connection_type        = serial;
 ;
 
@@ -1150,6 +1170,7 @@ programmer
     id                     = "stk500v1";
     desc                   = "Atmel STK500 Version 1.x firmware";
     type                   = "stk500";
+    prog_modes             = PM_ISP;
     connection_type        = serial;
 ;
 
@@ -1161,6 +1182,7 @@ programmer
     id                     = "mib510";
     desc                   = "Crossbow MIB510 programming board";
     type                   = "stk500";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
 ;
 
@@ -1172,6 +1194,7 @@ programmer
     id                     = "stk500v2";
     desc                   = "Atmel STK500 Version 2.x firmware";
     type                   = "stk500v2";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
 ;
 
@@ -1183,6 +1206,7 @@ programmer
     id                     = "stk500pp";
     desc                   = "Atmel STK500 V2 in parallel programming mode";
     type                   = "stk500pp";
+    prog_modes             = PM_HVPP;
     connection_type        = serial;
 ;
 
@@ -1194,6 +1218,7 @@ programmer
     id                     = "stk500hvsp";
     desc                   = "Atmel STK500 V2 in high-voltage serial programming mode";
     type                   = "stk500hvsp";
+    prog_modes             = PM_HVSP;
     connection_type        = serial;
 ;
 
@@ -1205,6 +1230,7 @@ programmer
     id                     = "stk600";
     desc                   = "Atmel STK600";
     type                   = "stk600";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
 ;
 
@@ -1216,6 +1242,7 @@ programmer
     id                     = "stk600pp";
     desc                   = "Atmel STK600 in parallel programming mode";
     type                   = "stk600pp";
+    prog_modes             = PM_HVPP;
     connection_type        = usb;
 ;
 
@@ -1227,6 +1254,7 @@ programmer
     id                     = "stk600hvsp";
     desc                   = "Atmel STK600 in high-voltage serial programming mode";
     type                   = "stk600hvsp";
+    prog_modes             = PM_HVSP;
     connection_type        = usb;
 ;
 
@@ -1238,6 +1266,7 @@ programmer
     id                     = "avr910";
     desc                   = "Atmel Low Cost Serial Programmer";
     type                   = "avr910";
+    prog_modes             = PM_ISP;
     connection_type        = serial;
 ;
 
@@ -1249,6 +1278,7 @@ programmer
     id                     = "ft245r";
     desc                   = "FT245R Synchronous BitBang";
     type                   = "ftdi_syncbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     reset                  = 4; # D4
     sck                    = 0; # D0
@@ -1264,6 +1294,7 @@ programmer
     id                     = "ft232r";
     desc                   = "FT232R Synchronous BitBang";
     type                   = "ftdi_syncbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     reset                  = 4;  # DTR
     sck                    = 0;  # TxD
@@ -1281,6 +1312,7 @@ programmer
     id                     = "bwmega";
     desc                   = "BitWizard ftdi_atmega builtin programmer";
     type                   = "ftdi_syncbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     reset                  = 7;  # RI
     sck                    = 6;  # DCD
@@ -1299,6 +1331,7 @@ programmer
     id                     = "arduino-ft232r";
     desc                   = "Arduino: FT232R connected to ISP";
     type                   = "ftdi_syncbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     reset                  = 7;  # RI  X3(4)
     sck                    = 5;  # DSR X3(2)
@@ -1314,6 +1347,7 @@ programmer
     id                     = "tc2030";
     desc                   = "Tag-Connect TC2030";
     type                   = "ftdi_syncbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
   #                      FOR TPI devices:
     reset                  = 3;  # CTS = D3 (wire to ~RESET)
@@ -1348,6 +1382,7 @@ programmer
     id                     = "uncompatino";
     desc                   = "uncompatino with all pairs of pins shorted";
     type                   = "ftdi_syncbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     reset                  = 7; # ri
     sck                    = 5; # dsr
@@ -1377,6 +1412,7 @@ programmer
     id                     = "ttl232r";
     desc                   = "FTDI TTL232R-5V with ICSP adapter";
     type                   = "ftdi_syncbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     reset                  = 0; # txd
     sck                    = 1; # rxd
@@ -1392,6 +1428,7 @@ programmer
     id                     = "usbasp";
     desc                   = "USBasp, http://www.fischl.de/usbasp/";
     type                   = "usbasp";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x16c0; # VOTI
     usbpid                 = 0x05dc; # Obdev's free shared PID
@@ -1420,6 +1457,7 @@ programmer
     id                     = "nibobee";
     desc                   = "NIBObee";
     type                   = "usbasp";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x16c0; # VOTI
     usbpid                 = 0x092f; # NIBObee PID
@@ -1435,6 +1473,7 @@ programmer
     id                     = "usbasp-clone";
     desc                   = "Any usbasp clone with correct VID/PID";
     type                   = "usbasp";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x16c0; # VOTI
     usbpid                 = 0x05dc; # Obdev's free shared PID
@@ -1453,6 +1492,7 @@ programmer
     id                     = "usbtiny";
     desc                   = "USBtiny simple USB programmer, https://learn.adafruit.com/usbtinyisp";
     type                   = "usbtiny";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x1781;
     usbpid                 = 0x0c9f;
@@ -1466,6 +1506,7 @@ programmer
     id                     = "arduinoisp";
     desc                   = "Arduino ISP Programmer";
     type                   = "usbtiny";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x2341;
     usbpid                 = 0x0049;
@@ -1479,6 +1520,7 @@ programmer
     id                     = "arduinoisporg";
     desc                   = "Arduino ISP Programmer";
     type                   = "usbtiny";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x2a03;
     usbpid                 = 0x0049;
@@ -1494,6 +1536,7 @@ programmer
     id                     = "ehajo-isp";
     desc                   = "avr-isp-programmer from eHaJo, http://www.eHaJo.de";
     type                   = "usbtiny";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x16d0;
     usbpid                 = 0x0ba5;
@@ -1510,6 +1553,7 @@ programmer
     id                     = "iseavrprog";
     desc                   = "USBtiny-based programmer, https://iascaled.com";
     type                   = "usbtiny";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x1209;
     usbpid                 = 0x6570;
@@ -1523,6 +1567,7 @@ programmer
     id                     = "micronucleus";
     desc                   = "Micronucleus Bootloader";
     type                   = "micronucleus";
+    prog_modes             = PM_SPM;
     connection_type        = usb;
     usbvid                 = 0x16d0;
     usbpid                 = 0x0753;
@@ -1536,6 +1581,7 @@ programmer
     id                     = "teensy";
     desc                   = "Teensy Bootloader";
     type                   = "teensy";
+    prog_modes             = PM_SPM;
     connection_type        = usb;
     usbvid                 = 0x16c0;
     usbpid                 = 0x0478;
@@ -1549,6 +1595,7 @@ programmer
     id                     = "butterfly";
     desc                   = "Atmel Butterfly Development Board";
     type                   = "butterfly";
+    prog_modes             = PM_SPM;
     connection_type        = serial;
 ;
 
@@ -1560,6 +1607,7 @@ programmer
     id                     = "avr109";
     desc                   = "Atmel AppNote AVR109 Boot Loader";
     type                   = "butterfly";
+    prog_modes             = PM_SPM;
     connection_type        = serial;
 ;
 
@@ -1571,6 +1619,7 @@ programmer
     id                     = "avr911";
     desc                   = "Atmel AppNote AVR911 AVROSP";
     type                   = "butterfly";
+    prog_modes             = PM_SPM;
     connection_type        = serial;
 ;
 
@@ -1584,6 +1633,7 @@ programmer
     id                     = "mkbutterfly";
     desc                   = "Mikrokopter.de Butterfly";
     type                   = "butterfly_mk";
+    prog_modes             = PM_SPM;
     connection_type        = serial;
 ;
 
@@ -1603,6 +1653,7 @@ programmer
     id                     = "jtagmkI";
     desc                   = "Atmel JTAG ICE (mkI)";
     type                   = "jtagmki";
+    prog_modes             = PM_JTAG;
     connection_type        = serial;
     baudrate               = 115200;    # default is 115200
 ;
@@ -1641,6 +1692,7 @@ programmer
     id                     = "jtagmkII";
     desc                   = "Atmel JTAG ICE mkII";
     type                   = "jtagmkii";
+    prog_modes             = PM_JTAG;
     connection_type        = usb;
     baudrate               = 19200;    # default is 19200
 ;
@@ -1686,6 +1738,7 @@ programmer
     id                     = "jtag2isp";
     desc                   = "Atmel JTAG ICE mkII in ISP mode";
     type                   = "jtagmkii_isp";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1700,6 +1753,7 @@ programmer
     id                     = "jtag2dw";
     desc                   = "Atmel JTAG ICE mkII in debugWire mode";
     type                   = "jtagmkii_dw";
+    prog_modes             = PM_debugWIRE;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1714,6 +1768,7 @@ programmer
     id                     = "jtagmkII_avr32";
     desc                   = "Atmel JTAG ICE mkII im AVR32 mode";
     type                   = "jtagmkii_avr32";
+    prog_modes             = PM_aWire;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1728,6 +1783,7 @@ programmer
     id                     = "jtag2avr32";
     desc                   = "Atmel JTAG ICE mkII im AVR32 mode";
     type                   = "jtagmkii_avr32";
+    prog_modes             = PM_aWire;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1742,6 +1798,7 @@ programmer
     id                     = "jtag2pdi";
     desc                   = "Atmel JTAG ICE mkII PDI mode";
     type                   = "jtagmkii_pdi";
+    prog_modes             = PM_PDI;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1756,6 +1813,7 @@ programmer
     id                     = "dragon_jtag";
     desc                   = "Atmel AVR Dragon in JTAG mode";
     type                   = "dragon_jtag";
+    prog_modes             = PM_JTAG;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1770,6 +1828,7 @@ programmer
     id                     = "dragon_isp";
     desc                   = "Atmel AVR Dragon in ISP mode";
     type                   = "dragon_isp";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1784,6 +1843,7 @@ programmer
     id                     = "dragon_pp";
     desc                   = "Atmel AVR Dragon in PP mode";
     type                   = "dragon_pp";
+    prog_modes             = PM_HVPP;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1798,6 +1858,7 @@ programmer
     id                     = "dragon_hvsp";
     desc                   = "Atmel AVR Dragon in HVSP mode";
     type                   = "dragon_hvsp";
+    prog_modes             = PM_HVSP;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1812,6 +1873,7 @@ programmer
     id                     = "dragon_dw";
     desc                   = "Atmel AVR Dragon in debugWire mode";
     type                   = "dragon_dw";
+    prog_modes             = PM_debugWIRE;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1826,6 +1888,7 @@ programmer
     id                     = "dragon_pdi";
     desc                   = "Atmel AVR Dragon in PDI mode";
     type                   = "dragon_pdi";
+    prog_modes             = PM_PDI;
     connection_type        = usb;
     baudrate               = 115200;
 ;
@@ -1838,6 +1901,7 @@ programmer
     id                     = "jtag3";
     desc                   = "Atmel AVR JTAGICE3 in JTAG mode";
     type                   = "jtagice3";
+    prog_modes             = PM_JTAG;
     connection_type        = usb;
     usbpid                 = 0x2110, 0x2140;
 ;
@@ -1850,6 +1914,7 @@ programmer
     id                     = "jtag3pdi";
     desc                   = "Atmel AVR JTAGICE3 in PDI mode";
     type                   = "jtagice3_pdi";
+    prog_modes             = PM_PDI;
     connection_type        = usb;
     usbpid                 = 0x2110, 0x2140;
 ;
@@ -1862,6 +1927,7 @@ programmer
     id                     = "jtag3updi";
     desc                   = "Atmel AVR JTAGICE3 in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x2110, 0x2140;
     hvupdi_support         = 1;
@@ -1875,6 +1941,7 @@ programmer
     id                     = "jtag3dw";
     desc                   = "Atmel AVR JTAGICE3 in debugWIRE mode";
     type                   = "jtagice3_dw";
+    prog_modes             = PM_debugWIRE;
     connection_type        = usb;
     usbpid                 = 0x2110, 0x2140;
 ;
@@ -1887,6 +1954,7 @@ programmer
     id                     = "jtag3isp";
     desc                   = "Atmel AVR JTAGICE3 in ISP mode";
     type                   = "jtagice3_isp";
+    prog_modes             = PM_ISP;
     connection_type        = usb;
     usbpid                 = 0x2110, 0x2140;
 ;
@@ -1899,6 +1967,7 @@ programmer
     id                     = "xplainedpro";
     desc                   = "Atmel AVR XplainedPro in JTAG mode";
     type                   = "jtagice3";
+    prog_modes             = PM_JTAG;
     connection_type        = usb;
     usbpid                 = 0x2111;
 ;
@@ -1911,6 +1980,7 @@ programmer
     id                     = "xplainedpro_updi";
     desc                   = "Atmel AVR XplainedPro in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x2111;
     hvupdi_support         = 1;
@@ -1924,6 +1994,7 @@ programmer
     id                     = "xplainedmini";
     desc                   = "Atmel AVR XplainedMini in ISP mode";
     type                   = "jtagice3_isp";
+    prog_modes             = PM_ISP;
     connection_type        = usb;
     usbpid                 = 0x2145;
 ;
@@ -1936,6 +2007,7 @@ programmer
     id                     = "xplainedmini_dw";
     desc                   = "Atmel AVR XplainedMini in debugWIRE mode";
     type                   = "jtagice3_dw";
+    prog_modes             = PM_debugWIRE;
     connection_type        = usb;
     usbpid                 = 0x2145;
 ;
@@ -1948,6 +2020,7 @@ programmer
     id                     = "xplainedmini_updi";
     desc                   = "Atmel AVR XplainedMini in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x2145;
     hvupdi_support         = 1;
@@ -1961,6 +2034,7 @@ programmer
     id                     = "atmelice";
     desc                   = "Atmel-ICE (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
+    prog_modes             = PM_JTAG;
     connection_type        = usb;
     usbpid                 = 0x2141;
 ;
@@ -1973,6 +2047,7 @@ programmer
     id                     = "atmelice_pdi";
     desc                   = "Atmel-ICE (ARM/AVR) in PDI mode";
     type                   = "jtagice3_pdi";
+    prog_modes             = PM_PDI;
     connection_type        = usb;
     usbpid                 = 0x2141;
 ;
@@ -1985,6 +2060,7 @@ programmer
     id                     = "atmelice_updi";
     desc                   = "Atmel-ICE (ARM/AVR) in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x2141;
     hvupdi_support         = 1;
@@ -1998,6 +2074,7 @@ programmer
     id                     = "atmelice_dw";
     desc                   = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
     type                   = "jtagice3_dw";
+    prog_modes             = PM_PDI | PM_debugWIRE;
     connection_type        = usb;
     usbpid                 = 0x2141;
 ;
@@ -2010,6 +2087,7 @@ programmer
     id                     = "atmelice_isp";
     desc                   = "Atmel-ICE (ARM/AVR) in ISP mode";
     type                   = "jtagice3_isp";
+    prog_modes             = PM_ISP;
     connection_type        = usb;
     usbpid                 = 0x2141;
 ;
@@ -2022,6 +2100,7 @@ programmer
     id                     = "powerdebugger";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
+    prog_modes             = PM_JTAG;
     connection_type        = usb;
     usbpid                 = 0x2144;
 ;
@@ -2034,6 +2113,7 @@ programmer
     id                     = "powerdebugger_pdi";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
     type                   = "jtagice3_pdi";
+    prog_modes             = PM_PDI;
     connection_type        = usb;
     usbpid                 = 0x2144;
 ;
@@ -2046,6 +2126,7 @@ programmer
     id                     = "powerdebugger_updi";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x2144;
     hvupdi_support         = 0, 1;
@@ -2059,6 +2140,7 @@ programmer
     id                     = "powerdebugger_dw";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
     type                   = "jtagice3_dw";
+    prog_modes             = PM_debugWIRE;
     connection_type        = usb;
     usbpid                 = 0x2144;
 ;
@@ -2071,6 +2153,7 @@ programmer
     id                     = "powerdebugger_isp";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
     type                   = "jtagice3_isp";
+    prog_modes             = PM_ISP;
     connection_type        = usb;
     usbpid                 = 0x2144;
 ;
@@ -2083,6 +2166,7 @@ programmer
     id                     = "pickit4_updi";
     desc                   = "MPLAB(R) PICkit 4 in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
     hvupdi_support         = 0, 1, 2;
@@ -2096,6 +2180,7 @@ programmer
     id                     = "pickit4_pdi";
     desc                   = "MPLAB(R) PICkit 4 in PDI mode";
     type                   = "jtagice3_pdi";
+    prog_modes             = PM_PDI;
     connection_type        = usb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
@@ -2108,6 +2193,7 @@ programmer
     id                     = "pickit4_isp";
     desc                   = "MPLAB(R) PICkit 4 in ISP mode";
     type                   = "jtagice3_isp";
+    prog_modes             = PM_ISP;
     connection_type        = usb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
@@ -2120,6 +2206,7 @@ programmer
     id                     = "snap_updi";
     desc                   = "MPLAB(R) SNAP in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x217f, 0x2180, 0x2181;
     hvupdi_support         = 1;
@@ -2133,6 +2220,7 @@ programmer
     id                     = "snap_pdi";
     desc                   = "MPLAB(R) SNAP in PDI mode";
     type                   = "jtagice3_pdi";
+    prog_modes             = PM_PDI;
     connection_type        = usb;
     usbpid                 = 0x217f, 0x2180, 0x2181;
 ;
@@ -2145,6 +2233,7 @@ programmer
     id                     = "snap_isp";
     desc                   = "MPLAB(R) SNAP in ISP mode";
     type                   = "jtagice3_isp";
+    prog_modes             = PM_ISP;
     connection_type        = usb;
     usbpid                 = 0x217f, 0x2180, 0x2181;
 ;
@@ -2157,6 +2246,7 @@ programmer
     id                     = "pkobn_updi";
     desc                   = "Curiosity nano (nEDBG) in UPDI mode";
     type                   = "jtagice3_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = usb;
     usbpid                 = 0x2175;
     hvupdi_support         = 1;
@@ -2170,6 +2260,7 @@ programmer
     id                     = "pavr";
     desc                   = "Jason Kyle's pAVR Serial Programmer";
     type                   = "avr910";
+    prog_modes             = PM_ISP;
     connection_type        = serial;
 ;
 
@@ -2181,6 +2272,7 @@ programmer
     id                     = "pickit2";
     desc                   = "MicroChip's PICkit2 Programmer";
     type                   = "pickit2";
+    prog_modes             = PM_ISP;
     connection_type        = usb;
 ;
 
@@ -2192,6 +2284,7 @@ programmer
     id                     = "flip1";
     desc                   = "FLIP USB DFU protocol version 1 (doc7618)";
     type                   = "flip1";
+    prog_modes             = PM_SPM;
     connection_type        = usb;
 ;
 
@@ -2203,6 +2296,7 @@ programmer
     id                     = "flip2";
     desc                   = "FLIP USB DFU protocol version 2 (AVR4023)";
     type                   = "flip2";
+    prog_modes             = PM_SPM;
     connection_type        = usb;
 ;
 
@@ -2234,6 +2328,7 @@ programmer
     id                     = "ponyser";
     desc                   = "design ponyprog serial, reset=!txd sck=rts mosi=dtr miso=cts";
     type                   = "serbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
     reset                  = ~3;
     sck                    = 7;
@@ -2264,6 +2359,7 @@ programmer
     id                     = "dasa";
     desc                   = "serial port banging, reset=rts sck=dtr mosi=txd miso=cts";
     type                   = "serbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
     reset                  = 7;
     sck                    = 4;
@@ -2282,6 +2378,7 @@ programmer
     id                     = "dasa3";
     desc                   = "serial port banging, reset=!dtr sck=rts mosi=txd miso=cts";
     type                   = "serbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
     reset                  = ~4;
     sck                    = 7;
@@ -2300,6 +2397,7 @@ programmer
     id                     = "c2n232i";
     desc                   = "serial port banging, reset=dtr sck=!rts mosi=!txd miso=!cts";
     type                   = "serbb";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
     reset                  = 4;
     sck                    = ~7;
@@ -2318,6 +2416,7 @@ programmer
     id                     = "jtag2updi";
     desc                   = "JTAGv2 to UPDI bridge";
     type                   = "jtagmkii_updi";
+    prog_modes             = PM_UPDI;
     connection_type        = serial;
     baudrate               = 115200;
     hvupdi_support         = 1;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -403,6 +403,7 @@ programmer
     id                     = "bsd";
     desc                   = "Brian Dean's Programmer, http://www.bsdhome.com/avrdude/";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     vcc                    = 2, 3, 4, 5;
     reset                  = 7;
     sck                    = 8;
@@ -418,6 +419,7 @@ programmer
     id                     = "stk200";
     desc                   = "STK200";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     buff                   = 4, 5;
     reset                  = 9;
     sck                    = 6;
@@ -448,6 +450,7 @@ programmer
     id                     = "dt006";
     desc                   = "Dontronics DT006";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     reset                  = 4;
     sck                    = 5;
     mosi                   = 2;
@@ -471,6 +474,7 @@ programmer
     id                     = "alf";
     desc                   = "Nightshade ALF-PgmAVR, http://nightshade.homeip.net/";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     vcc                    = 2, 3, 4, 5;
     buff                   = 6;
     reset                  = 7;
@@ -491,6 +495,7 @@ programmer
     id                     = "sp12";
     desc                   = "Steve Bolt's Programmer";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     vcc                    = 4, 5, 6, 7, 8;
     reset                  = 3;
     sck                    = 2;
@@ -506,6 +511,7 @@ programmer
     id                     = "picoweb";
     desc                   = "Picoweb Programming Cable, http://www.picoweb.net/";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     reset                  = 2;
     sck                    = 3;
     mosi                   = 4;
@@ -520,6 +526,7 @@ programmer
     id                     = "abcmini";
     desc                   = "ABCmini Board, aka Dick Smith HOTCHIP";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     reset                  = 4;
     sck                    = 3;
     mosi                   = 2;
@@ -534,6 +541,7 @@ programmer
     id                     = "futurlec";
     desc                   = "Futurlec.com programming cable.";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     reset                  = 3;
     sck                    = 2;
     mosi                   = 1;
@@ -556,6 +564,7 @@ programmer
     id                     = "xil";
     desc                   = "Xilinx JTAG cable";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     vcc                    = 6;
     buff                   = 5;
     reset                  = 4;
@@ -572,6 +581,7 @@ programmer
     id                     = "dapa";
     desc                   = "Direct AVR Parallel Access cable";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     vcc                    = 3;
     reset                  = 16;
     sck                    = 1;
@@ -587,6 +597,7 @@ programmer
     id                     = "atisp";
     desc                   = "AT-ISP V1.1 programming cable for AVR-SDK1 from <http://micro-research.co.th/> micro-research.co.th";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     reset                  = ~6;
     sck                    = ~8;
     mosi                   = ~7;
@@ -601,6 +612,7 @@ programmer
     id                     = "ere-isp-avr";
     desc                   = "ERE ISP-AVR <http://www.ere.co.th/download/sch050713.pdf>";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     reset                  = ~4;
     sck                    = 3;
     mosi                   = 2;
@@ -615,6 +627,7 @@ programmer
     id                     = "blaster";
     desc                   = "Altera ByteBlaster";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     buff                   = 14;
     reset                  = 3;
     sck                    = 2;
@@ -647,6 +660,7 @@ programmer
     id                     = "89isp";
     desc                   = "Atmel at89isp cable";
     type                   = "par";
+    prog_modes             = PM_TPI | PM_ISP;
     reset                  = 17;
     sck                    = 1;
     mosi                   = 2;

--- a/src/config.c
+++ b/src/config.c
@@ -267,6 +267,9 @@ TOKEN *new_constant(const char *con) {
     !strcmp("PM_HVPP", con)? PM_HVPP:
     !strcmp("PM_debugWIRE", con)? PM_debugWIRE:
     !strcmp("PM_JTAG", con)? PM_JTAG:
+    !strcmp("PM_JTAGmkI", con)? PM_JTAGmkI:
+    !strcmp("PM_XMEGAJTAG", con)? PM_XMEGAJTAG:
+    !strcmp("PM_AVR32JTAG", con)? PM_AVR32JTAG:
     !strcmp("PM_aWire", con)? PM_aWire:
     (assigned = 0);
 

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1122,7 +1122,7 @@ part_parm :
       if ($3->primary == K_YES)
         current_part->prog_modes |= PM_JTAG;
       else if ($3->primary == K_NO)
-        current_part->prog_modes &= ~PM_JTAG;
+        current_part->prog_modes &= ~(PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG);
       free_token($3);
     } |
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -232,6 +232,12 @@ static char *prog_modes_str(int pm) {
     strcat(type, " | PM_debugWIRE");
   if(pm & PM_JTAG)
     strcat(type, " | PM_JTAG");
+  if(pm & PM_JTAGmkI)
+    strcat(type, " | PM_JTAGmkI");
+  if(pm & PM_XMEGAJTAG)
+    strcat(type, " | PM_XMEGAJTAG");
+  if(pm & PM_AVR32JTAG)
+    strcat(type, " | PM_AVR32JTAG");
   if(pm & PM_aWire)
     strcat(type, " | PM_aWire");
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -53,11 +53,18 @@
 #include "developer_opts.h"
 #include "developer_opts_private.h"
 
-  // Inject part parameters into a semi-automated rewrite of avrdude.conf
-  //  - Add entries to the tables below; they get written on -p*/i
-  //  - Use the output in a new avrdude.conf
-  //  - Output again with -p* (no /i) and use that for final avrdude.conf
-  //  - Remove entries from below tables
+// Inject part parameters into a semi-automated rewrite of avrdude.conf
+//  - Add entries to the tables below; they get written on -p*/si or -c*/si
+//  - Use the output in a new avrdude.conf
+//  - Output again with -p* or -c* (no /i) and use that for final avrdude.conf
+//  - Remove entries from below tables
+
+static struct {
+  const char *pgmid, *var, *value;
+} pgminj[] = {
+  // Add triples here, eg, {"stk500v2", "prog_modes", "PM_TPI|PM_ISP"},
+  {NULL, NULL, NULL},
+};
 
 static struct {
   const char *mcu, *var, *value;
@@ -812,7 +819,7 @@ void dev_output_pgm_part(int dev_opt_c, char *programmer, int dev_opt_p, char *p
 }
 
 
-// -p */[dASsrcow*t]
+// -p */[dASsrcow*ti]
 void dev_output_part_defs(char *partdesc) {
   bool cmdok, waits, opspi, descs, astrc, strct, cmpst, injct, raw, all, tsv;
   char *flags;
@@ -1171,7 +1178,7 @@ static const char *connstr(conntype_t conntype) {
   }
 }
 
-static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *base) {
+static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *base, bool injct) {
   char *id = ldata(lfirst(pgm->id));
   LNODEID ln;
   COMMENT *cp;
@@ -1289,6 +1296,14 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
     }
   }
 
+  if(injct)
+    for(size_t i=0; i<sizeof pgminj/sizeof*pgminj; i++)
+      if(pgminj[i].pgmid)
+        for(LNODEID *ln=lfirst(pgm->id); ln; ln=lnext(ln))
+          if(strcmp(pgminj[i].pgmid, ldata(ln)) == 0)
+            dev_part_strct_entry(tsv, ".prog", ldata(ln), NULL,
+              pgminj[i].var, cfg_strdup("pgminj", pgminj[i].value), NULL);
+
   if(!tsv) {
     dev_cout(pgm->comments, ";", 0, 0);
     dev_info(";\n");
@@ -1296,9 +1311,9 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
 }
 
 
-// -c */[ASsrt]
+// -c */[ASsrti]
 void dev_output_pgm_defs(char *pgmid) {
-  bool astrc, strct, cmpst, raw, tsv;
+  bool astrc, strct, cmpst, raw, tsv, injct;
   char *flags;
   int nprinted;
   PROGRAMMER *nullpgm = pgm_new();
@@ -1309,7 +1324,7 @@ void dev_output_pgm_defs(char *pgmid) {
   if(!flags && !strcmp(pgmid, "*")) // Treat -c * as if it was -c */s
     flags = "s";
 
-  if(!*flags || !strchr("ASsrt", *flags)) {
+  if(!*flags || !strchr("ASsrti", *flags)) {
     dev_info("%s: flags for developer option -c <wildcard>/<flags> not recognised\n", progname);
     dev_info(
       "Wildcard examples (these need protecting in the shell through quoting):\n"
@@ -1323,6 +1338,7 @@ void dev_output_pgm_defs(char *pgmid) {
       "       s  show short entries of avrdude.conf programmers using parent\n"
       "       r  show entries of avrdude.conf programmers as raw dump\n"
       "       t  use tab separated values as much as possible\n"
+      "       i  inject assignments from source code table\n"
       "Examples:\n"
       "  $ avrdude -c usbasp/s\n"
       "  $ avrdude -c */st | grep baudrate\n"
@@ -1343,6 +1359,7 @@ void dev_output_pgm_defs(char *pgmid) {
   cmpst = !!strchr(flags, 's');
   raw   = !!strchr(flags, 'r');
   tsv   = !!strchr(flags, 't');
+  injct = !!strchr(flags, 'i');
 
   nprinted = dev_nprinted;
 
@@ -1368,7 +1385,8 @@ void dev_output_pgm_defs(char *pgmid) {
       dev_pgm_strct(pgm, tsv,
         astrc? NULL:
         strct? nullpgm:
-        pgm->parent_id && *pgm->parent_id? locate_programmer(programmers, pgm->parent_id): nullpgm);
+        pgm->parent_id && *pgm->parent_id? locate_programmer(programmers, pgm->parent_id): nullpgm,
+        injct);
 
     if(raw)
       dev_pgm_raw(pgm);

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -399,14 +399,19 @@ following options are recognized:
 
 @table @code
 @item -p @var{partno}
-This is the only mandatory option and it tells AVRDUDE what type of part
-(MCU) that is connected to the programmer.  The @var{partno} parameter
-is the part's id listed in the configuration file.  Specify -p ? to list
-all parts in the configuration file.  If a part is unknown
-to AVRDUDE, it means that there is no config file entry for that part,
-but it can be added to the configuration file if you have the Atmel
-datasheet so that you can enter the programming specifications.
-Currently, the following MCU types are understood:
+This option tells AVRDUDE what part (MCU) is connected to the programmer.
+The @var{partno} parameter is the part's id listed in the configuration file.
+For currently supported MCU types use ? as partno, which will print a list of
+partno ids and official part names on the terminal. Both can be used with the
+-p option.  If a part is unknown to AVRDUDE, it means that there is no config
+file entry for that part, but it can be added to the configuration file if
+you have the Atmel datasheet so that you can enter the programming
+specifications. If @code{-p ?} is specified with a specific programmer, see
+@code{-c} below, then only those parts are output that the programmer expects
+to be able to handle, together with the programming interface(s) that can be
+used in that combination. In reality there can be deviations from this list,
+particularly if programming is directly via a bootloader. Currently, the
+following MCU types are understood:
 
 @cindex Device support
 
@@ -459,7 +464,12 @@ AVRDUDE, and the programmer is controlled via the PC parallel port,
 there's a good chance that it can be easily added to the configuration
 file without any code changes to AVRDUDE.  Simply copy an existing entry
 and change the pin definitions to match that of the unknown programmer.
-Currently, the following programmer ids are understood and supported:
+If @code{-c ?} is specified with a specific part, see @code{-p} above, then
+only those programmers are output that expect to be able to handle this part,
+together with the programming interface(s) that can be used in that
+combination. In reality there can be deviations from this list, particularly
+if programming is directly via a bootloader. Currently, the following
+programmer ids are understood and supported:
 
 @cindex Programmer support
 
@@ -1737,7 +1747,10 @@ Known programming modes are
 @item @code{PM_HVSP}: High Voltage Serial Programming (some classic parts)
 @item @code{PM_HVPP}: High Voltage Parallel Programming (most non-HVSP classic parts)
 @item @code{PM_debugWIRE}: Simpler alternative to JTAG (a subset of HVPP/HVSP parts)
-@item @code{PM_JTAG}: Joint Test Action Group standard (some classic parts, some xmega)
+@item @code{PM_JTAG}: Joint Test Action Group standard (some classic parts)
+@item @code{PM_JTAGmkI}: Subset of @code{PM_JTAG}, older parts, Atmel ICE mkI
+@item @code{PM_XMEGAJTAG}: JTAG, some XMEGA parts
+@item @code{PM_AVR32JTAG}: JTAG for 32-bit AVRs
 @item @code{PM_aWire}: AVR32 parts
 @end itemize
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1076,7 +1076,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       conn = PARM3_CONN_UPDI;
   } else {
     ifname = "JTAG";
-    if (p->prog_modes & PM_JTAG)
+    if (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG))
       conn = PARM3_CONN_JTAG;
   }
 
@@ -1376,7 +1376,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (use_ext_reset > 1) {
-      if(strcmp(pgm->type, "JTAGICE3") == 0 && (p->prog_modes & PM_JTAG))
+      if(strcmp(pgm->type, "JTAGICE3") == 0 && (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG)))
         avrdude_message(MSG_INFO, "%s: JTAGEN fuse disabled?\n", progname);
       return -1;
   }

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -523,11 +523,14 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char cmd[1], resp[5];
   unsigned char b;
 
-  if (!(p->prog_modes & PM_JTAG)) {
+  if (!(p->prog_modes & (PM_JTAGmkI | PM_JTAG))) {
     avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): part %s has no JTAG interface\n",
 	    progname, p->desc);
     return -1;
   }
+  if (!(p->prog_modes & PM_JTAGmkI))
+    avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): warning part %s has JTAG interface, but may be too new\n",
+	    progname, p->desc);
 
   jtagmkI_drain(pgm, 0);
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1308,7 +1308,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       ok = 1;
   } else {
     ifname = "JTAG";
-    if (p->prog_modes & PM_JTAG)
+    if (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG))
       ok = 1;
   }
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -133,7 +133,7 @@ prog_modes|mcuid|n_interrupts|n_page_erase { /* Components for assignment  */
   return TKN_COMPONENT;
 }
 
-PM_SPM|PM_TPI|PM_ISP|PM_PDI|PM_UPDI|PM_HVSP|PM_HVPP|PM_debugWIRE|PM_JTAG|PM_aWire { /* Constants */
+PM_(SPM|TPI|ISP|PDI|UPDI|HVSP|HVPP|debugWIRE|JTAG|JTAGmkI|XMEGAJTAG|AVR32JTAG|aWire) { /* Constants */
   yylval = new_constant(yytext);
   return TKN_NUMBER;
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -201,8 +201,11 @@ typedef struct opcode {
 #define PM_HVSP              32 // High Voltage Serial Programming (some classic parts)
 #define PM_HVPP              64 // High Voltage Parallel Programming (most non-HVSP classic parts)
 #define PM_debugWIRE        128 // Simpler alternative to JTAG (a subset of HVPP/HVSP parts)
-#define PM_JTAG             256 // Joint Test Action Group standard (some classic parts, some xmega)
-#define PM_aWire            512 // AVR32 parts
+#define PM_JTAG             256 // Joint Test Action Group standard (some classic parts)
+#define PM_JTAGmkI          512 // Subset of PM_JTAG, older parts, Atmel ICE mkI
+#define PM_XMEGAJTAG       1024 // JTAG, some XMEGA parts
+#define PM_AVR32JTAG       2048 // JTAG for 32-bit AVRs
+#define PM_aWire           4096 // For 32-bit AVRs
 
 #define HV_UPDI_VARIANT_0      0 /* Shared UPDI/GPIO/RESET pin, HV on UPDI pin (tinyAVR0/1/2)*/
 #define HV_UPDI_VARIANT_1      1 /* Dedicated UPDI pin, no HV (megaAVR0/AVR-Dx) */

--- a/src/main.c
+++ b/src/main.c
@@ -190,6 +190,7 @@ static void pmshorten(char *desc, const char *modes) {
     {" in JTAG mode", "JTAGmkI"},
     {" in JTAG mode", "XMEGAJTAG"},
     {" in JTAG mode", "AVR32JTAG"},
+    {" for bootloader", "bootloader"},
   };
   size_t len = strlen(desc);
 

--- a/src/main.c
+++ b/src/main.c
@@ -196,7 +196,7 @@ static void pmshorten(char *desc, const char *modes) {
 
   for(size_t i=0; i<sizeof pairs/sizeof*pairs; i++) {
     size_t elen = strlen(pairs[i].end);
-    if(len > elen && strcmp(desc+len-elen, pairs[i].end) == 0 && strcmp(modes, pairs[i].mode) == 0) {
+    if(len > elen && strcasecmp(desc+len-elen, pairs[i].end) == 0 && strcmp(modes, pairs[i].mode) == 0) {
       desc[len-elen] = 0;
       break;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -138,6 +138,10 @@ static void usage(void)
 static char *via_prog_modes(int pm) {
   static char type[1024];
 
+  // Suppress PM_JTAGmkI if also PM_JTAG is given
+  if((pm & PM_JTAG) && (pm & PM_JTAGmkI))
+    pm &= ~PM_JTAGmkI;
+
   strcpy(type, "?");
   if(pm & PM_SPM)
     strcat(type, ", bootloader");
@@ -157,6 +161,12 @@ static char *via_prog_modes(int pm) {
     strcat(type, ", debugWIRE");
   if(pm & PM_JTAG)
     strcat(type, ", JTAG");
+  if(pm & PM_JTAGmkI)
+    strcat(type, ", JTAGmkI");
+  if(pm & PM_XMEGAJTAG)
+    strcat(type, ", XMEGAJTAG");
+  if(pm & PM_AVR32JTAG)
+    strcat(type, ", AVR32JTAG");
   if(pm & PM_aWire)
     strcat(type, ", aWire");
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1316,7 +1316,7 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   LNODEID ln;
   AVRMEM * m;
 
-  // FIXME: condition below looks fishy, suspect the code wants !(p->prog_modes & (PM_debugWIRE | PM_JTAG))
+  // FIXME: condition below looks fishy, suspect the code wants !(p->prog_modes & (PM_debugWIRE | PM_JTAG | PM_JTAGmkI /* | PM_XMEGAJTAG | PM_AVR32JTAG */))
   if (p->prog_modes & (PM_PDI | PM_TPI)) {
     avrdude_message(MSG_INFO, "%s: jtag3_initialize(): part %s has no ISP interface\n",
 	    progname, p->desc);


### PR DESCRIPTION
Resolves Discussion #1019. Try
```
    $ avrdude -p m328p -c?
    $ avrdude -p? -c jtag2dw
```

Known bug: When enabling `HAVE_PARPORT` the following programmers do not have `prog_modes` set. Hence these programmers are shown as `via ?` in the output of `avrdude -p m328p -c?`.