### PR TITLE
Provide cached byte-wise read/write API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ add_library(libavrdude
     avr.c
     avr910.c
     avr910.h
+    avrcache.c
     avrdude.h
     avrftdi.c
     avrftdi.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,7 +92,7 @@ libavrdude_a_SOURCES = \
 	avr.c \
 	avr910.c \
 	avr910.h \
-        avrcache.c \
+	avrcache.c \
 	avrdude.h \
 	avrftdi.c \
 	avrftdi.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,6 +92,7 @@ libavrdude_a_SOURCES = \
 	avr.c \
 	avr910.c \
 	avr910.h \
+        avrcache.c \
 	avrdude.h \
 	avrftdi.c \
 	avrftdi.h \

--- a/src/avr.c
+++ b/src/avr.c
@@ -1336,7 +1336,7 @@ void report_progress (int completed, int total, char *hdr)
   if (hdr) {
     last = 0;
     start_time = t;
-    update_progress (percent, t - start_time, hdr);
+    update_progress (percent, t - start_time, hdr, total > 0);
   }
 
   if (percent > 100)
@@ -1344,7 +1344,7 @@ void report_progress (int completed, int total, char *hdr)
 
   if (percent > last) {
     last = percent;
-    update_progress (percent, t - start_time, hdr);
+    update_progress (percent, t - start_time, hdr, total > 0);
   }
 
   if (percent == 100)

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -483,7 +483,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
             pgm->page_erase(pgm, p, mem, n);
           if(writeCachePage(cp, pgm, p, mem, n, MSG_INFO) < 0)
             return LIBAVRDUDE_GENERAL_FAILURE;
-          if(iwr > nwr/2 || memcmp(cp->copy + n, cp->cont + n, cp->page_size)) {
+          if(memcmp(cp->copy + n, cp->cont + n, cp->page_size)) {
             report_progress(1, -1, NULL);
             if(!quell_progress)
               avrdude_message(MSG_INFO, "%s: ", progname);

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -1,0 +1,495 @@
+/*
+ * avrdude - A Downloader/Uploader for AVR device programmers
+ * Copyright (C) 2022 Stefan Rueger <stefan.rueger@urclocks.c>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* $Id$ */
+
+#include "ac_cfg.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#include "avrdude.h"
+#include "libavrdude.h"
+
+// EEPROM and flash cache for byte-wise access (used in terminal, eg)
+
+// FIXME: check out n_page_erase (some parts have larger page size for erase than for write)
+
+static void setCacheSize(AVR_Cache *cp, const AVRMEM *mem) {
+  cp->size = 256;
+  if(cp->size < mem->page_size)
+    cp->size = mem->page_size;
+}
+
+
+// Return the address of the page that contains addr
+static int baseaddr(AVR_Cache *cp, const AVRMEM *mem, int addr) {
+  if(cp->base < 0 || !cp->page || !cp->copy || cp->size < 1)
+    setCacheSize(cp, mem);
+
+  return addr - addr%cp->size;
+}
+
+
+/*
+ * Paged access?
+ *  - Programmer must have paged routines and
+ *  - Memory a positive page size, which is a power of two
+ */
+int avr_has_paged_access(const PROGRAMMER *pgm, const AVRMEM *m) {
+  return pgm->paged_load && pgm->paged_write && m->page_size > 0 &&
+         (m->page_size & (m->page_size-1)) == 0;
+}
+
+
+/*
+ * Read the page containing addr from the device into buf
+ *   - Caller to ensure buf has mem->size bytes
+ *   - Part memory buffer mem is unaffected by this (though temporarily changed)
+ */
+int avr_read_page_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, int addr, unsigned char *buf) {
+  if(!avr_has_paged_access(pgm, mem) || addr < 0 || addr >= mem->size)
+    return LIBAVRDUDE_GENERAL_FAILURE;
+
+  int rc, pgsize = mem->page_size, off = addr & ~(pgsize-1);
+  unsigned char *pagecopy = cfg_malloc("avr_read_page_default()", pgsize);
+
+  memcpy(pagecopy, mem->buf+off, pgsize);
+  if((rc = pgm->paged_load(pgm, p, mem, pgsize, off, pgsize)) >= 0)
+    memcpy(buf, mem->buf+off, pgsize);
+  memcpy(mem->buf+off, pagecopy, pgsize);
+  free(pagecopy);
+
+  return rc;
+}
+
+
+/*
+ * Write the data page to the device into the page containing addr
+ *   - Caller to provide all mem->page_size bytes incl padding if any
+ *   - Part memory buffer mem is unaffected by this (though temporarily changed)
+ */
+int avr_write_page_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, int addr, unsigned char *data) {
+  if(!avr_has_paged_access(pgm, mem) || addr < 0 || addr >= mem->size)
+    return LIBAVRDUDE_GENERAL_FAILURE;
+
+  int rc, pgsize = mem->page_size, off = addr & ~(pgsize-1);
+  unsigned char *pagecopy = cfg_malloc("avr_write_page_default()", pgsize);
+
+  memcpy(pagecopy, mem->buf+off, pgsize);
+  memcpy(mem->buf+off, data, pgsize);
+  rc = pgm->paged_write(pgm, p, mem, pgsize, off, pgsize);
+  memcpy(mem->buf+off, pagecopy, pgsize);
+  free(pagecopy);
+
+  return rc;
+}
+
+
+// Could memory region s1 be the result of a NOR-memory copy of s3 onto s2?
+int avr_is_and(const unsigned char *s1, const unsigned char *s2, const unsigned char *s3, size_t n) {
+  while(n--)
+    if(*s1++ != (*s2++ & *s3++))
+      return 0;
+
+  return 1;
+}
+
+
+// Expand the given cache to cover the full memory region of memtype == "flash" or "eeprom"
+int avr_expand_cache(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype) {
+  AVRMEM *m, *mem;
+
+  if(!(m = avr_locate_mem(p, memtype))) {
+    avrdude_message(MSG_NOTICE, "%s: avr_expand_cache() cannot locate memory %s\n", progname, memtype);
+    return LIBAVRDUDE_GENERAL_FAILURE;
+  }
+
+  AVR_Cache *cp = strcmp(memtype, "flash") == 0? pgm->cp_flash: pgm->cp_eeprom;
+
+  mem = avr_dup_mem(m);
+  if(avr_read_mem(pgm, p, mem, NULL) < 0) {
+    avr_free_mem(mem);
+    avrdude_message(MSG_NOTICE, "%s: avr_expand_cache() cannot read memory %s\n", progname, memtype);
+    return LIBAVRDUDE_GENERAL_FAILURE;
+  }
+  unsigned char *newpage, *newcopy;
+  newpage = cfg_malloc("avr_expand_cache()", mem->size);
+  newcopy = cfg_malloc("avr_expand_cache()", mem->size);
+  memcpy(newpage, mem->buf, mem->size);
+  memcpy(newcopy, newpage, mem->size);
+  avr_free_mem(mem);
+
+  // If cache existed, copy over the existing cache, then free it
+  if(cp->base >= 0 && cp->page && cp->copy && cp->size > 0) {
+    if(cp->base+cp->size <= mem->size)
+      memcpy(newpage+cp->base, cp->page, cp->size);
+    free(cp->page);
+    free(cp->copy);
+  }
+
+  cp->base = 0;
+  cp->size = mem->size;
+  cp->flags &= ~CACHE_USE_PAGE_ERASE;
+  cp->flags |= CACHE_FULL_DEVICE;
+  cp->page = newpage;
+  cp->copy = newcopy;
+
+  return LIBAVRDUDE_SUCCESS;
+}
+
+
+// Sync the given full-memory cache to the device, memtype == "flash" or "eeprom"
+int avr_sync_cache(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype) {
+  AVRMEM *m, *mem;
+
+  if(!(m = avr_locate_mem(p, memtype))) {
+    avrdude_message(MSG_NOTICE, "%s: avr_sync_cache() cannot locate memory %s\n", progname, memtype);
+    return LIBAVRDUDE_GENERAL_FAILURE;
+  }
+
+  AVR_Cache *cp = strcmp(memtype, "flash") == 0? pgm->cp_flash: pgm->cp_eeprom;
+
+  mem = avr_dup_mem(m);
+  // Set buf and tags of the memory to reflect the cache
+  memcpy(mem->buf, cp->page, cp->size);
+  for(int i=0; i < cp->size; i++)
+    mem->tags[i] = cp->page[i] == cp->copy[i]? 0: TAG_ALLOCATED;
+
+  // Write memory to the device
+  if(avr_write_mem(pgm, p, mem, cp->size, 0) < 0) {
+    avrdude_message(MSG_NOTICE, "%s: avr_sync_cache() cannot write memory %s\n", progname, memtype);
+    avr_free_mem(mem);
+    return LIBAVRDUDE_GENERAL_FAILURE;
+  }
+
+  // Read memory back from device and update copy of cache contents
+  if(avr_read_mem(pgm, p, mem, NULL) < 0) {
+    avrdude_message(MSG_NOTICE, "%s: avr_sync_cache() cannot read memory %s\n", progname, memtype);
+    avr_free_mem(mem);
+    return LIBAVRDUDE_GENERAL_FAILURE;
+  }
+  memcpy(cp->copy, mem->buf, cp->size);
+
+  // Verify cache against device readback
+  for(int i=0; i < cp->size; i++)
+    if(mem->buf[i] != cp->page[i]) {
+      avrdude_message(MSG_NOTICE, "%s: avr_sync_cache() verification error for %s\n",
+        progname, memtype);
+      avrdude_message(MSG_NOTICE, "%*s first mismatch at 0x04x, device = %02x, cache = %02x\n",
+        strlen(progname)+1, "", i, mem->buf[i], cp->page[i]);
+      avr_free_mem(mem);
+      return LIBAVRDUDE_GENERAL_FAILURE;
+    }
+
+  avr_free_mem(mem);
+  return LIBAVRDUDE_SUCCESS;
+}
+
+
+
+/*
+ * writeCache(cp, pgm, p, mem)
+ *
+ * Writes the normally small cache to the device using paged write for those
+ * pages that were changed. Some memories look like NOR memories, ie, they
+ * can only write 0 bits, not 1 bits, so in this case either page erase needs
+ * to be deployed or, if that is not available, both EEPROM and flash caches
+ * are expanded to cover the full device, no matter which cache writeCache()
+ * was called with. In this case writeCache() does not try to immediately
+ * erase the chip and write back the contents, as it could well be that the
+ * user intended more modifications in other chip areas; writeCache() returns
+ * LIBAVRDUDE_SOFTFAIL instead and marks in both EEPROM and flash caches that
+ * now both cached are considered jointly on the next call to writeCache()
+ * when a chip erase will be issued and both flash and EEPROM are
+ * synchronised with the device.
+ *
+ * Possible return values
+ *
+ *   - LIBAVRDUDE_SUCCESS: All good
+ *
+ *   - LIBAVRDUDE_GENERAL_FAILURE: Failed, the device has the wrong contents
+ *
+ *   - LIBAVRDUDE_SOFTFAIL: Expanded both caches to the full device;
+ *       writeCache() needs calling again to actually sync with device
+ */
+
+static int writeCache(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
+  // Cache not in use? All good
+  if(cp->base < 0 || !cp->page || !cp->copy || cp->size < 1)
+    return LIBAVRDUDE_SUCCESS;
+
+  if(!avr_has_paged_access(pgm, mem)) {
+    avrdude_message(MSG_NOTICE, "%s: writeCache() called for memory without paged access\n", progname);
+    return LIBAVRDUDE_GENERAL_FAILURE;
+  }
+
+  if(cp->flags & CACHE_FULL_DEVICE) { // Need to treat both EEPROM and flash
+    // Has the cache been modified? If not all is good
+    if(!memcmp(pgm->cp_flash->copy, pgm->cp_flash->page, pgm->cp_flash->size) &&
+       !memcmp(pgm->cp_eeprom->copy, pgm->cp_eeprom->page, pgm->cp_eeprom->size))
+      return LIBAVRDUDE_SUCCESS;
+
+    avrdude_message(MSG_INFO, "%s: erasing chip and writing caches to all flash and EEPROM (takes time)...\n", progname);
+
+    // Erase chip
+    if(avr_chip_erase(pgm, p) < 0) {
+      avrdude_message(MSG_NOTICE, "%s: writeCache() chip erase failed\n", progname);
+      return LIBAVRDUDE_GENERAL_FAILURE;
+    }
+    memset(pgm->cp_flash->copy, 0xff, pgm->cp_flash->size);
+    // Don't know whether chip erase will have erased EEPROM: read from device
+    if(avr_expand_cache(pgm, p, "eeprom") < 0) {
+      avrdude_message(MSG_NOTICE, "%s: writeCache() EEPROM read failed\n", progname);
+      return LIBAVRDUDE_GENERAL_FAILURE;
+    }
+
+    int rc = LIBAVRDUDE_SUCCESS;
+    if(avr_sync_cache(pgm, p, "flash") < 0) {
+      avrdude_message(MSG_NOTICE, "%s: writeCache() cannot synchronise flash to device\n", progname);
+      rc = LIBAVRDUDE_GENERAL_FAILURE;
+    }
+    if(avr_sync_cache(pgm, p, "eeprom") < 0) {
+      avrdude_message(MSG_NOTICE, "%s: writeCache() cannot synchronise EEPROM to device\n", progname);
+      rc = LIBAVRDUDE_GENERAL_FAILURE;
+    }
+
+    return rc;
+  }
+
+  for(int pgsize = mem->page_size, n = 0; n < cp->size; n += pgsize) {
+    if(memcmp(cp->copy+n, cp->page+n, pgsize)) { // Page needs copying
+      int page_erased = 0;
+
+      // Erase the page if can do and needed
+      if((cp->flags & CACHE_USE_PAGE_ERASE) && pgm->page_erase)
+        if(!avr_is_and(cp->page+n, cp->copy+n, cp->page+n, pgsize)) {
+          if(pgm->page_erase(pgm, p, mem, cp->base+n) < 0) {
+            avrdude_message(MSG_NOTICE, "%s: writeCache() page erase error (b)\n", progname);
+            return LIBAVRDUDE_GENERAL_FAILURE;
+          }
+          page_erased = 1;
+        }
+
+      // Write page to device
+      if(avr_write_page_default(pgm, p, mem, cp->base+n, cp->page+n) < 0) {
+        avrdude_message(MSG_NOTICE, "%s: writeCache() page write error\n", progname);
+        return LIBAVRDUDE_GENERAL_FAILURE;
+      }
+
+      // Read page back from device
+      unsigned char *devmem = cfg_malloc("writeCache()", pgsize);
+      if(avr_read_page_default(pgm, p, mem, cp->base+n, devmem) < 0) {
+        avrdude_message(MSG_NOTICE, "%s: writeCache() page read error (b)\n", progname);
+        free(devmem);
+        return LIBAVRDUDE_GENERAL_FAILURE;
+      }
+
+      if(memcmp(devmem, cp->page+n, pgsize)) { // Written page is different
+        if(avr_is_and(devmem, cp->copy+n, cp->page+n, pgsize)) { // OK, prob NOR-memory
+          if(!page_erased && pgm->page_erase) {
+            if(pgm->page_erase(pgm, p, mem, cp->base+n) < 0)
+              avrdude_message(MSG_NOTICE, "%s: writeCache() page erase error (a)\n", progname);
+            // Write and verify page again
+            if(avr_write_page_default(pgm, p, mem, cp->base+n, cp->page+n) < 0 ||
+               avr_read_page_default(pgm, p, mem, cp->base+n, devmem) < 0) {
+              avrdude_message(MSG_NOTICE, "%s: writeCache() page write/read error\n", progname);
+              free(devmem);
+              return LIBAVRDUDE_GENERAL_FAILURE;
+            }
+            if(memcmp(devmem, cp->page+n, pgsize)) { // Still different?
+              avrdude_message(MSG_NOTICE, "%s: writeCache() verification error after page erase and write\n", progname);
+              free(devmem);
+              return LIBAVRDUDE_GENERAL_FAILURE;
+            }
+            // Page erase did the trick, do that in future straight away
+            cp->flags |= CACHE_USE_PAGE_ERASE;
+          } else { // Page erase not available or failed, so cache all flash and EEPROM
+            avrdude_message(MSG_INFO, "%s: expanding cache to all flash and EEPROM (takes time)...\n", progname);
+            if(avr_expand_cache(pgm, p, "flash") < 0)
+              return LIBAVRDUDE_GENERAL_FAILURE;
+            if(avr_expand_cache(pgm, p, "eeprom") < 0)
+              return LIBAVRDUDE_GENERAL_FAILURE;
+            // Needs a second call to writeCache() to write back the chip contents
+            free(devmem);
+            return LIBAVRDUDE_SOFTFAIL;
+          }
+        } else {
+          avrdude_message(MSG_NOTICE, "%s: writeCache() verification error\n", progname);
+          free(devmem);
+          return LIBAVRDUDE_GENERAL_FAILURE;
+        }
+      }
+
+      free(devmem);
+      // All good, update copy of cache contents
+      memcpy(cp->copy+n, cp->page+n, pgsize);
+    }
+  }
+
+  return LIBAVRDUDE_SUCCESS;
+}
+
+
+static int readCache(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, int base) {
+  if(!avr_has_paged_access(pgm, mem)) {
+    avrdude_message(MSG_NOTICE, "%s: readCache() called for memory without paged access\n", progname);
+    return LIBAVRDUDE_GENERAL_FAILURE;
+  }
+
+  // First save what's cached to the device if needed
+  if(writeCache(cp, pgm, p, mem) == LIBAVRDUDE_GENERAL_FAILURE)
+    return LIBAVRDUDE_GENERAL_FAILURE;
+
+  // Init cache if needed
+  if(!cp->page || !cp->copy || cp->size < 1) {
+    cp->base = -1;
+    setCacheSize(cp, mem);
+    cp->flags = 0;
+    cp->page = cfg_malloc("readCache()", cp->size);
+    cp->copy = cfg_malloc("readCache()", cp->size);
+  }
+
+  // Read cached section from device
+  for(int n = 0; n < cp->size; n += mem->page_size)
+    if(avr_read_page_default(pgm, p, mem, base + n, cp->page + n) < 0) {
+      avrdude_message(MSG_NOTICE, "%s: readCache() %s read failed\n", progname, mem->desc);
+      return LIBAVRDUDE_GENERAL_FAILURE;
+    }
+
+  // Copy so we can later check for changes
+  memcpy(cp->copy, cp->page, cp->size);
+
+  // And update the base of the freshly cached data
+  cp->base = base;
+
+  return LIBAVRDUDE_SUCCESS;
+}
+
+
+// Write both EEPROM and flash caches to device and free them
+int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
+  int rc = LIBAVRDUDE_SUCCESS;
+  const char *mems[2] = { "flash", "eeprom" };
+
+  for(int i = 0; i < sizeof mems/sizeof*mems; i++) {
+    AVRMEM *mem = avr_locate_mem(p, mems[i]);
+    AVR_Cache *cp = strcmp(mems[i], "flash") == 0? pgm->cp_flash: pgm->cp_eeprom;
+
+    if(mem) {
+      int rr = writeCache(cp, pgm, p, mem);
+      if(rr == LIBAVRDUDE_SOFTFAIL)
+        rr =  writeCache(cp, pgm, p, mem);
+      if(rr < 0)
+        rc = LIBAVRDUDE_GENERAL_FAILURE;
+    } else
+      rc = LIBAVRDUDE_GENERAL_FAILURE;
+
+    // Free cache
+    if(cp->page)
+     free(cp->page);
+    if(cp->copy)
+     free(cp->copy);
+    memset(cp, 0, sizeof*cp);
+  }
+
+  return rc;
+}
+
+
+/*
+ * Read byte via a read/write cache
+ *  - Used if paged routines available and if memory is EEPROM or flash
+ *  - Otherwise fall back to pgm->read_byte()
+ *  - Out of memory addr: call writeCache() and pretend reading a 0 correctly
+ *  - Out of cache addr: call writeCache(), then readCache() for addr, return byte
+ *  - Cache is automagically created and initialised if needed
+ *  - User should call avr_flush_cache() to write cache to device and free it
+ */
+int avr_read_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+  unsigned long addr, unsigned char *value) {
+
+  int isflash  = avr_mem_is_flash_type(mem);
+  int iseeprom = avr_mem_is_eeprom_type(mem);
+
+  // Use pgm->read_byte() if not EEPROM/flash or no paged access
+  if((!isflash && !iseeprom) || !avr_has_paged_access(pgm, mem))
+    return pgm->read_byte(pgm, p, mem, addr, value);
+
+  AVR_Cache *cp = isflash? pgm->cp_flash: pgm->cp_eeprom;
+
+  // If address is out of range write cache (if any) and pretend reading a zero
+  if(addr >= (unsigned long) mem->size) {
+    writeCache(cp, pgm, p, mem);
+    *value = 0;
+    return LIBAVRDUDE_SUCCESS;
+  }
+
+  int base = baseaddr(cp, mem, addr);
+  // If no cache set up or address not in cached range, initialise cache
+  if(cp->base < 0 || !cp->page || !cp->copy || cp->base != base)
+    if(readCache(cp, pgm, p, mem, base) < 0)
+      return LIBAVRDUDE_GENERAL_FAILURE;
+
+  *value = cp->page[(int)addr-base];
+
+  return LIBAVRDUDE_SUCCESS;
+}
+
+
+/*
+ * Write byte via a read/write cache
+ *  - Used if paged routines available and if memory is EEPROM or flash
+ *  - Otherwise fall back to pgm->write_byte()
+ *  - Out of memory addr: call writeCache() and pretend writing correctly
+ *  - Out of cache addr: call writeCache(), then readCache() to write to addr
+ *  - Cache is automagically created and initialised if needed
+ *  - User should call avr_flush_cache() to write cache to device and free it
+ */
+int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+  unsigned long addr, unsigned char data) {
+
+  int isflash  = avr_mem_is_flash_type(mem);
+  int iseeprom = avr_mem_is_eeprom_type(mem);
+
+  // Use pgm->write_byte() if not EEPROM/flash or no paged access
+  if((!isflash && !iseeprom) || !avr_has_paged_access(pgm, mem))
+    return pgm->write_byte(pgm, p, mem, addr, data);
+
+  AVR_Cache *cp = isflash? pgm->cp_flash: pgm->cp_eeprom;
+
+  // If address is out of range write cache (if any) and pretend successfully written
+  if(addr >= (unsigned long) mem->size) {
+    writeCache(cp, pgm, p, mem);
+    return LIBAVRDUDE_SUCCESS;
+  }
+
+  int base = baseaddr(cp, mem, addr);
+  // If no cache set up or address not in cached range, initialise cache
+  if(cp->base < 0 || !cp->page || !cp->copy || cp->base != base)
+    if(readCache(cp, pgm, p, mem, base) < 0)
+      return LIBAVRDUDE_GENERAL_FAILURE;
+
+  cp->page[(int)addr-base] = data;
+
+  return LIBAVRDUDE_SUCCESS;
+}

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -310,7 +310,6 @@ programmer expects to be able to handle, together with the programming
 interface(s) that can be used in that combination. In reality there can be
 deviations from this list, particularly if programming is directly via a
 bootloader.
