### PR TITLE
Support for Power Debugger analog readings in terminal mode

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2416,76 +2416,79 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
     verbose ? "" : "             ", b2_to_u16(buf) / 1000.0);
 
   // Print features unique to the Power Debugger
-  if (strncmp("powerdebugger", ldata(lfirst(pgm->id)), strlen("powerdebugger")) == 0) {
-    short analog_raw_data;
+  for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
+    if(matches(ldata(ln), "powerdebugger")) {
+      short analog_raw_data;
 
-    // Read generator set voltage value (VOUT)
-    if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
-      return;
-    analog_raw_data = b2_to_u16(buf);
-    avrdude_message(MSG_INFO, "%sVout set        %s: %.2f V\n", p,
-      verbose ? "" : "             ", analog_raw_data / 1000.0);
+      // Read generator set voltage value (VOUT)
+      if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
+        return;
+      analog_raw_data = b2_to_u16(buf);
+      avrdude_message(MSG_INFO, "%sVout set        %s: %.2f V\n", p,
+        verbose ? "" : "             ", analog_raw_data / 1000.0);
 
-    // Read measured generator voltage value (VOUT)
-    if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_TSUP_VOLTAGE_MEAS, buf, 2) < 0)
-      return;
-    analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
-    if ((buf[0] & 0xF0) != 0x30)
-      avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_TSUP_VOLTAGE_MEAS data packet format\n", progname);
-    else {
-      if (analog_raw_data & 0x0800)
-        analog_raw_data |= 0xF000;
-      avrdude_message(MSG_INFO, "%sVout measured   %s: %.02f V\n", p,
-        verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
-    }
+      // Read measured generator voltage value (VOUT)
+      if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_TSUP_VOLTAGE_MEAS, buf, 2) < 0)
+        return;
+      analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
+      if ((buf[0] & 0xF0) != 0x30)
+        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_TSUP_VOLTAGE_MEAS data packet format\n", progname);
+      else {
+        if (analog_raw_data & 0x0800)
+          analog_raw_data |= 0xF000;
+        avrdude_message(MSG_INFO, "%sVout measured   %s: %.02f V\n", p,
+          verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
+      }
 
-    // Read channel A voltage
-    if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_A_VOLTAGE, buf, 2) < 0)
-      return;
-    analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
-    if ((buf[0] & 0xF0) != 0x20)
-      avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_VOLTAGE data packet format\n", progname);
-    else {
-      if (analog_raw_data & 0x0800)
-        analog_raw_data |= 0xF000;
-      avrdude_message(MSG_INFO, "%sCh A voltage    %s: %.03f V\n", p,
-        verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
-    }
+      // Read channel A voltage
+      if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_A_VOLTAGE, buf, 2) < 0)
+        return;
+      analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
+      if ((buf[0] & 0xF0) != 0x20)
+        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_VOLTAGE data packet format\n", progname);
+      else {
+        if (analog_raw_data & 0x0800)
+          analog_raw_data |= 0xF000;
+        avrdude_message(MSG_INFO, "%sCh A voltage    %s: %.03f V\n", p,
+          verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
+      }
 
-    // Read channel A current
-    if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_A_CURRENT, buf, 3) < 0)
-      return;
-    analog_raw_data = (buf[1] << 8) + buf[2];
-    if (buf[0] != 0x90)
-      avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_CURRENT data packet format\n", progname);
-    else
-      avrdude_message(MSG_INFO, "%sCh A current    %s: %.3f mA\n", p,
-        verbose ? "" : "             ", ((float)analog_raw_data * 0.003472));
+      // Read channel A current
+      if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_A_CURRENT, buf, 3) < 0)
+        return;
+      analog_raw_data = (buf[1] << 8) + buf[2];
+      if (buf[0] != 0x90)
+        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_CURRENT data packet format\n", progname);
+      else
+        avrdude_message(MSG_INFO, "%sCh A current    %s: %.3f mA\n", p,
+          verbose ? "" : "             ", ((float)analog_raw_data * 0.003472));
 
