### PR TITLE
saving errno of ioctl() call in a temporary variable to prevent overwrite

### DIFF
--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -93,9 +93,10 @@ static int linuxspi_spi_duplex(const PROGRAMMER *pgm, const unsigned char *tx, u
     errno = 0;
     ret = ioctl(fd_spidev, SPI_IOC_MESSAGE(1), &tr);
     if (ret != len) {
+        int ioctl_errno = errno;
         avrdude_message(MSG_INFO, "\n%s: unable to send SPI message", progname);
-        if (errno)
-            avrdude_message(MSG_INFO, ". %s", strerror(errno));
+        if (ioctl_errno)
+            avrdude_message(MSG_INFO, ". %s", strerror(ioctl_errno));
         avrdude_message(MSG_INFO, "\n");
     }
 


### PR DESCRIPTION
Thank you for accepting PR #1100 !
The purpose of this PR is bugfix to avoid unintended overwirte for `errno` variable.