-
 .Pp
 Following parts need special attention:
 .Bl -tag -width "ATmega1234"
@@ -809,26 +808,63 @@ a command history using
 so previously entered command lines can be recalled and edited.  The
 following commands are currently implemented:
 .Bl -tag -offset indent -width indent
-.It Ar dump memtype addr nbytes
+.It Ar dump  memory addr len
 Read
-.Ar nbytes
+.Ar len
 bytes from the specified memory area, and display them in the usual
 hexadecimal and ASCII form.
+.It Ar dump memory addr ...
+Read all bytes from the specified memory starting at address
+.Ar addr,
+and display them.
+.It Ar dump memory addr
+Read 256 bytes from the specified memory area, and display them.
+.It Ar dump memory ...
+Read all bytes from the specified memory, and display them.
 .It Ar dump
 Continue dumping the memory contents for another
-.Ar nbytes
-where the previous
+.Ar 256
+bytes where the previous
 .Ar dump
 command left off.
-.It Ar write memtype addr byte1 ... byteN
+.It Ar write memory addr data[,] {data[,]}
 Manually program the respective memory cells, starting at address
 .Ar addr ,
-using the values
-.Ar byte1
-through
-.Ar byteN .
-This feature is not implemented for bank-addressed memories such as
-the flash memory of ATMega devices.
+using the data items provided.
+.Ar data
+can be hexadecimal, octal or decimal integers, floating point numbers
+or C-style strings and characters. For integers, an optional case-insensitive
+suffix specifies the data size: HH 8 bit, H/S 16 bit, L 32 bit, LL 64 bit.
+Suffix D indicates a 64-bit double, F a 32-bit float, whilst a floating point
+number without suffix defaults to 32-bit float. Hexadecimal floating point
+notation is supported. An ambiguous trailing suffix, eg, 0x1.8D, is read as
+no-suffix float where D is part of the mantissa; use a zero exponent 0x1.8p0D
+to clarify.
+.Pp
+An optional U suffix makes integers unsigned. Ordinary 0x hex integers are
+always treated as unsigned. +0x or -0x hex numbers are treated as signed
+unless they have a U suffix. Unsigned integers cannot be larger than 2^64-1.
+If n is an unsigned integer then -n is also a valid unsigned integer as in C.
+Signed integers must fall into the [-2^63, 2^63-1] range or a correspondingly
+smaller range when a suffix specifies a smaller type. Out of range signed
+numbers trigger a warning.
+.Pp
+Ordinary 0x hex integers with n hex digits (counting leading zeros) use the
+smallest size of 1, 2, 4 and 8 bytes that can accommodate any n-digit hex
+integer. If an integer suffix specifies a size explicitly the corresponding
+number of least significant bytes are written. Otherwise, signed and unsigned
+integers alike occupy the smallest of 1, 2, 4, or 8 bytes needed to
+accommodate them in their respective representation.
+.It Ar write memory addr len data[,] {data[,]} ...
+The ellipsis ... form writes <len> bytes padded by repeating the last
+.Ar data
+item.
+.It Ar abort
+Reading and writing flash and EEPROM type memories is normally implemented
+through a cache and paged access functions. These caches are only ever
+actually written to the device at the end of the terminal session after
+typing quit, or after EOF on input is encountered. The abort command resets
+the cache, making all previous writes to flash and EEPROM void.
 .It Ar erase
 Perform a chip erase.
 .It Ar send b1 b2 b3 b4

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -831,6 +831,12 @@ command left off.
 Manually program the respective memory cells, starting at address
 .Ar addr ,
 using the data items provided.
