### PR TITLE
Fix jtag3_page_erase for targets with UPDI

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1700,7 +1700,7 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   cmd[1] = CMD3_ERASE_MEMORY;
   cmd[2] = 0;
 
-  if (strcmp(m->desc, "flash") == 0) {
+  if (avr_mem_is_flash_type(m)) {
     if (p->prog_modes & PM_UPDI || jtag3_memtype(pgm, p, addr) == MTYPE_FLASH)
       cmd[3] = XMEGA_ERASE_APP_PAGE;
     else
@@ -1710,8 +1710,6 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   } else if (strcmp(m->desc, "usersig") == 0 ||
              strcmp(m->desc, "userrow") == 0) {
     cmd[3] = XMEGA_ERASE_USERSIG;
-  } else if (strcmp(m->desc, "boot") == 0) {
-    cmd[3] = XMEGA_ERASE_BOOT_PAGE;
   } else {
     cmd[3] = XMEGA_ERASE_APP_PAGE;
   }


### PR DESCRIPTION
Very handy now that #1106 is merged.

Tested and proved to work with an ATmega4808 and an ATxmega128A3U using a Power Debugger, ann an AVR128DB48 using a pkobn_updi (Curiosity Nano board).

Here are some reference benchmarks.

Commands:
```
echo erase | ./avrdude -p avr128db48 -c pkobn_updi -t 
echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t
echo 'write flash 0x1000 "hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t
echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t
echo 'write flash 0x1000 "Hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t
echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t
echo 'write flash 0x1000 "hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t
echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t
```

<details>
<summary> Without jtag3 UPDI page erase fix </summary>

```
$ echo erase | ./avrdude -p avr128db48 -c pkobn_updi -t 

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> erase 
avrdude: erasing chip

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|


avrdude done.  Thank you.

$ echo 'write flash 0x1000 "hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> write flash 0x1000 "hello, world\n" 

Writing | ################################################## | 100% 0.09s

avrdude: writing cache to device... done

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  68 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |hello, world ...|


avrdude done.  Thank you.

$ echo 'write flash 0x1000 "Hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> write flash 0x1000 "Hello, world\n" 

Writing | ################################################## | 100% 0.09s

avrdude: writing cache to device... done

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  48 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |Hello, world ...|


avrdude done.  Thank you.

$ echo 'write flash 0x1000 "hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> write flash 0x1000 "hello, world\n" 

Writing | ################################################## | 100% 0.09s

avrdude: writing cache to device... avrdude: jtag3_page_erase: not an Xmega device

Reading | ################################################## | 100% 21.94s
Erasing | ################################################## | 100% 0.02s
Writing | ################################################## | 100% 0.24s

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  68 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |hello, world ...|


avrdude done.  Thank you.
```
</details>

<details>
<summary> With jtag3 UPDI page erase fix </summary>

```
echo erase | ./avrdude -p avr128db48 -c pkobn_updi -t 

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> erase 
avrdude: erasing chip

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|


avrdude done.  Thank you.

$ echo 'write flash 0x1000 "hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> write flash 0x1000 "hello, world\n" 

Writing | ################################################## | 100% 0.09s

avrdude: writing cache to device... done

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  68 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |hello, world ...|


avrdude done.  Thank you.

$ echo 'write flash 0x1000 "Hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> write flash 0x1000 "Hello, world\n" 

Writing | ################################################## | 100% 0.09s

avrdude: writing cache to device... done

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  48 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |Hello, world ...|


avrdude done.  Thank you.

$ echo 'write flash 0x1000 "hello, world\n"' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> write flash 0x1000 "hello, world\n" 

Writing | ################################################## | 100% 0.09s

avrdude: writing cache to device... done

avrdude done.  Thank you.

$ echo 'read flash 0x1000 16' | ./avrdude -p avr128db48 -c pkobn_updi -t

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 100 kHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.01s

avrdude: Device signature = 0x1e970c (probably avr128db48)
>>> read flash 0x1000 16 

Reading | ################################################## | 100% 0.09s

1000  68 65 6c 6c 6f 2c 20 77  6f 72 6c 64 0a 00 ff ff  |hello, world ...|


avrdude done.  Thank you.
```
</details>