### PR TITLE
Fix writing of last word on DWORD TPI parts

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -895,6 +895,20 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
       }
       report_progress(i, wsize, NULL);
     }
+
+    /*
+     * Some TPI parts like the ATtiny20 use DWORD_WRITE instead of WORD_WRITE.
+     * Words must be written in pairs, as the second word triggers the flash
+     * write.
+     */
+    if ((wsize / 2) & 0x1) {
+      cmd[0] = TPI_CMD_SST_PI;
+      cmd[1] = 0xFF;
+      rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+      rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+      while (avr_tpi_poll_nvmbsy(pgm));
+    }
+
     return i;
   }
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -856,6 +856,9 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
 
 
   if ((p->prog_modes & PM_TPI) && m->page_size > 1 && pgm->cmd_tpi) {
+    unsigned int    chunk; /* number of words for each write command */
+    unsigned int    j, writeable_chunk;
+
     if (wsize == 1) {
       /* fuse (configuration) memory: only single byte to write */
       return avr_write_byte(pgm, p, m, 0, m->buf[0]) == 0? 1: LIBAVRDUDE_GENERAL_FAILURE;
@@ -866,47 +869,48 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     /* setup for WORD_WRITE */
     avr_tpi_setup_rw(pgm, m, 0, TPI_NVMCMD_WORD_WRITE);
 
-    /* make sure it's aligned to a word boundary */
-    if (wsize & 0x1) {
-      wsize++;
+    /*
+     * Some TPI devices can only program 2 or 4 words (4 or 8 bytes) at a time.
+     * This is set by the n_word_writes option of the AVRMEM config section.
+     * Ensure that we align our write size to this boundary.
+     */
+    if (m->n_word_writes < 0 || m->n_word_writes > 4 || m->n_word_writes == 3) {
+      avrdude_message(MSG_INFO, "\n%s: ERROR: Unsupported n_word_writes value of %d "
+                      "configured for %s memory\n"
+                      "%sAborting write\n",
+                      progname, m->n_word_writes, m->desc, progbuf);
+      return LIBAVRDUDE_GENERAL_FAILURE;
     }
+    chunk = m->n_word_writes > 0 ? 2*m->n_word_writes : 2;
+    wsize = (wsize+chunk-1) / chunk * chunk;
 
-    /* write words, low byte first */
-    for (lastaddr = i = 0; i < wsize; i += 2) {
-      if ((m->tags[i] & TAG_ALLOCATED) != 0 ||
-          (m->tags[i + 1] & TAG_ALLOCATED) != 0) {
+    /* write words in chunks, low byte first */
+    for (lastaddr = i = 0; i < wsize; i += chunk) {
+      /* check that at least one byte in this chunk is allocated */
+      for (writeable_chunk = j = 0; !writeable_chunk && j < chunk; j++) {
+        writeable_chunk = m->tags[i+j] & TAG_ALLOCATED;
+      }
 
+      if (writeable_chunk) {
         if (lastaddr != i) {
           /* need to setup new address */
           avr_tpi_setup_rw(pgm, m, i, TPI_NVMCMD_WORD_WRITE);
           lastaddr = i;
         }
 
+        // Write each byte of the chunk. Unallocated bytes should read
+        // as 0xFF, which should no-op.
         cmd[0] = TPI_CMD_SST_PI;
-        cmd[1] = m->buf[i];
-        rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+        for (j = 0; j < chunk; j++) {
+          cmd[1] = m->buf[i+j];
+          rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+        }
 
-        cmd[1] = m->buf[i + 1];
-        rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
-
-        lastaddr += 2;
+        lastaddr += chunk;
 
         while (avr_tpi_poll_nvmbsy(pgm));
       }
       report_progress(i, wsize, NULL);
-    }
-
-    /*
-     * Some TPI parts like the ATtiny20 use DWORD_WRITE instead of WORD_WRITE.
-     * Words must be written in pairs, as the second word triggers the flash
-     * write.
-     */
-    if ((wsize / 2) & 0x1) {
-      cmd[0] = TPI_CMD_SST_PI;
-      cmd[1] = 0xFF;
-      rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
-      rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
-      while (avr_tpi_poll_nvmbsy(pgm));
     }
 
     return i;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -148,6 +148,7 @@
 #           size            = <num> ;             # bytes
 #           page_size       = <num> ;             # bytes
 #           num_pages       = <num> ;             # numeric
+#           n_word_writes   = <num> ;             # TPI only: if set, number of words to write
 #           min_write_delay = <num> ;             # micro-seconds
 #           max_write_delay = <num> ;             # micro-seconds
 #           readback        = <num> <num> ;       # pair of byte values

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -13346,6 +13346,7 @@ part parent ".reduced_core_tiny"
     memory "flash"
         size               = 2048;
         page_size          = 16;
+        n_word_writes      = 2;
         offset             = 0x4000;
         blocksize          = 128;
     ;
@@ -13365,6 +13366,7 @@ part parent ".reduced_core_tiny"
     memory "flash"
         size               = 4096;
         page_size          = 64;
+        n_word_writes      = 4;
         offset             = 0x4000;
         blocksize          = 128;
     ;

--- a/src/config.c
+++ b/src/config.c
@@ -70,6 +70,9 @@ Component_t avr_comp[] = {
   part_comp_desc(mcuid, COMP_INT),
   part_comp_desc(n_interrupts, COMP_INT),
   part_comp_desc(n_page_erase, COMP_INT),
+
+  // AVRMEM
+  mem_comp_desc(n_word_writes, COMP_INT),
 };
 
 #define DEBUG 0

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -103,6 +103,7 @@ static int pin_name;
 %token K_MISO
 %token K_MOSI
 %token K_NUM_PAGES
+%token K_N_WORD_WRITES
 %token K_NVM_BASE
 %token K_OCD_BASE
 %token K_OCDREV
@@ -1421,6 +1422,12 @@ mem_spec :
   K_NUM_PAGES       TKN_EQUAL numexpr
     {
       current_mem->num_pages = $3->value.number;
+      free_token($3);
+    } |
+
+  K_N_WORD_WRITES   TKN_EQUAL numexpr
+    {
+      current_mem->n_word_writes = $3->value.number;
       free_token($3);
     } |
 

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -103,7 +103,6 @@ static int pin_name;
 %token K_MISO
 %token K_MOSI
 %token K_NUM_PAGES
-%token K_N_WORD_WRITES
 %token K_NVM_BASE
 %token K_OCD_BASE
 %token K_OCDREV
@@ -1422,12 +1421,6 @@ mem_spec :
   K_NUM_PAGES       TKN_EQUAL numexpr
     {
       current_mem->num_pages = $3->value.number;
-      free_token($3);
-    } |
-
-  K_N_WORD_WRITES   TKN_EQUAL numexpr
-    {
-      current_mem->n_word_writes = $3->value.number;
       free_token($3);
     } |
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -746,6 +746,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
     _if_memout(intcmp, m->size > 8192? "0x%x": "%d", size);
     _if_memout(intcmp, "%d", page_size);
     _if_memout(intcmp, "%d", num_pages);
+    _if_memout(intcmp, "%d", n_word_writes);
     _if_memout(intcmp, "0x%x", offset);
     _if_memout(intcmp, "%d", min_write_delay);
     _if_memout(intcmp, "%d", max_write_delay);

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1921,7 +1921,7 @@ part
         size            = <num> ;             # bytes
         page_size       = <num> ;             # bytes
         num_pages       = <num> ;             # numeric
-        n_word_writes   = <num> ;             # numeric
+        n_word_writes   = <num> ;             # TPI only: if set, number of words to write
         min_write_delay = <num> ;             # micro-seconds
         max_write_delay = <num> ;             # micro-seconds
         readback        = <num> <num> ;       # pair of byte values

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1921,6 +1921,7 @@ part
         size            = <num> ;             # bytes
         page_size       = <num> ;             # bytes
         num_pages       = <num> ;             # numeric
+        n_word_writes   = <num> ;             # numeric
         min_write_delay = <num> ;             # micro-seconds
         max_write_delay = <num> ;             # micro-seconds
         readback        = <num> <num> ;       # pair of byte values

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -121,7 +121,7 @@ SIGN     [+-]
      }
 
 
-prog_modes|mcuid|n_interrupts|n_page_erase { /* Components for assignment  */
+prog_modes|mcuid|n_interrupts|n_page_erase|n_word_writes { /* Components for assignment  */
   Component_t *cp = cfg_comp_search(yytext, current_strct);
   if(!cp) {
     yyerror("Unknown component %s in %s", yytext, cfg_strct_name(current_strct));
@@ -203,7 +203,6 @@ no               { yylval=new_token(K_NO); return K_NO; }
 NULL             { yylval=NULL; return K_NULL; }
 num_banks        { yylval=NULL; return K_NUM_PAGES; }
 num_pages        { yylval=NULL; ccap(); return K_NUM_PAGES; }
-n_word_writes    { yylval=NULL; ccap(); return K_N_WORD_WRITES; }
 nvm_base         { yylval=NULL; ccap(); return K_NVM_BASE; }
 ocd_base         { yylval=NULL; ccap(); return K_OCD_BASE; }
 ocdrev           { yylval=NULL; ccap(); return K_OCDREV; }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -203,6 +203,7 @@ no               { yylval=new_token(K_NO); return K_NO; }
 NULL             { yylval=NULL; return K_NULL; }
 num_banks        { yylval=NULL; return K_NUM_PAGES; }
 num_pages        { yylval=NULL; ccap(); return K_NUM_PAGES; }
+n_word_writes    { yylval=NULL; ccap(); return K_N_WORD_WRITES; }
 nvm_base         { yylval=NULL; ccap(); return K_NVM_BASE; }
 ocd_base         { yylval=NULL; ccap(); return K_OCD_BASE; }
 ocdrev           { yylval=NULL; ccap(); return K_OCDREV; }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -309,6 +309,7 @@ typedef struct avrmem {
   int size;                   /* total memory size in bytes */
   int page_size;              /* size of memory page (if page addressed) */
   int num_pages;              /* number of pages (if page addressed) */
+  int n_word_writes;          /* TPI only: number words to write at a time */
   unsigned int offset;        /* offset in IO memory (ATxmega) */
   int min_write_delay;        /* microseconds */
   int max_write_delay;        /* microseconds */


### PR DESCRIPTION
This PR addresses an issue I discovered last Summer and first reported in [this AVR Freaks forum post](https://www.avrfreaks.net/forum/problems-uploading-only-certain-programs-avrdude-attiny20-using-tpi-ft232h).

While AVRDude's TPI code implements the WORD_WRITE NVMCMD for writing a single word at a time to flash memory, the ATtiny20 (and possibly other parts, I haven't checked) instead specifies a DWORD_WRITE instruction which "conveniently" uses the same NVMCMD hex code. From the [Tiny20's datasheet, section 19.4.3](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8235-8-bit-AVR-Microcontroller-ATtiny20_Datasheet.pdf):

> The Flash is written two words at a time but the data space uses byte-addressing to access Flash that has been mapped to data memory. It is therefore important to write the two words in the correct order to the Flash, namely low bytes before high bytes. The low byte of the first word is first written to the temporary buffer, then the high byte. **Writing the low byte and then the high byte to the buffer latches the two words into the Flash write buffer, starting the actual Flash write operation.**

This means that programs with an odd word count will fail to write the final word. Given this minimalist example program, gcc-avr compiles it to 66 bytes, or 33 words:

```cpp
#ifndef __AVR_ATtiny20__
#define __AVR_ATtiny20__
#endif

#include <avr/cpufunc.h>

int main(void)
{
	_NOP();
	_NOP();
}
```

This causes AVRDude to think it's successfully written the full program, yet it fails when verifying the final two bytes:

```
avrdude: writing 66 bytes flash ...

Writing | ################################################## | 100% 1.16s

avrdude: 66 bytes of flash written
avrdude: verifying flash memory against tpi_dword_test.hex
avrdude: reading on-chip flash data ...

Reading | ################################################## | 100% 1.08s

avrdude: verifying ...
avrdude: verification error, first mismatch at byte 0x0041
         0xff != 0xcf
avrdude: verification error; content mismatch
```

My proposed change to `avr_write_mem()`'s TPI loop is to write a final 0xFFFF word if the total word count is odd. This should fill the second word of the flash write buffer and trigger the write on DWORD_WRITE chips. For single-word chips, my assumption is that writing this extra word won't hurt and is probably fine. However, if needed, I could expand the PR to include a specific DWORD configuration setting that would alter behavior only for specified chips.

With this proposed change, AVRDude successfully writes the final word:

```
avrdude: writing 66 bytes flash ...

Writing | ################################################## | 100% 1.20s

avrdude: 66 bytes of flash written
avrdude: verifying flash memory against tpi_dword_test.hex
avrdude: reading on-chip flash data ...

Reading | ################################################## | 100% 1.08s

avrdude: verifying ...
avrdude: 66 bytes of flash verified
```