+The terminal implements reading from and writing to flash and EEPROM type
+memories normally through a cache and paged access functions. All other
+memories are directly written to without use of a cache. Some
+older parts without paged access will also have flash and EEPROM directly
+accessed without cache.
+.Pp
 .Ar data
 can be hexadecimal, octal or decimal integers, floating point numbers
 or C-style strings and characters. For integers, an optional case-insensitive
@@ -855,18 +861,34 @@ integer. If an integer suffix specifies a size explicitly the corresponding
 number of least significant bytes are written. Otherwise, signed and unsigned
 integers alike occupy the smallest of 1, 2, 4, or 8 bytes needed to
 accommodate them in their respective representation.
+.Pp
+One trailing comma at the end of
+.Ar data
+items is ignored to facilitate copy & paste of lists.
 .It Ar write memory addr len data[,] {data[,]} ...
 The ellipsis ... form writes <len> bytes padded by repeating the last
 .Ar data
 item.
+.It Ar flush
+Synchronise with the device all pending cached writes to EEPROM or flash.
+With some programmer and part combinations, flash (and sometimes EEPROM,
+too) looks like a NOR memory, ie, one can only write 0 bits, not 1 bits.
+When this is detected, either page erase is deployed (eg, with parts that
+have PDI/UPDI interfaces), or if that is not available, both EEPROM and
+flash caches are fully read in, a chip erase command is issued and both
+EEPROM and flash are written back to the device. Hence, it can take
+minutes to ensure that a single previously cleared bit is set and,
+therefore, this command should be used sparingly.
 .It Ar abort
