### PR TITLE
Change condition for using paged access in avr_read() and avr_write()

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -382,8 +382,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     return avr_mem_hiaddr(mem);
   }
 
-  if (pgm->paged_load != NULL && mem->page_size > 1 &&
-      mem->size % mem->page_size == 0) {
+  if (avr_has_paged_access(pgm, mem)) {
     /*
      * the programmer supports a paged mode read
      */
@@ -898,7 +897,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     return i;
   }
 
-  if (pgm->paged_write != NULL && m->page_size > 1) {
+  if (avr_has_paged_access(pgm, m)) {
     /*
      * the programmer supports a paged mode write
      */

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -107,13 +107,13 @@
  *  - Programmer must have paged routines
  *  - Memory has positive page size, which is a power of two
  *  - Memory has positive size, which is a multiple of the page size
- *  - Memory is flash type or eeprom type
+ *  - Memory is either flash type with page size > 1 or eeprom
  */
 int avr_has_paged_access(const PROGRAMMER *pgm, const AVRMEM *mem) {
   return pgm->paged_load && pgm->paged_write &&
          mem->page_size > 0 && (mem->page_size & (mem->page_size-1)) == 0 &&
          mem->size > 0 && mem->size % mem->page_size == 0 &&
-         (avr_mem_is_flash_type(mem) || avr_mem_is_eeprom_type(mem));
+         ((avr_mem_is_flash_type(mem) && mem->page_size > 1) || avr_mem_is_eeprom_type(mem));
 }
 
 


### PR DESCRIPTION
Supposed to fix #970.

The fundamental avr_read() and avr_write() functions that carry out `-U` use `if(pgm->paged_... && mem->page_size > 1)` to decide whether to use paged access. I believe the condition `mem->page_size > 1` serves as a proxy for whether the memory is of flash or eeprom type (application, apptable, ...). 

This has disadvantages when it comes to bootloaders and EEPROM for which the newer parts(UPDI / AVR8X) and some older parts (ATmega161 ATmega163 ATmega8515 ATmega8535) declare a page_size of 1. The problem is that bootloaders often only implement paged access for EEPROM and flash, so are bound to fail. See Issue #970

I suggest using a more comprehensive condition of when to use paged access functions: https://github.com/avrdudes/avrdude/blob/44fe5bec2dd2f016d135f0d2f02173045d7aeef5/src/avrcache.c#L105-L117 

As this is a change for the fundamental strategy how *all* `-U` operations are carried out, this requires careful consideration. Comments? Ramifications I overlooked?