-    // Read channel B voltage
-    if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_B_VOLTAGE, buf, 2) < 0)
-      return;
-    analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
-    if ((buf[0] & 0xF0) != 0x10)
-      avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_VOLTAGE data packet format\n", progname);
-    else {
-      if (analog_raw_data & 0x0800)
-        analog_raw_data |= 0xF000;
-      avrdude_message(MSG_INFO, "%sCh B voltage    %s: %.03f V\n", p,
-        verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
-    }
+      // Read channel B voltage
+      if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_B_VOLTAGE, buf, 2) < 0)
+        return;
+      analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
+      if ((buf[0] & 0xF0) != 0x10)
+        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_VOLTAGE data packet format\n", progname);
+      else {
+        if (analog_raw_data & 0x0800)
+          analog_raw_data |= 0xF000;
+        avrdude_message(MSG_INFO, "%sCh B voltage    %s: %.03f V\n", p,
+          verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
+      }
 
-    // Read channel B current
-    if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_B_CURRENT, buf, 3) < 0)
-      return;
-    analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
-    if ((buf[0] & 0xF0) != 0x00)
-      avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_CURRENT data packet format\n", progname);
-    else {
-      if (analog_raw_data & 0x0800)
-        analog_raw_data |= 0xF000;
-      avrdude_message(MSG_INFO, "%sCh B current    %s: %.3f mA\n", p,
-        verbose ? "" : "             ", ((float)analog_raw_data * 0.555556));
+      // Read channel B current
+      if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_B_CURRENT, buf, 3) < 0)
+        return;
+      analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
+      if ((buf[0] & 0xF0) != 0x00)
+        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_CURRENT data packet format\n", progname);
+      else {
+        if (analog_raw_data & 0x0800)
+          analog_raw_data |= 0xF000;
+        avrdude_message(MSG_INFO, "%sCh B current    %s: %.3f mA\n", p,
+          verbose ? "" : "             ", ((float)analog_raw_data * 0.555556));
+      }
+      break;
     }
   }
 
@@ -2599,8 +2602,12 @@ void jtag3_initpgm(PROGRAMMER *pgm) {
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_JTAG;
 
-  if (matches(ldata(lfirst(pgm->id)), "powerdebugger"))
-    pgm->set_vtarget  = jtag3_set_vtarget;
+  for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
+    if (matches(ldata(ln), "powerdebugger")) {
+      pgm->set_vtarget  = jtag3_set_vtarget;
+      break;
+    }
+  }
 }
 
 const char jtag3_dw_desc[] = "Atmel JTAGICE3 in debugWire mode";
@@ -2633,8 +2640,12 @@ void jtag3_dw_initpgm(PROGRAMMER *pgm) {
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_DW;
 
-  if (matches(ldata(lfirst(pgm->id)), "powerdebugger_dw"))
-    pgm->set_vtarget  = jtag3_set_vtarget;
+  for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
+    if (matches(ldata(ln), "powerdebugger")) {
+      pgm->set_vtarget  = jtag3_set_vtarget;
+      break;
+    }
+  }
 }
 
 const char jtag3_pdi_desc[] = "Atmel JTAGICE3 in PDI mode";
@@ -2669,8 +2680,12 @@ void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_PDI;
 
-  if (matches(ldata(lfirst(pgm->id)), "powerdebugger_pdi"))
-    pgm->set_vtarget  = jtag3_set_vtarget;
+  for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
+    if (matches(ldata(ln), "powerdebugger")) {
+      pgm->set_vtarget  = jtag3_set_vtarget;
+      break;
+    }
+  }
 }
 
 const char jtag3_updi_desc[] = "Atmel JTAGICE3 in UPDI mode";
@@ -2708,8 +2723,12 @@ void jtag3_updi_initpgm(PROGRAMMER *pgm) {
   pgm->unlock         = jtag3_unlock_erase_key;
   pgm->read_sib       = jtag3_read_sib;
 
-  if (matches(ldata(lfirst(pgm->id)), "pkobn_updi") ||
-      matches(ldata(lfirst(pgm->id)), "powerdebugger_updi"))
-    pgm->set_vtarget  = jtag3_set_vtarget;
+  for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
+    if (matches(ldata(ln), "powerdebugger") ||
+        matches(ldata(ln), "pkob")) {
+      pgm->set_vtarget  = jtag3_set_vtarget;
+      break;
+    }
+  }
 }
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2416,8 +2416,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
     verbose ? "" : "             ", b2_to_u16(buf) / 1000.0);
 
   // Print features unique to the Power Debugger
-  //if (strncmp("powerdebugger", ldata(lfirst(pgm->id)), strlen("powerdebugger")) == 0)
-  if (*(int *)(ldata(lfirst(pgm->usbpid))) == 0x2144){
+  if (strncmp("powerdebugger", ldata(lfirst(pgm->id)), strlen("powerdebugger")) == 0) {
     short analog_raw_data;
 
     // Read generator set voltage value (VOUT)

--- a/src/jtag3.h
+++ b/src/jtag3.h
@@ -38,6 +38,8 @@ int jtag3_setparm(const PROGRAMMER *pgm, unsigned char scope,
 		  unsigned char *value, unsigned char length);
 int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen,
 		  unsigned char **resp, const char *descr);
+void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p);
+int jtag3_set_vtarget(const PROGRAMMER *pgm, double voltage);
 extern const char jtag3_desc[];
 extern const char jtag3_dw_desc[];
 extern const char jtag3_pdi_desc[];