-Reading and writing flash and EEPROM type memories is normally implemented
-through a cache and paged access functions. These caches are only ever
-actually written to the device at the end of the terminal session after
-typing quit, or after EOF on input is encountered. The abort command resets
-the cache, making all previous writes to flash and EEPROM void.
+Normally, caches are only ever
+actually written to the device when using the
+.Ar flush
+command, at the end of the terminal session after typing
+.Ar quit ,
+or after EOF on input is encountered. The abort command resets
+the cache discarding all previous writes to the flash and EEPROM cache.
 .It Ar erase
-Perform a chip erase.
+Perform a chip erase and discard all pending writes to EEPROM and flash.
 .It Ar send b1 b2 b3 b4
 Send raw instruction codes to the AVR device.  If you need access to a
 feature of an AVR part that is not directly supported by

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1342,9 +1342,7 @@ previous dump command left off.
 
 @item write @var{memtype} @var{start_addr} @var{data1} @var{data2} @dots{} @var{dataN}
 Manually program the respective memory cells, starting at address @var{start_addr},
-using the values @var{data1} through @var{dataN}.  This feature is not
-implemented for bank-addressed memories such as the flash memory of
-ATMega devices.
+using the values @var{data1} through @var{dataN}.
 
 Items @var{dataN} can have the following formats:
 
