### PR TITLE
Fix avr109 extended address

### DIFF
--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -405,14 +405,26 @@ static void butterfly_display(const PROGRAMMER *pgm, const char *p) {
 
 
 static void butterfly_set_addr(const PROGRAMMER *pgm, unsigned long addr) {
-  char cmd[3];
+  if( addr < 0x10000 ) {
+    char cmd[3];
 
-  cmd[0] = 'A';
-  cmd[1] = (addr >> 8) & 0xff;
-  cmd[2] = addr & 0xff;
+    cmd[0] = 'A';
+    cmd[1] = (addr >> 8) & 0xff;
+    cmd[2] = addr & 0xff;
   
-  butterfly_send(pgm, cmd, sizeof(cmd));
-  butterfly_vfy_cmd_sent(pgm, "set addr");
+    butterfly_send(pgm, cmd, sizeof(cmd));
+    butterfly_vfy_cmd_sent(pgm, "set addr");
+  } else {
+    char cmd[4];
+
+    cmd[0] = 'H';
+    cmd[1] = (addr >> 16) & 0xff;
+    cmd[2] = (addr >> 8) & 0xff;
+    cmd[3] = addr & 0xff;
+
+    butterfly_send(pgm, cmd, sizeof(cmd));
+    butterfly_vfy_cmd_sent(pgm, "set extaddr");
+  }
 }
 
 


### PR DESCRIPTION
Fix pulled from issue #454. Makes it possible to write to flash addresses above the 128kiB mark.

Resolves issue #360 and issue #454.

Without this PR:

```
$ ./avrdude -cavr109 -p atxmega256a3bu -b 115200 -P /dev/cu.usbserial-1410 -e -Uflash:w:../../avrdude-terminal/src/0x55_256kib.hex:i

Connecting to programmer: .
Found programmer: Id = "XBoot++"; type = S
    Software Version = 1.7; No Hardware Version given.
Programmer supports auto addr increment.
Programmer supports buffered memory access with buffersize=512 bytes.

Programmer supports the following devices:
    Device code: 0x7b

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e9843 (probably x256a3bu)
avrdude: erasing chip
avrdude: reading input file ../../avrdude-terminal/src/0x55_256kib.hex for flash
avrdude: writing 262143 bytes flash ...

Writing | ################################################## | 100% 31.81s

avrdude: 262143 bytes of flash written
avrdude: verifying flash memory against ../../avrdude-terminal/src/0x55_256kib.hex

Reading | ################################################## | 100% 25.64s

avrdude: verification error, first mismatch at byte 0x1ffff
         0xff != 0x55
avrdude: verification error; content mismatch

avrdude done.  Thank you.
```

With this PR:

```
$ ./avrdude -cavr109 -p atxmega256a3bu -b 115200 -P /dev/cu.usbserial-1410 -e -Uflash:w:../../avrdude-terminal/src/0x55_256kib.hex:i

Connecting to programmer: .
Found programmer: Id = "XBoot++"; type = S
    Software Version = 1.7; No Hardware Version given.
Programmer supports auto addr increment.
Programmer supports buffered memory access with buffersize=512 bytes.

Programmer supports the following devices:
    Device code: 0x7b

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: Device signature = 0x1e9843 (probably x256a3bu)
avrdude: erasing chip
avrdude: reading input file ../../avrdude-terminal/src/0x55_256kib.hex for flash
avrdude: writing 262143 bytes flash ...

Writing | ################################################## | 100% 31.83s

avrdude: 262143 bytes of flash written
avrdude: verifying flash memory against ../../avrdude-terminal/src/0x55_256kib.hex

Reading | ################################################## | 100% 25.68s

avrdude: 262143 bytes of flash verified

avrdude done.  Thank you.
```