### PR TITLE
Fix UPDI erase when target is locked

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -14856,6 +14856,7 @@ part parent ".avr8x_mega"
 part
     desc                   = "AVR-Dx family common values";
     id                     = ".avrdx";
+    family_id              = "AVR    ";
     prog_modes             = PM_SPM | PM_UPDI;
     # Dedicated UPDI pin, no HV
     hvupdi_variant         = 1;
@@ -15012,6 +15013,7 @@ part
 part parent ".avrdx"
     desc                   = "AVR32DA28";
     id                     = "avr32da28";
+    family_id              = "    AVR";
     mcuid                  = 338;
     signature              = 0x1e 0x95 0x34;
 
@@ -15036,6 +15038,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR32DA32";
     id                     = "avr32da32";
+    family_id              = "    AVR";
     mcuid                  = 342;
     signature              = 0x1e 0x95 0x33;
 
@@ -15060,6 +15063,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR32DA48";
     id                     = "avr32da48";
+    family_id              = "    AVR";
     mcuid                  = 346;
     signature              = 0x1e 0x95 0x32;
 
@@ -15084,6 +15088,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR64DA28";
     id                     = "avr64da28";
+    family_id              = "    AVR";
     mcuid                  = 351;
     signature              = 0x1e 0x96 0x15;
 
@@ -15108,6 +15113,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR64DA32";
     id                     = "avr64da32";
+    family_id              = "    AVR";
     mcuid                  = 355;
     signature              = 0x1e 0x96 0x14;
 
@@ -15132,6 +15138,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR64DA48";
     id                     = "avr64da48";
+    family_id              = "    AVR";
     mcuid                  = 359;
     signature              = 0x1e 0x96 0x13;
 
@@ -15156,6 +15163,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR64DA64";
     id                     = "avr64da64";
+    family_id              = "    AVR";
     mcuid                  = 362;
     signature              = 0x1e 0x96 0x12;
 
@@ -15180,6 +15188,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR128DA28";
     id                     = "avr128da28";
+    family_id              = "    AVR";
     mcuid                  = 364;
     signature              = 0x1e 0x97 0x0a;
 
@@ -15204,6 +15213,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR128DA32";
     id                     = "avr128da32";
+    family_id              = "    AVR";
     mcuid                  = 366;
     signature              = 0x1e 0x97 0x09;
 
@@ -15228,6 +15238,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR128DA48";
     id                     = "avr128da48";
+    family_id              = "    AVR";
     mcuid                  = 368;
     signature              = 0x1e 0x97 0x08;
 
@@ -15252,6 +15263,7 @@ part parent ".avrdx"
 part parent ".avrdx"
     desc                   = "AVR128DA64";
     id                     = "avr128da64";
+    family_id              = "    AVR";
     mcuid                  = 370;
     signature              = 0x1e 0x97 0x07;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1191,24 +1191,14 @@ int main(int argc, char * argv [])
         if (rc == LIBAVRDUDE_SOFTFAIL && (p->prog_modes & PM_UPDI) && attempt < 1) {
           attempt++;
           if (pgm->read_sib) {
-             // Read SIB and compare FamilyID
-             char sib[AVR_SIBLEN + 1];
-             pgm->read_sib(pgm, p, sib);
-             avrdude_message(MSG_NOTICE, "%s: System Information Block: \"%s\"\n",
-                             progname, sib);
+            // Read SIB and compare FamilyID
+            char sib[AVR_SIBLEN + 1];
+            pgm->read_sib(pgm, p, sib);
+            avrdude_message(MSG_NOTICE, "%s: System Information Block: \"%s\"\n", progname, sib);
             if (quell_progress < 2)
               avrdude_message(MSG_INFO, "%s: Received FamilyID: \"%.*s\"\n", progname, AVR_FAMILYIDLEN, sib);
-
-            if (strncmp(p->family_id, sib, AVR_FAMILYIDLEN)) {
+            if (strncmp(p->family_id, sib, AVR_FAMILYIDLEN))
               avrdude_message(MSG_INFO, "%s: Expected FamilyID: \"%s\"\n", progname, p->family_id);
-              if (!ovsigck) {
-                avrdude_message(MSG_INFO, "%sDouble check chip, "
-                        "or use -F to override this check.\n",
-                        progbuf);
-                exitrc = 1;
-                goto main_exit;
-              }
-            }
           }
           if(erase) {
             erase = 0;
@@ -1223,6 +1213,12 @@ int main(int argc, char * argv [])
               goto sig_again;
             }
           }
+          if (!ovsigck) {
+            avrdude_message(MSG_INFO, "%sDouble check chip, or use -F to override this check.\n",
+              progbuf);
+            exitrc = 1;
+            goto main_exit;
+          }
         }
         avrdude_message(MSG_INFO, "%s: error reading signature data, rc=%d\n",
           progname, rc);
@@ -1235,9 +1231,7 @@ int main(int argc, char * argv [])
     if (sig == NULL) {
       avrdude_message(MSG_INFO, "%s: WARNING: signature data not defined for device \"%s\"\n",
                       progname, p->desc);
-    }
-
-    if (sig != NULL) {
+    } else {
       int ff, zz;
 
       if (quell_progress < 2) {

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -903,6 +903,7 @@ static int serialupdi_read_signature(const PROGRAMMER *pgm, const AVRPART *p, co
     m->buf[0]=0x00;
     m->buf[1]=0x00;
     m->buf[2]=0x00;
+    return LIBAVRDUDE_SOFTFAIL;
   } else {
     updi_read_byte(pgm, m->offset + 0, m->buf);
     updi_read_byte(pgm, m->offset + 1, m->buf+1);


### PR DESCRIPTION
This PR resolved issue #1124. Now a chip erase will be performed as long as `-e` is specified. Note that this is still an issue with the jtag2updi programmer, and appears to either be a JTAGmkII protocol or a jtag2updi limitation.

Regarding the newly added `family_id` in avrdude.conf. I've been in contact with Microchip directly, and they confirmed that the AVR-DA `family_id` is shifted to the right (probably a mistake that's too late to fix), while for AVR-DB, AVR-DD, and AVR-EA it's shifted to the left.

Tested and works with SerialUPDI, PICkit4, SNAP, Curiosity Nano and Xplained Mini.

Please review!