@@ -1353,58 +1351,86 @@ Items @var{dataN} can have the following formats:
 @tab @strong{Example}
 @tab @strong{Size (bytes)}
 
+@item String
+@tab @code{"Hello, world\n"}
+@tab varying
+
 @item Character
 @tab @code{'A'}
 @tab 1
 
 @item Decimal integer
 @tab 12345
-@tab 1, 2, 4, or 8 (see below)
+@tab 1, 2, 4, or 8
 
 @item Octal integer
 @tab 012345
-@tab 1, 2, 4, or 8 (see below)
+@tab 1, 2, 4, or 8
 
 @item Hexadecimal integer
 @tab 0x12345
-@tab 1, 2, 4, or 8 (see below)
+@tab 1, 2, 4, or 8
 
 @item Float
 @tab 3.1415926
 @tab 4
 
+@item Double
+@tab 3.141592653589793D
+@tab 8
+
 @end multitable
 
-Integer constants can be 1, 2, 4, or 8 bytes long.
-By default, the smallest possible size will be used where
-the specified number just fits into.
-A specific size can be denoted by appending one of these suffixes:
-
+@var{data}
+can be hexadecimal, octal or decimal integers, floating point numbers
+or C-style strings and characters. For integers, an optional case-insensitive
+suffix specifies the data size as in the table below:
 @table @code
 @item LL
-@itemx ll
 8 bytes / 64 bits
 @item L
-@itemx l
 4 bytes / 32 bits
-@item H
-@itemx h
-@itemx S
-@itemx s
+@item H or S
 2 bytes / 16 bits
 @item HH
-@itemx hh
 1 byte / 8 bits
 @end table
 