--- a/src/jtag3_private.h
+++ b/src/jtag3_private.h
@@ -184,16 +184,24 @@
  * precedes each parameter address.  There are distinct parameter
  * sets for generic and AVR scope.
  */
-#define PARM3_HW_VER      0x00  /* section 0, generic scope, 1 byte */
-#define PARM3_FW_MAJOR    0x01  /* section 0, generic scope, 1 byte */
-#define PARM3_FW_MINOR    0x02  /* section 0, generic scope, 1 byte */
-#define PARM3_FW_RELEASE  0x03  /* section 0, generic scope, 1 byte;
-                                 * always asked for by Atmel Studio,
-                                 * but never displayed there */
-#define PARM3_VTARGET     0x00  /* section 1, generic scope, 2 bytes, in millivolts */
-#define PARM3_VBUF        0x01  /* section 1, generic scope, 2 bytes, bufferred target voltage reference */
-#define PARM3_VUSB        0x02  /* section 1, generic scope, 2 bytes, USB voltage */
-#define PARM3_VADJUST     0x20  /* section 1, generic scope, 2 bytes, set voltage */
+#define PARM3_HW_VER            0x00  /* section 0, generic scope, 1 byte */
+#define PARM3_FW_MAJOR          0x01  /* section 0, generic scope, 1 byte */
+#define PARM3_FW_MINOR          0x02  /* section 0, generic scope, 1 byte */
+#define PARM3_FW_RELEASE        0x03  /* section 0, generic scope, 1 byte;
+                                       * always asked for by Atmel Studio,
+                                       * but never displayed there */
+
+#define PARM3_VTARGET           0x00  /* section 1, generic scope, 2 bytes, in millivolts */
+#define PARM3_VBUF              0x01  /* section 1, generic scope, 2 bytes, bufferred target voltage reference */
+#define PARM3_VUSB              0x02  /* section 1, generic scope, 2 bytes, USB voltage */
+#define PARM3_ANALOG_A_CURRENT  0x10  /* section 1, generic scope, 2 bytes, Ch A current in milliamps,  Powerdebugger only */
+#define PARM3_ANALOG_A_VOLTAGE  0x11  /* section 1, generic scope, 2 bytes, Ch A voltage in millivolts, Powerdebugger only */
+#define PARM3_ANALOG_B_CURRENT  0x12  /* section 1, generic scope, 2 bytes, Ch B current in milliamps,  Powerdebugger only */
+#define PARM3_ANALOG_B_VOLTAGE  0x13  /* section 1, generic scope, 2 bytes, Ch V voltage in millivolts, Powerdebugger only */
+#define PARM3_TSUP_VOLTAGE_MEAS 0x14  /* section 1, generic scope, 2 bytes, target voltage measurement in millivolts */
+#define PARM3_USB_VOLTAGE_MEAS  0x15  /* section 1, generic scope, 2 bytes, USB voltage measurement in millivolts */
+#define PARM3_VADJUST           0x20  /* section 1, generic scope, 2 bytes, set voltage in millivolts */
+#define PARM3_ANALOG_STATUS     0x30  /* section 1, generic scope, 2 bytes, analog status */
 
 #define PARM3_DEVICEDESC  0x00  /* section 2, memory etc. configuration,
                                  * 31 bytes for tiny/mega AVR, 47 bytes

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3226,11 +3226,8 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
   } else if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE3) {
     PROGRAMMER *pgmcp = pgm_dup(pgm);
     pgmcp->cookie = PDATA(pgm)->chained_pdata;
-    jtag3_getparm(pgmcp, SCOPE_GENERAL, 1, PARM3_VTARGET, vtarget_jtag, 2);
+    jtag3_print_parms1(pgmcp, p);
     pgm_free(pgmcp);
-    avrdude_message(MSG_INFO, "%sVtarget         : %.1f V\n", p,
-	    b2_to_u16(vtarget_jtag) / 1000.0);
-
   } else {
     stk500v2_getparm(pgm, PARAM_VTARGET, &vtarget);
     avrdude_message(MSG_INFO, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
@@ -3282,7 +3279,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
       if (stk500v2_jtag3_send(pgm, cmd, 1) >= 0 &&
 	  stk500v2_jtag3_recv(pgm, cmd, 4) >= 2) {
 	unsigned int sck = cmd[1] | (cmd[2] << 8);
-	avrdude_message(MSG_INFO, "%sSCK period      : %.2f us\n", p,
+	avrdude_message(MSG_INFO, "%sSCK period                   : %.2f us\n", p,
 		(float)(1E6 / (1000.0 * sck)));
       }
     }
@@ -4681,4 +4678,7 @@ void stk500v2_jtag3_initpgm(PROGRAMMER *pgm) {
   pgm->setup          = stk500v2_jtag3_setup;
   pgm->teardown       = stk500v2_jtag3_teardown;
   pgm->page_size      = 256;
+
+  if (strcmp(ldata(lfirst(pgm->id)), "powerdebugger_isp") == 0)
+    pgm->set_vtarget  = jtag3_set_vtarget;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3226,6 +3226,10 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
   } else if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE3) {
     PROGRAMMER *pgmcp = pgm_dup(pgm);
     pgmcp->cookie = PDATA(pgm)->chained_pdata;
+    pgmcp->id = lcreat(NULL, 0);
+    // Copy pgm->id contents over to pgmcp->id
+    for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln))
+      ladd(pgmcp->id, cfg_strdup("stk500v2_print_parms1()", ldata(ln)));
     jtag3_print_parms1(pgmcp, p);
     pgm_free(pgmcp);
   } else {

--- a/src/term.c
+++ b/src/term.c
@@ -854,7 +854,7 @@ static int cmd_parms(PROGRAMMER * pgm, struct avrpart * p,
     return -1;
   }
   pgm->print_parms(pgm);
-
+  terminal_message(MSG_INFO, "\n");
   return 0;
 }
 