-Similarly, floating-point constants can have an @code{F} or @code{f}
-appended, but only 32-bit floating-point values are supported.
+Suffix @code{D} indicates a 64-bit double, @code{F} a 32-bit float, whilst a
+floating point number without suffix defaults to 32-bit float. Hexadecimal
+floating point notation is supported. An ambiguous trailing suffix, eg,
+@code{0x1.8D}, is read as no-suffix float where @code{D} is part of the
+mantissa; use a zero exponent @code{0x1.8p0D} to clarify.
+
+An optional @code{U} suffix makes integers unsigned. Ordinary @code{0x} hex
+integers are always treated as unsigned. @code{+0x} or @code{-0x} hex
+numbers are treated as signed unless they have a @code{U} suffix. Unsigned
+integers cannot be larger than 2^64-1. If @var{n} is an unsigned integer then @var{-n}
+is also a valid unsigned integer as in C. Signed integers must fall into
+the [-2^63, 2^63-1] range or a correspondingly smaller range when a suffix
+specifies a smaller type. Out of range signed numbers trigger a warning.
+
+Ordinary @code{0x} hex integers with @var{n} hex digits (counting leading
+zeros) use the smallest size of 1, 2, 4 and 8 bytes that can accommodate
+any n-digit hex integer. If an integer suffix specifies a size explicitly
+the corresponding number of least significant bytes are written.
+Otherwise, signed and unsigned integers alike occupy the smallest of 1, 2,
+4, or 8 bytes needed to accommodate them in their respective
+representation.
 
 @item write @var{memtype} @var{start_addr} @var{length} @var{data1} @var{data2} @var{dataN} @dots{}
 
 Similar to the above, but @var{length} byte of the memory are written.
 For that purpose, after writing the initial items, @var{dataN} is
 replicated as many times as needed.
+
+@item abort
+Reading and writing flash and EEPROM type memories is normally implemented
+through a cache and paged access functions. These caches are only ever
+actually written to the device at the end of the terminal session after
+typing @code{quit}, or after EOF on input is encountered. The @code{abort}
+command resets the cache, making all previous writes to flash and EEPROM
+void.
 
 @item erase
 Perform a chip erase.

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1329,22 +1329,32 @@ The following commands are implemented:
 
 @table @code
 
-@item dump @var{memtype} [@var{start_addr} [@var{nbytes}]]
+@item dump @var{memtype} @var{addr} @var{nbytes}
 Read @var{nbytes} from the specified memory area, and display them in
 the usual hexadecimal and ASCII form.
 
-@item dump @var{memtype} [@var{start_addr}] @dots{}
-Start reading from @var{start_addr}, all the way to the last memory address.
+@item dump @var{memtype} @var{addr} @dots{}
+Start reading from @var{addr}, all the way to the last memory address.
+
+@item dump @var{memtype} @var{addr}
+Read 256 bytes from the specified memory area, and display them.
+
+@item dump @var{memtype} @dots{}
+Read all bytes from the specified memory, and display them.
 
 @item dump @var{memtype}
 Continue dumping the memory contents for another @var{nbytes} where the
 previous dump command left off.
 
-@item write @var{memtype} @var{start_addr} @var{data1} @var{data2} @dots{} @var{dataN}
-Manually program the respective memory cells, starting at address @var{start_addr},
-using the values @var{data1} through @var{dataN}.
+@item write @var{memtype} @var{addr} @var{data[,]} @{@var{data[,]}@}
+Manually program the respective memory cells, starting at address
+@var{addr}, using the data items provided. The terminal implements
+reading from and writing to flash and EEPROM type memories normally
+through a cache and paged access functions. All other memories are
+directly written to without use of a cache. Some older parts without paged
+access will also have flash and EEPROM directly accessed without cache.
 
-Items @var{dataN} can have the following formats:
+Items @var{data} can have the following formats:
 
 @multitable @columnfractions .3 .4 .3
 @item @strong{Type}
@@ -1418,28 +1428,40 @@ Otherwise, signed and unsigned integers alike occupy the smallest of 1, 2,
 4, or 8 bytes needed to accommodate them in their respective
 representation.
 
-@item write @var{memtype} @var{start_addr} @var{length} @var{data1} @var{data2} @var{dataN} @dots{}
+One trailing comma at the end of data items is ignored to facilitate copy
+and paste of lists.
 
-Similar to the above, but @var{length} byte of the memory are written.
-For that purpose, after writing the initial items, @var{dataN} is
-replicated as many times as needed.
+@item write @var{memtype} @var{addr} @var{length} @var{data[,]} @{@var{data[,]}@} @dots{}
+The ellipses form @dots{} of write is similar to above, but @var{length}
+byte of the memory are written. For that purpose, after writing the
+initial items, the last @var{data} item is replicated as many times as
+needed.
+
+@item flush
+Synchronise with the device all pending cached writes to EEPROM or flash.
+With some programmer and part combinations, flash (and sometimes EEPROM,
+too) looks like a NOR memory, ie, one can only write 0 bits, not 1 bits.
+When this is detected, either page erase is deployed (eg, with parts that
+have PDI/UPDI interfaces), or if that is not available, both EEPROM and
+flash caches are fully read in, a chip erase command is issued and both
+EEPROM and flash are written back to the device. Hence, it can take
+minutes to ensure that a single previously cleared bit is set and,
+therefore, this command should be used sparingly.
 
 @item abort
-Reading and writing flash and EEPROM type memories is normally implemented
-through a cache and paged access functions. These caches are only ever
-actually written to the device at the end of the terminal session after
-typing @code{quit}, or after EOF on input is encountered. The @code{abort}
-command resets the cache, making all previous writes to flash and EEPROM
-void.
+Normally, caches are only ever actually written to the device when using
+@code{flush}, at the end of the terminal session after typing @code{quit},
+or after EOF on input is encountered. The @code{abort} command resets the
+cache discarding all previous writes to the flash and EEPROM cache.
 
 @item erase
-Perform a chip erase.
+Perform a chip erase and discard all pending writes to EEPROM and flash.
 
 @item send @var{b1} @var{b2} @var{b3} @var{b4}
-Send raw instruction codes to the AVR device.  If you need access to a
+Send raw instruction codes to the AVR device. If you need access to a
 feature of an AVR part that is not directly supported by AVRDUDE, this
 command allows you to use it, even though AVRDUDE does not implement the
-command.   When using direct SPI mode, up to 3 bytes
+command. When using direct SPI mode, up to 3 bytes
 can be omitted.
 
 @item sig

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -845,7 +845,7 @@ void sort_programmers(LISTID programmers);
 
 /* formerly avr.h */
 
-typedef void (*FP_UpdateProgress)(int percent, double etime, char *hdr);
+typedef void (*FP_UpdateProgress)(int percent, double etime, char *hdr, int trailing);
 
 extern struct avrpart parts[];
 extern const char *avr_mem_order[100];

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -845,7 +845,7 @@ void sort_programmers(LISTID programmers);
 
 /* formerly avr.h */
 
-typedef void (*FP_UpdateProgress)(int percent, double etime, char *hdr, int trailing);
+typedef void (*FP_UpdateProgress)(int percent, double etime, const char *hdr, int finish);
 
 extern struct avrpart parts[];
 extern const char *avr_mem_order[100];
@@ -904,7 +904,7 @@ int avr_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
 
 int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p);
 
-void report_progress (int completed, int total, char *hdr);
+void report_progress(int completed, int total, const char *hdr);
 
 int avr_has_paged_access(const PROGRAMMER *pgm, const AVRMEM *m);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -669,9 +669,9 @@ extern struct serial_device usbhid_serdev;
 #define CACHE_USE_PAGE_ERASE  1 // Use page erase for this cache
 #define CACHE_FULL_DEVICE     2 // Expanded both caches to capture full EEPROM and flash
 
-typedef struct {
-  int base, size, flags;
-  unsigned char *page, *copy;
+typedef struct {                // Memory cache for a subset of cached pages
+  unsigned char *cont, *copy;   // current memory contens and device copy of it
+  unsigned char *iscached;      // iscached[i] set when page i has been loaded
 } AVR_Cache;
 
 /* formerly pgm.h */
@@ -802,7 +802,9 @@ typedef struct programmer_t {
                           unsigned long addr, unsigned char value);
   int (*read_byte_cached)(const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
                           unsigned long addr, unsigned char *value);
+  int (*chip_erase_cached)(const struct programmer_t *pgm, const AVRPART *p);
   int (*flush_cache)     (const struct programmer_t *pgm, const AVRPART *p);
+  int (*reset_cache)     (const struct programmer_t *pgm, const AVRPART *p);
   AVR_Cache *cp_flash, *cp_eeprom;
 
   const char *config_file;      // Config file where defined
@@ -913,16 +915,12 @@ int avr_write_page_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
 int avr_is_and(const unsigned char *s1, const unsigned char *s2, const unsigned char *s3, size_t n);
 
-int avr_expand_cache(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype);
-
-int avr_sync_cache(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype);
-
-int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p);
-
+// byte-wise cached read/write API
 int avr_read_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned long addr, unsigned char *value);
-
 int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned long addr, unsigned char data);
-
+int avr_chip_erase_cached(const PROGRAMMER *pgm, const AVRPART *p);
+int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p);
+int avr_reset_cache(const PROGRAMMER *pgm, const AVRPART *p);
 
 #ifdef __cplusplus
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -666,10 +666,9 @@ extern struct serial_device usbhid_serdev;
 #define serial_set_dtr_rts (serdev->set_dtr_rts)
 
 // See avrcache.c