### PR DESCRIPTION
The Power Debugger has some additional hardware other Microchip branded programmers don't.
It as two analog channels, A and B, which can be used to read voltage and current.

It has also a voltage generator (VOUT), and can set a voltage level, read the set value and also measure the exact voltage outputted. This PR exposes all these reading under the terminal `parms` command.

Big thanks to Microchip for helping me out figuring out the undocumented EDBG protocol and the mathematical formulas used to convert the readings into something that makes sense.

**~~This PR is only a draft,~~ and I'm opening the PR to get some feedback**. Here's a few things:

* Is is OK to display this data under the `parms` command (since these data is read-only), or should we introduce a new command?
* ~~When setting the target voltage on a Curiosity Nano board without a target connected, usually when using the nEDBG chip as a standalone programmer, the target voltage is set correctly, but cannot be verified by Avrdude. This can be fixed with the extended protocol data provided in this PR. I'll look into this later~~ Turned out to be caused by aincent nEDBG firmware running on my Curiosity Nano board. Not Avrdude's fault.
* To prevent duplicate code, I'm using the `jtag3_print_parms1` function in both jtag3.c and stk500v2.c when in terminal mode. For some reason, I couldn't use `pgm` directly, since I would get a malloc error when running the `quit` command saying it tried to free a pointer that was not allocated. Instead, I needed to make a duplicate (line 3227 in stk500v2.c). Hovever, the diplicate doesn't contain any `id` information, and I can't figure out how to copy the data stored in `pgm->id` over to `pgmcp->id` before passing `pgmcp` to `jtag3_print_parms1`. Instead, I'm checking on the Power Debuggers USB PID, which is really hacky. I would much rather check the `id` instead. So if someone knows how to copy the data stored in `pgm->id` over to `pgmcp->id`, please let me know!

Output with no device connected, 2V generated and loaded though a 200 ohm resistor passing current though both channels (no target connected, forcing terminal mode with -F):
```
$ ./avrdude -cpowerdebugger_isp -p atmega32 -t -F

avrdude: stk500v2_command(): command failed
avrdude: initialization failed, rc=-1
avrdude: AVR device initialized and ready to accept instructions
avrdude: Device signature = 0x000000 (retrying)
avrdude: Device signature = 0x000000 (retrying)
avrdude: Device signature = 0x000000
avrdude: Yikes!  Invalid device signature.
avrdude: Expected signature for ATmega32 is 1E 95 02
avrdude> vtarg 2
>>> vtarg 2 
avrdude: jtag3_set_vtarget(): changing V[target] from 0.2 to 2.0
avrdude> parms
>>> parms 
Vtarget                      : 0.23 V
Vout set                     : 2.00 V
Vout measured                : 2.00 V
Ch A voltage                 : 1.985 V
Ch A current                 : 9.159 mA
Ch B voltage                 : 1.945 V
Ch B current                 : 10.000 mA
JTAG clock megaAVR/program   : 1000 kHz
JTAG clock megaAVR/debug     : 1000 kHz
JTAG clock Xmega             : 1000 kHz
PDI/UPDI clock Xmega/megaAVR : 500 kHz
SCK period                   : 125.00 us
```

Hardware setup:
![IMG_3507](https://user-images.githubusercontent.com/3238730/192997668-0693f034-839a-4fb8-86c6-14da6599dc24.jpg)