-#define CACHE_USE_PAGE_ERASE  1 // Use page erase for this cache
-#define CACHE_FULL_DEVICE     2 // Expanded both caches to capture full EEPROM and flash
-
 typedef struct {                // Memory cache for a subset of cached pages
+  int size, page_size;          // Size of cache (flash or eeprom size) and page size
+  unsigned int offset;          // Offset of flash/eeprom memory
   unsigned char *cont, *copy;   // current memory contens and device copy of it
   unsigned char *iscached;      // iscached[i] set when page i has been loaded
 } AVR_Cache;

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -121,7 +121,9 @@ PROGRAMMER *pgm_new(void) {
   pgm->vfy_led        = pgm_default_led;
   pgm->read_byte_cached = avr_read_byte_cached;
   pgm->write_byte_cached = avr_write_byte_cached;
+  pgm->chip_erase_cached = avr_chip_erase_cached;
   pgm->flush_cache    = avr_flush_cache;
+  pgm->reset_cache = avr_reset_cache;
 
   /*
    * optional functions - these are checked to make sure they are

--- a/src/term.c
+++ b/src/term.c
@@ -321,7 +321,7 @@ static int cmd_dump(PROGRAMMER * pgm, struct avrpart * p,
 
   report_progress(0, 1, "Reading");
   for (int i = 0; i < len; i++) {
-    int rc = pgm->read_byte(pgm, p, mem, addr + i, &buf[i]);
+    int rc = pgm->read_byte_cached(pgm, p, mem, addr + i, &buf[i]);
     if (rc != 0) {
       terminal_message(MSG_INFO, "%s (dump): error reading %s address 0x%05lx of part %s\n",
         progname, mem->desc, (long) addr + i, p->desc);
@@ -691,7 +691,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
   bool werror = false;
   report_progress(0, 1, "Writing");
   for (i = 0; i < (len + data.bytes_grown); i++) {
-    int rc = avr_write_byte(pgm, p, mem, addr+i, buf[i]);
+    int rc = pgm->write_byte_cached(pgm, p, mem, addr+i, buf[i]);
     if (rc) {
       terminal_message(MSG_INFO, "%s (write): error writing 0x%02x at 0x%05lx, rc=%d\n",
         progname, buf[i], (long) addr+i, (int) rc);
@@ -702,7 +702,7 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
     }
 
     uint8_t b;
-    rc = pgm->read_byte(pgm, p, mem, addr+i, &b);
+    rc = pgm->read_byte_cached(pgm, p, mem, addr+i, &b);
     if (b != buf[i]) {
       terminal_message(MSG_INFO, "%s (write): error writing 0x%02x at 0x%05lx cell=0x%02x\n",
         progname, buf[i], (long) addr+i, b);
@@ -1319,6 +1319,8 @@ int terminal_mode(PROGRAMMER * pgm, struct avrpart * p)
     }
     free(cmdbuf);
   }
+
+  pgm->flush_cache(pgm, p);
 
   return rc;
 }

--- a/src/term.c
+++ b/src/term.c
@@ -1366,8 +1366,7 @@ int terminal_message(const int msglvl, const char *format, ...) {
 }
 
 
-static void update_progress_tty (int percent, double etime, char *hdr)
-{
+static void update_progress_tty (int percent, double etime, char *hdr, int trailing) {
   static char hashes[51];
   static char *header;
   static int last = 0;
@@ -1394,14 +1393,15 @@ static void update_progress_tty (int percent, double etime, char *hdr)
   }
 
   if (percent == 100) {
-    if (!last) avrdude_message(MSG_INFO, "\n\n");
+    if (!last && trailing)
+      avrdude_message(MSG_INFO, "\n\n");
     last = 1;
   }
 
   setvbuf(stderr, (char*)NULL, _IOLBF, 0);
 }
 
-static void update_progress_no_tty (int percent, double etime, char *hdr)
+static void update_progress_no_tty (int percent, double etime, char *hdr, int trailing)
 {
   static int done = 0;
   static int last = 0;
@@ -1422,7 +1422,9 @@ static void update_progress_no_tty (int percent, double etime, char *hdr)
   }
 
   if ((percent == 100) && (done == 0)) {
-    avrdude_message(MSG_INFO, " | 100%% %0.2fs\n\n", etime);
+    avrdude_message(MSG_INFO, " | 100%% %0.2fs", etime);
+    if(trailing)
+      avrdude_message(MSG_INFO, "\n\n");
     last = 0;
     done = 1;
   }

--- a/src/term.c
+++ b/src/term.c
@@ -51,6 +51,12 @@ static int cmd_dump  (PROGRAMMER * pgm, struct avrpart * p,
 static int cmd_write (PROGRAMMER * pgm, struct avrpart * p,
 		      int argc, char *argv[]);
 
+static int cmd_flush (PROGRAMMER * pgm, struct avrpart * p,
+		      int argc, char *argv[]);
+
+static int cmd_abort (PROGRAMMER * pgm, struct avrpart * p,
+		      int argc, char *argv[]);
+
 static int cmd_erase (PROGRAMMER * pgm, struct avrpart * p,
 		      int argc, char *argv[]);
 
@@ -64,9 +70,6 @@ static int cmd_help  (PROGRAMMER * pgm, struct avrpart * p,
 		      int argc, char *argv[]);
 
 static int cmd_quit  (PROGRAMMER * pgm, struct avrpart * p,
-		      int argc, char *argv[]);
-
-static int cmd_abort (PROGRAMMER * pgm, struct avrpart * p,
 		      int argc, char *argv[]);
 
 static int cmd_send  (PROGRAMMER * pgm, struct avrpart * p,
@@ -103,6 +106,7 @@ struct command cmd[] = {
   { "dump",  cmd_dump,  "%s <memory> [<addr> <len> | <addr> ... | <addr> | ...]" },
   { "read",  cmd_dump,  "alias for dump" },
   { "write", cmd_write, "%s <memory> <addr> [<data>[,] {<data>[,]} | <len> <data>[,] {<data>[,]} ...]" },
+  { "flush", cmd_flush, "synchronise flash & EEPROM writes with the device" },
   { "abort", cmd_abort, "abort flash & EEPROM writes (reset the r/w cache)" },
   { "erase", cmd_erase, "perform a chip erase" },
   { "sig",   cmd_sig,   "display device signature bytes" },
@@ -723,6 +727,12 @@ static int cmd_write(PROGRAMMER * pgm, struct avrpart * p,
 
   free(buf);
 
+  return 0;
+}
+
+
+static int cmd_flush(PROGRAMMER *pgm, struct avrpart *p, int ac, char *av[]) {
+  pgm->flush_cache(pgm, p);
   return 0;
 }
 


### PR DESCRIPTION
Supposed to alleviate Issue #1020.

Provides an API for cached byte-wise access
 - `int avr_read_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned long addr, unsigned char *value);`
 - `int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned long addr, unsigned char data);`
 - `int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p);`

`avr_read_byte_cached()`
  - Uses a cache if paged routines available and if memory is EEPROM or flash
  - Otherwise fall back to pgm->read_byte()
  - Out of memory addr: writes the current (page) cache and pretends reading a 0 correctly
  - Out of cache addr: writes the current (page) cache, then reads cache page for addr, and reads the correct byte
  - Cache is automagically created and initialised if needed

`avr_write_byte_cached()`
  - Uses a cache if paged routines available and if memory is EEPROM or flash
  - Otherwise fall back to pgm->write_byte()
  - Out of memory addr: write current (page) cache and pretend writing correctly
  - Out of cache addr: write current (page) Cache, then fills cache to write to addr
  - Cache is automagically created and initialised if needed

`avr_flush_cache()`
  - User should call this at the end to finally write all caches to device and free them

The terminal calls `pgm->read_byte_cached()`, `pgm->read_write_cached()` and `pgm->flush_cache()`; these are initialised with  `avr_read_byte_cached()`, `avr_write_byte_cached()` and `avr_flush_cache()`. This indirection is useful b/c this cache is implemented with vvv generic paged load/write calls; individual programmers might have a much slicker cache and can overload correspondingly.

Writing the current cache page is a bit tricky. Normally one can use a small cache and write to the device using paged write for those pages that were changed. However, some memories look like NOR memories, ie, they can only write 0 bits, not 1 bits. When this is detected, either page erase is deployed (typically PDI/UPDI parts only), or if that is not available, both EEPROM and flash caches are expanded to cover the full device.  This takes some time, of course. When finally at the end the cache is synchronised to the device, again, this takes some time, as a full chip erase is needed followed by writing back both EEPROM and flash memories.



Give it a spin!

Here my simple test (note the time taken for changing the character H to h in flash):


```
$ echo 'read flash 0x3100 16' | avrdude -qqp m328p -c usbtiny -t
avrdude> read flash 0x3100 16
3100  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|

$ echo 'write flash 0x3100 "hello, world\n"' | avrdude -qqp m328p -c usbtiny -t
avrdude> write flash 0x3100 "hello, world\n"
avrdude>

$ echo 'read flash 0x3100 16' | avrdude -qqp m328p -c usbtiny -t
avrdude> read flash 0x3100 16
3100  68 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |hello, world ...|

$ echo 'write flash 0x3100 "Hello, world\n"' | avrdude -qqp m328p -c usbtiny -t
avrdude> write flash 0x3100 "Hello, world\n"
avrdude>

$ echo 'read flash 0x3100 16' | avrdude -qqp m328p -c usbtiny -t
avrdude> read flash 0x3100 16
3100  48 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |Hello, world ...|

$ echo 'write flash 0x3100 "hello, world\n"' | avrdude -qqp m328p -c usbtiny -t
avrdude> write flash 0x3100 "hello, world\n"
avrdude> avrdude: expanding cache to all flash and EEPROM (takes time)...
avrdude: erasing chip and writing caches to all flash and EEPROM (takes time)...

$ echo  'read flash 0x3100 16' | avrdude -qqp m328p -c usbtiny -t
avrdude> read flash 0x3100 16
3100  68 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |hello, world ...|
```
