### PR TITLE
Review and overhaul AVRDUDE's messaging system

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -44,7 +44,7 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   /* Signature byte reads are always 3 bytes. */
 
   if (m->size < 3) {
-    avrdude_message(MSG_INFO, "%s: memsize too small for sig byte read", progname);
+    msg_info("%s: memsize too small for sig byte read", progname);
     return -1;
   }
 
@@ -56,17 +56,17 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   if (serial_recv(&pgm->fd, buf, 5) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_cmd(): programmer is out of sync\n",
+    msg_info("%s: stk500_cmd(): programmer is out of sync\n",
 			progname);
 	return -1;
   } else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "\n%s: arduino_read_sig_bytes(): (a) protocol error, "
+    msg_info("\n%s: arduino_read_sig_bytes(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
 	return -2;
   }
   if (buf[4] != Resp_STK_OK) {
-    avrdude_message(MSG_INFO, "\n%s: arduino_read_sig_bytes(): (a) protocol error, "
+    msg_info("\n%s: arduino_read_sig_bytes(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_OK, buf[4]);
     return -3;

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -44,7 +44,7 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   /* Signature byte reads are always 3 bytes. */
 
   if (m->size < 3) {
-    msg_info("%s: memsize too small for sig byte read", progname);
+    pmsg_info("memsize too small for sig byte read");
     return -1;
   }
 
@@ -56,19 +56,18 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   if (serial_recv(&pgm->fd, buf, 5) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    msg_info("%s: stk500_cmd(): programmer is out of sync\n",
-			progname);
+    pmsg_info("stk500_cmd(): programmer is out of sync\n");
 	return -1;
   } else if (buf[0] != Resp_STK_INSYNC) {
     msg_info("\n%s: arduino_read_sig_bytes(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
-	return -2;
+      "expect=0x%02x, resp=0x%02x\n",
+      progname, Resp_STK_INSYNC, buf[0]);
+    return -2;
   }
   if (buf[4] != Resp_STK_OK) {
     msg_info("\n%s: arduino_read_sig_bytes(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_OK, buf[4]);
+      "expect=0x%02x, resp=0x%02x\n",
+      progname, Resp_STK_OK, buf[4]);
     return -3;
   }
 

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -44,7 +44,7 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   /* Signature byte reads are always 3 bytes. */
 
   if (m->size < 3) {
-    pmsg_info("memsize too small for sig byte read");
+    pmsg_error("memsize too small for sig byte read");
     return -1;
   }
 
@@ -56,18 +56,16 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   if (serial_recv(&pgm->fd, buf, 5) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    pmsg_info("stk500_cmd(): programmer is out of sync\n");
+    pmsg_error("stk500_cmd(): programmer is out of sync\n");
 	return -1;
   } else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("\n%s: arduino_read_sig_bytes(): (a) protocol error, "
-      "expect=0x%02x, resp=0x%02x\n",
-      progname, Resp_STK_INSYNC, buf[0]);
+    msg_error("\n");
+    pmsg_error("arduino_read_sig_bytes(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -2;
   }
   if (buf[4] != Resp_STK_OK) {
-    msg_info("\n%s: arduino_read_sig_bytes(): (a) protocol error, "
-      "expect=0x%02x, resp=0x%02x\n",
-      progname, Resp_STK_OK, buf[4]);
+    msg_error("\n");
+    pmsg_error("arduino_read_sig_bytes(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[4]);
     return -3;
   }
 

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -56,16 +56,16 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   if (serial_recv(&pgm->fd, buf, 5) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    pmsg_error("stk500_cmd(): programmer is out of sync\n");
+    pmsg_error("programmer is out of sync\n");
 	return -1;
   } else if (buf[0] != Resp_STK_INSYNC) {
     msg_error("\n");
-    pmsg_error("arduino_read_sig_bytes(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -2;
   }
   if (buf[4] != Resp_STK_OK) {
     msg_error("\n");
-    pmsg_error("arduino_read_sig_bytes(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[4]);
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[4]);
     return -3;
   }
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -58,7 +58,7 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     /* Set Pointer Register */
     mem = avr_locate_mem(p, "flash");
     if (mem == NULL) {
-      avrdude_message(MSG_INFO, "No flash memory to erase for part %s\n",
+      msg_info("No flash memory to erase for part %s\n",
           p->desc);
       return -1;
     }
@@ -91,7 +91,7 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     return 0;
   } else {
-		avrdude_message(MSG_INFO, "%s called for a part that has no TPI\n", __func__);
+		msg_info("%s called for a part that has no TPI\n", __func__);
 		return -1;
 	}
 }
@@ -115,7 +115,7 @@ int avr_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p, unsigned cha
     cmd[0] = (TPI_CMD_SLDCS | TPI_REG_TPIIR);
 		err = pgm->cmd_tpi(pgm, cmd, 1, &response, sizeof(response));
     if (err || response != TPI_IDENT_CODE) {
-      avrdude_message(MSG_INFO, "TPIIR not correct\n");
+      msg_info("TPIIR not correct\n");
       return -1;
     }
 
@@ -135,12 +135,12 @@ int avr_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p, unsigned cha
 			return 0;
 		}
 
-		avrdude_message(MSG_INFO, "Error enabling TPI external programming mode:");
-		avrdude_message(MSG_INFO, "Target does not reply\n");
+		msg_info("Error enabling TPI external programming mode:");
+		msg_info("Target does not reply\n");
 		return -1;
 
 	} else {
-		avrdude_message(MSG_INFO, "%s called for a part that has no TPI\n", __func__);
+		msg_info("%s called for a part that has no TPI\n", __func__);
 		return -1;
 	}
 }
@@ -185,7 +185,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
   OPCODE * readop, * lext;
 
   if (pgm->cmd == NULL) {
-    avrdude_message(MSG_INFO, "%s: Error: %s programmer uses avr_read_byte_default() but does not\n"
+    msg_info("%s: Error: %s programmer uses avr_read_byte_default() but does not\n"
                     "provide a cmd() method.\n",
                     progname, pgm->type);
     return -1;
@@ -196,7 +196,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
   if (p->prog_modes & PM_TPI) {
     if (pgm->cmd_tpi == NULL) {
-      avrdude_message(MSG_INFO, "%s: Error: %s programmer does not support TPI\n",
+      msg_info("%s: Error: %s programmer does not support TPI\n",
           progname, pgm->type);
       return -1;
     }
@@ -231,7 +231,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
   if (readop == NULL) {
 #if DEBUG
-    avrdude_message(MSG_INFO, "avr_read_byte_default(): operation not supported on memory type \"%s\"\n",
+    msg_info("avr_read_byte_default(): operation not supported on memory type \"%s\"\n",
                     mem->desc);
 #endif
     return -1;
@@ -322,7 +322,7 @@ int avr_mem_hiaddr(const AVRMEM * mem)
 int avr_read(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype, const AVRPART *v) {
   AVRMEM *mem = avr_locate_mem(p, memtype);
   if (mem == NULL) {
-    avrdude_message(MSG_INFO, "No %s memory for part %s\n", memtype, p->desc);
+    msg_info("No %s memory for part %s\n", memtype, p->desc);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -373,7 +373,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
         rc = pgm->cmd_tpi(pgm, cmd, 1, mem->buf + i, 1);
         lastaddr++;
         if (rc == -1) {
-          avrdude_message(MSG_INFO, "avr_read_mem(): error reading address 0x%04lx\n", i);
+          msg_info("avr_read_mem(): error reading address 0x%04lx\n", i);
           return -1;
         }
       }
@@ -431,7 +431,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
           /* paged load failed, fall back to byte-at-a-time read below */
           failure = 1;
       } else {
-        avrdude_message(MSG_DEBUG, "%s: avr_read_mem(): skipping page %u: no interesting data\n",
+        msg_debug("%s: avr_read_mem(): skipping page %u: no interesting data\n",
                         progname, pageaddr / mem->page_size);
       }
       nread++;
@@ -454,13 +454,13 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     {
       rc = pgm->read_byte(pgm, p, mem, i, mem->buf + i);
       if (rc != LIBAVRDUDE_SUCCESS) {
-        avrdude_message(MSG_INFO, "avr_read_mem(): error reading address 0x%04lx\n", i);
+        msg_info("avr_read_mem(): error reading address 0x%04lx\n", i);
         if (rc == LIBAVRDUDE_GENERAL_FAILURE) {
-          avrdude_message(MSG_INFO, "    read operation not supported for memory %s\n",
+          msg_info("    read operation not supported for memory %s\n",
                           mem->desc);
           return LIBAVRDUDE_NOTSUPPORTED;
         }
-        avrdude_message(MSG_INFO, "    read operation failed for memory %s\n", mem->desc);
+        msg_info("    read operation failed for memory %s\n", mem->desc);
         return LIBAVRDUDE_SOFTFAIL;
       }
     }
@@ -483,7 +483,7 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
   OPCODE * wp, * lext;
 
   if (pgm->cmd == NULL) {
-    avrdude_message(MSG_INFO, "%s: Error: %s programmer uses avr_write_page() but does not\n"
+    msg_info("%s: Error: %s programmer uses avr_write_page() but does not\n"
                     "provide a cmd() method.\n",
                     progname, pgm->type);
     return -1;
@@ -491,7 +491,7 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 
   wp = mem->op[AVR_OP_WRITEPAGE];
   if (wp == NULL) {
-    avrdude_message(MSG_INFO, "avr_write_page(): memory \"%s\" not configured for page writes\n",
+    msg_info("avr_write_page(): memory \"%s\" not configured for page writes\n",
                     mem->desc);
     return -1;
   }
@@ -553,7 +553,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   struct timeval tv;
 
   if (pgm->cmd == NULL) {
-    avrdude_message(MSG_INFO, "%s: Error: %s programmer uses avr_write_byte_default() but does not\n"
+    msg_info("%s: Error: %s programmer uses avr_write_byte_default() but does not\n"
                     "provide a cmd() method.\n",
                     progname, pgm->type);
     return -1;
@@ -561,16 +561,16 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
   if (p->prog_modes & PM_TPI) {
     if (pgm->cmd_tpi == NULL) {
-      avrdude_message(MSG_INFO, "%s: Error: %s programmer does not support TPI\n",
+      msg_info("%s: Error: %s programmer does not support TPI\n",
           progname, pgm->type);
       return -1;
     }
 
     if (strcmp(mem->desc, "flash") == 0) {
-      avrdude_message(MSG_INFO, "Writing a byte to flash is not supported for %s\n", p->desc);
+      msg_info("Writing a byte to flash is not supported for %s\n", p->desc);
       return -1;
     } else if ((mem->offset + addr) & 1) {
-      avrdude_message(MSG_INFO, "Writing a byte to an odd location is not supported for %s\n", p->desc);
+      msg_info("Writing a byte to an odd location is not supported for %s\n", p->desc);
       return -1;
     }
 
@@ -657,7 +657,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
   if (writeop == NULL) {
 #if DEBUG
-    avrdude_message(MSG_INFO, "avr_write_byte_default(): write not supported for memory type \"%s\"\n",
+    msg_info("avr_write_byte_default(): write not supported for memory type \"%s\"\n",
                     mem->desc);
 #endif
     return -1;
@@ -750,24 +750,24 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
        * device if the data read back does not match what we wrote.
        */
       pgm->pgm_led(pgm, OFF);
-      avrdude_message(MSG_INFO, "%s: this device must be powered off and back on to continue\n",
+      msg_info("%s: this device must be powered off and back on to continue\n",
                       progname);
       if (pgm->pinno[PPI_AVR_VCC]) {
-        avrdude_message(MSG_INFO, "%s: attempting to do this now ...\n", progname);
+        msg_info("%s: attempting to do this now ...\n", progname);
         pgm->powerdown(pgm);
         usleep(250000);
         rc = pgm->initialize(pgm, p);
         if (rc < 0) {
-          avrdude_message(MSG_INFO, "%s: initialization failed, rc=%d\n", progname, rc);
-          avrdude_message(MSG_INFO, "%s: can't re-initialize device after programming the "
+          msg_info("%s: initialization failed, rc=%d\n", progname, rc);
+          msg_info("%s: can't re-initialize device after programming the "
                           "%s bits\n", progname, mem->desc);
-          avrdude_message(MSG_INFO, "%s: you must manually power-down the device and restart\n"
+          msg_info("%s: you must manually power-down the device and restart\n"
                           "%s:   %s to continue.\n",
                           progname, progname, progname);
           return -3;
         }
         
-        avrdude_message(MSG_INFO, "%s: device was successfully re-initialized\n",
+        msg_info("%s: device was successfully re-initialized\n",
                 progname);
         return 0;
       }
@@ -813,7 +813,7 @@ int avr_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype, int size, int auto_erase) {
   AVRMEM *m = avr_locate_mem(p, memtype);
   if (m == NULL) {
-    avrdude_message(MSG_INFO, "No \"%s\" memory for part %s\n",
+    msg_info("No \"%s\" memory for part %s\n",
             memtype, p->desc);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
@@ -847,7 +847,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     wsize = size;
   }
   else if (size > wsize) {
-    avrdude_message(MSG_INFO, "%s: WARNING: %d bytes requested, but memory region is only %d"
+    msg_info("%s: WARNING: %d bytes requested, but memory region is only %d"
                     "bytes\n"
                     "%sOnly %d bytes will actually be written\n",
                     progname, size, wsize,
@@ -941,7 +941,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
           /* paged write failed, fall back to byte-at-a-time write below */
           failure = 1;
       } else {
-        avrdude_message(MSG_DEBUG, "%s: avr_write_mem(): skipping page %u: no interesting data\n",
+        msg_debug("%s: avr_write_mem(): skipping page %u: no interesting data\n",
                         progname, pageaddr / m->page_size);
       }
       nwritten++;
@@ -1001,8 +1001,8 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     if (do_write) {
       rc = avr_write_byte(pgm, p, m, i, data);
       if (rc) {
-        avrdude_message(MSG_INFO, " ***failed;  ");
-        avrdude_message(MSG_INFO, "\n");
+        msg_info(" ***failed;  ");
+        msg_info("\n");
         pgm->err_led(pgm, ON);
         werror = 1;
       }
@@ -1015,11 +1015,11 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     if (flush_page) {
       rc = avr_write_page(pgm, p, m, i);
       if (rc) {
-        avrdude_message(MSG_INFO, " *** page %d (addresses 0x%04x - 0x%04x) failed "
+        msg_info(" *** page %d (addresses 0x%04x - 0x%04x) failed "
                         "to write\n",
                         i % m->page_size,
                         i - m->page_size + 1, i);
-        avrdude_message(MSG_INFO, "\n");
+        msg_info("\n");
         pgm->err_led(pgm, ON);
           werror = 1;
       }
@@ -1048,7 +1048,7 @@ int avr_signature(const PROGRAMMER *pgm, const AVRPART *p) {
   report_progress (0,1,"Reading");
   rc = avr_read(pgm, p, "signature", 0);
   if (rc < LIBAVRDUDE_SUCCESS) {
-    avrdude_message(MSG_INFO, "%s: error reading signature data for part \"%s\", rc=%d\n",
+    msg_info("%s: error reading signature data for part \"%s\", rc=%d\n",
                     progname, p->desc, rc);
     return rc;
   }
@@ -1103,14 +1103,14 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
 
   a = avr_locate_mem(p, memtype);
   if (a == NULL) {
-    avrdude_message(MSG_INFO, "avr_verify(): memory type \"%s\" not defined for part %s\n",
+    msg_info("avr_verify(): memory type \"%s\" not defined for part %s\n",
                     memtype, p->desc);
     return -1;
   }
 
   b = avr_locate_mem(v, memtype);
   if (b == NULL) {
-    avrdude_message(MSG_INFO, "avr_verify(): memory type \"%s\" not defined for part %s\n",
+    msg_info("avr_verify(): memory type \"%s\" not defined for part %s\n",
                     memtype, v->desc);
     return -1;
   }
@@ -1120,7 +1120,7 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
   vsize = a->size;
 
   if (vsize < size) {
-    avrdude_message(MSG_INFO, "%s: WARNING: requested verification for %d bytes\n"
+    msg_info("%s: WARNING: requested verification for %d bytes\n"
                     "%s%s memory region only contains %d bytes\n"
                     "%sOnly %d bytes will be verified.\n",
                     progname, size,
@@ -1135,7 +1135,7 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
       uint8_t bitmask = get_fuse_bitmask(a);
       if((buf1[i] & bitmask) != (buf2[i] & bitmask)) {
         // Mismatch is not just in unused bits
-        avrdude_message(MSG_INFO, "%s: verification error, first mismatch at byte 0x%04x\n"
+        msg_info("%s: verification error, first mismatch at byte 0x%04x\n"
                         "%s0x%02x != 0x%02x\n",
                         progname, i,
                         progbuf, buf1[i], buf2[i]);
@@ -1144,13 +1144,13 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
         // Mismatch is only in unused bits
         if ((buf1[i] | bitmask) != 0xff) {
           // Programmer returned unused bits as 0, must be the part/programmer
-          avrdude_message(MSG_INFO, "%s: WARNING: ignoring mismatch in unused bits of \"%s\"\n"
+          msg_info("%s: WARNING: ignoring mismatch in unused bits of \"%s\"\n"
                           "%s(0x%02x != 0x%02x). To prevent this warning fix the part\n"
                           "%sor programmer definition in the config file.\n",
                           progname, memtype, progbuf, buf1[i], buf2[i], progbuf);
         } else {
           // Programmer returned unused bits as 1, must be the user
-          avrdude_message(MSG_INFO, "%s: WARNING: ignoring mismatch in unused bits of \"%s\"\n"
+          msg_info("%s: WARNING: ignoring mismatch in unused bits of \"%s\"\n"
                           "%s(0x%02x != 0x%02x). To prevent this warning set unused bits\n"
                           "%sto 1 when writing (double check with your datasheet first).\n",
                           progname, memtype, progbuf, buf1[i], buf2[i], progbuf);
@@ -1178,7 +1178,7 @@ int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles) {
   for (i=4; i>0; i--) {
     rc = pgm->read_byte(pgm, p, a, a->size-i, &v1);
   if (rc < 0) {
-    avrdude_message(MSG_INFO, "%s: WARNING: can't read memory for cycle count, rc=%d\n",
+    msg_info("%s: WARNING: can't read memory for cycle count, rc=%d\n",
             progname, rc);
     return -1;
   }
@@ -1218,7 +1218,7 @@ int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles) {
 
     rc = avr_write_byte(pgm, p, a, a->size-i, v1);
     if (rc < 0) {
-      avrdude_message(MSG_INFO, "%s: WARNING: can't write memory for cycle count, rc=%d\n",
+      msg_info("%s: WARNING: can't write memory for cycle count, rc=%d\n",
               progname, rc);
       return -1;
     }
@@ -1252,7 +1252,7 @@ void avr_add_mem_order(const char *str) {
       return;
     }
   }
-  avrdude_message(MSG_INFO,
+  msg_info(
     "%s: avr_mem_order[] under-dimensioned in avr.c; increase and recompile\n",
     progname);
   exit(1);

--- a/src/avr.c
+++ b/src/avr.c
@@ -185,9 +185,8 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
   OPCODE * readop, * lext;
 
   if (pgm->cmd == NULL) {
-    msg_info("%s: Error: %s programmer uses avr_read_byte_default() but does not\n"
-                    "provide a cmd() method.\n",
-                    progname, pgm->type);
+    pmsg_info("%s programmer uses avr_read_byte_default() but does not\n"
+                    "provide a cmd() method\n", pgm->type);
     return -1;
   }
 
@@ -196,8 +195,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
   if (p->prog_modes & PM_TPI) {
     if (pgm->cmd_tpi == NULL) {
-      msg_info("%s: Error: %s programmer does not support TPI\n",
-          progname, pgm->type);
+      pmsg_info("%s programmer does not support TPI\n", pgm->type);
       return -1;
     }
 
@@ -231,7 +229,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
   if (readop == NULL) {
 #if DEBUG
-    msg_info("avr_read_byte_default(): operation not supported on memory type \"%s\"\n",
+    msg_info("avr_read_byte_default(): operation not supported on memory type %s\n",
                     mem->desc);
 #endif
     return -1;
@@ -431,8 +429,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
           /* paged load failed, fall back to byte-at-a-time read below */
           failure = 1;
       } else {
-        msg_debug("%s: avr_read_mem(): skipping page %u: no interesting data\n",
-                        progname, pageaddr / mem->page_size);
+        pmsg_debug("avr_read_mem(): skipping page %u: no interesting data\n", pageaddr / mem->page_size);
       }
       nread++;
       report_progress(nread, npages, NULL);
@@ -483,15 +480,14 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
   OPCODE * wp, * lext;
 
   if (pgm->cmd == NULL) {
-    msg_info("%s: Error: %s programmer uses avr_write_page() but does not\n"
-                    "provide a cmd() method.\n",
-                    progname, pgm->type);
+    pmsg_info("%s programmer uses avr_write_page() but does not\n"
+      "provide a cmd() method\n", pgm->type);
     return -1;
   }
 
   wp = mem->op[AVR_OP_WRITEPAGE];
   if (wp == NULL) {
-    msg_info("avr_write_page(): memory \"%s\" not configured for page writes\n",
+    msg_info("avr_write_page(): memory %s not configured for page writes\n",
                     mem->desc);
     return -1;
   }
@@ -553,16 +549,14 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   struct timeval tv;
 
   if (pgm->cmd == NULL) {
-    msg_info("%s: Error: %s programmer uses avr_write_byte_default() but does not\n"
-                    "provide a cmd() method.\n",
-                    progname, pgm->type);
+    pmsg_info("%s programmer uses avr_write_byte_default() but does not\n"
+      "provide a cmd() method\n", pgm->type);
     return -1;
   }
 
   if (p->prog_modes & PM_TPI) {
     if (pgm->cmd_tpi == NULL) {
-      msg_info("%s: Error: %s programmer does not support TPI\n",
-          progname, pgm->type);
+      pmsg_info("%s programmer does not support TPI\n", pgm->type);
       return -1;
     }
 
@@ -657,8 +651,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
   if (writeop == NULL) {
 #if DEBUG
-    msg_info("avr_write_byte_default(): write not supported for memory type \"%s\"\n",
-                    mem->desc);
+    msg_info("avr_write_byte_default(): write not supported for memory type %s\n", mem->desc);
 #endif
     return -1;
   }
@@ -750,25 +743,21 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
        * device if the data read back does not match what we wrote.
        */
       pgm->pgm_led(pgm, OFF);
-      msg_info("%s: this device must be powered off and back on to continue\n",
-                      progname);
+      pmsg_info("this device must be powered off and back on to continue\n");
       if (pgm->pinno[PPI_AVR_VCC]) {
-        msg_info("%s: attempting to do this now ...\n", progname);
+        pmsg_info("attempting to do this now ...\n");
         pgm->powerdown(pgm);
         usleep(250000);
         rc = pgm->initialize(pgm, p);
         if (rc < 0) {
-          msg_info("%s: initialization failed, rc=%d\n", progname, rc);
-          msg_info("%s: can't re-initialize device after programming the "
-                          "%s bits\n", progname, mem->desc);
-          msg_info("%s: you must manually power-down the device and restart\n"
-                          "%s:   %s to continue.\n",
-                          progname, progname, progname);
+          pmsg_info("initialization failed, rc=%d\n", rc);
+          pmsg_info("cannot re-initialize device after programming the %s bits\n", mem->desc);
+          pmsg_info("you must manually power-down the device and restart\n"
+            "%*s %s to continue\n", (int) strlen(progname)+1, "", progname);
           return -3;
         }
         
-        msg_info("%s: device was successfully re-initialized\n",
-                progname);
+        pmsg_info("device was successfully re-initialized\n");
         return 0;
       }
     }
@@ -813,8 +802,7 @@ int avr_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype, int size, int auto_erase) {
   AVRMEM *m = avr_locate_mem(p, memtype);
   if (m == NULL) {
-    msg_info("No \"%s\" memory for part %s\n",
-            memtype, p->desc);
+    msg_info("no %s memory for part %s\n", memtype, p->desc);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -847,11 +835,8 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     wsize = size;
   }
   else if (size > wsize) {
-    msg_info("%s: WARNING: %d bytes requested, but memory region is only %d"
-                    "bytes\n"
-                    "%sOnly %d bytes will actually be written\n",
-                    progname, size, wsize,
-                    progbuf, wsize);
+    pmsg_info("warning, %d bytes requested, but memory region is only %d bytes\n"
+      "%sOnly %d bytes will actually be written\n", size, wsize, progbuf, wsize);
   }
 
 
@@ -941,8 +926,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
           /* paged write failed, fall back to byte-at-a-time write below */
           failure = 1;
       } else {
-        msg_debug("%s: avr_write_mem(): skipping page %u: no interesting data\n",
-                        progname, pageaddr / m->page_size);
+        pmsg_debug("avr_write_mem(): skipping page %u: no interesting data\n", pageaddr / m->page_size);
       }
       nwritten++;
       report_progress(nwritten, npages, NULL);
@@ -1048,8 +1032,7 @@ int avr_signature(const PROGRAMMER *pgm, const AVRPART *p) {
   report_progress (0,1,"Reading");
   rc = avr_read(pgm, p, "signature", 0);
   if (rc < LIBAVRDUDE_SUCCESS) {
-    msg_info("%s: error reading signature data for part \"%s\", rc=%d\n",
-                    progname, p->desc, rc);
+    pmsg_info("error reading signature data for part %s, rc=%d\n", p->desc, rc);
     return rc;
   }
   report_progress (1,1,NULL);
@@ -1103,14 +1086,13 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
 
   a = avr_locate_mem(p, memtype);
   if (a == NULL) {
-    msg_info("avr_verify(): memory type \"%s\" not defined for part %s\n",
-                    memtype, p->desc);
+    msg_info("avr_verify(): memory type %s not defined for part %s\n", memtype, p->desc);
     return -1;
   }
 
   b = avr_locate_mem(v, memtype);
   if (b == NULL) {
-    msg_info("avr_verify(): memory type \"%s\" not defined for part %s\n",
+    msg_info("avr_verify(): memory type %s not defined for part %s\n",
                     memtype, v->desc);
     return -1;
   }
@@ -1120,12 +1102,11 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
   vsize = a->size;
 
   if (vsize < size) {
-    msg_info("%s: WARNING: requested verification for %d bytes\n"
-                    "%s%s memory region only contains %d bytes\n"
-                    "%sOnly %d bytes will be verified.\n",
-                    progname, size,
-                    progbuf, memtype, vsize,
-                    progbuf, vsize);
+    pmsg_info("warning, requested verification for %d bytes\n"
+      "%s%s memory region only contains %d bytes\n"
+      "%sOnly %d bytes will be verified\n", size,
+      progbuf, memtype, vsize,
+      progbuf, vsize);
     size = vsize;
   }
 
@@ -1135,25 +1116,23 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
       uint8_t bitmask = get_fuse_bitmask(a);
       if((buf1[i] & bitmask) != (buf2[i] & bitmask)) {
         // Mismatch is not just in unused bits
-        msg_info("%s: verification error, first mismatch at byte 0x%04x\n"
-                        "%s0x%02x != 0x%02x\n",
-                        progname, i,
-                        progbuf, buf1[i], buf2[i]);
+        pmsg_info("verification error, first mismatch at byte 0x%04x\n"
+          "%s0x%02x != 0x%02x\n", i, progbuf, buf1[i], buf2[i]);
         return -1;
       } else {
         // Mismatch is only in unused bits
         if ((buf1[i] | bitmask) != 0xff) {
           // Programmer returned unused bits as 0, must be the part/programmer
-          msg_info("%s: WARNING: ignoring mismatch in unused bits of \"%s\"\n"
-                          "%s(0x%02x != 0x%02x). To prevent this warning fix the part\n"
-                          "%sor programmer definition in the config file.\n",
-                          progname, memtype, progbuf, buf1[i], buf2[i], progbuf);
+          pmsg_info("warning: ignoring mismatch in unused bits of %s\n"
+            "%s(0x%02x != 0x%02x). To prevent this warning fix the part\n"
+            "%sor programmer definition in the config file\n", memtype,
+            progbuf, buf1[i], buf2[i], progbuf);
         } else {
           // Programmer returned unused bits as 1, must be the user
-          msg_info("%s: WARNING: ignoring mismatch in unused bits of \"%s\"\n"
-                          "%s(0x%02x != 0x%02x). To prevent this warning set unused bits\n"
-                          "%sto 1 when writing (double check with your datasheet first).\n",
-                          progname, memtype, progbuf, buf1[i], buf2[i], progbuf);
+          pmsg_info("warning, ignoring mismatch in unused bits of %s\n"
+            "%s(0x%02x != 0x%02x). To prevent this warning set unused bits\n"
+            "%sto 1 when writing (double check with your datasheet first)\n",
+            memtype, progbuf, buf1[i], buf2[i], progbuf);
         }
       }
     }
@@ -1178,8 +1157,7 @@ int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles) {
   for (i=4; i>0; i--) {
     rc = pgm->read_byte(pgm, p, a, a->size-i, &v1);
   if (rc < 0) {
-    msg_info("%s: WARNING: can't read memory for cycle count, rc=%d\n",
-            progname, rc);
+    pmsg_info("warning, cannot read memory for cycle count, rc=%d\n", rc);
     return -1;
   }
     cycle_count = (cycle_count << 8) | v1;
@@ -1218,8 +1196,7 @@ int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles) {
 
     rc = avr_write_byte(pgm, p, a, a->size-i, v1);
     if (rc < 0) {
-      msg_info("%s: WARNING: can't write memory for cycle count, rc=%d\n",
-              progname, rc);
+      pmsg_info("warning, cannot write memory for cycle count, rc=%d\n", rc);
       return -1;
     }
   }
@@ -1252,9 +1229,7 @@ void avr_add_mem_order(const char *str) {
       return;
     }
   }
-  msg_info(
-    "%s: avr_mem_order[] under-dimensioned in avr.c; increase and recompile\n",
-    progname);
+  pmsg_info("avr_mem_order[] under-dimensioned in avr.c; increase and recompile\n");
   exit(1);
 }
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -746,8 +746,8 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
         rc = pgm->initialize(pgm, p);
         if (rc < 0) {
           pmsg_error("initialization failed, rc=%d\n", rc);
-          pmsg_error("cannot re-initialize device after programming the %s bits\n", mem->desc);
-          pmsg_error("you must manually power-down the device and restart %s to continue\n", progname);
+          imsg_error("cannot re-initialize device after programming the %s bits\n", mem->desc);
+          imsg_error("you must manually power-down the device and restart %s to continue\n", progname);
           return -3;
         }
         

--- a/src/avr.c
+++ b/src/avr.c
@@ -90,7 +90,7 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     return 0;
   } else {
-    pmsg_error("%s called for a part that has no TPI\n", __func__);
+    pmsg_error("part has no TPI\n");
     return -1;
   }
 }
@@ -138,7 +138,7 @@ int avr_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p, unsigned cha
 		return -1;
 
 	} else {
-		pmsg_error("%s called for a part that has no TPI\n", __func__);
+		pmsg_error("part has no TPI\n");
 		return -1;
 	}
 }
@@ -227,7 +227,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
   if (readop == NULL) {
 #if DEBUG
-    pmsg_error("avr_read_byte_default(): operation not supported on memory type %s\n", mem->desc);
+    pmsg_error("operation not supported on memory type %s\n", mem->desc);
 #endif
     return -1;
   }
@@ -368,7 +368,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
         rc = pgm->cmd_tpi(pgm, cmd, 1, mem->buf + i, 1);
         lastaddr++;
         if (rc == -1) {
-          pmsg_error("avr_read_mem(): unable to read address 0x%04lx\n", i);
+          pmsg_error("unable to read address 0x%04lx\n", i);
           return -1;
         }
       }
@@ -448,13 +448,12 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     {
       rc = pgm->read_byte(pgm, p, mem, i, mem->buf + i);
       if (rc != LIBAVRDUDE_SUCCESS) {
-        pmsg_error("avr_read_mem(): unable to read byte at address 0x%04lx\n", i);
+        pmsg_error("unable to read byte at address 0x%04lx\n", i);
         if (rc == LIBAVRDUDE_GENERAL_FAILURE) {
-          pmsg_error("    read operation not supported for memory %s\n",
-                          mem->desc);
+          pmsg_error("read operation not supported for memory %s\n", mem->desc);
           return LIBAVRDUDE_NOTSUPPORTED;
         }
-        pmsg_error("    read operation failed for memory %s\n", mem->desc);
+        pmsg_error("read operation failed for memory %s\n", mem->desc);
         return LIBAVRDUDE_SOFTFAIL;
       }
     }
@@ -484,7 +483,7 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 
   wp = mem->op[AVR_OP_WRITEPAGE];
   if (wp == NULL) {
-    pmsg_error("avr_write_page(): memory %s not configured for page writes\n", mem->desc);
+    pmsg_error("memory %s not configured for page writes\n", mem->desc);
     return -1;
   }
 
@@ -647,7 +646,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
   if (writeop == NULL) {
 #if DEBUG
-    pmsg_error("avr_write_byte_default(): write not supported for memory type %s\n", mem->desc);
+    pmsg_error("write not supported for memory type %s\n", mem->desc);
 #endif
     return -1;
   }
@@ -1078,13 +1077,13 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
 
   a = avr_locate_mem(p, memtype);
   if (a == NULL) {
-    pmsg_error("avr_verify(): memory type %s not defined for part %s\n", memtype, p->desc);
+    pmsg_error("memory type %s not defined for part %s\n", memtype, p->desc);
     return -1;
   }
 
   b = avr_locate_mem(v, memtype);
   if (b == NULL) {
-    pmsg_error("avr_verify(): memory type %s not defined for part %s\n", memtype, v->desc);
+    pmsg_error("memory type %s not defined for part %s\n", memtype, v->desc);
     return -1;
   }
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -992,9 +992,8 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     if (flush_page) {
       rc = avr_write_page(pgm, p, m, i);
       if (rc) {
-        msg_error(" *** page %d (addresses 0x%04x - 0x%04x) failed to write\n",
+        msg_error(" *** page %d (addresses 0x%04x - 0x%04x) failed to write\n\n",
           i / m->page_size, i - m->page_size + 1, i);
-        msg_error("\n");
         pgm->err_led(pgm, ON);
           werror = 1;
       }

--- a/src/avr.c
+++ b/src/avr.c
@@ -183,8 +183,8 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
   OPCODE * readop, * lext;
 
   if (pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses avr_read_byte_default() but does not\n"
-       "%*s provide a cmd() method\n", pgm->type, (int) strlen(progname)+1, "");
+    pmsg_error("%s programmer uses avr_read_byte_default() but does not\n", pgm->type);
+    imsg_error("provide a cmd() method\n");
     return -1;
   }
 
@@ -477,8 +477,8 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
   OPCODE * wp, * lext;
 
   if (pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses avr_write_page() but does not\n"
-      "%*s provide a cmd() method\n", pgm->type, (int) strlen(progname)+1, "");
+    pmsg_error("%s programmer uses avr_write_page() but does not\n", pgm->type);
+    imsg_error("provide a cmd() method\n");
     return -1;
   }
 
@@ -545,8 +545,8 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   struct timeval tv;
 
   if (pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses avr_write_byte_default() but does not\n"
-      "%*s provide a cmd() method\n", pgm->type, (int) strlen(progname)+1, "");
+    pmsg_error("%s programmer uses avr_write_byte_default() but does not\n", pgm->type);
+    imsg_error("provide a cmd() method\n");
     return -1;
   }
 
@@ -830,8 +830,8 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     wsize = size;
   }
   else if (size > wsize) {
-    pmsg_warning("%d bytes requested, but memory region is only %d bytes\n"
-      "%sOnly %d bytes will actually be written\n", size, wsize, progbuf, wsize);
+    pmsg_warning("%d bytes requested, but memory region is only %d bytes\n", size, wsize);
+    imsg_warning("Only %d bytes will actually be written\n", wsize);
   }
 
 
@@ -1093,11 +1093,9 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
   vsize = a->size;
 
   if (vsize < size) {
-    pmsg_warning("requested verification for %d bytes\n"
-      "%s%s memory region only contains %d bytes\n"
-      "%sonly %d bytes will be verified\n", size,
-      progbuf, memtype, vsize,
-      progbuf, vsize);
+    pmsg_warning("requested verification for %d bytes\n", size);
+    imsg_warning("%s memory region only contains %d bytes\n", memtype, vsize);
+    imsg_warning("only %d bytes will be verified\n", vsize);
     size = vsize;
   }
 
@@ -1106,23 +1104,21 @@ int avr_verify(const AVRPART * p, const AVRPART * v, const char * memtype, int s
       uint8_t bitmask = get_fuse_bitmask(a);
       if((buf1[i] & bitmask) != (buf2[i] & bitmask)) {
         // Mismatch is not just in unused bits
-        pmsg_error("verification mismatch, first at byte 0x%04x\n"
-          "%s0x%02x != 0x%02x\n", i, progbuf, buf1[i], buf2[i]);
+        pmsg_error("verification mismatch, first encountered at addr 0x%04x\n", i);
+        imsg_error("device 0x%02x != input 0x%02x\n", buf1[i], buf2[i]);
         return -1;
       } else {
         // Mismatch is only in unused bits
         if ((buf1[i] | bitmask) != 0xff) {
           // Programmer returned unused bits as 0, must be the part/programmer
-          pmsg_warning("ignoring mismatch in unused bits of %s\n"
-            "%s(0x%02x != 0x%02x); to prevent this warning fix the part\n"
-            "%sor programmer definition in the config file\n", memtype,
-            progbuf, buf1[i], buf2[i], progbuf);
+          pmsg_warning("ignoring mismatch in unused bits of %s\n", memtype);
+          imsg_warning("(device 0x%02x != input 0x%02x); to prevent this warning fix\n", buf1[i], buf2[i]);
+          imsg_warning("the part or programmer definition in the config file\n");
         } else {
           // Programmer returned unused bits as 1, must be the user
-          pmsg_warning("ignoring mismatch in unused bits of %s\n"
-            "%s(0x%02x != 0x%02x); to prevent this warning set unused bits\n"
-            "%sto 1 when writing (double check with your datasheet first)\n",
-            memtype, progbuf, buf1[i], buf2[i], progbuf);
+          pmsg_warning("ignoring mismatch in unused bits of %s\n", memtype);
+          imsg_warning("(device 0x%02x != input 0x%02x); to prevent this warning set\n", buf1[i], buf2[i]);
+          imsg_warning("unused bits to 1 when writing (double check with datasheet)\n");
         }
       }
     }

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -57,8 +57,7 @@ struct pdata
 static void avr910_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: avr910_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("avr910_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -81,8 +80,7 @@ static int avr910_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
   if (rv < 0) {
-    msg_info("%s: avr910_recv(): programmer is not responding\n",
-                    progname);
+    pmsg_info("avr910_recv(): programmer is not responding\n");
     return 1;
   }
   return 0;
@@ -99,8 +97,7 @@ static int avr910_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
 
   avr910_recv(pgm, &c, 1);
   if (c != '\r') {
-    msg_info("%s: error: programmer did not respond to command: %s\n",
-            progname, errmsg);
+    pmsg_info("programmer did not respond to command: %s\n", errmsg);
     return 1;
   }
   return 0;
@@ -176,7 +173,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   avr910_send(pgm, "p", 1);
   avr910_recv(pgm, &type, 1);
 
-  msg_info("Found programmer: Id = \"%s\"; type = %c\n", id, type);
+  msg_info("Found programmer: Id = %s; type = %c\n", id, type);
   msg_info("    Software Version = %c.%c; ", sw[0], sw[1]);
   msg_info("Hardware Version = %c.%c\n", hw[0], hw[1]);
 
@@ -185,7 +182,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   avr910_send(pgm, "a", 1);
   avr910_recv(pgm, &PDATA(pgm)->has_auto_incr_addr, 1);
   if (PDATA(pgm)->has_auto_incr_addr == 'Y')
-      msg_notice("Programmer supports auto addr increment.\n");
+      msg_notice("programmer supports auto addr increment\n");
 
   /* Check support for buffered memory access, ignore if not available */
 
@@ -198,7 +195,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       avr910_recv(pgm, &c, 1);
       PDATA(pgm)->buffersize += (unsigned int)(unsigned char)c;
       msg_notice("Programmer supports buffered memory access with "
-                      "buffersize = %u bytes.\n",
+                      "buffersize = %u bytes\n",
                       PDATA(pgm)->buffersize);
       PDATA(pgm)->use_blockmode = 1;
     } else {
@@ -235,8 +232,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     msg_notice("\n");
 
     if (!dev_supported) {
-      msg_info("%s: %s: selected device is not supported by programmer: %s\n",
-                      progname, ovsigck? "warning": "error", p->id);
+      pmsg_info("%s, selected device is not supported by programmer: %s\n", ovsigck? "warning": "error", p->id);
       if (!ovsigck)
 	return -1;
     }
@@ -255,8 +251,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   avr910_send(pgm, buf, 2);
   avr910_vfy_cmd_sent(pgm, "select device");
 
-  msg_notice("%s: avr910_devcode selected: 0x%02x\n",
-                  progname, (unsigned)buf[1]);
+  pmsg_notice("avr910_devcode selected: 0x%02x\n", (unsigned) buf[1]);
 
   avr910_enter_prog_mode(pgm);
 
@@ -319,27 +314,23 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int devcode;
       if (sscanf(extended_param, "devcode=%i", &devcode) != 1 ||
 	  devcode <= 0 || devcode > 255) {
-        msg_info("%s: avr910_parseextparms(): invalid devcode '%s'\n",
-                        progname, extended_param);
+        pmsg_info("avr910_parseextparms(): invalid devcode '%s'\n", extended_param);
         rv = -1;
         continue;
       }
-      msg_notice2("%s: avr910_parseextparms(): devcode overwritten as 0x%02x\n",
-                      progname, devcode);
+      pmsg_notice2("avr910_parseextparms(): devcode overwritten as 0x%02x\n", devcode);
       PDATA(pgm)->devcode = devcode;
 
       continue;
     }
     if (strncmp(extended_param, "no_blockmode", strlen("no_blockmode")) == 0) {
-      msg_notice2("%s: avr910_parseextparms(-x): no testing for Blockmode\n",
-                      progname);
+      pmsg_notice2("avr910_parseextparms(-x): no testing for Blockmode\n");
       PDATA(pgm)->test_blockmode = 0;
 
       continue;
     }
 
-    msg_info("%s: avr910_parseextparms(): invalid extended parameter '%s'\n",
-                    progname, extended_param);
+    pmsg_info("avr910_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 
@@ -708,7 +699,7 @@ static int avr910_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
   unsigned char tmp;
 
   if (m->size < 3) {
-    msg_info("%s: memsize too small for sig byte read", progname);
+    pmsg_info("memsize too small for sig byte read");
     return -1;
   }
 

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -57,7 +57,7 @@ struct pdata
 static void avr910_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_info("avr910_setup(): Out of memory allocating private data\n");
+    pmsg_error("avr910_setup(): out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -80,7 +80,7 @@ static int avr910_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
   if (rv < 0) {
-    pmsg_info("avr910_recv(): programmer is not responding\n");
+    pmsg_error("avr910_recv(): programmer is not responding\n");
     return 1;
   }
   return 0;
@@ -97,7 +97,7 @@ static int avr910_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
 
   avr910_recv(pgm, &c, 1);
   if (c != '\r') {
-    pmsg_info("programmer did not respond to command: %s\n", errmsg);
+    pmsg_error("programmer did not respond to command: %s\n", errmsg);
     return 1;
   }
   return 0;
@@ -173,9 +173,9 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   avr910_send(pgm, "p", 1);
   avr910_recv(pgm, &type, 1);
 
-  msg_info("Found programmer: Id = %s; type = %c\n", id, type);
-  msg_info("    Software Version = %c.%c; ", sw[0], sw[1]);
-  msg_info("Hardware Version = %c.%c\n", hw[0], hw[1]);
+  msg_notice("Programmer id    = %s; type = %c\n", id, type);
+  msg_notice("Software version = %c.%c; ", sw[0], sw[1]);
+  msg_notice("Hardware version = %c.%c\n", hw[0], hw[1]);
 
   /* See if programmer supports autoincrement of address. */
 
@@ -194,7 +194,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       PDATA(pgm)->buffersize = (unsigned int)(unsigned char)c<<8;
       avr910_recv(pgm, &c, 1);
       PDATA(pgm)->buffersize += (unsigned int)(unsigned char)c;
-      msg_notice("Programmer supports buffered memory access with "
+      msg_notice("programmer supports buffered memory access with "
                       "buffersize = %u bytes\n",
                       PDATA(pgm)->buffersize);
       PDATA(pgm)->use_blockmode = 1;
@@ -212,7 +212,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     /* Get list of devices that the programmer supports. */
 
     avr910_send(pgm, "t", 1);
-    msg_notice("\nProgrammer supports the following devices:\n");
+    msg_notice2("\nProgrammer supports the following devices:\n");
     devtype_1st = 0;
     while (1) {
       avr910_recv(pgm, &c, 1);
@@ -222,17 +222,21 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 	break;
       part = locate_part_by_avr910_devcode(part_list, c);
 
-      msg_notice("    Device code: 0x%02x = %s\n", c & 0xff, part? part->desc: "(unknown)");
+      msg_notice2("    Device code: 0x%02x = %s\n", c & 0xff, part? part->desc: "(unknown)");
 
       /* FIXME: Need to lookup devcode and report the device. */
 
       if (p->avr910_devcode == c)
 	dev_supported = 1;
     };
-    msg_notice("\n");
+    msg_notice2("\n");
 
     if (!dev_supported) {
-      pmsg_info("%s, selected device is not supported by programmer: %s\n", ovsigck? "warning": "error", p->id);
+      if(ovsigck)
+        pmsg_warning("selected device is not supported by programmer %s\n", p->id);
+      else
+        pmsg_error("selected device is not supported by programmer %s\n", p->id);
+
       if (!ovsigck)
 	return -1;
     }
@@ -314,7 +318,7 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int devcode;
       if (sscanf(extended_param, "devcode=%i", &devcode) != 1 ||
 	  devcode <= 0 || devcode > 255) {
-        pmsg_info("avr910_parseextparms(): invalid devcode '%s'\n", extended_param);
+        pmsg_error("avr910_parseextparms(): invalid devcode '%s'\n", extended_param);
         rv = -1;
         continue;
       }
@@ -330,7 +334,7 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    pmsg_info("avr910_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("avr910_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 
@@ -699,7 +703,7 @@ static int avr910_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
   unsigned char tmp;
 
   if (m->size < 3) {
-    pmsg_info("memsize too small for sig byte read");
+    pmsg_error("memsize too small for sig byte read");
     return -1;
   }
 

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -57,7 +57,7 @@ struct pdata
 static void avr910_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("avr910_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -80,7 +80,7 @@ static int avr910_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
   if (rv < 0) {
-    pmsg_error("avr910_recv(): programmer is not responding\n");
+    pmsg_error("programmer is not responding\n");
     return 1;
   }
   return 0;
@@ -318,7 +318,7 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int devcode;
       if (sscanf(extended_param, "devcode=%i", &devcode) != 1 ||
 	  devcode <= 0 || devcode > 255) {
-        pmsg_error("avr910_parseextparms(): invalid devcode '%s'\n", extended_param);
+        pmsg_error("invalid devcode '%s'\n", extended_param);
         rv = -1;
         continue;
       }
@@ -334,7 +334,7 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    pmsg_error("avr910_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -234,11 +234,10 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if (!dev_supported) {
       if(ovsigck)
         pmsg_warning("selected device is not supported by programmer %s\n", p->id);
-      else
+      else {
         pmsg_error("selected device is not supported by programmer %s\n", p->id);
-
-      if (!ovsigck)
 	return -1;
+      }
     }
     /* If the user forced the selection, use the first device
        type that is supported by the programmer. */

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -198,12 +198,12 @@ static int cacheAddress(int addr, const AVR_Cache *cp, const AVRMEM *mem) {
   int cacheaddr = addr + (int) (mem->offset - cp->offset);
 
   if(cacheaddr < 0 || cacheaddr >= cp->size) { // Should never happen (unless offsets wrong in avrdude.conf)
-    pmsg_info("%s cache address 0x%04x out of range [0, 0x%04x]\n", mem->desc, cacheaddr, cp->size);
+    pmsg_error("%s cache address 0x%04x out of range [0, 0x%04x]\n", mem->desc, cacheaddr, cp->size);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
   if(mem->page_size != cp->page_size) { // Should never happen (unless incompatible page sizes in avrdude.conf)
-    pmsg_info("%s page size %d incompatible with cache page size %d\n", mem->desc, mem->page_size, cp->page_size);
+    pmsg_error("%s page size %d incompatible with cache page size %d\n", mem->desc, mem->page_size, cp->page_size);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -221,7 +221,7 @@ static int loadCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p,
       report_progress(1, -1, NULL);
       if(nlOnErr && quell_progress)
         msg_info("\n");
-      pmsg_info("loadCachePage() %s read error at addr 0x%04x\n", mem->desc, addr);
+      pmsg_error("loadCachePage(): unable to read %s page at addr 0x%04x\n", mem->desc, addr);
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
@@ -240,7 +240,7 @@ static int writeCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
       msg_info("\n");
-    pmsg_info("writeCachePage() %s write error at addr 0x%04x\n", mem->desc, base);
+    pmsg_error("writeCachePage(): unable to write %s page at addr 0x%04x\n", mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
   // Read page back from device and update copy to what is on device
@@ -248,7 +248,7 @@ static int writeCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
       msg_info("\n");
-    pmsg_info("writeCachePage() %s read error at addr 0x%04x\n", mem->desc, base);
+    pmsg_error("writeCachePage(): unable to read %s page at addr 0x%04x\n", mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -330,7 +330,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       if(initCache(cp, pgm, p) < 0) {
         if(quell_progress)
           msg_info("\n");
-        pmsg_info("initialising the cache failed\n");
+        pmsg_error("unable to initialise the cache\n");
         return LIBAVRDUDE_GENERAL_FAILURE;
       }
 
@@ -411,7 +411,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       report_progress(1, -1, NULL);
       if(quell_progress)
         msg_info("\n");
-      pmsg_info("avr_flush_cache() chip erase failed\n");
+      pmsg_error("avr_flush_cache() chip erase failed\n");
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
@@ -435,7 +435,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
               report_progress(1, -1, NULL);
               if(quell_progress)
                 msg_info("\n");
-              pmsg_info("flash read failed at addr 0x%04x\n", n);
+              pmsg_error("flash read failed at addr 0x%04x\n", n);
               return LIBAVRDUDE_GENERAL_FAILURE;
             }
           }
@@ -448,7 +448,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
               report_progress(1, -1, NULL);
               if(quell_progress)
                 msg_info("\n");
-              pmsg_info("EEPROM read failed at addr 0x%04x\n", n);
+              pmsg_error("EEPROM read failed at addr 0x%04x\n", n);
               return LIBAVRDUDE_GENERAL_FAILURE;
             }
             // EEPROM zapped by chip erase? Set all copy to 0xff
@@ -494,7 +494,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
             report_progress(1, -1, NULL);
             if(quell_progress)
               msg_info("\n");
-            pmsg_info("%s verification error at addr 0x%04x\n", mem->desc, n);
+            pmsg_error("verification mismatch at %s page addr 0x%04x\n", mem->desc, n);
             return LIBAVRDUDE_GENERAL_FAILURE;
           }
           report_progress(iwr++, nwr, NULL);

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -198,14 +198,12 @@ static int cacheAddress(int addr, const AVR_Cache *cp, const AVRMEM *mem) {
   int cacheaddr = addr + (int) (mem->offset - cp->offset);
 
   if(cacheaddr < 0 || cacheaddr >= cp->size) { // Should never happen (unless offsets wrong in avrdude.conf)
-    msg_info("%s: cacheAddress() %s cache address 0x%04x out of range [0, 0x%04x]\n",
-      progname, mem->desc, cacheaddr, cp->size);
+    pmsg_info("%s cache address 0x%04x out of range [0, 0x%04x]\n", mem->desc, cacheaddr, cp->size);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
   if(mem->page_size != cp->page_size) { // Should never happen (unless incompatible page sizes in avrdude.conf)
-    msg_info("%s: cacheAddress() %s page size %d incompatible with cache page size %d\n",
-      progname, mem->desc, mem->page_size, cp->page_size);
+    pmsg_info("%s page size %d incompatible with cache page size %d\n", mem->desc, mem->page_size, cp->page_size);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -223,7 +221,7 @@ static int loadCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p,
       report_progress(1, -1, NULL);
       if(nlOnErr && quell_progress)
         msg_info("\n");
-      msg_info("%s: loadCachePage() %s read error at addr 0x%04x\n", progname, mem->desc, addr);
+      pmsg_info("loadCachePage() %s read error at addr 0x%04x\n", mem->desc, addr);
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
@@ -242,7 +240,7 @@ static int writeCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
       msg_info("\n");
-    msg_info("%s: writeCachePage() %s write error at addr 0x%04x\n", progname, mem->desc, base);
+    pmsg_info("writeCachePage() %s write error at addr 0x%04x\n", mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
   // Read page back from device and update copy to what is on device
@@ -250,7 +248,7 @@ static int writeCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
       msg_info("\n");
-    msg_info("%s: writeCachePage() %s read error at addr 0x%04x\n", progname, mem->desc, base);
+    pmsg_info("writeCachePage() %s read error at addr 0x%04x\n", mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -320,7 +318,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
   if(!chpages)
     return LIBAVRDUDE_SUCCESS;
 
-  msg_info("%s: synching cache to device... ", progname);
+  pmsg_info("synching cache to device ... ");
   fflush(stderr);
 
   // Check whether page erase needed and working and whether chip erase needed
@@ -330,7 +328,9 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if(!cp->cont)           // Ensure cache is initialised from now on
       if(initCache(cp, pgm, p) < 0) {
-        msg_info("%s: initialising the cache failed\n", progname);
+        if(quell_progress)
+          msg_info("\n");
+        pmsg_info("initialising the cache failed\n");
         return LIBAVRDUDE_GENERAL_FAILURE;
       }
 
@@ -411,7 +411,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       report_progress(1, -1, NULL);
       if(quell_progress)
         msg_info("\n");
-      msg_info("%s: avr_flush_cache() chip erase failed\n", progname);
+      pmsg_info("avr_flush_cache() chip erase failed\n");
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
@@ -435,7 +435,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
               report_progress(1, -1, NULL);
               if(quell_progress)
                 msg_info("\n");
-              msg_info("%s: flash read failed at addr 0x%04x\n", progname, n);
+              pmsg_info("flash read failed at addr 0x%04x\n", n);
               return LIBAVRDUDE_GENERAL_FAILURE;
             }
           }
@@ -448,7 +448,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
               report_progress(1, -1, NULL);
               if(quell_progress)
                 msg_info("\n");
-              msg_info("%s: EEPROM read failed at addr 0x%04x\n", progname, n);
+              pmsg_info("EEPROM read failed at addr 0x%04x\n", n);
               return LIBAVRDUDE_GENERAL_FAILURE;
             }
             // EEPROM zapped by chip erase? Set all copy to 0xff
@@ -494,7 +494,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
             report_progress(1, -1, NULL);
             if(quell_progress)
               msg_info("\n");
-            msg_info("%s: %s verification error at addr 0x%04x\n", progname, mem->desc, n);
+            pmsg_info("%s verification error at addr 0x%04x\n", mem->desc, n);
             return LIBAVRDUDE_GENERAL_FAILURE;
           }
           report_progress(iwr++, nwr, NULL);

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -221,7 +221,7 @@ static int loadCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p,
       report_progress(1, -1, NULL);
       if(nlOnErr && quell_progress)
         msg_info("\n");
-      pmsg_error("loadCachePage(): unable to read %s page at addr 0x%04x\n", mem->desc, addr);
+      pmsg_error("unable to read %s page at addr 0x%04x\n", mem->desc, addr);
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
@@ -240,7 +240,7 @@ static int writeCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
       msg_info("\n");
-    pmsg_error("writeCachePage(): unable to write %s page at addr 0x%04x\n", mem->desc, base);
+    pmsg_error("unable to write %s page at addr 0x%04x\n", mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
   // Read page back from device and update copy to what is on device
@@ -248,7 +248,7 @@ static int writeCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
       msg_info("\n");
-    pmsg_error("writeCachePage(): unable to read %s page at addr 0x%04x\n", mem->desc, base);
+    pmsg_error("unable to read %s page at addr 0x%04x\n", mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -411,7 +411,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       report_progress(1, -1, NULL);
       if(quell_progress)
         msg_info("\n");
-      pmsg_error("avr_flush_cache() chip erase failed\n");
+      pmsg_error("chip erase failed\n");
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -198,13 +198,13 @@ static int cacheAddress(int addr, const AVR_Cache *cp, const AVRMEM *mem) {
   int cacheaddr = addr + (int) (mem->offset - cp->offset);
 
   if(cacheaddr < 0 || cacheaddr >= cp->size) { // Should never happen (unless offsets wrong in avrdude.conf)
-    avrdude_message(MSG_INFO, "%s: cacheAddress() %s cache address 0x%04x out of range [0, 0x%04x]\n",
+    msg_info("%s: cacheAddress() %s cache address 0x%04x out of range [0, 0x%04x]\n",
       progname, mem->desc, cacheaddr, cp->size);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
   if(mem->page_size != cp->page_size) { // Should never happen (unless incompatible page sizes in avrdude.conf)
-    avrdude_message(MSG_INFO, "%s: cacheAddress() %s page size %d incompatible with cache page size %d\n",
+    msg_info("%s: cacheAddress() %s page size %d incompatible with cache page size %d\n",
       progname, mem->desc, mem->page_size, cp->page_size);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
@@ -222,8 +222,8 @@ static int loadCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p,
     if(avr_read_page_default(pgm, p, mem, addr & ~(cp->page_size-1), cp->cont + cachebase) < 0) {
       report_progress(1, -1, NULL);
       if(nlOnErr && quell_progress)
-        avrdude_message(MSG_INFO, "\n");
-      avrdude_message(MSG_INFO, "%s: loadCachePage() %s read error at addr 0x%04x\n", progname, mem->desc, addr);
+        msg_info("\n");
+      msg_info("%s: loadCachePage() %s read error at addr 0x%04x\n", progname, mem->desc, addr);
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
@@ -241,16 +241,16 @@ static int writeCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p
   if(avr_write_page_default(pgm, p, mem, base, cp->cont + base) < 0) {
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
-      avrdude_message(MSG_INFO, "\n");
-    avrdude_message(MSG_INFO, "%s: writeCachePage() %s write error at addr 0x%04x\n", progname, mem->desc, base);
+      msg_info("\n");
+    msg_info("%s: writeCachePage() %s write error at addr 0x%04x\n", progname, mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
   // Read page back from device and update copy to what is on device
   if(avr_read_page_default(pgm, p, mem, base, cp->copy + base) < 0) {
     report_progress(1, -1, NULL);
     if(nlOnErr && quell_progress)
-      avrdude_message(MSG_INFO, "\n");
-    avrdude_message(MSG_INFO, "%s: writeCachePage() %s read error at addr 0x%04x\n", progname, mem->desc, base);
+      msg_info("\n");
+    msg_info("%s: writeCachePage() %s read error at addr 0x%04x\n", progname, mem->desc, base);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -320,7 +320,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
   if(!chpages)
     return LIBAVRDUDE_SUCCESS;
 
-  avrdude_message(MSG_INFO, "%s: synching cache to device... ", progname);
+  msg_info("%s: synching cache to device... ", progname);
   fflush(stderr);
 
   // Check whether page erase needed and working and whether chip erase needed
@@ -330,7 +330,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if(!cp->cont)           // Ensure cache is initialised from now on
       if(initCache(cp, pgm, p) < 0) {
-        avrdude_message(MSG_INFO, "%s: initialising the cache failed\n", progname);
+        msg_info("%s: initialising the cache failed\n", progname);
         return LIBAVRDUDE_GENERAL_FAILURE;
       }
 
@@ -363,13 +363,13 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if(!chpages) {
-    avrdude_message(MSG_INFO, "done\n");
+    msg_info("done\n");
     return LIBAVRDUDE_SUCCESS;
   }
 
   if(chiperase) {
     if(quell_progress) {
-      avrdude_message(MSG_INFO, "reading/chip erase/writing cycle needed ... ");
+      msg_info("reading/chip erase/writing cycle needed ... ");
       fflush(stderr);
     }
 
@@ -410,8 +410,8 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
     if(avr_chip_erase(pgm, p) < 0) {
       report_progress(1, -1, NULL);
       if(quell_progress)
-        avrdude_message(MSG_INFO, "\n");
-      avrdude_message(MSG_INFO, "%s: avr_flush_cache() chip erase failed\n", progname);
+        msg_info("\n");
+      msg_info("%s: avr_flush_cache() chip erase failed\n", progname);
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
@@ -434,8 +434,8 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
             if(avr_read_page_default(pgm, p, mem, n, cp->copy + n) < 0) {
               report_progress(1, -1, NULL);
               if(quell_progress)
-                avrdude_message(MSG_INFO, "\n");
-              avrdude_message(MSG_INFO, "%s: flash read failed at addr 0x%04x\n", progname, n);
+                msg_info("\n");
+              msg_info("%s: flash read failed at addr 0x%04x\n", progname, n);
               return LIBAVRDUDE_GENERAL_FAILURE;
             }
           }
@@ -447,8 +447,8 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
             if(avr_read_page_default(pgm, p, mem, n, cp->copy + n) < 0) {
               report_progress(1, -1, NULL);
               if(quell_progress)
-                avrdude_message(MSG_INFO, "\n");
-              avrdude_message(MSG_INFO, "%s: EEPROM read failed at addr 0x%04x\n", progname, n);
+                msg_info("\n");
+              msg_info("%s: EEPROM read failed at addr 0x%04x\n", progname, n);
               return LIBAVRDUDE_GENERAL_FAILURE;
             }
             // EEPROM zapped by chip erase? Set all copy to 0xff
@@ -493,8 +493,8 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
           if(memcmp(cp->copy + n, cp->cont + n, cp->page_size)) {
             report_progress(1, -1, NULL);
             if(quell_progress)
-              avrdude_message(MSG_INFO, "\n");
-            avrdude_message(MSG_INFO, "%s: %s verification error at addr 0x%04x\n", progname, mem->desc, n);
+              msg_info("\n");
+            msg_info("%s: %s verification error at addr 0x%04x\n", progname, mem->desc, n);
             return LIBAVRDUDE_GENERAL_FAILURE;
           }
           report_progress(iwr++, nwr, NULL);
@@ -504,7 +504,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
   }
   report_progress(1, 0, NULL);
 
-  avrdude_message(MSG_INFO, quell_progress? "done\n": "\n");
+  msg_info(quell_progress? "done\n": "\n");
   return LIBAVRDUDE_SUCCESS;
 }
 

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -28,20 +28,34 @@
 #define USER_CONF_FILE ".avrduderc"
 #endif
 
-extern char * progname;		/* name of program, for messages */
-extern char progbuf[];		/* spaces same length as progname */
+extern char *progname;          // name of program, for messages
+extern char progbuf[];          // spaces same length as progname
 
-extern int ovsigck;		/* override signature check (-F) */
-extern int verbose;		/* verbosity level (-v, -vv, ...) */
-extern int quell_progress;	/* quietness level (-q, -qq) */
+extern int ovsigck;             // override signature check (-F)
+extern int verbose;             // verbosity level (-v, -vv, ...)
+extern int quell_progress;      // quell progress report -q, reduce effective verbosity level (-qq, -qqq)
 
 int avrdude_message(const int msglvl, const char *format, ...);
 
-#define MSG_INFO    (0) /* no -v option, can be suppressed with -qq */
-#define MSG_NOTICE  (1) /* displayed with -v */
-#define MSG_NOTICE2 (2) /* displayed with -vv, used rarely */
-#define MSG_DEBUG   (3) /* displayed with -vvv */
-#define MSG_TRACE   (4) /* displayed with -vvvv, show trace communication */
-#define MSG_TRACE2  (5) /* displayed with -vvvvv */
+#define MSG_EXT_ERROR      (-3) // no -v option, can be suppressed with -qqqqq
+#define MSG_ERROR          (-2) // no -v option, can be suppressed with -qqqq
+#define MSG_WARNING        (-1) // no -v option, can be suppressed with -qqq
+#define MSG_INFO              0 // no -v option, can be suppressed with -qq
+#define MSG_NOTICE            1 // displayed with -v
+#define MSG_NOTICE2           2 // displayed with -vv, used rarely
+#define MSG_DEBUG             3 // displayed with -vvv
+#define MSG_TRACE             4 // displayed with -vvvv, show trace communication
+#define MSG_TRACE2            5 // displayed with -vvvvv
+
+// Shortcuts
+#define msg_ext_error(...) avrdude_message(MSG_ERROR, __VA_ARGS__)
+#define msg_error(...)     avrdude_message(MSG_ERROR, __VA_ARGS__)
+#define msg_warning(...)   avrdude_message(MSG_WARNING, __VA_ARGS__)
+#define msg_info(...)      avrdude_message(MSG_INFO, __VA_ARGS__)
+#define msg_notice(...)    avrdude_message(MSG_NOTICE, __VA_ARGS__)
+#define msg_notice2(...)   avrdude_message(MSG_NOTICE2, __VA_ARGS__)
+#define msg_debug(...)     avrdude_message(MSG_DEBUG, __VA_ARGS__)
+#define msg_trace(...)     avrdude_message(MSG_TRACE, __VA_ARGS__)
+#define msg_trace2(...)    avrdude_message(MSG_TRACE2, __VA_ARGS__)
 
 #endif

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -28,27 +28,31 @@
 #define USER_CONF_FILE ".avrduderc"
 #endif
 
-extern char *progname;          // name of program, for messages
-extern char progbuf[];          // spaces same length as progname
+extern char *progname;       // name of program, for messages
+extern char progbuf[];       // spaces same length as progname
 
-extern int ovsigck;             // override signature check (-F)
-extern int verbose;             // verbosity level (-v, -vv, ...)
-extern int quell_progress;      // quell progress report -q, reduce effective verbosity level (-qq, -qqq)
+extern int ovsigck;          // override signature check (-F)
+extern int verbose;          // verbosity level (-v, -vv, ...)
+extern int quell_progress;   // quell progress report -q, reduce effective verbosity level (-qq, -qqq)
 
-int avrdude_message(const int msglvl, const char *format, ...);
+int avrdude_message(int msglvl, const char *format, ...);
+int avrdude_message2(int msgmode, int msglvl, const char *format, ...);
 
-#define MSG_EXT_ERROR      (-3) // no -v option, can be suppressed with -qqqqq
-#define MSG_ERROR          (-2) // no -v option, can be suppressed with -qqqq
-#define MSG_WARNING        (-1) // no -v option, can be suppressed with -qqq
-#define MSG_INFO              0 // no -v option, can be suppressed with -qq
-#define MSG_NOTICE            1 // displayed with -v
-#define MSG_NOTICE2           2 // displayed with -vv, used rarely
-#define MSG_DEBUG             3 // displayed with -vvv
-#define MSG_TRACE             4 // displayed with -vvvv, show trace communication
-#define MSG_TRACE2            5 // displayed with -vvvvv
+#define MSG_EXT_ERROR   (-3) // OS-type error, no -v option, can be suppressed with -qqqqq
+#define MSG_ERROR       (-2) // Avrdude error, no -v option, can be suppressed with -qqqq
+#define MSG_WARNING     (-1) // Warning, no -v option, can be suppressed with -qqq
+#define MSG_INFO           0 // Commentary, no -v option, can be suppressed with -qq
+#define MSG_NOTICE         1 // Displayed with -v
+#define MSG_NOTICE2        2 // Displayed with -vv, used rarely
+#define MSG_DEBUG          3 // Displayed with -vvv
+#define MSG_TRACE          4 // Displayed with -vvvv, show trace communication
+#define MSG_TRACE2         5 // Displayed with -vvvvv
+
+#define MSG2_PROGNAME      1 // Start by printing progname
+#define MSG2_FLUSH         2 // Flush before and after printing
 
 // Shortcuts
-#define msg_ext_error(...) avrdude_message(MSG_ERROR, __VA_ARGS__)
+#define msg_ext_error(...) avrdude_message(MSG_EXT_ERROR, __VA_ARGS__)
 #define msg_error(...)     avrdude_message(MSG_ERROR, __VA_ARGS__)
 #define msg_warning(...)   avrdude_message(MSG_WARNING, __VA_ARGS__)
 #define msg_info(...)      avrdude_message(MSG_INFO, __VA_ARGS__)
@@ -57,5 +61,15 @@ int avrdude_message(const int msglvl, const char *format, ...);
 #define msg_debug(...)     avrdude_message(MSG_DEBUG, __VA_ARGS__)
 #define msg_trace(...)     avrdude_message(MSG_TRACE, __VA_ARGS__)
 #define msg_trace2(...)    avrdude_message(MSG_TRACE2, __VA_ARGS__)
+
+#define pmsg_ext_error(...) avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
+#define pmsg_error(...)     avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
+#define pmsg_warning(...)   avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
+#define pmsg_info(...)      avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
+#define pmsg_notice(...)    avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE, __VA_ARGS__)
+#define pmsg_notice2(...)   avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE2, __VA_ARGS__)
+#define pmsg_debug(...)     avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_DEBUG, __VA_ARGS__)
+#define pmsg_trace(...)     avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE, __VA_ARGS__)
+#define pmsg_trace2(...)    avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE2, __VA_ARGS__)
 
 #endif

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -66,9 +66,9 @@ int avrdude_message2(const char *fname, int msgmode, int msglvl, const char *for
 #define msg_trace(...)     avrdude_message2(__func__, 0, MSG_TRACE, __VA_ARGS__)
 #define msg_trace2(...)    avrdude_message2(__func__, 0, MSG_TRACE2, __VA_ARGS__)
 
-#define pmsg_ext_error(...) avrdude_message2(__func__, MSG2_PROGNAME|MSG2_TYPE|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
-#define pmsg_error(...)     avrdude_message2(__func__, MSG2_PROGNAME|MSG2_TYPE|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
-#define pmsg_warning(...)   avrdude_message2(__func__, MSG2_PROGNAME|MSG2_TYPE|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
+#define pmsg_ext_error(...) avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_TYPE|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
+#define pmsg_error(...)     avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_TYPE|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
+#define pmsg_warning(...)   avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_TYPE|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
 #define pmsg_info(...)      avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
 #define pmsg_notice(...)    avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE, __VA_ARGS__)
 #define pmsg_notice2(...)   avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE2, __VA_ARGS__)

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -36,40 +36,54 @@ extern int verbose;          // verbosity level (-v, -vv, ...)
 extern int quell_progress;   // quell progress report -q, reduce effective verbosity level (-qq, -qqq)
 
 int avrdude_message(int msglvl, const char *format, ...);
-int avrdude_message2(int msgmode, int msglvl, const char *format, ...);
+int avrdude_message2(const char *fname, int msgmode, int msglvl, const char *format, ...);
 
 #define MSG_EXT_ERROR   (-3) // OS-type error, no -v option, can be suppressed with -qqqqq
 #define MSG_ERROR       (-2) // Avrdude error, no -v option, can be suppressed with -qqqq
 #define MSG_WARNING     (-1) // Warning, no -v option, can be suppressed with -qqq
 #define MSG_INFO           0 // Commentary, no -v option, can be suppressed with -qq
 #define MSG_NOTICE         1 // Displayed with -v
-#define MSG_NOTICE2        2 // Displayed with -vv, used rarely
+#define MSG_NOTICE2        2 // Displayed with -vv
 #define MSG_DEBUG          3 // Displayed with -vvv
 #define MSG_TRACE          4 // Displayed with -vvvv, show trace communication
 #define MSG_TRACE2         5 // Displayed with -vvvvv
 
 #define MSG2_PROGNAME      1 // Start by printing progname
-#define MSG2_FLUSH         2 // Flush before and after printing
+#define MSG2_FUNCTION      2 // Print calling function (1st arg) after progname
+#define MSG2_TYPE          4 // Print message type after function or progname
+#define MSG2_INDENT1       8 // Start by printing indentation of progname+1 blanks
+#define MSG2_INDENT2      16 // Start by printing indentation of progname+2 blanks
+#define MSG2_FLUSH        32 // Flush before and after printing
 
 // Shortcuts
-#define msg_ext_error(...) avrdude_message(MSG_EXT_ERROR, __VA_ARGS__)
-#define msg_error(...)     avrdude_message(MSG_ERROR, __VA_ARGS__)
-#define msg_warning(...)   avrdude_message(MSG_WARNING, __VA_ARGS__)
-#define msg_info(...)      avrdude_message(MSG_INFO, __VA_ARGS__)
-#define msg_notice(...)    avrdude_message(MSG_NOTICE, __VA_ARGS__)
-#define msg_notice2(...)   avrdude_message(MSG_NOTICE2, __VA_ARGS__)
-#define msg_debug(...)     avrdude_message(MSG_DEBUG, __VA_ARGS__)
-#define msg_trace(...)     avrdude_message(MSG_TRACE, __VA_ARGS__)
-#define msg_trace2(...)    avrdude_message(MSG_TRACE2, __VA_ARGS__)
+#define msg_ext_error(...) avrdude_message2(__func__, 0, MSG_EXT_ERROR, __VA_ARGS__)
+#define msg_error(...)     avrdude_message2(__func__, 0, MSG_ERROR, __VA_ARGS__)
+#define msg_warning(...)   avrdude_message2(__func__, 0, MSG_WARNING, __VA_ARGS__)
+#define msg_info(...)      avrdude_message2(__func__, 0, MSG_INFO, __VA_ARGS__)
+#define msg_notice(...)    avrdude_message2(__func__, 0, MSG_NOTICE, __VA_ARGS__)
+#define msg_notice2(...)   avrdude_message2(__func__, 0, MSG_NOTICE2, __VA_ARGS__)
+#define msg_debug(...)     avrdude_message2(__func__, 0, MSG_DEBUG, __VA_ARGS__)
+#define msg_trace(...)     avrdude_message2(__func__, 0, MSG_TRACE, __VA_ARGS__)
+#define msg_trace2(...)    avrdude_message2(__func__, 0, MSG_TRACE2, __VA_ARGS__)
 
-#define pmsg_ext_error(...) avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
-#define pmsg_error(...)     avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
-#define pmsg_warning(...)   avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
-#define pmsg_info(...)      avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
-#define pmsg_notice(...)    avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE, __VA_ARGS__)
-#define pmsg_notice2(...)   avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE2, __VA_ARGS__)
-#define pmsg_debug(...)     avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_DEBUG, __VA_ARGS__)
-#define pmsg_trace(...)     avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE, __VA_ARGS__)
-#define pmsg_trace2(...)    avrdude_message2(MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE2, __VA_ARGS__)
+#define pmsg_ext_error(...) avrdude_message2(__func__, MSG2_PROGNAME|MSG2_TYPE|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
+#define pmsg_error(...)     avrdude_message2(__func__, MSG2_PROGNAME|MSG2_TYPE|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
+#define pmsg_warning(...)   avrdude_message2(__func__, MSG2_PROGNAME|MSG2_TYPE|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
+#define pmsg_info(...)      avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
+#define pmsg_notice(...)    avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE, __VA_ARGS__)
+#define pmsg_notice2(...)   avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE2, __VA_ARGS__)
+#define pmsg_debug(...)     avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_DEBUG, __VA_ARGS__)
+#define pmsg_trace(...)     avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE, __VA_ARGS__)
+#define pmsg_trace2(...)    avrdude_message2(__func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE2, __VA_ARGS__)
+
+#define imsg_ext_error(...) avrdude_message2(__func__, MSG2_INDENT1|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
+#define imsg_error(...)     avrdude_message2(__func__, MSG2_INDENT1|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
+#define imsg_warning(...)   avrdude_message2(__func__, MSG2_INDENT1|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
+#define imsg_info(...)      avrdude_message2(__func__, MSG2_INDENT2|MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
+#define imsg_notice(...)    avrdude_message2(__func__, MSG2_INDENT2|MSG2_FLUSH, MSG_NOTICE, __VA_ARGS__)
+#define imsg_notice2(...)   avrdude_message2(__func__, MSG2_INDENT2|MSG2_FLUSH, MSG_NOTICE2, __VA_ARGS__)
+#define imsg_debug(...)     avrdude_message2(__func__, MSG2_INDENT2|MSG2_FLUSH, MSG_DEBUG, __VA_ARGS__)
+#define imsg_trace(...)     avrdude_message2(__func__, MSG2_INDENT2|MSG2_FLUSH, MSG_TRACE, __VA_ARGS__)
+#define imsg_trace2(...)    avrdude_message2(__func__, MSG2_INDENT2|MSG2_FLUSH, MSG_TRACE2, __VA_ARGS__)
 
 #endif

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -51,8 +51,7 @@
 #ifdef DO_NOT_BUILD_AVRFTDI
 
 static int avrftdi_noftdi_open(PROGRAMMER *pgm, const char *name) {
-	pmsg_info("no libftdi or libusb support; install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again\n");
-
+	pmsg_error("no libftdi or libusb support; install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again\n");
 	return -1;
 }
 
@@ -139,14 +138,14 @@ void avrftdi_log(int level, const char * func, int line,
 		if(!skip_prefix)
 		{
 			switch(level) {
-				case ERR: msg_info("E "); break;
-				case WARN:  msg_info("W "); break;
-				case INFO:  msg_info("I "); break;
-				case DEBUG: msg_info("D "); break;
-				case TRACE: msg_info("T "); break;
-				default: msg_info("  "); break;
+				case ERR:   msg_error("E "); break;
+				case WARN:  msg_error("W "); break;
+				case INFO:  msg_error("I "); break;
+				case DEBUG: msg_error("D "); break;
+				case TRACE: msg_error("T "); break;
+				default:    msg_error("  "); break;
 			}
-			msg_info("%s(%d): ", func, line);
+			msg_error("%s(%d): ", func, line);
 		}
 		va_start(ap, fmt);
 		vfprintf(stderr, fmt, ap);
@@ -659,7 +658,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 	if (usbpid) {
 		pid = *(int *)(ldata(usbpid));
 		if (lnext(usbpid))
-			pmsg_info("Warning: using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
+			pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
 	} else
 		pid = USB_DEVICE_FT2232;
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -51,8 +51,7 @@
 #ifdef DO_NOT_BUILD_AVRFTDI
 
 static int avrftdi_noftdi_open(PROGRAMMER *pgm, const char *name) {
-	msg_info("%s: Error: no libftdi or libusb support. Install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again.\n",
-                        progname);
+	pmsg_info("no libftdi or libusb support; install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again\n");
 
 	return -1;
 }
@@ -347,7 +346,7 @@ static int avrftdi_transmit_bb(const PROGRAMMER *pgm, unsigned char mode, const 
 	size_t max_size = MIN(pdata->ftdic->max_packet_size, (unsigned int) pdata->tx_buffer_size);
 	// select block size so that resulting commands does not exceed max_size if possible
 	blocksize = MAX(1,(max_size-7)/((8*2*6)+(8*1*2)));
-	//msg_info("blocksize %d \n",blocksize);
+	// msg_info("blocksize %d \n", blocksize);
 
 	unsigned char* send_buffer = alloca((8 * 2 * 6) * blocksize + (8 * 1 * 2) * blocksize + 7);
 	unsigned char* recv_buffer = alloca(2 * 16 * blocksize);
@@ -611,7 +610,8 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 	}
 
 	pdata->use_bitbanging = !pin_check_mpsse;
-	if (pdata->use_bitbanging) log_info("Because of pin configuration fallback to bitbanging mode.\n");
+	if (pdata->use_bitbanging)
+		log_info("Because of pin configuration fallback to bitbanging mode.\n");
 
 	/*
 	 * TODO: No need to fail for a wrongly configured led or something.
@@ -659,8 +659,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 	if (usbpid) {
 		pid = *(int *)(ldata(usbpid));
 		if (lnext(usbpid))
-			msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
-                                        progname, pid);
+			pmsg_info("Warning: using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
 	} else
 		pid = USB_DEVICE_FT2232;
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -51,7 +51,7 @@
 #ifdef DO_NOT_BUILD_AVRFTDI
 
 static int avrftdi_noftdi_open(PROGRAMMER *pgm, const char *name) {
-	avrdude_message(MSG_INFO, "%s: Error: no libftdi or libusb support. Install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again.\n",
+	msg_info("%s: Error: no libftdi or libusb support. Install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again.\n",
                         progname);
 
 	return -1;
@@ -140,14 +140,14 @@ void avrftdi_log(int level, const char * func, int line,
 		if(!skip_prefix)
 		{
 			switch(level) {
-				case ERR: avrdude_message(MSG_INFO, "E "); break;
-				case WARN:  avrdude_message(MSG_INFO, "W "); break;
-				case INFO:  avrdude_message(MSG_INFO, "I "); break;
-				case DEBUG: avrdude_message(MSG_INFO, "D "); break;
-				case TRACE: avrdude_message(MSG_INFO, "T "); break;
-				default: avrdude_message(MSG_INFO, "  "); break;
+				case ERR: msg_info("E "); break;
+				case WARN:  msg_info("W "); break;
+				case INFO:  msg_info("I "); break;
+				case DEBUG: msg_info("D "); break;
+				case TRACE: msg_info("T "); break;
+				default: msg_info("  "); break;
 			}
-			avrdude_message(MSG_INFO, "%s(%d): ", func, line);
+			msg_info("%s(%d): ", func, line);
 		}
 		va_start(ap, fmt);
 		vfprintf(stderr, fmt, ap);
@@ -170,16 +170,16 @@ static void buf_dump(const unsigned char *buf, int len, char *desc,
 		     int offset, int width)
 {
 	int i;
-	avrdude_message(MSG_INFO, "%s begin:\n", desc);
+	msg_info("%s begin:\n", desc);
 	for (i = 0; i < offset; i++)
-		avrdude_message(MSG_INFO, "%02x ", buf[i]);
-	avrdude_message(MSG_INFO, "\n");
+		msg_info("%02x ", buf[i]);
+	msg_info("\n");
 	for (i++; i <= len; i++) {
-		avrdude_message(MSG_INFO, "%02x ", buf[i-1]);
+		msg_info("%02x ", buf[i-1]);
 		if((i-offset) != 0 && (i-offset)%width == 0)
-		    avrdude_message(MSG_INFO, "\n");
+		    msg_info("\n");
 	}
-	avrdude_message(MSG_INFO, "%s end\n", desc);
+	msg_info("%s end\n", desc);
 }
 
 /*
@@ -347,7 +347,7 @@ static int avrftdi_transmit_bb(const PROGRAMMER *pgm, unsigned char mode, const 
 	size_t max_size = MIN(pdata->ftdic->max_packet_size, (unsigned int) pdata->tx_buffer_size);
 	// select block size so that resulting commands does not exceed max_size if possible
 	blocksize = MAX(1,(max_size-7)/((8*2*6)+(8*1*2)));
-	//avrdude_message(MSG_INFO, "blocksize %d \n",blocksize);
+	//msg_info("blocksize %d \n",blocksize);
 
 	unsigned char* send_buffer = alloca((8 * 2 * 6) * blocksize + (8 * 1 * 2) * blocksize + 7);
 	unsigned char* recv_buffer = alloca(2 * 16 * blocksize);
@@ -659,7 +659,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 	if (usbpid) {
 		pid = *(int *)(ldata(usbpid));
 		if (lnext(usbpid))
-			avrdude_message(MSG_INFO, "%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
+			msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
                                         progname, pid);
 	} else
 		pid = USB_DEVICE_FT2232;

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -43,7 +43,7 @@ enum { ERR, WARN, INFO, DEBUG, TRACE };
 	do {                                                              \
 		if ((x))                                                        \
 		{                                                               \
-			msg_info("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
+			msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
 					__FILE__, __LINE__, __FUNCTION__,                         \
 					#x, strerror(errno), errno, ftdi_get_error_string(ftdi)); \
 			return -1;                                                    \
@@ -54,7 +54,7 @@ enum { ERR, WARN, INFO, DEBUG, TRACE };
 	do {                                                              \
 		if ((x))                                                        \
 		{                                                               \
-			msg_info("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
+			msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
 					__FILE__, __LINE__, __FUNCTION__,                         \
 	 			 #x, strerror(errno), errno, ftdi_get_error_string(ftdi));  \
 		}                                                               \

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -43,7 +43,7 @@ enum { ERR, WARN, INFO, DEBUG, TRACE };
 	do {                                                              \
 		if ((x))                                                        \
 		{                                                               \
-			avrdude_message(MSG_INFO, "%s:%d %s() %s: %s (%d)\n\t%s\n",             \
+			msg_info("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
 					__FILE__, __LINE__, __FUNCTION__,                         \
 					#x, strerror(errno), errno, ftdi_get_error_string(ftdi)); \
 			return -1;                                                    \
@@ -54,7 +54,7 @@ enum { ERR, WARN, INFO, DEBUG, TRACE };
 	do {                                                              \
 		if ((x))                                                        \
 		{                                                               \
-			avrdude_message(MSG_INFO, "%s:%d %s() %s: %s (%d)\n\t%s\n",             \
+			msg_info("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
 					__FILE__, __LINE__, __FUNCTION__,                         \
 	 			 #x, strerror(errno), errno, ftdi_get_error_string(ftdi));  \
 		}                                                               \

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -14,7 +14,8 @@
 # define HAVE_LIBFTDI_TYPE_232H 1
 #elif defined(HAVE_LIBFTDI)
 #include <ftdi.h>
-#else 
+#else
+
 #ifdef _MSC_VER
 #pragma message("No libftdi or libusb support. Install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again.")
 #else
@@ -30,7 +31,7 @@ enum { ERR, WARN, INFO, DEBUG, TRACE };
 #define __log(lvl, fmt, ...)                                  \
   do {                                                        \
     avrftdi_log(lvl, __func__, __LINE__, fmt, ##__VA_ARGS__); \
-	} while(0)
+  } while(0)
 
 
 #define log_err(fmt, ...)   __log(ERR, fmt, ##__VA_ARGS__)
@@ -40,49 +41,49 @@ enum { ERR, WARN, INFO, DEBUG, TRACE };
 #define log_trace(fmt, ...) __log(TRACE, fmt, ##__VA_ARGS__)
 
 #define E(x, ftdi)                                                  \
-	do {                                                              \
-		if ((x))                                                        \
-		{                                                               \
-			msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
-					__FILE__, __LINE__, __FUNCTION__,                         \
-					#x, strerror(errno), errno, ftdi_get_error_string(ftdi)); \
-			return -1;                                                    \
-		}                                                               \
-	} while(0)
+  do {                                                              \
+    if ((x))                                                        \
+    {                                                               \
+      msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",                   \
+          __FILE__, __LINE__, __FUNCTION__,                         \
+          #x, strerror(errno), errno, ftdi_get_error_string(ftdi)); \
+      return -1;                                                    \
+    }                                                               \
+  } while(0)
 
 #define E_VOID(x, ftdi)                                             \
-	do {                                                              \
-		if ((x))                                                        \
-		{                                                               \
-			msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",             \
-					__FILE__, __LINE__, __FUNCTION__,                         \
-	 			 #x, strerror(errno), errno, ftdi_get_error_string(ftdi));  \
-		}                                                               \
-	} while(0)
+  do {                                                              \
+    if ((x))                                                        \
+    {                                                               \
+      msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",                   \
+          __FILE__, __LINE__, __FUNCTION__,                         \
+          #x, strerror(errno), errno, ftdi_get_error_string(ftdi)); \
+    }                                                               \
+  } while(0)
 
 
 #define to_pdata(pgm) \
-	((avrftdi_t *)((pgm)->cookie))
+  ((avrftdi_t *)((pgm)->cookie))
 
 typedef struct avrftdi_s {
-	/* pointer to struct maintained by libftdi to identify the device */
-	struct ftdi_context* ftdic; 
-	/* bitmask of values for pins. bit 0 represents pin 0 ([A|B]DBUS0) */
-	uint16_t pin_value;
-	/* bitmask of pin direction. a '1' make a pin an output.
-	 * bit 0 corresponds to pin 0. */
-	uint16_t pin_direction;
-	/* don't know. not useful. someone put it in. */
-	uint16_t led_mask;
-	/* total number of pins supported by a programmer. varies with FTDI chips */
-	int pin_limit;
-	/* internal RX buffer of the device. needed for INOUT transfers */
-	int rx_buffer_size;
-	int tx_buffer_size;
-	/* use bitbanging instead of mpsse spi */
-	bool use_bitbanging;
-	/* bits 16-23 of extended 24-bit word flash address for parts with flash > 128k */
-	uint8_t lext_byte;
+  /* pointer to struct maintained by libftdi to identify the device */
+  struct ftdi_context* ftdic;
+  /* bitmask of values for pins. bit 0 represents pin 0 ([A|B]DBUS0) */
+  uint16_t pin_value;
+  /* bitmask of pin direction. a '1' make a pin an output.
+   * bit 0 corresponds to pin 0. */
+  uint16_t pin_direction;
+  /* don't know. not useful. someone put it in. */
+  uint16_t led_mask;
+  /* total number of pins supported by a programmer. varies with FTDI chips */
+  int pin_limit;
+  /* internal RX buffer of the device. needed for INOUT transfers */
+  int rx_buffer_size;
+  int tx_buffer_size;
+  /* use bitbanging instead of mpsse spi */
+  bool use_bitbanging;
+  /* bits 16-23 of extended 24-bit word flash address for parts with flash > 128k */
+  uint8_t lext_byte;
 } avrftdi_t;
 
 void avrftdi_log(int level, const char * func, int line, const char * fmt, ...);

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -774,7 +774,7 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(  f, "%sMemory Detail                 :\n\n", prefix);
 
   px = prefix;
-  buf = (char *)cfg_malloc("avr_display()", strlen(prefix) + 5);
+  buf = (char *) cfg_malloc("avr_display()", strlen(prefix) + 5);
   strcpy(buf, prefix);
   strcat(buf, "  ");
   px = buf;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -538,7 +538,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
               m->readback[1]);
     }
     if (verbose > 4) {
-      avrdude_message(MSG_TRACE2, "%s  Memory Ops:\n"
+      msg_trace2("%s  Memory Ops:\n"
                       "%s    Oeration     Inst Bit  Bit Type  Bitno  Value\n"
                       "%s    -----------  --------  --------  -----  -----\n",
                       prefix, prefix, prefix);

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -258,7 +258,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
       break;
   }
   if (b != 0) {
-    msg_info("bitbang_tpi_rx: start bit not received correctly\n");
+    pmsg_error("bitbang_tpi_rx: start bit not received correctly\n");
     return -1;
   }
 
@@ -273,7 +273,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
 
   /* parity bit */
   if (bitbang_tpi_clk(pgm) != parity) {
-    msg_info("bitbang_tpi_rx: parity bit is wrong\n");
+    pmsg_error("bitbang_tpi_rx: parity bit is wrong\n");
     return -1;
   }
 
@@ -282,7 +282,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
   b &= bitbang_tpi_clk(pgm);
   b &= bitbang_tpi_clk(pgm);
   if (b != 1) {
-    msg_info("bitbang_tpi_rx: stop bits not received correctly\n");
+    pmsg_error("bitbang_tpi_rx: stop bits not received correctly\n");
     return -1;
   }
   
@@ -431,8 +431,7 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     /* Set Pointer Register */
     mem = avr_locate_mem(p, "flash");
     if (mem == NULL) {
-      msg_info("No flash memory to erase for part %s\n",
-          p->desc);
+      pmsg_error("no flash memory to erase for part %s\n", p->desc);
       return -1;
     }
     bitbang_tpi_tx(pgm, TPI_CMD_SSTPR | 0);
@@ -452,7 +451,7 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    msg_info("chip erase instruction not defined for part %s\n", p->desc);
+    pmsg_error("chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -491,8 +490,7 @@ int bitbang_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-    msg_info("program enable instruction not defined for part %s\n",
-            p->desc);
+    pmsg_error("program enable instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -523,7 +521,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (p->prog_modes & PM_TPI) {
     /* make sure cmd_tpi() is defined */
     if (pgm->cmd_tpi == NULL) {
-      pmsg_info("%s programmer does not support TPI\n", pgm->type);
+      pmsg_error("%s programmer does not support TPI\n", pgm->type);
       return -1;
     }
 
@@ -538,12 +536,12 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     pgm->setpin(pgm, PIN_AVR_MOSI, 0);
     if (pgm->getpin(pgm, PIN_AVR_MISO) != 0) {
-      msg_info("MOSI->MISO 0 failed\n");
+      pmsg_error("MOSI->MISO 0 failed\n");
       return -1;
     }
     pgm->setpin(pgm, PIN_AVR_MOSI, 1);
     if (pgm->getpin(pgm, PIN_AVR_MISO) != 1) {
-      msg_info("MOSI->MISO 1 failed\n");
+      pmsg_error("MOSI->MISO 1 failed\n");
       return -1;
     }
 
@@ -568,7 +566,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     bitbang_tpi_tx(pgm, TPI_CMD_SLDCS | TPI_REG_TPIIR);
     rc = bitbang_tpi_rx(pgm);
     if (rc != 0x80) {
-      msg_info("TPIIR not correct\n");
+      pmsg_error("TPIIR not correct\n");
       return -1;
     }
   } else {
@@ -602,7 +600,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
      * can't sync with the device, maybe it's not attached?
      */
     if (rc) {
-      pmsg_info("AVR device not responding\n");
+      pmsg_error("AVR device not responding\n");
       return -1;
     }
   }
@@ -612,7 +610,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
 static int verify_pin_assigned(const PROGRAMMER *pgm, int pin, char *desc) {
   if (pgm->pinno[pin] == 0) {
-    pmsg_info("no pin has been assigned for %s\n", desc);
+    pmsg_error("no pin has been assigned for %s\n", desc);
     return -1;
   }
   return 0;
@@ -634,7 +632,7 @@ int bitbang_check_prerequisites(const PROGRAMMER *pgm) {
     return -1;
 
   if (pgm->cmd == NULL) {
-    pmsg_info("no cmd() method defined for bitbang programmer\n");
+    pmsg_error("no cmd() method defined for bitbang programmer\n");
     return -1;
   }
   return 0;

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -76,7 +76,7 @@ static void bitbang_calibrate_delay(void)
   if (QueryPerformanceFrequency(&freq))
   {
     has_perfcount = 1;
-    avrdude_message(MSG_NOTICE2, "%s: Using performance counter for bitbang delays\n",
+    msg_notice2("%s: Using performance counter for bitbang delays\n",
                     progname);
   }
   else
@@ -90,7 +90,7 @@ static void bitbang_calibrate_delay(void)
      * auto-calibration figures seen on various Unix systems on
      * comparable hardware.
      */
-    avrdude_message(MSG_NOTICE2, "%s: Using guessed per-microsecond delay count for bitbang delays\n",
+    msg_notice2("%s: Using guessed per-microsecond delay count for bitbang delays\n",
                     progname);
     delay_decrement = 100;
   }
@@ -98,7 +98,7 @@ static void bitbang_calibrate_delay(void)
   struct itimerval itv;
   volatile int i;
 
-  avrdude_message(MSG_NOTICE2, "%s: Calibrating delay loop...",
+  msg_notice2("%s: Calibrating delay loop...",
                   progname);
   i = 0;
   done = 0;
@@ -125,7 +125,7 @@ static void bitbang_calibrate_delay(void)
    * Calculate back from 100 ms to 1 us.
    */
   delay_decrement = -i / 100000;
-  avrdude_message(MSG_NOTICE2, " calibrated to %d cycles per us\n",
+  msg_notice2(" calibrated to %d cycles per us\n",
                   delay_decrement);
 #endif /* WIN32 */
 }
@@ -261,7 +261,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
       break;
   }
   if (b != 0) {
-    avrdude_message(MSG_INFO, "bitbang_tpi_rx: start bit not received correctly\n");
+    msg_info("bitbang_tpi_rx: start bit not received correctly\n");
     return -1;
   }
 
@@ -276,7 +276,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
 
   /* parity bit */
   if (bitbang_tpi_clk(pgm) != parity) {
-    avrdude_message(MSG_INFO, "bitbang_tpi_rx: parity bit is wrong\n");
+    msg_info("bitbang_tpi_rx: parity bit is wrong\n");
     return -1;
   }
 
@@ -285,7 +285,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
   b &= bitbang_tpi_clk(pgm);
   b &= bitbang_tpi_clk(pgm);
   if (b != 1) {
-    avrdude_message(MSG_INFO, "bitbang_tpi_rx: stop bits not received correctly\n");
+    msg_info("bitbang_tpi_rx: stop bits not received correctly\n");
     return -1;
   }
   
@@ -328,15 +328,15 @@ int bitbang_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 
     if(verbose >= 2)
 	{
-        avrdude_message(MSG_NOTICE2, "bitbang_cmd(): [ ");
+        msg_notice2("bitbang_cmd(): [ ");
         for(i = 0; i < 4; i++)
-            avrdude_message(MSG_NOTICE2, "%02X ", cmd[i]);
-        avrdude_message(MSG_NOTICE2, "] [ ");
+            msg_notice2("%02X ", cmd[i]);
+        msg_notice2("] [ ");
         for(i = 0; i < 4; i++)
 		{
-            avrdude_message(MSG_NOTICE2, "%02X ", res[i]);
+            msg_notice2("%02X ", res[i]);
 		}
-        avrdude_message(MSG_NOTICE2, "]\n");
+        msg_notice2("]\n");
 	}
 
   return 0;
@@ -363,15 +363,15 @@ int bitbang_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
 
   if(verbose >= 2)
   {
-    avrdude_message(MSG_NOTICE2, "bitbang_cmd_tpi(): [ ");
+    msg_notice2("bitbang_cmd_tpi(): [ ");
     for(i = 0; i < cmd_len; i++)
-      avrdude_message(MSG_NOTICE2, "%02X ", cmd[i]);
-    avrdude_message(MSG_NOTICE2, "] [ ");
+      msg_notice2("%02X ", cmd[i]);
+    msg_notice2("] [ ");
     for(i = 0; i < res_len; i++)
     {
-      avrdude_message(MSG_NOTICE2, "%02X ", res[i]);
+      msg_notice2("%02X ", res[i]);
     }
-    avrdude_message(MSG_NOTICE2, "]\n");
+    msg_notice2("]\n");
   }
 
   pgm->pgm_led(pgm, OFF);
@@ -399,15 +399,15 @@ int bitbang_spi(const PROGRAMMER *pgm, const unsigned char *cmd,
 
   if(verbose >= 2)
 	{
-        avrdude_message(MSG_NOTICE2, "bitbang_cmd(): [ ");
+        msg_notice2("bitbang_cmd(): [ ");
         for(i = 0; i < count; i++)
-            avrdude_message(MSG_NOTICE2, "%02X ", cmd[i]);
-        avrdude_message(MSG_NOTICE2, "] [ ");
+            msg_notice2("%02X ", cmd[i]);
+        msg_notice2("] [ ");
         for(i = 0; i < count; i++)
 		{
-            avrdude_message(MSG_NOTICE2, "%02X ", res[i]);
+            msg_notice2("%02X ", res[i]);
 		}
-        avrdude_message(MSG_NOTICE2, "]\n");
+        msg_notice2("]\n");
 	}
 
   return 0;
@@ -434,7 +434,7 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     /* Set Pointer Register */
     mem = avr_locate_mem(p, "flash");
     if (mem == NULL) {
-      avrdude_message(MSG_INFO, "No flash memory to erase for part %s\n",
+      msg_info("No flash memory to erase for part %s\n",
           p->desc);
       return -1;
     }
@@ -455,7 +455,7 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    avrdude_message(MSG_INFO, "chip erase instruction not defined for part \"%s\"\n",
+    msg_info("chip erase instruction not defined for part \"%s\"\n",
             p->desc);
     return -1;
   }
@@ -495,7 +495,7 @@ int bitbang_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-    avrdude_message(MSG_INFO, "program enable instruction not defined for part \"%s\"\n",
+    msg_info("program enable instruction not defined for part \"%s\"\n",
             p->desc);
     return -1;
   }
@@ -527,7 +527,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (p->prog_modes & PM_TPI) {
     /* make sure cmd_tpi() is defined */
     if (pgm->cmd_tpi == NULL) {
-      avrdude_message(MSG_INFO, "%s: Error: %s programmer does not support TPI\n",
+      msg_info("%s: Error: %s programmer does not support TPI\n",
           progname, pgm->type);
       return -1;
     }
@@ -539,20 +539,20 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     /* RESET must be LOW in case the existing code is driving the TPI pins: */
     pgm->setpin(pgm, PIN_AVR_RESET, 0);
 
-    avrdude_message(MSG_NOTICE2, "doing MOSI-MISO link check\n");
+    msg_notice2("doing MOSI-MISO link check\n");
 
     pgm->setpin(pgm, PIN_AVR_MOSI, 0);
     if (pgm->getpin(pgm, PIN_AVR_MISO) != 0) {
-      avrdude_message(MSG_INFO, "MOSI->MISO 0 failed\n");
+      msg_info("MOSI->MISO 0 failed\n");
       return -1;
     }
     pgm->setpin(pgm, PIN_AVR_MOSI, 1);
     if (pgm->getpin(pgm, PIN_AVR_MISO) != 1) {
-      avrdude_message(MSG_INFO, "MOSI->MISO 1 failed\n");
+      msg_info("MOSI->MISO 1 failed\n");
       return -1;
     }
 
-    avrdude_message(MSG_NOTICE2, "MOSI-MISO link present\n");
+    msg_notice2("MOSI-MISO link present\n");
   }
 
   pgm->setpin(pgm, PIN_AVR_SCK, 0);
@@ -573,7 +573,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     bitbang_tpi_tx(pgm, TPI_CMD_SLDCS | TPI_REG_TPIIR);
     rc = bitbang_tpi_rx(pgm);
     if (rc != 0x80) {
-      avrdude_message(MSG_INFO, "TPIIR not correct\n");
+      msg_info("TPIIR not correct\n");
       return -1;
     }
   } else {
@@ -607,7 +607,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
      * can't sync with the device, maybe it's not attached?
      */
     if (rc) {
-      avrdude_message(MSG_INFO, "%s: AVR device not responding\n", progname);
+      msg_info("%s: AVR device not responding\n", progname);
       return -1;
     }
   }
@@ -617,7 +617,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
 static int verify_pin_assigned(const PROGRAMMER *pgm, int pin, char *desc) {
   if (pgm->pinno[pin] == 0) {
-    avrdude_message(MSG_INFO, "%s: error: no pin has been assigned for %s\n",
+    msg_info("%s: error: no pin has been assigned for %s\n",
             progname, desc);
     return -1;
   }
@@ -640,7 +640,7 @@ int bitbang_check_prerequisites(const PROGRAMMER *pgm) {
     return -1;
 
   if (pgm->cmd == NULL) {
-    avrdude_message(MSG_INFO, "%s: error: no cmd() method defined for bitbang programmer\n",
+    msg_info("%s: error: no cmd() method defined for bitbang programmer\n",
             progname);
     return -1;
   }

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -258,7 +258,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
       break;
   }
   if (b != 0) {
-    pmsg_error("bitbang_tpi_rx: start bit not received correctly\n");
+    pmsg_error("start bit not received correctly\n");
     return -1;
   }
 
@@ -273,7 +273,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
 
   /* parity bit */
   if (bitbang_tpi_clk(pgm) != parity) {
-    pmsg_error("bitbang_tpi_rx: parity bit is wrong\n");
+    pmsg_error("parity bit is wrong\n");
     return -1;
   }
 
@@ -282,7 +282,7 @@ int bitbang_tpi_rx(const PROGRAMMER *pgm)  {
   b &= bitbang_tpi_clk(pgm);
   b &= bitbang_tpi_clk(pgm);
   if (b != 1) {
-    pmsg_error("bitbang_tpi_rx: stop bits not received correctly\n");
+    pmsg_error("stop bits not received correctly\n");
     return -1;
   }
   

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -76,8 +76,7 @@ static void bitbang_calibrate_delay(void)
   if (QueryPerformanceFrequency(&freq))
   {
     has_perfcount = 1;
-    msg_notice2("%s: Using performance counter for bitbang delays\n",
-                    progname);
+    pmsg_notice2("using performance counter for bitbang delays\n");
   }
   else
   {
@@ -90,16 +89,14 @@ static void bitbang_calibrate_delay(void)
      * auto-calibration figures seen on various Unix systems on
      * comparable hardware.
      */
-    msg_notice2("%s: Using guessed per-microsecond delay count for bitbang delays\n",
-                    progname);
+    pmsg_notice2("using guessed per-microsecond delay count for bitbang delays\n");
     delay_decrement = 100;
   }
 #else  /* !WIN32 */
   struct itimerval itv;
   volatile int i;
 
-  msg_notice2("%s: Calibrating delay loop...",
-                  progname);
+  pmsg_notice2("calibrating delay loop ...");
   i = 0;
   done = 0;
   saved_alarmhandler = signal(SIGALRM, alarmhandler);
@@ -455,8 +452,7 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    msg_info("chip erase instruction not defined for part \"%s\"\n",
-            p->desc);
+    msg_info("chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -495,7 +491,7 @@ int bitbang_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-    msg_info("program enable instruction not defined for part \"%s\"\n",
+    msg_info("program enable instruction not defined for part %s\n",
             p->desc);
     return -1;
   }
@@ -527,8 +523,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (p->prog_modes & PM_TPI) {
     /* make sure cmd_tpi() is defined */
     if (pgm->cmd_tpi == NULL) {
-      msg_info("%s: Error: %s programmer does not support TPI\n",
-          progname, pgm->type);
+      pmsg_info("%s programmer does not support TPI\n", pgm->type);
       return -1;
     }
 
@@ -607,7 +602,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
      * can't sync with the device, maybe it's not attached?
      */
     if (rc) {
-      msg_info("%s: AVR device not responding\n", progname);
+      pmsg_info("AVR device not responding\n");
       return -1;
     }
   }
@@ -617,8 +612,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
 static int verify_pin_assigned(const PROGRAMMER *pgm, int pin, char *desc) {
   if (pgm->pinno[pin] == 0) {
-    msg_info("%s: error: no pin has been assigned for %s\n",
-            progname, desc);
+    pmsg_info("no pin has been assigned for %s\n", desc);
     return -1;
   }
   return 0;
@@ -640,8 +634,7 @@ int bitbang_check_prerequisites(const PROGRAMMER *pgm) {
     return -1;
 
   if (pgm->cmd == NULL) {
-    msg_info("%s: error: no cmd() method defined for bitbang programmer\n",
-            progname);
+    pmsg_info("no cmd() method defined for bitbang programmer\n");
     return -1;
   }
   return 0;

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -88,28 +88,28 @@ buspirate_uses_ascii(const PROGRAMMER *pgm) {
 
 /* ====== Serial talker functions - binmode ====== */
 
-static void dump_mem(const int msglvl, const unsigned char *buf, size_t len)
+static void dump_mem(const unsigned char *buf, size_t len)
 {
 	size_t i;
 
 	for (i = 0; i<len; i++) {
 		if (i % 8 == 0)
-			avrdude_message(msglvl, "\t");
-		avrdude_message(msglvl, "0x%02x ", buf[i]);
+			msg_debug("\t");
+		msg_debug("0x%02x ", buf[i]);
 		if (i % 8 == 3)
-			avrdude_message(msglvl, "  ");
+			msg_debug("  ");
 		else if (i % 8 == 7)
-			avrdude_message(msglvl, "\n");
+			msg_debug("\n");
 	}
 	if (i % 8 != 7)
-		avrdude_message(msglvl, "\n");
+		msg_debug("\n");
 }
 
 static int buspirate_send_bin(const PROGRAMMER *pgm, const unsigned char *data, size_t len) {
 	int rc;
 
 	pmsg_debug("buspirate_send_bin():\n");
-	dump_mem(MSG_DEBUG, data, len);
+	dump_mem(data, len);
 
 	rc = serial_send(&pgm->fd, data, len);
 
@@ -124,7 +124,7 @@ static int buspirate_recv_bin(const PROGRAMMER *pgm, unsigned char *buf, size_t 
 		return EOF;
 
 	pmsg_debug("buspirate_recv_bin():\n");
-	dump_mem(MSG_DEBUG, buf, len);
+	dump_mem(buf, len);
 
 	return len;
 }

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -301,7 +301,7 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 		if (sscanf(extended_param, "spifreq=%u", &spifreq) == 1) {
 			if (spifreq & (~0x07)) {
 				pmsg_error("spifreq must be between 0 and 7\n");
-				pmsg_error("see BusPirate manual for details\n");
+				imsg_error("see BusPirate manual for details\n");
 				return -1;
 			}
 			if (PDATA(pgm)->flag & BP_FLAG_XPARM_RAWFREQ) {
@@ -331,7 +331,7 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 			/* lower limit comes from 'cpufreq > 4 * spifreq', spifreq in ascii mode is 30kHz. */
 			if (cpufreq < 125 || cpufreq > 4000) {
 				pmsg_error("cpufreq must be between 125 and 4000 kHz\n");
-				pmsg_error("see BusPirate manual for details\n");
+				imsg_error("see BusPirate manual for details\n");
 				return -1;
 			}
 			PDATA(pgm)->cpufreq = cpufreq;
@@ -645,7 +645,7 @@ static int buspirate_start_spi_mode_ascii(const PROGRAMMER *pgm) {
 	}
 	if (spi_cmd == -1) {
 		pmsg_error("SPI mode number not found; does your BusPirate support SPI?\n");
-		pmsg_error("try powercycling your BusPirate and try again\n");
+		imsg_error("try powercycling your BusPirate and try again\n");
 		return -1;
 	}
 	snprintf(buf, sizeof(buf), "%d\n", spi_cmd);
@@ -787,7 +787,7 @@ static void buspirate_powerup(const PROGRAMMER *pgm) {
 	}
 
 	pmsg_warning("did not get a response to PowerUp command\n");
-	pmsg_warning("trying to continue anyway ...\n");
+	imsg_warning("trying to continue anyway ...\n");
 }
 
 static void buspirate_powerdown(const PROGRAMMER *pgm) {

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -135,7 +135,7 @@ static int buspirate_expect_bin(const PROGRAMMER *pgm,
 {
 	unsigned char *recv_buf = alloca(expect_len);
 	if ((PDATA(pgm)->flag & BP_FLAG_IN_BINMODE) == 0) {
-		pmsg_error("buspirate_send_bin() called from ascii mode\n");
+		pmsg_error("called from ascii mode\n");
 		return -1;
 	}
 
@@ -159,7 +159,7 @@ static int buspirate_getc(const PROGRAMMER *pgm) {
 	unsigned char ch = 0;
 
 	if (PDATA(pgm)->flag & BP_FLAG_IN_BINMODE) {
-		pmsg_error("buspirate_getc() called from binmode\n");
+		pmsg_error("called from binmode\n");
 		return EOF;
 	}
 
@@ -209,7 +209,7 @@ static char *buspirate_readline(const PROGRAMMER *pgm, char *buf, size_t len) {
 
 	ret = buspirate_readline_noexit(pgm, buf, len);
 	if (! ret) {
-		pmsg_error("buspirate_readline(): programmer is not responding\n");
+		pmsg_error("programmer is not responding\n");
 		return NULL;
 	}
 	return ret;
@@ -221,7 +221,7 @@ static int buspirate_send(const PROGRAMMER *pgm, const char *str) {
 	pmsg_debug("buspirate_send(): %s", str);
 
 	if (PDATA(pgm)->flag & BP_FLAG_IN_BINMODE) {
-		pmsg_error("buspirate_send() called from binmode\n");
+		pmsg_error("called from binmode\n");
 		return -1;
 	}
 
@@ -884,7 +884,7 @@ static int buspirate_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
 
 	// This should never happen, but still ...
 	if (PDATA(pgm)->flag & BP_FLAG_NOPAGEDREAD) {
-		pmsg_error("buspirate_paged_load() called while in nopagedread mode\n");
+		pmsg_error("called while in nopagedread mode\n");
 		return -1;
 	}
 
@@ -1093,7 +1093,7 @@ static void buspirate_setup(PROGRAMMER *pgm)
 {
 	/* Allocate private data */
 	if ((pgm->cookie = calloc(1, sizeof(struct pdata))) == 0) {
-		pmsg_error("buspirate_initpgm(): out of memory allocating private data\n");
+		pmsg_error("out of memory allocating private data\n");
 		exit(1);
 	}
 	PDATA(pgm)->serial_recv_timeout = 100;

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -108,7 +108,7 @@ static void dump_mem(const int msglvl, const unsigned char *buf, size_t len)
 static int buspirate_send_bin(const PROGRAMMER *pgm, const unsigned char *data, size_t len) {
 	int rc;
 
-	avrdude_message(MSG_DEBUG, "%s: buspirate_send_bin():\n", progname);
+	msg_debug("%s: buspirate_send_bin():\n", progname);
 	dump_mem(MSG_DEBUG, data, len);
 
 	rc = serial_send(&pgm->fd, data, len);
@@ -123,7 +123,7 @@ static int buspirate_recv_bin(const PROGRAMMER *pgm, unsigned char *buf, size_t 
 	if (rc < 0)
 		return EOF;
 
-	avrdude_message(MSG_DEBUG, "%s: buspirate_recv_bin():\n", progname);
+	msg_debug("%s: buspirate_recv_bin():\n", progname);
 	dump_mem(MSG_DEBUG, buf, len);
 
 	return len;
@@ -135,7 +135,7 @@ static int buspirate_expect_bin(const PROGRAMMER *pgm,
 {
 	unsigned char *recv_buf = alloca(expect_len);
 	if ((PDATA(pgm)->flag & BP_FLAG_IN_BINMODE) == 0) {
-		avrdude_message(MSG_INFO, "BusPirate: Internal error: buspirate_send_bin() called from ascii mode\n");
+		msg_info("BusPirate: Internal error: buspirate_send_bin() called from ascii mode\n");
 		return -1;
 	}
 
@@ -159,7 +159,7 @@ static int buspirate_getc(const PROGRAMMER *pgm) {
 	unsigned char ch = 0;
 
 	if (PDATA(pgm)->flag & BP_FLAG_IN_BINMODE) {
-		avrdude_message(MSG_INFO, "BusPirate: Internal error: buspirate_getc() called from binmode\n");
+		msg_info("BusPirate: Internal error: buspirate_getc() called from binmode\n");
 		return EOF;
 	}
 
@@ -197,7 +197,7 @@ static char *buspirate_readline_noexit(const PROGRAMMER *pgm, char *buf, size_t 
 		serial_recv_timeout = PDATA(pgm)->serial_recv_timeout;
 	}
 	serial_recv_timeout = orig_serial_recv_timeout;
-	avrdude_message(MSG_DEBUG, "%s: buspirate_readline(): %s%s",
+	msg_debug("%s: buspirate_readline(): %s%s",
 	                progname, buf,
 	                buf[strlen(buf) - 1] == '\n' ? "" : "\n");
 	if (! buf[0])
@@ -211,7 +211,7 @@ static char *buspirate_readline(const PROGRAMMER *pgm, char *buf, size_t len) {
 
 	ret = buspirate_readline_noexit(pgm, buf, len);
 	if (! ret) {
-		avrdude_message(MSG_INFO, "%s: buspirate_readline(): programmer is not responding\n",
+		msg_info("%s: buspirate_readline(): programmer is not responding\n",
                                 progname);
 		return NULL;
 	}
@@ -221,10 +221,10 @@ static int buspirate_send(const PROGRAMMER *pgm, const char *str) {
 	int rc;
 	const char * readline;
 
-	avrdude_message(MSG_DEBUG, "%s: buspirate_send(): %s", progname, str);
+	msg_debug("%s: buspirate_send(): %s", progname, str);
 
 	if (PDATA(pgm)->flag & BP_FLAG_IN_BINMODE) {
-		avrdude_message(MSG_INFO, "BusPirate: Internal error: buspirate_send() called from binmode\n");
+		msg_info("BusPirate: Internal error: buspirate_send() called from binmode\n");
 		return -1;
 	}
 
@@ -303,12 +303,12 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 
 		if (sscanf(extended_param, "spifreq=%u", &spifreq) == 1) {
 			if (spifreq & (~0x07)) {
-				avrdude_message(MSG_INFO, "BusPirate: spifreq must be between 0 and 7.\n");
-				avrdude_message(MSG_INFO, "BusPirate: see BusPirate manual for details.\n");
+				msg_info("BusPirate: spifreq must be between 0 and 7.\n");
+				msg_info("BusPirate: see BusPirate manual for details.\n");
 				return -1;
 			}
 			if (PDATA(pgm)->flag & BP_FLAG_XPARM_RAWFREQ) {
-				avrdude_message(MSG_INFO, "BusPirate: set either spifreq or rawfreq\n");
+				msg_info("BusPirate: set either spifreq or rawfreq\n");
 				return -1;
 			}
 			PDATA(pgm)->flag |=  BP_FLAG_XPARM_SPIFREQ;
@@ -318,12 +318,12 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 
 		if (sscanf(extended_param, "rawfreq=%u", &rawfreq) == 1) {
 			if (rawfreq >= 4) {
-				avrdude_message(MSG_INFO, "BusPirate: rawfreq must be "
+				msg_info("BusPirate: rawfreq must be "
 				                "between 0 and 3.\n");
 				return -1;
 			}
 			if (PDATA(pgm)->flag & BP_FLAG_XPARM_SPIFREQ) {
-				avrdude_message(MSG_INFO, "BusPirate: set either spifreq or rawfreq\n");
+				msg_info("BusPirate: set either spifreq or rawfreq\n");
 				return -1;
 			}
 			PDATA(pgm)->flag |=  BP_FLAG_XPARM_RAWFREQ;
@@ -334,8 +334,8 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 		if (sscanf(extended_param, "cpufreq=%u", &cpufreq) == 1) {
 			/* lower limit comes from 'cpufreq > 4 * spifreq', spifreq in ascii mode is 30kHz. */
 			if (cpufreq < 125 || cpufreq > 4000) {
-				avrdude_message(MSG_INFO, "BusPirate: cpufreq must be between 125 and 4000 kHz.\n");
-				avrdude_message(MSG_INFO, "BusPirate: see BusPirate manual for details.\n");
+				msg_info("BusPirate: cpufreq must be between 125 and 4000 kHz.\n");
+				msg_info("BusPirate: see BusPirate manual for details.\n");
 				return -1;
 			}
 			PDATA(pgm)->cpufreq = cpufreq;
@@ -354,7 +354,7 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 				else if (strcasecmp(resetpin, "aux2") == 0)
 					PDATA(pgm)->reset |= BP_RESET_AUX2;
 				else {
-					avrdude_message(MSG_INFO, "BusPirate: reset must be either CS or AUX.\n");
+					msg_info("BusPirate: reset must be either CS or AUX.\n");
 					return -1;
 				}
 			}
@@ -374,14 +374,14 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 
 		if (sscanf(extended_param, "serial_recv_timeout=%d", &serial_recv_timeout) == 1) {
 			if (serial_recv_timeout < 1) {
-				avrdude_message(MSG_INFO, "BusPirate: serial_recv_timeout must be greater 0.\n");
+				msg_info("BusPirate: serial_recv_timeout must be greater 0.\n");
 				return -1;
 			}
 			PDATA(pgm)->serial_recv_timeout = serial_recv_timeout;
 			continue;
 		}
 
-		avrdude_message(MSG_INFO, "BusPirate: do not understand extended param '%s'.\n", extended_param);
+		msg_info("BusPirate: do not understand extended param '%s'.\n", extended_param);
 		return -1;
 	}
 
@@ -395,13 +395,13 @@ buspirate_verifyconfig(const PROGRAMMER *pgm) {
 		PDATA(pgm)->reset |= BP_RESET_CS;
 
 	if ((PDATA(pgm)->reset != BP_RESET_CS) && buspirate_uses_ascii(pgm)) {
-		avrdude_message(MSG_INFO, "BusPirate: RESET pin other than CS is not supported in ASCII mode\n");
+		msg_info("BusPirate: RESET pin other than CS is not supported in ASCII mode\n");
 		return -1;
 	}
 
 	if (  ((PDATA(pgm)->flag & BP_FLAG_XPARM_SPIFREQ) || (PDATA(pgm)->flag & BP_FLAG_XPARM_RAWFREQ))
 	   && buspirate_uses_ascii(pgm)) {
-		avrdude_message(MSG_INFO, "BusPirate: SPI speed selection is not supported in ASCII mode\n");
+		msg_info("BusPirate: SPI speed selection is not supported in ASCII mode\n");
 		return -1;
 	}
 
@@ -444,13 +444,13 @@ static void buspirate_reset_from_binmode(const PROGRAMMER *pgm) {
 	if (PDATA(pgm)->flag & BP_FLAG_XPARM_CPUFREQ) {
 		/* disable pwm */
 		if (buspirate_expect_bin_byte(pgm, 0x13, 0x01) != 1) {
-			avrdude_message(MSG_INFO, "%s: warning: did not get a response to stop PWM command.\n", progname);
+			msg_info("%s: warning: did not get a response to stop PWM command.\n", progname);
 		}
 	}
 	/* 0b0100wxyz - Configure peripherals w=power, x=pull-ups, y=AUX, z=CS
 	 * we want everything off -- 0b01000000 = 0x40 */
 	if (buspirate_expect_bin_byte(pgm, 0x40, 0x00) == 1) {
-		avrdude_message(MSG_INFO, "%s: warning: did not get a response to power off command.\n", progname);
+		msg_info("%s: warning: did not get a response to power off command.\n", progname);
 	}
 
 	buf[0] = 0x0F;	/* BinMode: reset */
@@ -472,11 +472,11 @@ static void buspirate_reset_from_binmode(const PROGRAMMER *pgm) {
 	}
 
 	if (PDATA(pgm)->flag & BP_FLAG_IN_BINMODE) {
-		avrdude_message(MSG_INFO, "BusPirate reset failed. You may need to powercycle it.\n");
+		msg_info("BusPirate reset failed. You may need to powercycle it.\n");
 		return;
 	}
 
-	avrdude_message(MSG_NOTICE, "BusPirate is back in the text mode\n");
+	msg_notice("BusPirate is back in the text mode\n");
 }
 
 static int buspirate_start_mode_bin(PROGRAMMER *pgm)
@@ -517,11 +517,11 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 	memset(buf, 0, sizeof(buf));
 	buspirate_recv_bin(pgm, buf, 5);
 	if (sscanf((const char*)buf, "BBIO%1d", &PDATA(pgm)->binmode_version) != 1) {
-		avrdude_message(MSG_INFO, "Binary mode not confirmed: '%s'\n", buf);
+		msg_info("Binary mode not confirmed: '%s'\n", buf);
 		buspirate_reset_from_binmode(pgm);
 		return -1;
 	}
-	avrdude_message(MSG_NOTICE, "BusPirate binmode version: %d\n",
+	msg_notice("BusPirate binmode version: %d\n",
                 PDATA(pgm)->binmode_version);
 
 	PDATA(pgm)->flag |= BP_FLAG_IN_BINMODE;
@@ -533,8 +533,8 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 		pwm_period = 16000/(PDATA(pgm)->cpufreq) - 1; // oscillator runs at 32MHz, we don't use a prescaler
 		pwm_duty = pwm_period/2; // 50% duty cycle
 
-		avrdude_message(MSG_NOTICE, "Setting up PWM for cpufreq\n");
-		avrdude_message(MSG_DEBUG, "PWM settings: Prescaler=1, Duty Cycle=%hd, Period=%hd\n", pwm_duty, pwm_period);
+		msg_notice("Setting up PWM for cpufreq\n");
+		msg_debug("PWM settings: Prescaler=1, Duty Cycle=%hd, Period=%hd\n", pwm_duty, pwm_period);
 
 		buf[0] = 0x12; // pwm setup
 		buf[1] = 0; // prescaler 1
@@ -546,7 +546,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 
 		buspirate_recv_bin(pgm, buf, 1);
 		if (buf[0] != 0x01)
-			avrdude_message(MSG_INFO, "cpufreq (PWM) setup failed\n");
+			msg_info("cpufreq (PWM) setup failed\n");
 	}
 
 	/* == Set protocol sub-mode of binary mode == */
@@ -555,16 +555,15 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 	memset(buf, 0, sizeof(buf));
 	buspirate_recv_bin(pgm, buf, 4);
 	if (sscanf((const char*)buf, submode.entered_format, &PDATA(pgm)->submode_version) != 1) {
-		avrdude_message(MSG_INFO, "%s mode not confirmed: '%s'\n",
+		msg_info("%s mode not confirmed: '%s'\n",
 		                submode.name, buf);
 		buspirate_reset_from_binmode(pgm);
 		return -1;
 	}
-	avrdude_message(MSG_NOTICE, "BusPirate %s version: %d\n", 
-	                submode.name, PDATA(pgm)->submode_version);
-
+	msg_notice("BusPirate %s version: %d\n",
+		submode.name, PDATA(pgm)->submode_version);
 	if (PDATA(pgm)->flag & BP_FLAG_NOPAGEDWRITE) {
-                avrdude_message(MSG_NOTICE, "%s: Paged flash write disabled.\n", progname);
+                msg_notice("%s: Paged flash write disabled.\n", progname);
 		pgm->paged_write = NULL;
 	} else {
 		/* Check for write-then-read without !CS/CS and disable paged_write if absent: */
@@ -581,12 +580,12 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 			buf[0] = 0x1;
 			buspirate_send_bin(pgm, buf, 1);
 
-			avrdude_message(MSG_NOTICE, "%s: Disabling paged flash write. (Need BusPirate firmware >=v5.10.)\n", progname);
+			msg_notice("%s: Disabling paged flash write. (Need BusPirate firmware >=v5.10.)\n", progname);
 
 			/* Flush serial buffer: */
 			serial_drain(&pgm->fd, 0);
 		} else {
-			avrdude_message(MSG_INFO, "%s: Paged flash write enabled.\n", progname);
+			msg_info("%s: Paged flash write enabled.\n", progname);
 		}
 	}
 
@@ -607,7 +606,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 
 	/* AVR Extended Commands - test for existence */
 	if (PDATA(pgm)->flag & BP_FLAG_NOPAGEDREAD) {
-                avrdude_message(MSG_NOTICE, "%s: Paged flash read disabled.\n", progname);
+                msg_notice("%s: Paged flash read disabled.\n", progname);
 		pgm->paged_load = NULL;
 	} else {
 		int rv = buspirate_expect_bin_byte(pgm, 0x06, 0x01);
@@ -619,9 +618,9 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 			buspirate_send_bin(pgm, buf2, sizeof(buf2));
 			buspirate_recv_bin(pgm, buf, 3);
 			ver = buf[1] << 8 | buf[2];
-			avrdude_message(MSG_NOTICE, "AVR Extended Commands version %d\n", ver);
+			msg_notice("AVR Extended Commands version %d\n", ver);
 		} else {
-			avrdude_message(MSG_NOTICE, "AVR Extended Commands not found.\n");
+			msg_notice("AVR Extended Commands not found.\n");
 			PDATA(pgm)->flag |= BP_FLAG_NOPAGEDREAD;
 			pgm->paged_load = NULL;
 		}
@@ -651,9 +650,9 @@ static int buspirate_start_spi_mode_ascii(const PROGRAMMER *pgm) {
 			break;
 	}
 	if (spi_cmd == -1) {
-		avrdude_message(MSG_INFO, "%s: SPI mode number not found. Does your BusPirate support SPI?\n",
+		msg_info("%s: SPI mode number not found. Does your BusPirate support SPI?\n",
 				progname);
-		avrdude_message(MSG_INFO, "%s: Try powercycling your BusPirate and try again.\n",
+		msg_info("%s: Try powercycling your BusPirate and try again.\n",
 				progname);
 		return -1;
 	}
@@ -674,7 +673,7 @@ static int buspirate_start_spi_mode_ascii(const PROGRAMMER *pgm) {
 		}
 		if (buspirate_is_prompt(rcvd)) {
 			if (strncmp(rcvd, "SPI>", 4) == 0) {
-				avrdude_message(MSG_INFO, "BusPirate is now configured for SPI\n");
+				msg_info("BusPirate is now configured for SPI\n");
 				break;
 			}
 			/* Not yet 'SPI>' prompt */
@@ -700,7 +699,7 @@ static void buspirate_enable(PROGRAMMER *pgm, const AVRPART *p) {
 
 	/* Attempt to start binary SPI mode unless explicitly told otherwise: */
 	if (!buspirate_uses_ascii(pgm)) {
-		avrdude_message(MSG_INFO, "Attempting to initiate BusPirate binary mode...\n");
+		msg_info("Attempting to initiate BusPirate binary mode...\n");
 
 		/* Send two CRs to ensure we're not in a sub-menu of the UI if we're in ASCII mode: */
 		buspirate_send_bin(pgm, (const unsigned char*)"\n\n", 2);
@@ -712,23 +711,23 @@ static void buspirate_enable(PROGRAMMER *pgm, const AVRPART *p) {
 		if (buspirate_start_mode_bin(pgm) >= 0)
 			return;
 		else
-			avrdude_message(MSG_INFO, "%s: Failed to start binary mode, falling back to ASCII...\n", progname);
+			msg_info("%s: Failed to start binary mode, falling back to ASCII...\n", progname);
 	}
 
-	avrdude_message(MSG_INFO, "Attempting to initiate BusPirate ASCII mode...\n");
+	msg_info("Attempting to initiate BusPirate ASCII mode...\n");
 
 	/* Call buspirate_send_bin() instead of buspirate_send() 
 	 * because we don't know if BP is in text or bin mode */
 	rc = buspirate_send_bin(pgm, (const unsigned char*)reset_str, strlen(reset_str));
 	if (rc) {
-		avrdude_message(MSG_INFO, "BusPirate is not responding. Serial port error: %d\n", rc);
+		msg_info("BusPirate is not responding. Serial port error: %d\n", rc);
 		return;
 	}
 
 	while(1) {
 		rcvd = buspirate_readline_noexit(pgm, NULL, 0);
 		if (! rcvd) {
-			avrdude_message(MSG_INFO, "%s: Fatal: Programmer is not responding.\n", progname);
+			msg_info("%s: Fatal: Programmer is not responding.\n", progname);
 			return;
 		}
 		if (strncmp(rcvd, "Are you sure?", 13) == 0) {
@@ -739,17 +738,17 @@ static void buspirate_enable(PROGRAMMER *pgm, const AVRPART *p) {
 			continue;
 		}
 		if (buspirate_is_prompt(rcvd)) {
-			avrdude_message(MSG_DEBUG, "**\n");
+			msg_debug("**\n");
 			break;
 		}
 		if (print_banner)
-			avrdude_message(MSG_DEBUG, "**  %s", rcvd);
+			msg_debug("**  %s", rcvd);
 	}
 
 	if (!(PDATA(pgm)->flag & BP_FLAG_IN_BINMODE)) {
-		avrdude_message(MSG_INFO, "BusPirate: using ASCII mode\n");
+		msg_info("BusPirate: using ASCII mode\n");
 		if (buspirate_start_spi_mode_ascii(pgm) < 0) {
-			avrdude_message(MSG_INFO, "%s: Failed to start ascii SPI mode\n", progname);
+			msg_info("%s: Failed to start ascii SPI mode\n", progname);
 			return;
 		}
 	}
@@ -788,15 +787,15 @@ static void buspirate_powerup(const PROGRAMMER *pgm) {
 					}
 				}
 				if(!ok) {
-					avrdude_message(MSG_INFO, "%s: warning: did not get a response to start PWM command.\n", progname);
+					msg_info("%s: warning: did not get a response to start PWM command.\n", progname);
 				}
 			}
 			return;
 		}
 	}
 
-	avrdude_message(MSG_INFO, "%s: warning: did not get a response to PowerUp command.\n", progname);
-	avrdude_message(MSG_INFO, "%s: warning: Trying to continue anyway...\n", progname);
+	msg_info("%s: warning: did not get a response to PowerUp command.\n", progname);
+	msg_info("%s: warning: Trying to continue anyway...\n", progname);
 }
 
 static void buspirate_powerdown(const PROGRAMMER *pgm) {
@@ -806,14 +805,14 @@ static void buspirate_powerdown(const PROGRAMMER *pgm) {
 	} else {
 		if (PDATA(pgm)->flag & BP_FLAG_XPARM_CPUFREQ) {
 			if (!buspirate_expect(pgm, "g\n", "PWM disabled", 1)) {
-				avrdude_message(MSG_INFO, "%s: warning: did not get a response to stop PWM command.\n", progname);
+				msg_info("%s: warning: did not get a response to stop PWM command.\n", progname);
 			}
 		}
 		if (buspirate_expect(pgm, "w\n", "POWER SUPPLIES OFF", 1))
 			return;
 	}
 
-	avrdude_message(MSG_INFO, "%s: warning: did not get a response to PowerDown command.\n", progname);
+	msg_info("%s: warning: did not get a response to PowerDown command.\n", progname);
 }
 
 static int buspirate_cmd_bin(const PROGRAMMER *pgm,
@@ -860,7 +859,7 @@ static int buspirate_cmd_ascii(const PROGRAMMER *pgm,
 	}
 
 	if (i != 4) {
-		avrdude_message(MSG_INFO, "%s: error: SPI has not read 4 bytes back\n", progname);
+		msg_info("%s: error: SPI has not read 4 bytes back\n", progname);
 		return -1;
 	}
 
@@ -889,11 +888,11 @@ static int buspirate_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
 	unsigned char buf[275];
 	unsigned int addr = 0;
 
-	avrdude_message(MSG_NOTICE, "BusPirate: buspirate_paged_load(..,%s,%d,%d,%d)\n",m->desc,m->page_size,address,n_bytes);
+	msg_notice("BusPirate: buspirate_paged_load(..,%s,%d,%d,%d)\n",m->desc,m->page_size,address,n_bytes);
 
 	// This should never happen, but still...
 	if (PDATA(pgm)->flag & BP_FLAG_NOPAGEDREAD) {
-		avrdude_message(MSG_INFO, "BusPirate: buspirate_paged_load() called while in nopagedread mode!\n");
+		msg_info("BusPirate: buspirate_paged_load() called while in nopagedread mode!\n");
 		return -1;
 	}
 
@@ -923,7 +922,7 @@ static int buspirate_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
 	buspirate_recv_bin(pgm, buf, 1);
 
 	if (buf[0] != 0x01) {
-		avrdude_message(MSG_INFO, "BusPirate: Paged Read command returned zero.\n");
+		msg_info("BusPirate: Paged Read command returned zero.\n");
 		return -1;
 	}
 
@@ -966,12 +965,12 @@ static int buspirate_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const 
 
 	/* pre-check opcodes */
 	if (m->op[AVR_OP_LOADPAGE_LO] == NULL) {
-		avrdude_message(MSG_INFO, "%s failure: %s command not defined for %s\n",
+		msg_info("%s failure: %s command not defined for %s\n",
 		                progname, "AVR_OP_LOADPAGE_LO", p->desc);
 		return -1;
 	}
 	if (m->op[AVR_OP_LOADPAGE_HI] == NULL) {
-		avrdude_message(MSG_INFO, "%s failure: %s command not defined for %s\n",
+		msg_info("%s failure: %s command not defined for %s\n",
 		                progname, "AVR_OP_LOADPAGE_HI", p->desc);
 		return -1;
 	}
@@ -1032,7 +1031,7 @@ static int buspirate_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const 
 
 		/* Check for write failure: */
 		if ((buspirate_recv_bin(pgm, &recv_byte, 1) == EOF) || (recv_byte != 0x01)) {
-			avrdude_message(MSG_INFO, "BusPirate: Fatal error: Write Then Read did not succeed.\n");
+			msg_info("BusPirate: Fatal error: Write Then Read did not succeed.\n");
 			pgm->pgm_led(pgm, OFF);
 			pgm->err_led(pgm, ON);
 			return -1;
@@ -1062,7 +1061,7 @@ static int buspirate_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 		buspirate_expect(pgm, "{\n", "CS ENABLED", 1);
 
 	if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-		avrdude_message(MSG_INFO, "program enable instruction not defined for part \"%s\"\n",
+		msg_info("program enable instruction not defined for part \"%s\"\n",
 		                p->desc);
 		return -1;
 	}
@@ -1082,7 +1081,7 @@ static int buspirate_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 	unsigned char res[4];
 
 	if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-		avrdude_message(MSG_INFO, "chip erase instruction not defined for part \"%s\"\n",
+		msg_info("chip erase instruction not defined for part \"%s\"\n",
 		                p->desc);
 		return -1;
 	}
@@ -1106,7 +1105,7 @@ static void buspirate_setup(PROGRAMMER *pgm)
 {
 	/* Allocate private data */
 	if ((pgm->cookie = calloc(1, sizeof(struct pdata))) == 0) {
-		avrdude_message(MSG_INFO, "%s: buspirate_initpgm(): Out of memory allocating private data\n",
+		msg_info("%s: buspirate_initpgm(): Out of memory allocating private data\n",
 		                progname);
 		exit(1);
 	}
@@ -1158,7 +1157,7 @@ static void buspirate_bb_enable(PROGRAMMER *pgm, const AVRPART *p) {
 	if (bitbang_check_prerequisites(pgm) < 0)
 		return;             /* XXX should treat as error */
 
-	avrdude_message(MSG_INFO, "Attempting to initiate BusPirate bitbang binary mode...\n");
+	msg_info("Attempting to initiate BusPirate bitbang binary mode...\n");
 
 	/* Send two CRs to ensure we're not in a sub-menu of the UI if we're in ASCII mode: */
 	buspirate_send_bin(pgm, (const unsigned char*)"\n\n", 2);
@@ -1173,11 +1172,11 @@ static void buspirate_bb_enable(PROGRAMMER *pgm, const AVRPART *p) {
 	memset(buf, 0, sizeof(buf));
 	buspirate_recv_bin(pgm, buf, 5);
 	if (sscanf((char*)buf, "BBIO%1d", &PDATA(pgm)->binmode_version) != 1) {
-		avrdude_message(MSG_INFO, "Binary mode not confirmed: '%s'\n", buf);
+		msg_info("Binary mode not confirmed: '%s'\n", buf);
 		buspirate_reset_from_binmode(pgm);
 		return;
 	}
-	avrdude_message(MSG_INFO, "BusPirate binmode version: %d\n",
+	msg_info("BusPirate binmode version: %d\n",
 	                PDATA(pgm)->binmode_version);
 
 	PDATA(pgm)->flag |= BP_FLAG_IN_BINMODE;
@@ -1241,7 +1240,7 @@ static int buspirate_bb_getpin(const PROGRAMMER *pgm, int pinfunc) {
 	if (buf[0] & (1 << (pin - 1)))
 		value ^= 1;
 
-	avrdude_message(MSG_DEBUG, "get pin %d = %d\n", pin, value);
+	msg_debug("get pin %d = %d\n", pin, value);
 
 	return value;
 }
@@ -1257,7 +1256,7 @@ static int buspirate_bb_setpin_internal(const PROGRAMMER *pgm, int pin, int valu
 	if ((pin < 1 || pin > 5) && (pin != 7)) // 7 is POWER
 		return -1;
 
-	avrdude_message(MSG_DEBUG, "set pin %d = %d\n", pin, value);
+	msg_debug("set pin %d = %d\n", pin, value);
 
 	if (value)
 		PDATA(pgm)->pin_val |= (1 << (pin - 1));

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -63,7 +63,7 @@ struct pdata
 static void butterfly_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("butterfly_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -84,7 +84,7 @@ static int butterfly_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
   if (rv < 0) {
-    pmsg_error("butterfly_recv(): programmer is not responding\n");
+    pmsg_error("programmer is not responding\n");
     return -1;
   }
   return 0;
@@ -542,7 +542,7 @@ static int butterfly_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const A
     return -1;            /* not supported */
   if (strcmp(m->desc, "eeprom") == 0)
     return 0;             /* nothing to do */
-  pmsg_warning("butterfly_page_erase() called on memory type %s\n", m->desc);
+  pmsg_warning("called on memory type %s\n", m->desc);
   return -1;
 }
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -63,8 +63,7 @@ struct pdata
 static void butterfly_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: butterfly_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("butterfly_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -85,8 +84,7 @@ static int butterfly_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
   if (rv < 0) {
-    msg_info("%s: butterfly_recv(): programmer is not responding\n",
-                    progname);
+    pmsg_info("butterfly_recv(): programmer is not responding\n");
     return -1;
   }
   return 0;
@@ -103,8 +101,7 @@ static int butterfly_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
 
   butterfly_recv(pgm, &c, 1);
   if (c != '\r') {
-    msg_info("%s: error: programmer did not respond to command: %s\n",
-            progname, errmsg);
+    pmsg_info("error: programmer did not respond to command: %s\n", errmsg);
     return -1;
   }
   return 0;
@@ -278,10 +275,10 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   butterfly_send(pgm, "p", 1);
   butterfly_recv(pgm, &type, 1);
 
-  msg_info("Found programmer: Id = \"%s\"; type = %c\n", id, type);
+  msg_info("Found programmer: Id = %s; type = %c\n", id, type);
   msg_info("    Software Version = %c.%c; ", sw[0], sw[1]);
   if (hw[0]=='?') {
-    msg_info("No Hardware Version given.\n");
+    msg_info("no hardware version given\n");
   } else {
     msg_info("Hardware Version = %c.%c\n", hw[0], hw[1]);
   };
@@ -291,22 +288,22 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   butterfly_send(pgm, "a", 1);
   butterfly_recv(pgm, &PDATA(pgm)->has_auto_incr_addr, 1);
   if (PDATA(pgm)->has_auto_incr_addr == 'Y')
-      msg_info("Programmer supports auto addr increment.\n");
+      msg_info("programmer supports auto addr increment\n");
 
   /* Check support for buffered memory access, abort if not available */
 
   butterfly_send(pgm, "b", 1);
   butterfly_recv(pgm, &c, 1);
   if (c != 'Y') {
-    msg_info("%s: error: buffered memory access not supported. Maybe it isn't\n"\
-                    "a butterfly/AVR109 but a AVR910 device?\n", progname);
+    pmsg_info("error: buffered memory access not supported. Maybe it isn't\n"\
+      "a butterfly/AVR109 but a AVR910 device?\n");
     return -1;
   };
   butterfly_recv(pgm, &c, 1);
   PDATA(pgm)->buffersize = (unsigned int)(unsigned char)c<<8;
   butterfly_recv(pgm, &c, 1);
   PDATA(pgm)->buffersize += (unsigned int)(unsigned char)c;
-  msg_info("Programmer supports buffered memory access with buffersize=%i bytes.\n",
+  msg_info("programmer supports buffered memory access with buffersize=%i bytes\n",
                   PDATA(pgm)->buffersize);
 
   /* Get list of devices that the programmer supports. */
@@ -341,8 +338,7 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       return -1;
 
   if (verbose)
-    msg_info("%s: devcode selected: 0x%02x\n",
-                    progname, (unsigned)buf[1]);
+    pmsg_info("devcode selected: 0x%02x\n", (unsigned) buf[1]);
 
   butterfly_enter_prog_mode(pgm);
   butterfly_drain(pgm, 0);
@@ -545,8 +541,7 @@ static int butterfly_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const A
     return -1;            /* not supported */
   if (strcmp(m->desc, "eeprom") == 0)
     return 0;             /* nothing to do */
-  msg_info("%s: butterfly_page_erase() called on memory type \"%s\"\n",
-                  progname, m->desc);
+  pmsg_info("butterfly_page_erase() called on memory type %s\n", m->desc);
   return -1;
 }
 
@@ -697,7 +692,7 @@ static int butterfly_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, con
   unsigned char tmp;
 
   if (m->size < 3) {
-    msg_info("%s: memsize too small for sig byte read", progname);
+    pmsg_info("memsize too small for sig byte read");
     return -1;
   }
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -63,7 +63,7 @@ struct pdata
 static void butterfly_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: butterfly_setup(): Out of memory allocating private data\n",
+    msg_info("%s: butterfly_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -85,7 +85,7 @@ static int butterfly_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
   if (rv < 0) {
-    avrdude_message(MSG_INFO, "%s: butterfly_recv(): programmer is not responding\n",
+    msg_info("%s: butterfly_recv(): programmer is not responding\n",
                     progname);
     return -1;
   }
@@ -103,7 +103,7 @@ static int butterfly_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
 
   butterfly_recv(pgm, &c, 1);
   if (c != '\r') {
-    avrdude_message(MSG_INFO, "%s: error: programmer did not respond to command: %s\n",
+    msg_info("%s: error: programmer did not respond to command: %s\n",
             progname, errmsg);
     return -1;
   }
@@ -207,7 +207,7 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
    * Send some ESC to activate butterfly bootloader.  This is not needed
    * for plain avr109 bootloaders but does not harm there either.
    */
-  avrdude_message(MSG_INFO, "Connecting to programmer: ");
+  msg_info("Connecting to programmer: ");
   if (pgm->flag & IS_BUTTERFLY_MK)
     {
       char mk_reset_cmd[6] = {"#aR@S\r"};
@@ -231,7 +231,7 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       butterfly_recv(pgm, &c, 1);
       if ( c != 'M' && c != '?')
         {
-          avrdude_message(MSG_INFO, "\nConnection FAILED.");
+          msg_info("\nConnection FAILED.");
           return -1;
         }
       else
@@ -278,12 +278,12 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   butterfly_send(pgm, "p", 1);
   butterfly_recv(pgm, &type, 1);
 
-  avrdude_message(MSG_INFO, "Found programmer: Id = \"%s\"; type = %c\n", id, type);
-  avrdude_message(MSG_INFO, "    Software Version = %c.%c; ", sw[0], sw[1]);
+  msg_info("Found programmer: Id = \"%s\"; type = %c\n", id, type);
+  msg_info("    Software Version = %c.%c; ", sw[0], sw[1]);
   if (hw[0]=='?') {
-    avrdude_message(MSG_INFO, "No Hardware Version given.\n");
+    msg_info("No Hardware Version given.\n");
   } else {
-    avrdude_message(MSG_INFO, "Hardware Version = %c.%c\n", hw[0], hw[1]);
+    msg_info("Hardware Version = %c.%c\n", hw[0], hw[1]);
   };
 
   /* See if programmer supports autoincrement of address. */
@@ -291,14 +291,14 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   butterfly_send(pgm, "a", 1);
   butterfly_recv(pgm, &PDATA(pgm)->has_auto_incr_addr, 1);
   if (PDATA(pgm)->has_auto_incr_addr == 'Y')
-      avrdude_message(MSG_INFO, "Programmer supports auto addr increment.\n");
+      msg_info("Programmer supports auto addr increment.\n");
 
   /* Check support for buffered memory access, abort if not available */
 
   butterfly_send(pgm, "b", 1);
   butterfly_recv(pgm, &c, 1);
   if (c != 'Y') {
-    avrdude_message(MSG_INFO, "%s: error: buffered memory access not supported. Maybe it isn't\n"\
+    msg_info("%s: error: buffered memory access not supported. Maybe it isn't\n"\
                     "a butterfly/AVR109 but a AVR910 device?\n", progname);
     return -1;
   };
@@ -306,13 +306,13 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   PDATA(pgm)->buffersize = (unsigned int)(unsigned char)c<<8;
   butterfly_recv(pgm, &c, 1);
   PDATA(pgm)->buffersize += (unsigned int)(unsigned char)c;
-  avrdude_message(MSG_INFO, "Programmer supports buffered memory access with buffersize=%i bytes.\n",
+  msg_info("Programmer supports buffered memory access with buffersize=%i bytes.\n",
                   PDATA(pgm)->buffersize);
 
   /* Get list of devices that the programmer supports. */
 
   butterfly_send(pgm, "t", 1);
-  avrdude_message(MSG_INFO, "\nProgrammer supports the following devices:\n");
+  msg_info("\nProgrammer supports the following devices:\n");
   devtype_1st = 0;
   while (1) {
     butterfly_recv(pgm, &c, 1);
@@ -321,9 +321,9 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (c == 0)
       break;
-    avrdude_message(MSG_INFO, "    Device code: 0x%02x\n", (unsigned int)(unsigned char)c);
+    msg_info("    Device code: 0x%02x\n", (unsigned int)(unsigned char)c);
   };
-  avrdude_message(MSG_INFO, "\n");
+  msg_info("\n");
 
   /* Tell the programmer which part we selected.
      According to the AVR109 code, this is ignored by the bootloader.  As
@@ -341,7 +341,7 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       return -1;
 
   if (verbose)
-    avrdude_message(MSG_INFO, "%s: devcode selected: 0x%02x\n",
+    msg_info("%s: devcode selected: 0x%02x\n",
                     progname, (unsigned)buf[1]);
 
   butterfly_enter_prog_mode(pgm);
@@ -545,7 +545,7 @@ static int butterfly_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const A
     return -1;            /* not supported */
   if (strcmp(m->desc, "eeprom") == 0)
     return 0;             /* nothing to do */
-  avrdude_message(MSG_INFO, "%s: butterfly_page_erase() called on memory type \"%s\"\n",
+  msg_info("%s: butterfly_page_erase() called on memory type \"%s\"\n",
                   progname, m->desc);
   return -1;
 }
@@ -697,7 +697,7 @@ static int butterfly_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, con
   unsigned char tmp;
 
   if (m->size < 3) {
-    avrdude_message(MSG_INFO, "%s: memsize too small for sig byte read", progname);
+    msg_info("%s: memsize too small for sig byte read", progname);
     return -1;
   }
 

--- a/src/config.c
+++ b/src/config.c
@@ -102,7 +102,7 @@ int init_config(void)
 void *cfg_malloc(const char *funcname, size_t n) {
   void *ret = malloc(n);
   if(!ret) {
-    msg_info("%s: out of memory in %s (needed %lu bytes)\n", progname, funcname, (unsigned long) n);
+    pmsg_info("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
     exit(1);
   }
   memset(ret, 0, n);
@@ -113,7 +113,7 @@ void *cfg_realloc(const char *funcname, void *p, size_t n) {
   void *ret;
 
   if(!(ret = p? realloc(p, n): calloc(1, n))) {
-    msg_info("%s: out of memory in %s (needed %lu bytes)\n", progname, funcname, (unsigned long) n);
+    pmsg_info("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
     exit(1);
   }
 
@@ -124,7 +124,7 @@ void *cfg_realloc(const char *funcname, void *p, size_t n) {
 char *cfg_strdup(const char *funcname, const char *s) {
   char *ret = strdup(s);
   if(!ret) {
-    msg_info("%s: out of memory in %s\n", progname, funcname);
+    pmsg_info("out of memory in %s\n", funcname);
     exit(1);
   }
   return ret;
@@ -146,7 +146,7 @@ int yyerror(char * errmsg, ...)
   va_start(args, errmsg);
 
   vsnprintf(message, sizeof(message), errmsg, args);
-  msg_info("%s: error at %s:%d: %s\n", progname, cfg_infile, cfg_lineno, message);
+  pmsg_info("error at %s:%d: %s\n", cfg_infile, cfg_lineno, message);
 
   va_end(args);
 
@@ -163,7 +163,7 @@ int yywarning(char * errmsg, ...)
   va_start(args, errmsg);
 
   vsnprintf(message, sizeof(message), errmsg, args);
-  msg_info("%s: warning at %s:%d: %s\n", progname, cfg_infile, cfg_lineno, message);
+  pmsg_info("warning at %s:%d: %s\n", cfg_infile, cfg_lineno, message);
 
   va_end(args);
 
@@ -240,7 +240,7 @@ TOKEN *new_hexnumber(const char *text) {
   tkn->value.type   = V_NUM;
   tkn->value.number = strtoul(text, &e, 16);
   if ((e == text) || (*e != 0)) {
-    yyerror("can't scan hex number \"%s\"", text);
+    yyerror("cannot scan hex number %s", text);
     free_token(tkn);
     return NULL;
   }
@@ -335,7 +335,7 @@ void print_token(TOKEN * tkn)
 void pyytext(void)
 {
 #if DEBUG
-  msg_info("TOKEN: \"%s\"\n", yytext);
+  msg_info("TOKEN: %s\n", yytext);
 #endif
 }
 
@@ -351,15 +351,13 @@ int read_config(const char * file)
   int r;
 
   if(!(cfg_infile = realpath(file, NULL))) {
-    msg_info("%s: can't determine realpath() of config file \"%s\": %s\n",
-            progname, file, strerror(errno));
+    pmsg_info("cannot determine realpath() of config file %s: %s\n", file, strerror(errno));
     return -1;
   }
 
   f = fopen(cfg_infile, "r");
   if (f == NULL) {
-    msg_info("%s: can't open config file \"%s\": %s\n",
-            progname, cfg_infile, strerror(errno));
+    pmsg_info("cannot open config file %s: %s\n", cfg_infile, strerror(errno));
     free(cfg_infile);
     cfg_infile = NULL;
     return -1;

--- a/src/config.c
+++ b/src/config.c
@@ -102,7 +102,7 @@ int init_config(void)
 void *cfg_malloc(const char *funcname, size_t n) {
   void *ret = malloc(n);
   if(!ret) {
-    pmsg_info("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
+    pmsg_error("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
     exit(1);
   }
   memset(ret, 0, n);
@@ -113,7 +113,7 @@ void *cfg_realloc(const char *funcname, void *p, size_t n) {
   void *ret;
 
   if(!(ret = p? realloc(p, n): calloc(1, n))) {
-    pmsg_info("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
+    pmsg_error("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
     exit(1);
   }
 
@@ -124,7 +124,7 @@ void *cfg_realloc(const char *funcname, void *p, size_t n) {
 char *cfg_strdup(const char *funcname, const char *s) {
   char *ret = strdup(s);
   if(!ret) {
-    pmsg_info("out of memory in %s\n", funcname);
+    pmsg_error("out of memory in %s\n", funcname);
     exit(1);
   }
   return ret;
@@ -146,7 +146,7 @@ int yyerror(char * errmsg, ...)
   va_start(args, errmsg);
 
   vsnprintf(message, sizeof(message), errmsg, args);
-  pmsg_info("error at %s:%d: %s\n", cfg_infile, cfg_lineno, message);
+  pmsg_error("%s [%s:%d]\n", message, cfg_infile, cfg_lineno);
 
   va_end(args);
 
@@ -163,7 +163,7 @@ int yywarning(char * errmsg, ...)
   va_start(args, errmsg);
 
   vsnprintf(message, sizeof(message), errmsg, args);
-  pmsg_info("warning at %s:%d: %s\n", cfg_infile, cfg_lineno, message);
+  pmsg_warning("%s [%s:%d]\n", message, cfg_infile, cfg_lineno);
 
   va_end(args);
 
@@ -246,7 +246,7 @@ TOKEN *new_hexnumber(const char *text) {
   }
   
 #if DEBUG
-  msg_info("HEXNUMBER(%g)\n", tkn->value.number);
+  msg_info("HEXNUMBER(%d)\n", tkn->value.number);
 #endif
 
   return tkn;
@@ -351,13 +351,13 @@ int read_config(const char * file)
   int r;
 
   if(!(cfg_infile = realpath(file, NULL))) {
-    pmsg_info("cannot determine realpath() of config file %s: %s\n", file, strerror(errno));
+    pmsg_ext_error("cannot determine realpath() of config file %s: %s\n", file, strerror(errno));
     return -1;
   }
 
   f = fopen(cfg_infile, "r");
   if (f == NULL) {
-    pmsg_info("cannot open config file %s: %s\n", cfg_infile, strerror(errno));
+    pmsg_ext_error("cannot open config file %s: %s\n", cfg_infile, strerror(errno));
     free(cfg_infile);
     cfg_infile = NULL;
     return -1;

--- a/src/config.c
+++ b/src/config.c
@@ -102,7 +102,7 @@ int init_config(void)
 void *cfg_malloc(const char *funcname, size_t n) {
   void *ret = malloc(n);
   if(!ret) {
-    avrdude_message(MSG_INFO, "%s: out of memory in %s (needed %lu bytes)\n", progname, funcname, (unsigned long) n);
+    msg_info("%s: out of memory in %s (needed %lu bytes)\n", progname, funcname, (unsigned long) n);
     exit(1);
   }
   memset(ret, 0, n);
@@ -113,7 +113,7 @@ void *cfg_realloc(const char *funcname, void *p, size_t n) {
   void *ret;
 
   if(!(ret = p? realloc(p, n): calloc(1, n))) {
-    avrdude_message(MSG_INFO, "%s: out of memory in %s (needed %lu bytes)\n", progname, funcname, (unsigned long) n);
+    msg_info("%s: out of memory in %s (needed %lu bytes)\n", progname, funcname, (unsigned long) n);
     exit(1);
   }
 
@@ -124,7 +124,7 @@ void *cfg_realloc(const char *funcname, void *p, size_t n) {
 char *cfg_strdup(const char *funcname, const char *s) {
   char *ret = strdup(s);
   if(!ret) {
-    avrdude_message(MSG_INFO, "%s: out of memory in %s\n", progname, funcname);
+    msg_info("%s: out of memory in %s\n", progname, funcname);
     exit(1);
   }
   return ret;
@@ -146,7 +146,7 @@ int yyerror(char * errmsg, ...)
   va_start(args, errmsg);
 
   vsnprintf(message, sizeof(message), errmsg, args);
-  avrdude_message(MSG_INFO, "%s: error at %s:%d: %s\n", progname, cfg_infile, cfg_lineno, message);
+  msg_info("%s: error at %s:%d: %s\n", progname, cfg_infile, cfg_lineno, message);
 
   va_end(args);
 
@@ -163,7 +163,7 @@ int yywarning(char * errmsg, ...)
   va_start(args, errmsg);
 
   vsnprintf(message, sizeof(message), errmsg, args);
-  avrdude_message(MSG_INFO, "%s: warning at %s:%d: %s\n", progname, cfg_infile, cfg_lineno, message);
+  msg_info("%s: warning at %s:%d: %s\n", progname, cfg_infile, cfg_lineno, message);
 
   va_end(args);
 
@@ -215,7 +215,7 @@ TOKEN *new_number(const char *text) {
   tkn->value.number = atoi(text);
 
 #if DEBUG
-  avrdude_message(MSG_INFO, "NUMBER(%d)\n", tkn->value.number);
+  msg_info("NUMBER(%d)\n", tkn->value.number);
 #endif
 
   return tkn;
@@ -227,7 +227,7 @@ TOKEN *new_number_real(const char *text) {
   tkn->value.number_real = atof(text);
 
 #if DEBUG
-  avrdude_message(MSG_INFO, "NUMBER(%g)\n", tkn->value.number_real);
+  msg_info("NUMBER(%g)\n", tkn->value.number_real);
 #endif
 
   return tkn;
@@ -246,7 +246,7 @@ TOKEN *new_hexnumber(const char *text) {
   }
   
 #if DEBUG
-  avrdude_message(MSG_INFO, "HEXNUMBER(%g)\n", tkn->value.number);
+  msg_info("HEXNUMBER(%g)\n", tkn->value.number);
 #endif
 
   return tkn;
@@ -280,7 +280,7 @@ TOKEN *new_constant(const char *con) {
   }
 
 #if DEBUG
-  avrdude_message(MSG_INFO, "CONSTANT(%s=%d)\n", con, tkn->value.number);
+  msg_info("CONSTANT(%s=%d)\n", con, tkn->value.number);
 #endif
 
   return tkn;
@@ -292,7 +292,7 @@ TOKEN *new_string(const char *text) {
   tkn->value.string = cfg_strdup("new_string()", text);
 
 #if DEBUG
-  avrdude_message(MSG_INFO, "STRING(%s)\n", tkn->value.string);
+  msg_info("STRING(%s)\n", tkn->value.string);
 #endif
 
   return tkn;
@@ -309,33 +309,33 @@ void print_token(TOKEN * tkn)
   if (!tkn)
     return;
 
-  avrdude_message(MSG_INFO, "token = %d = ", tkn->primary);
+  msg_info("token = %d = ", tkn->primary);
   switch (tkn->value.type) {
     case V_NUM:
-      avrdude_message(MSG_INFO, "NUMBER, value=%d", tkn->value.number);
+      msg_info("NUMBER, value=%d", tkn->value.number);
       break;
 
     case V_NUM_REAL:
-      avrdude_message(MSG_INFO, "NUMBER, value=%g", tkn->value.number_real);
+      msg_info("NUMBER, value=%g", tkn->value.number_real);
       break;
 
     case V_STR:
-      avrdude_message(MSG_INFO, "STRING, value=%s", tkn->value.string);
+      msg_info("STRING, value=%s", tkn->value.string);
       break;
 
     default:
-      avrdude_message(MSG_INFO, "<other>");
+      msg_info("<other>");
       break;
   }
 
-  avrdude_message(MSG_INFO, "\n");
+  msg_info("\n");
 }
 
 
 void pyytext(void)
 {
 #if DEBUG
-  avrdude_message(MSG_INFO, "TOKEN: \"%s\"\n", yytext);
+  msg_info("TOKEN: \"%s\"\n", yytext);
 #endif
 }
 
@@ -351,14 +351,14 @@ int read_config(const char * file)
   int r;
 
   if(!(cfg_infile = realpath(file, NULL))) {
-    avrdude_message(MSG_INFO, "%s: can't determine realpath() of config file \"%s\": %s\n",
+    msg_info("%s: can't determine realpath() of config file \"%s\": %s\n",
             progname, file, strerror(errno));
     return -1;
   }
 
   f = fopen(cfg_infile, "r");
   if (f == NULL) {
-    avrdude_message(MSG_INFO, "%s: can't open config file \"%s\": %s\n",
+    msg_info("%s: can't open config file \"%s\": %s\n",
             progname, cfg_infile, strerror(errno));
     free(cfg_infile);
     cfg_infile = NULL;

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1410,7 +1410,7 @@ mem_spec :
     {
       int ps = $3->value.number;
       if (ps <= 0)
-        avrdude_message(MSG_INFO,
+        msg_info(
                         "%s, line %d: invalid page size %d, ignored\n",
                         cfg_infile, cfg_lineno, ps);
       else

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1755,7 +1755,7 @@ static int parse_cmdbits(OPCODE * op, int opnum)
           op->bit[bitno].value = 0;
         }
         else {
-          yyerror("invalid bit specifier \"%s\"", s);
+          yyerror("invalid bit specifier %s", s);
           rv = -1;
           break;
         }

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1410,9 +1410,7 @@ mem_spec :
     {
       int ps = $3->value.number;
       if (ps <= 0)
-        msg_info(
-                        "%s, line %d: invalid page size %d, ignored\n",
-                        cfg_infile, cfg_lineno, ps);
+        pmsg_warning("invalid page size %d, ignored [%s:%d]\n", ps, cfg_infile, cfg_lineno);
       else
         current_mem->page_size = ps;
       free_token($3);

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -528,7 +528,7 @@ static int avrpart_deep_copy(AVRPARTdeep *d, const AVRPART *p) {
     m = p->mem? avr_locate_mem_noalias(p, avr_mem_order[mi]): NULL;
     if(m) {
       if(di >= sizeof d->mems/sizeof *d->mems) {
-        pmsg_info("ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n");
+        pmsg_error("ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n");
         exit(1);
       }
       avrmem_deep_copy(d->mems+di, m);

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -528,7 +528,7 @@ static int avrpart_deep_copy(AVRPARTdeep *d, const AVRPART *p) {
     m = p->mem? avr_locate_mem_noalias(p, avr_mem_order[mi]): NULL;
     if(m) {
       if(di >= sizeof d->mems/sizeof *d->mems) {
-        avrdude_message(MSG_INFO, "%s: ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n", progname);
+        msg_info("%s: ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n", progname);
         exit(1);
       }
       avrmem_deep_copy(d->mems+di, m);

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -528,7 +528,7 @@ static int avrpart_deep_copy(AVRPARTdeep *d, const AVRPART *p) {
     m = p->mem? avr_locate_mem_noalias(p, avr_mem_order[mi]): NULL;
     if(m) {
       if(di >= sizeof d->mems/sizeof *d->mems) {
-        msg_info("%s: ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n", progname);
+        pmsg_info("ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n");
         exit(1);
       }
       avrmem_deep_copy(d->mems+di, m);
@@ -615,7 +615,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
       dev_print_comment(cp->comms);
 
     if(p->parent_id && *p->parent_id)
-      dev_info("part parent \"%s\"\n", p->parent_id);
+      dev_info("part parent %s\n", p->parent_id);
     else
       dev_info("part\n");
   }

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -39,7 +39,7 @@
 #ifndef HAVE_LIBUSB
 
 struct dfu_dev *dfu_open(const char *port_name) {
-  avrdude_message(MSG_INFO, "%s: Error: No USB support in this compile of avrdude\n",
+  msg_info("%s: Error: No USB support in this compile of avrdude\n",
     progname);
   return NULL;
 }
@@ -111,7 +111,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
    */
 
   if (strncmp(port_spec, "usb", 3) != 0) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "Invalid port specification \"%s\" for USB device\n",
       progname, port_spec);
     return NULL;
@@ -120,7 +120,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
   if(':' == port_spec[3]) {
       bus_name = strdup(port_spec + 3 + 1);
       if (bus_name == NULL) {
-        avrdude_message(MSG_INFO, "%s: Out of memory in strdup\n", progname);
+        msg_info("%s: Out of memory in strdup\n", progname);
         return NULL;
       }
 
@@ -137,7 +137,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
 
   if (dfu == NULL)
   {
-    avrdude_message(MSG_INFO, "%s: out of memory\n", progname);
+    msg_info("%s: out of memory\n", progname);
     free(bus_name);
     return NULL;
   }
@@ -171,7 +171,7 @@ int dfu_init(struct dfu_dev *dfu, unsigned short vid, unsigned short pid)
    */
 
   if (pid == 0 && dfu->dev_name == NULL) {
-    avrdude_message(MSG_INFO, "%s: Error: No DFU support for part; "
+    msg_info("%s: Error: No DFU support for part; "
       "specify PID in config or USB address (via -P) to override.\n",
       progname);
     return -1;
@@ -208,19 +208,19 @@ int dfu_init(struct dfu_dev *dfu, unsigned short vid, unsigned short pid)
      * why the match failed, and if we came across another DFU-capable part.
      */
 
-    avrdude_message(MSG_INFO, "%s: Error: No matching USB device found\n", progname);
+    msg_info("%s: Error: No matching USB device found\n", progname);
     return -1;
   }
 
   if(verbose)
-    avrdude_message(MSG_INFO, "%s: Found VID=0x%04x PID=0x%04x at %s:%s\n",
+    msg_info("%s: Found VID=0x%04x PID=0x%04x at %s:%s\n",
                     progname, found->descriptor.idVendor, found->descriptor.idProduct,
                     found->bus->dirname, found->filename);
 
   dfu->dev_handle = usb_open(found);
 
   if (dfu->dev_handle == NULL) {
-    avrdude_message(MSG_INFO, "%s: Error: USB device at %s:%s: %s\n",
+    msg_info("%s: Error: USB device at %s:%s: %s\n",
       progname, found->bus->dirname, found->filename, usb_strerror());
     return -1;
   }
@@ -271,7 +271,7 @@ int dfu_getstatus(struct dfu_dev *dfu, struct dfu_status *status)
 {
   int result;
 
-  avrdude_message(MSG_TRACE, "%s: dfu_getstatus(): issuing control IN message\n",
+  msg_trace("%s: dfu_getstatus(): issuing control IN message\n",
             progname);
 
   result = usb_control_msg(dfu->dev_handle,
@@ -279,24 +279,24 @@ int dfu_getstatus(struct dfu_dev *dfu, struct dfu_status *status)
     (char*) status, sizeof(struct dfu_status), dfu->timeout);
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: Error: Failed to get DFU status: %s\n",
+    msg_info("%s: Error: Failed to get DFU status: %s\n",
       progname, usb_strerror());
     return -1;
   }
 
   if (result < sizeof(struct dfu_status)) {
-    avrdude_message(MSG_INFO, "%s: Error: Failed to get DFU status: %s\n",
+    msg_info("%s: Error: Failed to get DFU status: %s\n",
       progname, "short read");
     return -1;
   }
 
   if (result > sizeof(struct dfu_status)) {
-    avrdude_message(MSG_INFO, "%s: Error: Oversize read (should not happen); "
+    msg_info("%s: Error: Oversize read (should not happen); "
       "exiting\n", progname);
     exit(1);
   }
 
-  avrdude_message(MSG_TRACE, "%s: dfu_getstatus(): bStatus 0x%02x, bwPollTimeout %d, bState 0x%02x, iString %d\n",
+  msg_trace("%s: dfu_getstatus(): bStatus 0x%02x, bwPollTimeout %d, bState 0x%02x, iString %d\n",
                   progname,
                   status->bStatus,
                   status->bwPollTimeout[0] | (status->bwPollTimeout[1] << 8) | (status->bwPollTimeout[2] << 16),
@@ -310,7 +310,7 @@ int dfu_clrstatus(struct dfu_dev *dfu)
 {
   int result;
 
-  avrdude_message(MSG_TRACE, "%s: dfu_clrstatus(): issuing control OUT message\n",
+  msg_trace("%s: dfu_clrstatus(): issuing control OUT message\n",
                   progname);
 
   result = usb_control_msg(dfu->dev_handle,
@@ -318,7 +318,7 @@ int dfu_clrstatus(struct dfu_dev *dfu)
     NULL, 0, dfu->timeout);
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: Error: Failed to clear DFU status: %s\n",
+    msg_info("%s: Error: Failed to clear DFU status: %s\n",
       progname, usb_strerror());
     return -1;
   }
@@ -330,7 +330,7 @@ int dfu_abort(struct dfu_dev *dfu)
 {
   int result;
 
-  avrdude_message(MSG_TRACE, "%s: dfu_abort(): issuing control OUT message\n",
+  msg_trace("%s: dfu_abort(): issuing control OUT message\n",
                   progname);
 
   result = usb_control_msg(dfu->dev_handle,
@@ -338,7 +338,7 @@ int dfu_abort(struct dfu_dev *dfu)
     NULL, 0, dfu->timeout);
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: Error: Failed to reset DFU state: %s\n",
+    msg_info("%s: Error: Failed to reset DFU state: %s\n",
       progname, usb_strerror());
     return -1;
   }
@@ -351,7 +351,7 @@ int dfu_dnload(struct dfu_dev *dfu, void *ptr, int size)
 {
   int result;
 
-  avrdude_message(MSG_TRACE, "%s: dfu_dnload(): issuing control OUT message, wIndex = %d, ptr = %p, size = %d\n",
+  msg_trace("%s: dfu_dnload(): issuing control OUT message, wIndex = %d, ptr = %p, size = %d\n",
                   progname, wIndex, ptr, size);
 
   result = usb_control_msg(dfu->dev_handle,
@@ -359,19 +359,19 @@ int dfu_dnload(struct dfu_dev *dfu, void *ptr, int size)
     ptr, size, dfu->timeout);
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: Error: DFU_DNLOAD failed: %s\n",
+    msg_info("%s: Error: DFU_DNLOAD failed: %s\n",
       progname, usb_strerror());
     return -1;
   }
 
   if (result < size) {
-    avrdude_message(MSG_INFO, "%s: Error: DFU_DNLOAD failed: %s\n",
+    msg_info("%s: Error: DFU_DNLOAD failed: %s\n",
       progname, "short write");
     return -1;
   }
 
   if (result > size) {
-    avrdude_message(MSG_INFO, "%s: Error: Oversize write (should not happen); " \
+    msg_info("%s: Error: Oversize write (should not happen); " \
       "exiting\n", progname);
     exit(1);
   }
@@ -383,7 +383,7 @@ int dfu_upload(struct dfu_dev *dfu, void *ptr, int size)
 {
   int result;
 
-  avrdude_message(MSG_TRACE, "%s: dfu_upload(): issuing control IN message, wIndex = %d, ptr = %p, size = %d\n",
+  msg_trace("%s: dfu_upload(): issuing control IN message, wIndex = %d, ptr = %p, size = %d\n",
                   progname, wIndex, ptr, size);
 
   result = usb_control_msg(dfu->dev_handle,
@@ -391,19 +391,19 @@ int dfu_upload(struct dfu_dev *dfu, void *ptr, int size)
     ptr, size, dfu->timeout);
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: Error: DFU_UPLOAD failed: %s\n",
+    msg_info("%s: Error: DFU_UPLOAD failed: %s\n",
       progname, usb_strerror());
     return -1;
   }
 
   if (result < size) {
-    avrdude_message(MSG_INFO, "%s: Error: DFU_UPLOAD failed: %s\n",
+    msg_info("%s: Error: DFU_UPLOAD failed: %s\n",
       progname, "short read");
     return -1;
   }
 
   if (result > size) {
-    avrdude_message(MSG_INFO, "%s: Error: Oversize read (should not happen); "
+    msg_info("%s: Error: Oversize read (should not happen); "
       "exiting\n", progname);
     exit(1);
   }
@@ -414,26 +414,26 @@ int dfu_upload(struct dfu_dev *dfu, void *ptr, int size)
 void dfu_show_info(struct dfu_dev *dfu)
 {
   if (dfu->manf_str != NULL)
-    avrdude_message(MSG_INFO, "    USB Vendor          : %s (0x%04hX)\n",
+    msg_info("    USB Vendor          : %s (0x%04hX)\n",
       dfu->manf_str, (unsigned short) dfu->dev_desc.idVendor);
   else
-    avrdude_message(MSG_INFO, "    USB Vendor          : 0x%04hX\n",
+    msg_info("    USB Vendor          : 0x%04hX\n",
       (unsigned short) dfu->dev_desc.idVendor);
 
   if (dfu->prod_str != NULL)
-    avrdude_message(MSG_INFO, "    USB Product         : %s (0x%04hX)\n",
+    msg_info("    USB Product         : %s (0x%04hX)\n",
       dfu->prod_str, (unsigned short) dfu->dev_desc.idProduct);
   else
-    avrdude_message(MSG_INFO, "    USB Product         : 0x%04hX\n",
+    msg_info("    USB Product         : 0x%04hX\n",
       (unsigned short) dfu->dev_desc.idProduct);
 
-  avrdude_message(MSG_INFO, "    USB Release         : %hu.%hu.%hu\n",
+  msg_info("    USB Release         : %hu.%hu.%hu\n",
     ((unsigned short) dfu->dev_desc.bcdDevice >> 8) & 0xFF,
     ((unsigned short) dfu->dev_desc.bcdDevice >> 4) & 0xF,
     ((unsigned short) dfu->dev_desc.bcdDevice >> 0) & 0xF);
 
   if (dfu->serno_str != NULL)
-    avrdude_message(MSG_INFO, "    USB Serial No       : %s\n", dfu->serno_str);
+    msg_info("    USB Serial No       : %s\n", dfu->serno_str);
 }
 
 /* INTERNAL FUNCTION DEFINITIONS
@@ -450,7 +450,7 @@ char * get_usb_string(usb_dev_handle * dev_handle, int index) {
   result = usb_get_string_simple(dev_handle, index, buffer, sizeof(buffer)-1);
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: Warning: Failed to read USB device string %d: %s\n",
+    msg_info("%s: Warning: Failed to read USB device string %d: %s\n",
       progname, index, usb_strerror());
     return NULL;
   }
@@ -458,7 +458,7 @@ char * get_usb_string(usb_dev_handle * dev_handle, int index) {
   str = malloc(result+1);
 
   if (str == NULL) {
-    avrdude_message(MSG_INFO, "%s: Out of memory allocating a string\n", progname);
+    msg_info("%s: Out of memory allocating a string\n", progname);
     return 0;
   }
 

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -39,8 +39,7 @@
 #ifndef HAVE_LIBUSB
 
 struct dfu_dev *dfu_open(const char *port_name) {
-  msg_info("%s: Error: No USB support in this compile of avrdude\n",
-    progname);
+  pmsg_info("Error: No USB support in this compile of avrdude\n");
   return NULL;
 }
 
@@ -111,16 +110,14 @@ struct dfu_dev *dfu_open(const char *port_spec) {
    */
 
   if (strncmp(port_spec, "usb", 3) != 0) {
-    msg_info("%s: Error: "
-      "Invalid port specification \"%s\" for USB device\n",
-      progname, port_spec);
+    pmsg_info("invalid port specification %s for USB device\n", port_spec);
     return NULL;
   }
 
   if(':' == port_spec[3]) {
       bus_name = strdup(port_spec + 3 + 1);
       if (bus_name == NULL) {
-        msg_info("%s: Out of memory in strdup\n", progname);
+        pmsg_info("out of memory in strdup\n");
         return NULL;
       }
 
@@ -137,7 +134,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
 
   if (dfu == NULL)
   {
-    msg_info("%s: out of memory\n", progname);
+    pmsg_info("out of memory\n");
     free(bus_name);
     return NULL;
   }
@@ -171,9 +168,8 @@ int dfu_init(struct dfu_dev *dfu, unsigned short vid, unsigned short pid)
    */
 
   if (pid == 0 && dfu->dev_name == NULL) {
-    msg_info("%s: Error: No DFU support for part; "
-      "specify PID in config or USB address (via -P) to override.\n",
-      progname);
+    pmsg_info("no DFU support for part; "
+      "specify PID in config or USB address (via -P) to override\n");
     return -1;
   }
 
@@ -208,20 +204,19 @@ int dfu_init(struct dfu_dev *dfu, unsigned short vid, unsigned short pid)
      * why the match failed, and if we came across another DFU-capable part.
      */
 
-    msg_info("%s: Error: No matching USB device found\n", progname);
+    pmsg_info("no matching USB device found\n");
     return -1;
   }
 
   if(verbose)
-    msg_info("%s: Found VID=0x%04x PID=0x%04x at %s:%s\n",
-                    progname, found->descriptor.idVendor, found->descriptor.idProduct,
-                    found->bus->dirname, found->filename);
+    pmsg_info("found VID=0x%04x PID=0x%04x at %s:%s\n",
+      found->descriptor.idVendor, found->descriptor.idProduct,
+      found->bus->dirname, found->filename);
 
   dfu->dev_handle = usb_open(found);
 
   if (dfu->dev_handle == NULL) {
-    msg_info("%s: Error: USB device at %s:%s: %s\n",
-      progname, found->bus->dirname, found->filename, usb_strerror());
+    pmsg_info("error, USB device at %s:%s: %s\n", found->bus->dirname, found->filename, usb_strerror());
     return -1;
   }
 
@@ -271,37 +266,32 @@ int dfu_getstatus(struct dfu_dev *dfu, struct dfu_status *status)
 {
   int result;
 
-  msg_trace("%s: dfu_getstatus(): issuing control IN message\n",
-            progname);
+  pmsg_trace("dfu_getstatus(): issuing control IN message\n");
 
   result = usb_control_msg(dfu->dev_handle,
     0x80 | USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_GETSTATUS, 0, 0,
     (char*) status, sizeof(struct dfu_status), dfu->timeout);
 
   if (result < 0) {
-    msg_info("%s: Error: Failed to get DFU status: %s\n",
-      progname, usb_strerror());
+    pmsg_info("failed to get DFU status: %s\n", usb_strerror());
     return -1;
   }
 
   if (result < sizeof(struct dfu_status)) {
-    msg_info("%s: Error: Failed to get DFU status: %s\n",
-      progname, "short read");
+    pmsg_info("failed to get DFU status: %s\n", "short read");
     return -1;
   }
 
   if (result > sizeof(struct dfu_status)) {
-    msg_info("%s: Error: Oversize read (should not happen); "
-      "exiting\n", progname);
+    pmsg_info("oversize read (should not happen); exiting\n");
     exit(1);
   }
 
-  msg_trace("%s: dfu_getstatus(): bStatus 0x%02x, bwPollTimeout %d, bState 0x%02x, iString %d\n",
-                  progname,
-                  status->bStatus,
-                  status->bwPollTimeout[0] | (status->bwPollTimeout[1] << 8) | (status->bwPollTimeout[2] << 16),
-                  status->bState,
-                  status->iString);
+  pmsg_trace("dfu_getstatus(): bStatus 0x%02x, bwPollTimeout %d, bState 0x%02x, iString %d\n",
+    status->bStatus,
+    status->bwPollTimeout[0] | (status->bwPollTimeout[1] << 8) | (status->bwPollTimeout[2] << 16),
+    status->bState,
+    status->iString);
 
   return 0;
 }
@@ -310,16 +300,14 @@ int dfu_clrstatus(struct dfu_dev *dfu)
 {
   int result;
 
-  msg_trace("%s: dfu_clrstatus(): issuing control OUT message\n",
-                  progname);
+  pmsg_trace("dfu_clrstatus(): issuing control OUT message\n");
 
   result = usb_control_msg(dfu->dev_handle,
     USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_CLRSTATUS, 0, 0,
     NULL, 0, dfu->timeout);
 
   if (result < 0) {
-    msg_info("%s: Error: Failed to clear DFU status: %s\n",
-      progname, usb_strerror());
+    pmsg_info("failed to clear DFU status: %s\n", usb_strerror());
     return -1;
   }
 
@@ -330,16 +318,14 @@ int dfu_abort(struct dfu_dev *dfu)
 {
   int result;
 
-  msg_trace("%s: dfu_abort(): issuing control OUT message\n",
-                  progname);
+  pmsg_trace("dfu_abort(): issuing control OUT message\n");
 
   result = usb_control_msg(dfu->dev_handle,
     USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_ABORT, 0, 0,
     NULL, 0, dfu->timeout);
 
   if (result < 0) {
-    msg_info("%s: Error: Failed to reset DFU state: %s\n",
-      progname, usb_strerror());
+    pmsg_info("failed to reset DFU state: %s\n", usb_strerror());
     return -1;
   }
 
@@ -351,28 +337,25 @@ int dfu_dnload(struct dfu_dev *dfu, void *ptr, int size)
 {
   int result;
 
-  msg_trace("%s: dfu_dnload(): issuing control OUT message, wIndex = %d, ptr = %p, size = %d\n",
-                  progname, wIndex, ptr, size);
+  pmsg_trace("dfu_dnload(): issuing control OUT message, wIndex = %d, ptr = %p, size = %d\n",
+    wIndex, ptr, size);
 
   result = usb_control_msg(dfu->dev_handle,
     USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_DNLOAD, wIndex++, 0,
     ptr, size, dfu->timeout);
 
   if (result < 0) {
-    msg_info("%s: Error: DFU_DNLOAD failed: %s\n",
-      progname, usb_strerror());
+    pmsg_info("DFU_DNLOAD failed: %s\n", usb_strerror());
     return -1;
   }
 
   if (result < size) {
-    msg_info("%s: Error: DFU_DNLOAD failed: %s\n",
-      progname, "short write");
+    pmsg_info("DFU_DNLOAD failed: %s\n", "short write");
     return -1;
   }
 
   if (result > size) {
-    msg_info("%s: Error: Oversize write (should not happen); " \
-      "exiting\n", progname);
+    pmsg_info("oversize write (should not happen); exiting\n");
     exit(1);
   }
 
@@ -383,28 +366,25 @@ int dfu_upload(struct dfu_dev *dfu, void *ptr, int size)
 {
   int result;
 
-  msg_trace("%s: dfu_upload(): issuing control IN message, wIndex = %d, ptr = %p, size = %d\n",
-                  progname, wIndex, ptr, size);
+  pmsg_trace("dfu_upload(): issuing control IN message, wIndex = %d, ptr = %p, size = %d\n",
+    wIndex, ptr, size);
 
   result = usb_control_msg(dfu->dev_handle,
     0x80 | USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_UPLOAD, wIndex++, 0,
     ptr, size, dfu->timeout);
 
   if (result < 0) {
-    msg_info("%s: Error: DFU_UPLOAD failed: %s\n",
-      progname, usb_strerror());
+    pmsg_info("DFU_UPLOAD failed: %s\n", usb_strerror());
     return -1;
   }
 
   if (result < size) {
-    msg_info("%s: Error: DFU_UPLOAD failed: %s\n",
-      progname, "short read");
+    pmsg_info("DFU_UPLOAD failed: %s\n", "short read");
     return -1;
   }
 
   if (result > size) {
-    msg_info("%s: Error: Oversize read (should not happen); "
-      "exiting\n", progname);
+    pmsg_info("oversize read (should not happen); exiting\n");
     exit(1);
   }
 
@@ -450,15 +430,14 @@ char * get_usb_string(usb_dev_handle * dev_handle, int index) {
   result = usb_get_string_simple(dev_handle, index, buffer, sizeof(buffer)-1);
 
   if (result < 0) {
-    msg_info("%s: Warning: Failed to read USB device string %d: %s\n",
-      progname, index, usb_strerror());
+    pmsg_info("failed to read USB device string %d: %s\n", index, usb_strerror());
     return NULL;
   }
 
   str = malloc(result+1);
 
   if (str == NULL) {
-    msg_info("%s: Out of memory allocating a string\n", progname);
+    pmsg_info("out of memory allocating a string\n");
     return 0;
   }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -324,11 +324,11 @@ static int ihex2b(char * infile, FILE * inf,
     else if (rc != ihex.cksum) {
       if(ffmt == FMT_IHEX) {
         pmsg_error("checksum mismatch at line %d of %s\n", lineno, infile);
-        pmsg_error("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
+        imsg_error("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
         return -1;
       } else {                  /* Just warn with more permissive format FMT_IHXC */
         pmsg_notice("checksum mismatch at line %d of %s\n", lineno, infile);
-        pmsg_notice("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
+        imsg_notice("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
       }
     }
 
@@ -607,7 +607,7 @@ static int srec2b(char * infile, FILE * inf,
     }
     else if (rc != srec.cksum) {
       pmsg_error("checksum mismatch at line %d of %s\n", lineno, infile);
-      pmsg_error("checksum=0x%02x, computed checksum=0x%02x\n", srec.cksum, rc);
+      imsg_error("checksum=0x%02x, computed checksum=0x%02x\n", srec.cksum, rc);
       return -1;
     }
 
@@ -639,7 +639,7 @@ static int srec2b(char * infile, FILE * inf,
       case 0x35: /* S5 - count of S1,S2 and S3 records previously tx'd */
         if (srec.loadofs != reccount){
           pmsg_error("count of transmitted data records mismatch at line %d of %s\n", lineno, infile);
-          pmsg_error("transmitted data records= %d, expected value= %d\n", reccount, srec.loadofs);
+          imsg_error("transmitted data records= %d, expected value= %d\n", reccount, srec.loadofs);
           return -1;
         }
         break;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -126,7 +126,7 @@ static int b2ihex(unsigned char * inbuf, int bufsize,
   unsigned char cksum;
 
   if (recsize > 255) {
-    pmsg_info("recsize=%d, must be < 256\n", recsize);
+    pmsg_error("recsize=%d, must be < 256\n", recsize);
     return -1;
   }
 
@@ -318,13 +318,13 @@ static int ihex2b(char * infile, FILE * inf,
       continue;
     rc = ihex_readrec(&ihex, buffer);
     if (rc < 0) {
-      pmsg_info("invalid record at line %d of %s\n", lineno, infile);
+      pmsg_error("invalid record at line %d of %s\n", lineno, infile);
       return -1;
     }
     else if (rc != ihex.cksum) {
       if(ffmt == FMT_IHEX) {
-        pmsg_info("checksum mismatch at line %d of %s\n", lineno, infile);
-        pmsg_info("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
+        pmsg_error("checksum mismatch at line %d of %s\n", lineno, infile);
+        pmsg_error("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
         return -1;
       } else {                  /* Just warn with more permissive format FMT_IHXC */
         pmsg_notice("checksum mismatch at line %d of %s\n", lineno, infile);
@@ -335,13 +335,13 @@ static int ihex2b(char * infile, FILE * inf,
     switch (ihex.rectyp) {
       case 0: /* data record */
         if (fileoffset != 0 && baseaddr < fileoffset) {
-          pmsg_info("address 0x%04x out of range (below fileoffset 0x%x) at line %d of %s\n",
+          pmsg_error("address 0x%04x out of range (below fileoffset 0x%x) at line %d of %s\n",
             baseaddr, fileoffset, lineno, infile);
           return -1;
         }
         nextaddr = ihex.loadofs + baseaddr - fileoffset;
         if (nextaddr + ihex.reclen > (unsigned) bufsize) {
-          pmsg_info("address 0x%04x out of range at line %d of %s\n",
+          pmsg_error("address 0x%04x out of range at line %d of %s\n",
             nextaddr+ihex.reclen, lineno, infile);
           return -1;
         }
@@ -374,7 +374,7 @@ static int ihex2b(char * infile, FILE * inf,
         break;
 
       default:
-        pmsg_info("don't know how to deal with rectype=%d "
+        pmsg_error("do not know how to deal with rectype=%d "
           "at line %d of %s\n", ihex.rectyp, lineno, infile);
         return -1;
         break;
@@ -383,12 +383,12 @@ static int ihex2b(char * infile, FILE * inf,
   } /* while */
 
   if (maxaddr == 0) {
-    pmsg_info("ERROR: No valid record found in Intel Hex file %s\n", infile);
+    pmsg_error("no valid record found in Intel Hex file %s\n", infile);
 
     return -1;
   }
   else {
-    pmsg_info("WARNING: no end of file record found for Intel Hex file %s\n", infile);
+    pmsg_warning("no end of file record found for Intel Hex file %s\n", infile);
 
     return maxaddr;
   }
@@ -406,7 +406,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
   char * tmpl=0;
 
   if (recsize > 255) {
-    pmsg_info("recsize=%d, must be < 256\n", recsize);
+    pmsg_error("recsize=%d, must be < 256\n", recsize);
     return -1;
   }
   
@@ -438,7 +438,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
         tmpl="S3%02X%08X";
       }
       else {
-        pmsg_info("address=%d, out of range\n", nextaddr);
+        pmsg_error("address=%d, out of range\n", nextaddr);
         return -1;
       }
 
@@ -602,12 +602,12 @@ static int srec2b(char * infile, FILE * inf,
     rc = srec_readrec(&srec, buffer);
 
     if (rc < 0) {
-      pmsg_info("invalid record at line %d of %s\n", lineno, infile);
+      pmsg_error("invalid record at line %d of %s\n", lineno, infile);
       return -1;
     }
     else if (rc != srec.cksum) {
-      pmsg_info("checksum mismatch at line %d of %s\n", lineno, infile);
-      pmsg_info("checksum=0x%02x, computed checksum=0x%02x\n", srec.cksum, rc);
+      pmsg_error("checksum mismatch at line %d of %s\n", lineno, infile);
+      pmsg_error("checksum=0x%02x, computed checksum=0x%02x\n", srec.cksum, rc);
       return -1;
     }
 
@@ -633,13 +633,13 @@ static int srec2b(char * infile, FILE * inf,
         break;
 
       case 0x34: /* S4 - symbol record (LSI extension) */
-        pmsg_info("not supported record at line %d of %s\n", lineno, infile);
+        pmsg_error("not supported record at line %d of %s\n", lineno, infile);
         return -1;
 
       case 0x35: /* S5 - count of S1,S2 and S3 records previously tx'd */
         if (srec.loadofs != reccount){
-          pmsg_info("count of transmitted data records mismatch at line %d of %s\n", lineno, infile);
-          pmsg_info("transmitted data records= %d, expected value= %d\n", reccount, srec.loadofs);
+          pmsg_error("count of transmitted data records mismatch at line %d of %s\n", lineno, infile);
+          pmsg_error("transmitted data records= %d, expected value= %d\n", reccount, srec.loadofs);
           return -1;
         }
         break;
@@ -650,20 +650,20 @@ static int srec2b(char * infile, FILE * inf,
         return maxaddr;
 
       default:
-        pmsg_error("don't know how to deal with rectype S%d "
-          "at line %d of %s\n", srec.rectyp, lineno, infile);
+        pmsg_error("do not know how to deal with rectype S%d at line %d of %s\n",
+          srec.rectyp, lineno, infile);
         return -1;
     }
 
     if (datarec == 1) {
       nextaddr = srec.loadofs;
       if (nextaddr < fileoffset) {
-        msg_error(msg, nextaddr, "(below fileoffset) ", lineno, infile);
+        pmsg_error(msg, nextaddr, "(below fileoffset) ", lineno, infile);
         return -1;
       }
       nextaddr -= fileoffset;
       if (nextaddr + srec.reclen > (unsigned) bufsize) {
-        msg_error(msg, nextaddr+srec.reclen, "", lineno, infile);
+        pmsg_error(msg, nextaddr+srec.reclen, "", lineno, infile);
         return -1;
       }
       for (i=0; i<srec.reclen; i++) {
@@ -677,7 +677,7 @@ static int srec2b(char * infile, FILE * inf,
 
   }
 
-  pmsg_info("warning, no end of file record found for Motorola S-Records file %s\n", infile);
+  pmsg_warning("no end of file record found for Motorola S-Records file %s\n", infile);
 
   return maxaddr;
 }
@@ -720,7 +720,7 @@ static Elf_Scn *elf_get_scn(Elf *e, Elf32_Phdr *ph, Elf32_Shdr **shptr)
     Elf32_Shdr *sh;
     size_t ndx = elf_ndxscn(s);
     if ((sh = elf32_getshdr(s)) == NULL) {
-      pmsg_info("error reading section #%u header: %s\n", (unsigned int)ndx, elf_errmsg(-1));
+      pmsg_error("unable to read section #%u header: %s\n", (unsigned int)ndx, elf_errmsg(-1));
       continue;
     }
     if ((sh->sh_flags & SHF_ALLOC) == 0 ||
@@ -737,7 +737,7 @@ static Elf_Scn *elf_get_scn(Elf *e, Elf32_Phdr *ph, Elf32_Shdr **shptr)
     }
   }
 
-  pmsg_info("cannot find a matching section for program header entry @p_vaddr 0x%x\n", ph->p_vaddr);
+  pmsg_error("cannot find a matching section for program header entry @p_vaddr 0x%x\n", ph->p_vaddr);
   return NULL;
 }
 
@@ -808,7 +808,7 @@ static int elf2b(char * infile, FILE * inf,
   unsigned int low, high, foff;
 
   if (elf_mem_limits(mem, p, &low, &high, &foff) != 0) {
-    pmsg_info("cannot handle %s memory region from ELF file\n", mem->desc);
+    pmsg_error("cannot handle %s memory region from ELF file\n", mem->desc);
     return -1;
   }
 
@@ -825,7 +825,7 @@ static int elf2b(char * infile, FILE * inf,
        strcmp(mem->desc, "apptable") == 0)) {
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (flashmem == NULL) {
-      pmsg_info("no flash memory region found, cannot compute bounds of %s sub-region\n", mem->desc);
+      pmsg_error("no flash memory region found, cannot compute bounds of %s sub-region\n", mem->desc);
       return -1;
     }
     /* The config file offsets are PDI offsets, rebase to 0. */
@@ -834,15 +834,15 @@ static int elf2b(char * infile, FILE * inf,
   }
 
   if (elf_version(EV_CURRENT) == EV_NONE) {
-    pmsg_info("ELF library initialization failed: %s\n", elf_errmsg(-1));
+    pmsg_error("ELF library initialization failed: %s\n", elf_errmsg(-1));
     return -1;
   }
   if ((e = elf_begin(fileno(inf), ELF_C_READ, NULL)) == NULL) {
-    pmsg_info("cannot open %s as an ELF file: %s\n", infile, elf_errmsg(-1));
+    pmsg_error("cannot open %s as an ELF file: %s\n", infile, elf_errmsg(-1));
     return -1;
   }
   if (elf_kind(e) != ELF_K_ELF) {
-    pmsg_info("cannot use %s as an ELF input file\n", infile);
+    pmsg_error("cannot use %s as an ELF input file\n", infile);
     goto done;
   }
 
@@ -850,7 +850,7 @@ static int elf2b(char * infile, FILE * inf,
   const char *id = elf_getident(e, &isize);
 
   if (id == NULL) {
-    pmsg_info("error reading ident area of %s: %s\n", infile, elf_errmsg(-1));
+    pmsg_error("unable to read ident area of %s: %s\n", infile, elf_errmsg(-1));
     goto done;
   }
 
@@ -865,19 +865,19 @@ static int elf2b(char * infile, FILE * inf,
   }
   if (id[EI_CLASS] != ELFCLASS32 ||
       id[EI_DATA] != endianess) {
-    pmsg_info("ELF file %s is not a 32-bit, %s-endian file that was expected\n",
+    pmsg_error("ELF file %s is not a 32-bit, %s-endian file that was expected\n",
       infile, endianname);
     goto done;
   }
 
   Elf32_Ehdr *eh;
   if ((eh = elf32_getehdr(e)) == NULL) {
-    pmsg_info("error reading ehdr of %s: %s\n", infile, elf_errmsg(-1));
+    pmsg_error("unable to read ehdr of %s: %s\n", infile, elf_errmsg(-1));
     goto done;
   }
 
   if (eh->e_type != ET_EXEC) {
-    pmsg_info("ELF file %s is not an executable file\n", infile);
+    pmsg_error("ELF file %s is not an executable file\n", infile);
     goto done;
   }
 
@@ -891,24 +891,23 @@ static int elf2b(char * infile, FILE * inf,
     mname = "AVR";
   }
   if (eh->e_machine != machine) {
-    pmsg_info("ELF file %s is not for machine %s\n", infile, mname);
+    pmsg_error("ELF file %s is not for machine %s\n", infile, mname);
     goto done;
   }
   if (eh->e_phnum == 0xffff /* PN_XNUM */) {
-    pmsg_info("ELF file %s uses extended program header numbers which are not expected\n",
-      infile);
+    pmsg_error("ELF file %s uses extended program header numbers which are not expected\n", infile);
     goto done;
   }
 
   Elf32_Phdr *ph;
   if ((ph = elf32_getphdr(e)) == NULL) {
-    pmsg_info("error reading program header table of %s: %s\n", infile, elf_errmsg(-1));
+    pmsg_error("unable to read program header table of %s: %s\n", infile, elf_errmsg(-1));
     goto done;
   }
 
   size_t sndx;
   if (elf_getshdrstrndx(e, &sndx) != 0) {
-    pmsg_info("error obtaining section name string table: %s\n", elf_errmsg(-1));
+    pmsg_error("unable to obtain section name string table: %s\n", elf_errmsg(-1));
     sndx = 0;
   }
 
@@ -941,7 +940,7 @@ static int elf2b(char * infile, FILE * inf,
       unsigned int lma;
       lma = ph[i].p_paddr + sh->sh_offset - ph[i].p_offset;
 
-      pmsg_notice2("Found section %s, LMA 0x%x, sh_size %u\n", sname, lma, sh->sh_size);
+      pmsg_notice2("found section %s, LMA 0x%x, sh_size %u\n", sname, lma, sh->sh_size);
 
       if (lma >= low &&
           lma + sh->sh_size < high) {
@@ -959,7 +958,7 @@ static int elf2b(char * infile, FILE * inf,
        * from it, using the "foff" offset obtained above.
        */
       if (mem->size != 1 && sh->sh_size > (unsigned) mem->size) {
-        pmsg_info("ERROR: section %s does not fit into %s memory:\n"
+        pmsg_error("section %s does not fit into %s memory:\n"
           "    0x%x + %u > %u\n", sname, mem->desc, lma, sh->sh_size, mem->size);
         continue;
       }
@@ -970,9 +969,9 @@ static int elf2b(char * infile, FILE * inf,
                         d->d_buf, (unsigned int)d->d_off, (long) d->d_size);
         if (mem->size == 1) {
           if (d->d_off != 0) {
-            pmsg_info("unexpected data block at offset != 0\n");
+            pmsg_error("unexpected data block at offset != 0\n");
           } else if (foff >= d->d_size) {
-            pmsg_info("ELF file section does not contain byte at offset %d\n", foff);
+            pmsg_error("ELF file section does not contain byte at offset %d\n", foff);
           } else {
             msg_notice2("    Extracting one byte from file offset %d\n",
                             foff);
@@ -1056,12 +1055,12 @@ static int fileio_rbin(struct fioparms * fio,
       rc = fwrite(buf, 1, size, f);
       break;
     default:
-      pmsg_info("fileio: invalid operation=%d\n", fio->op);
+      pmsg_error("invalid fileio operation=%d\n", fio->op);
       return -1;
   }
 
   if (rc < 0 || (fio->op == FIO_WRITE && rc < size)) {
-    pmsg_info("%s error %s %s: %s; %s %d of the expected %d bytes\n",
+    pmsg_ext_error("%s error %s %s: %s; %s %d of the expected %d bytes\n",
       fio->iodesc, fio->dir, filename, strerror(errno), fio->rw, rc, size);
     return -1;
   }
@@ -1089,7 +1088,7 @@ static int fileio_imm(struct fioparms * fio,
 	    strtoul (p, &e, 0):
 	    strtoul (p + 2, &e, 2);
         if (*e != 0) {
-          pmsg_info("invalid byte value (%s) specified for immediate mode\n", p);
+          pmsg_error("invalid byte value (%s) specified for immediate mode\n", p);
           return -1;
         }
         mem->buf[loc] = b;
@@ -1100,16 +1099,16 @@ static int fileio_imm(struct fioparms * fio,
       break;
 
     case FIO_WRITE:
-      pmsg_info("invalid file format 'immediate' for output\n");
+      pmsg_error("invalid file format 'immediate' for output\n");
       return -1;
 
     default:
-      pmsg_info("fileio: invalid operation=%d\n", fio->op);
+      pmsg_error("fileio: invalid operation=%d\n", fio->op);
       return -1;
   }
 
   if (rc < 0 || (fio->op == FIO_WRITE && rc < size)) {
-    pmsg_info("%s error %s %s: %s; %s %d of the expected %d bytes\n",
+    pmsg_ext_error("%s error %s %s: %s; %s %d of the expected %d bytes\n",
       fio->iodesc, fio->dir, filename, strerror(errno), fio->rw, rc, size);
     return -1;
   }
@@ -1139,7 +1138,7 @@ static int fileio_ihex(struct fioparms * fio,
       break;
 
     default:
-      pmsg_info("invalid Intel Hex file I/O operation=%d\n", fio->op);
+      pmsg_error("invalid Intel Hex file I/O operation=%d\n", fio->op);
       return -1;
       break;
   }
@@ -1186,7 +1185,7 @@ static int fileio_elf(struct fioparms * fio,
 
   switch (fio->op) {
     case FIO_WRITE:
-      pmsg_info("write operation not supported for ELF\n");
+      pmsg_error("write operation not supported for ELF\n");
       return -1;
       break;
 
@@ -1195,7 +1194,7 @@ static int fileio_elf(struct fioparms * fio,
       return rc;
 
     default:
-      pmsg_info("invalid ELF file I/O operation=%d\n", fio->op);
+      pmsg_error("invalid ELF file I/O operation=%d\n", fio->op);
       return -1;
       break;
   }
@@ -1245,11 +1244,11 @@ static int fileio_num(struct fioparms * fio,
       break;
 
     case FIO_READ:
-      pmsg_info("invalid file format '%s' for input\n", name);
+      pmsg_error("invalid file format '%s' for input\n", name);
       return -1;
 
     default:
-      pmsg_info("fileio: invalid operation=%d\n", fio->op);
+      pmsg_error("fileio: invalid operation=%d\n", fio->op);
       return -1;
   }
 
@@ -1278,7 +1277,7 @@ static int fileio_num(struct fioparms * fio,
   return 0;
 
  writeerr:
-  pmsg_info("error writing to %s: %s\n", filename, strerror(errno));
+  pmsg_ext_error("unable to write to %s: %s\n", filename, strerror(errno));
   return -1;
 }
 
@@ -1304,7 +1303,7 @@ int fileio_setparms(int op, struct fioparms * fp,
       break;
 
     default:
-      pmsg_info("invalid I/O operation %d\n", op);
+      pmsg_error("invalid I/O operation %d\n", op);
       return -1;
       break;
   }
@@ -1335,7 +1334,7 @@ int fileio_fmt_autodetect(const char * fname)
   f = fopen(fname, "rb");
 #endif
   if (f == NULL) {
-    pmsg_info("error opening %s: %s\n", fname, strerror(errno));
+    pmsg_ext_error("unable to open %s: %s\n", fname, strerror(errno));
     return -1;
   }
 
@@ -1418,7 +1417,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
   op = oprwv == FIO_READ_FOR_VERIFY? FIO_READ: oprwv;
   mem = avr_locate_mem(p, memtype);
   if (mem == NULL) {
-    msg_info("fileio(): memory type %s not configured for device %s\n", memtype, p->desc);
+    pmsg_error("fileio(): memory type %s not configured for device %s\n", memtype, p->desc);
     return -1;
   }
 
@@ -1457,22 +1456,21 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     int format_detect;
 
     if (using_stdio) {
-      pmsg_info("can't auto detect file format when using stdin/out\n"
+      pmsg_error("cannot auto detect file format when using stdin/out\n"
         "%s  please specify a file format and try again\n", progbuf);
       return -1;
     }
 
     format_detect = fileio_fmt_autodetect(fname);
     if (format_detect < 0) {
-      pmsg_info("cannot determine file format for %s, specify explicitly\n", fname);
+      pmsg_error("cannot determine file format for %s, specify explicitly\n", fname);
       return -1;
     }
     format = format_detect;
 
-    if (quell_progress < 2) {
+    if (quell_progress < 2)
       pmsg_notice("%s file %s auto detected as %s\n",
         fio.iodesc, fname, fileio_fmtstr(format));
-    }
   }
 
 #if defined(WIN32)
@@ -1494,7 +1492,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     if (!using_stdio) {
       f = fopen(fname, fio.mode);
       if (f == NULL) {
-        pmsg_info("can't open %s file %s: %s\n", fio.iodesc, fname, strerror(errno));
+        pmsg_ext_error("cannot open %s file %s: %s\n", fio.iodesc, fname, strerror(errno));
         return -1;
       }
     }
@@ -1518,7 +1516,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
 #ifdef HAVE_LIBELF
       rc = fileio_elf(&fio, fname, f, mem, p, size);
 #else
-      pmsg_info("can't handle ELF file %s, ELF file support was not compiled in\n", fname);
+      pmsg_error("cannot handle ELF file %s, ELF file support was not compiled in\n", fname);
       rc = -1;
 #endif
       break;
@@ -1535,7 +1533,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
       break;
 
     default:
-      pmsg_info("invalid %s file format: %d\n", fio.iodesc, format);
+      pmsg_error("invalid %s file format: %d\n", fio.iodesc, format);
       return -1;
   }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -126,8 +126,7 @@ static int b2ihex(unsigned char * inbuf, int bufsize,
   unsigned char cksum;
 
   if (recsize > 255) {
-    msg_info("%s: recsize=%d, must be < 256\n",
-              progname, recsize);
+    pmsg_info("recsize=%d, must be < 256\n", recsize);
     return -1;
   }
 
@@ -319,36 +318,31 @@ static int ihex2b(char * infile, FILE * inf,
       continue;
     rc = ihex_readrec(&ihex, buffer);
     if (rc < 0) {
-      msg_info("%s: invalid record at line %d of \"%s\"\n",
-              progname, lineno, infile);
+      pmsg_info("invalid record at line %d of %s\n", lineno, infile);
       return -1;
     }
     else if (rc != ihex.cksum) {
       if(ffmt == FMT_IHEX) {
-        msg_info("%s: ERROR: checksum mismatch at line %d of \"%s\"\n",
-                progname, lineno, infile);
-        msg_info("%s: checksum=0x%02x, computed checksum=0x%02x\n",
-                progname, ihex.cksum, rc);
+        pmsg_info("checksum mismatch at line %d of %s\n", lineno, infile);
+        pmsg_info("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
         return -1;
       } else {                  /* Just warn with more permissive format FMT_IHXC */
-        msg_notice("%s: warning: checksum mismatch at line %d of \"%s\"\n",
-                progname, lineno, infile);
-        msg_notice("%s: checksum=0x%02x, computed checksum=0x%02x\n",
-                progname, ihex.cksum, rc);
+        pmsg_notice("checksum mismatch at line %d of %s\n", lineno, infile);
+        pmsg_notice("checksum=0x%02x, computed checksum=0x%02x\n", ihex.cksum, rc);
       }
     }
 
     switch (ihex.rectyp) {
       case 0: /* data record */
         if (fileoffset != 0 && baseaddr < fileoffset) {
-          msg_info("%s: ERROR: address 0x%04x out of range (below fileoffset 0x%x) at line %d of %s\n",
-                          progname, baseaddr, fileoffset, lineno, infile);
+          pmsg_info("address 0x%04x out of range (below fileoffset 0x%x) at line %d of %s\n",
+            baseaddr, fileoffset, lineno, infile);
           return -1;
         }
         nextaddr = ihex.loadofs + baseaddr - fileoffset;
         if (nextaddr + ihex.reclen > (unsigned) bufsize) {
-          msg_info("%s: ERROR: address 0x%04x out of range at line %d of %s\n",
-                          progname, nextaddr+ihex.reclen, lineno, infile);
+          pmsg_info("address 0x%04x out of range at line %d of %s\n",
+            nextaddr+ihex.reclen, lineno, infile);
           return -1;
         }
         for (i=0; i<ihex.reclen; i++) {
@@ -380,9 +374,8 @@ static int ihex2b(char * infile, FILE * inf,
         break;
 
       default:
-        msg_info("%s: don't know how to deal with rectype=%d "
-                        "at line %d of %s\n",
-                        progname, ihex.rectyp, lineno, infile);
+        pmsg_info("don't know how to deal with rectype=%d "
+          "at line %d of %s\n", ihex.rectyp, lineno, infile);
         return -1;
         break;
     }
@@ -390,16 +383,12 @@ static int ihex2b(char * infile, FILE * inf,
   } /* while */
 
   if (maxaddr == 0) {
-    msg_info("%s: ERROR: No valid record found in Intel Hex "
-                    "file \"%s\"\n",
-                    progname, infile);
+    pmsg_info("ERROR: No valid record found in Intel Hex file %s\n", infile);
 
     return -1;
   }
   else {
-    msg_info("%s: WARNING: no end of file record found for Intel Hex "
-                    "file \"%s\"\n",
-                    progname, infile);
+    pmsg_info("WARNING: no end of file record found for Intel Hex file %s\n", infile);
 
     return maxaddr;
   }
@@ -417,8 +406,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
   char * tmpl=0;
 
   if (recsize > 255) {
-    msg_info("%s: ERROR: recsize=%d, must be < 256\n",
-            progname, recsize);
+    pmsg_info("recsize=%d, must be < 256\n", recsize);
     return -1;
   }
   
@@ -450,8 +438,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
         tmpl="S3%02X%08X";
       }
       else {
-        msg_info("%s: ERROR: address=%d, out of range\n",
-                progname, nextaddr);
+        pmsg_info("address=%d, out of range\n", nextaddr);
         return -1;
       }
 
@@ -599,7 +586,7 @@ static int srec2b(char * infile, FILE * inf,
   unsigned int reccount;
   unsigned char datarec;
 
-  char * msg = 0;
+  char * msg = "";
 
   lineno   = 0;
   maxaddr  = 0;
@@ -615,15 +602,12 @@ static int srec2b(char * infile, FILE * inf,
     rc = srec_readrec(&srec, buffer);
 
     if (rc < 0) {
-      msg_info("%s: ERROR: invalid record at line %d of \"%s\"\n",
-              progname, lineno, infile);
+      pmsg_info("invalid record at line %d of %s\n", lineno, infile);
       return -1;
     }
     else if (rc != srec.cksum) {
-      msg_info("%s: ERROR: checksum mismatch at line %d of \"%s\"\n",
-              progname, lineno, infile);
-      msg_info("%s: checksum=0x%02x, computed checksum=0x%02x\n",
-              progname, srec.cksum, rc);
+      pmsg_info("checksum mismatch at line %d of %s\n", lineno, infile);
+      pmsg_info("checksum=0x%02x, computed checksum=0x%02x\n", srec.cksum, rc);
       return -1;
     }
 
@@ -635,32 +619,27 @@ static int srec2b(char * infile, FILE * inf,
 
       case 0x31: /* S1 - 16 bit address data record */
         datarec=1;
-        msg="%s: ERROR: address 0x%04x out of range %sat line %d of %s\n";
+        msg="address 0x%04x out of range %sat line %d of %s\n";
         break;
 
       case 0x32: /* S2 - 24 bit address data record */
         datarec=1;
-        msg="%s: ERROR: address 0x%06x out of range %sat line %d of %s\n";
+        msg="address 0x%06x out of range %sat line %d of %s\n";
         break;
 
       case 0x33: /* S3 - 32 bit address data record */
         datarec=1;
-        msg="%s: ERROR: address 0x%08x out of range %sat line %d of %s\n";
+        msg="address 0x%08x out of range %sat line %d of %s\n";
         break;
 
       case 0x34: /* S4 - symbol record (LSI extension) */
-        msg_info("%s: ERROR: not supported record at line %d of %s\n",
-                        progname, lineno, infile);
+        pmsg_info("not supported record at line %d of %s\n", lineno, infile);
         return -1;
 
       case 0x35: /* S5 - count of S1,S2 and S3 records previously tx'd */
         if (srec.loadofs != reccount){
-          msg_info("%s: ERROR: count of transmitted data records mismatch "
-                          "at line %d of \"%s\"\n",
-                          progname, lineno, infile);
-          msg_info("%s: transmitted data records= %d, expected "
-                  "value= %d\n",
-                  progname, reccount, srec.loadofs);
+          pmsg_info("count of transmitted data records mismatch at line %d of %s\n", lineno, infile);
+          pmsg_info("transmitted data records= %d, expected value= %d\n", reccount, srec.loadofs);
           return -1;
         }
         break;
@@ -671,24 +650,20 @@ static int srec2b(char * infile, FILE * inf,
         return maxaddr;
 
       default:
-        msg_info("%s: ERROR: don't know how to deal with rectype S%d "
-                        "at line %d of %s\n",
-                        progname, srec.rectyp, lineno, infile);
+        pmsg_error("don't know how to deal with rectype S%d "
+          "at line %d of %s\n", srec.rectyp, lineno, infile);
         return -1;
     }
 
     if (datarec == 1) {
       nextaddr = srec.loadofs;
       if (nextaddr < fileoffset) {
-        msg_info(msg, progname, nextaddr,
-                "(below fileoffset) ",
-                lineno, infile);
+        msg_error(msg, nextaddr, "(below fileoffset) ", lineno, infile);
         return -1;
       }
       nextaddr -= fileoffset;
       if (nextaddr + srec.reclen > (unsigned) bufsize) {
-        msg_info(msg, progname, nextaddr+srec.reclen, "",
-                lineno, infile);
+        msg_error(msg, nextaddr+srec.reclen, "", lineno, infile);
         return -1;
       }
       for (i=0; i<srec.reclen; i++) {
@@ -702,9 +677,7 @@ static int srec2b(char * infile, FILE * inf,
 
   }
 
-  msg_info("%s: WARNING: no end of file record found for Motorola S-Records "
-                  "file \"%s\"\n",
-                  progname, infile);
+  pmsg_info("warning, no end of file record found for Motorola S-Records file %s\n", infile);
 
   return maxaddr;
 }
@@ -747,8 +720,7 @@ static Elf_Scn *elf_get_scn(Elf *e, Elf32_Phdr *ph, Elf32_Shdr **shptr)
     Elf32_Shdr *sh;
     size_t ndx = elf_ndxscn(s);
     if ((sh = elf32_getshdr(s)) == NULL) {
-      msg_info("%s: ERROR: Error reading section #%u header: %s\n",
-                      progname, (unsigned int)ndx, elf_errmsg(-1));
+      pmsg_info("error reading section #%u header: %s\n", (unsigned int)ndx, elf_errmsg(-1));
       continue;
     }
     if ((sh->sh_flags & SHF_ALLOC) == 0 ||
@@ -765,9 +737,7 @@ static Elf_Scn *elf_get_scn(Elf *e, Elf32_Phdr *ph, Elf32_Shdr **shptr)
     }
   }
 
-  msg_info("%s: ERROR: Cannot find a matching section for "
-                  "program header entry @p_vaddr 0x%x\n",
-                  progname, ph->p_vaddr);
+  pmsg_info("cannot find a matching section for program header entry @p_vaddr 0x%x\n", ph->p_vaddr);
   return NULL;
 }
 
@@ -838,8 +808,7 @@ static int elf2b(char * infile, FILE * inf,
   unsigned int low, high, foff;
 
   if (elf_mem_limits(mem, p, &low, &high, &foff) != 0) {
-    msg_info("%s: ERROR: Cannot handle \"%s\" memory region from ELF file\n",
-                    progname, mem->desc);
+    pmsg_info("cannot handle %s memory region from ELF file\n", mem->desc);
     return -1;
   }
 
@@ -856,9 +825,7 @@ static int elf2b(char * infile, FILE * inf,
        strcmp(mem->desc, "apptable") == 0)) {
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (flashmem == NULL) {
-      msg_info("%s: ERROR: No \"flash\" memory region found, "
-                      "cannot compute bounds of \"%s\" sub-region.\n",
-                      progname, mem->desc);
+      pmsg_info("no flash memory region found, cannot compute bounds of %s sub-region\n", mem->desc);
       return -1;
     }
     /* The config file offsets are PDI offsets, rebase to 0. */
@@ -867,18 +834,15 @@ static int elf2b(char * infile, FILE * inf,
   }
 
   if (elf_version(EV_CURRENT) == EV_NONE) {
-    msg_info("%s: ERROR: ELF library initialization failed: %s\n",
-                    progname, elf_errmsg(-1));
+    pmsg_info("ELF library initialization failed: %s\n", elf_errmsg(-1));
     return -1;
   }
   if ((e = elf_begin(fileno(inf), ELF_C_READ, NULL)) == NULL) {
-    msg_info("%s: ERROR: Cannot open \"%s\" as an ELF file: %s\n",
-                    progname, infile, elf_errmsg(-1));
+    pmsg_info("cannot open %s as an ELF file: %s\n", infile, elf_errmsg(-1));
     return -1;
   }
   if (elf_kind(e) != ELF_K_ELF) {
-    msg_info("%s: ERROR: Cannot use \"%s\" as an ELF input file\n",
-                    progname, infile);
+    pmsg_info("cannot use %s as an ELF input file\n", infile);
     goto done;
   }
 
@@ -886,8 +850,7 @@ static int elf2b(char * infile, FILE * inf,
   const char *id = elf_getident(e, &isize);
 
   if (id == NULL) {
-    msg_info("%s: ERROR: Error reading ident area of \"%s\": %s\n",
-                    progname, infile, elf_errmsg(-1));
+    pmsg_info("error reading ident area of %s: %s\n", infile, elf_errmsg(-1));
     goto done;
   }
 
@@ -902,22 +865,19 @@ static int elf2b(char * infile, FILE * inf,
   }
   if (id[EI_CLASS] != ELFCLASS32 ||
       id[EI_DATA] != endianess) {
-    msg_info("%s: ERROR: ELF file \"%s\" is not a "
-                    "32-bit, %s-endian file that was expected\n",
-                    progname, infile, endianname);
+    pmsg_info("ELF file %s is not a 32-bit, %s-endian file that was expected\n",
+      infile, endianname);
     goto done;
   }
 
   Elf32_Ehdr *eh;
   if ((eh = elf32_getehdr(e)) == NULL) {
-    msg_info("%s: ERROR: Error reading ehdr of \"%s\": %s\n",
-                    progname, infile, elf_errmsg(-1));
+    pmsg_info("error reading ehdr of %s: %s\n", infile, elf_errmsg(-1));
     goto done;
   }
 
   if (eh->e_type != ET_EXEC) {
-    msg_info("%s: ERROR: ELF file \"%s\" is not an executable file\n",
-                    progname, infile);
+    pmsg_info("ELF file %s is not an executable file\n", infile);
     goto done;
   }
 
@@ -931,28 +891,24 @@ static int elf2b(char * infile, FILE * inf,
     mname = "AVR";
   }
   if (eh->e_machine != machine) {
-    msg_info("%s: ERROR: ELF file \"%s\" is not for machine %s\n",
-                    progname, infile, mname);
+    pmsg_info("ELF file %s is not for machine %s\n", infile, mname);
     goto done;
   }
   if (eh->e_phnum == 0xffff /* PN_XNUM */) {
-    msg_info("%s: ERROR: ELF file \"%s\" uses extended "
-                    "program header numbers which are not expected\n",
-                    progname, infile);
+    pmsg_info("ELF file %s uses extended program header numbers which are not expected\n",
+      infile);
     goto done;
   }
 
   Elf32_Phdr *ph;
   if ((ph = elf32_getphdr(e)) == NULL) {
-    msg_info("%s: ERROR: Error reading program header table of \"%s\": %s\n",
-                    progname, infile, elf_errmsg(-1));
+    pmsg_info("error reading program header table of %s: %s\n", infile, elf_errmsg(-1));
     goto done;
   }
 
   size_t sndx;
   if (elf_getshdrstrndx(e, &sndx) != 0) {
-    msg_info("%s: ERROR: Error obtaining section name string table: %s\n",
-                    progname, elf_errmsg(-1));
+    pmsg_info("error obtaining section name string table: %s\n", elf_errmsg(-1));
     sndx = 0;
   }
 
@@ -965,9 +921,8 @@ static int elf2b(char * infile, FILE * inf,
         ph[i].p_filesz == 0)
       continue;
 
-    msg_notice2("%s: Considering PT_LOAD program header entry #%d:\n"
-                    "    p_vaddr 0x%x, p_paddr 0x%x, p_filesz %d\n",
-                    progname, i, ph[i].p_vaddr, ph[i].p_paddr, ph[i].p_filesz);
+    pmsg_notice2("considering PT_LOAD program header entry #%d:\n"
+      "    p_vaddr 0x%x, p_paddr 0x%x, p_filesz %d\n", (int) i, ph[i].p_vaddr, ph[i].p_paddr, ph[i].p_filesz);
 
     Elf32_Shdr *sh;
     Elf_Scn *s = elf_get_scn(e, ph + i, &sh);
@@ -986,15 +941,13 @@ static int elf2b(char * infile, FILE * inf,
       unsigned int lma;
       lma = ph[i].p_paddr + sh->sh_offset - ph[i].p_offset;
 
-      msg_notice2("%s: Found section \"%s\", LMA 0x%x, sh_size %u\n",
-                      progname, sname, lma, sh->sh_size);
+      pmsg_notice2("Found section %s, LMA 0x%x, sh_size %u\n", sname, lma, sh->sh_size);
 
       if (lma >= low &&
           lma + sh->sh_size < high) {
         /* OK */
       } else {
-        msg_notice2("    => skipping, inappropriate for \"%s\" memory region\n",
-                        mem->desc);
+        msg_notice2("    => skipping, inappropriate for %s memory region\n", mem->desc);
         continue;
       }
       /*
@@ -1006,24 +959,20 @@ static int elf2b(char * infile, FILE * inf,
        * from it, using the "foff" offset obtained above.
        */
       if (mem->size != 1 && sh->sh_size > (unsigned) mem->size) {
-        msg_info("%s: ERROR: section \"%s\" does not fit into \"%s\" memory:\n"
-                        "    0x%x + %u > %u\n",
-                        progname, sname, mem->desc,
-                        lma, sh->sh_size, mem->size);
+        pmsg_info("ERROR: section %s does not fit into %s memory:\n"
+          "    0x%x + %u > %u\n", sname, mem->desc, lma, sh->sh_size, mem->size);
         continue;
       }
 
       Elf_Data *d = NULL;
       while ((d = elf_getdata(s, d)) != NULL) {
-        msg_notice2("    Data block: d_buf %p, d_off 0x%x, d_size %d\n",
-                        d->d_buf, (unsigned int)d->d_off, d->d_size);
+        msg_notice2("    Data block: d_buf %p, d_off 0x%x, d_size %ld\n",
+                        d->d_buf, (unsigned int)d->d_off, (long) d->d_size);
         if (mem->size == 1) {
           if (d->d_off != 0) {
-            msg_info("%s: ERROR: unexpected data block at offset != 0\n",
-                            progname);
+            pmsg_info("unexpected data block at offset != 0\n");
           } else if (foff >= d->d_size) {
-            msg_info("%s: ERROR: ELF file section does not contain byte at offset %d\n",
-                            progname, foff);
+            pmsg_info("ELF file section does not contain byte at offset %d\n", foff);
           } else {
             msg_notice2("    Extracting one byte from file offset %d\n",
                             foff);
@@ -1037,8 +986,8 @@ static int elf2b(char * infile, FILE * inf,
           idx = lma - low + d->d_off;
           if ((int)(idx + d->d_size) > rv)
             rv = idx + d->d_size;
-          msg_debug("    Writing %d bytes to mem offset 0x%x\n",
-                          d->d_size, idx);
+          msg_debug("    Writing %ld bytes to mem offset 0x%x\n",
+            (long) d->d_size, idx);
           memcpy(mem->buf + idx, d->d_buf, d->d_size);
           memset(mem->tags + idx, TAG_ALLOCATED, d->d_size);
         }
@@ -1107,15 +1056,13 @@ static int fileio_rbin(struct fioparms * fio,
       rc = fwrite(buf, 1, size, f);
       break;
     default:
-      msg_info("%s: fileio: invalid operation=%d\n",
-              progname, fio->op);
+      pmsg_info("fileio: invalid operation=%d\n", fio->op);
       return -1;
   }
 
   if (rc < 0 || (fio->op == FIO_WRITE && rc < size)) {
-    msg_info("%s: %s error %s %s: %s; %s %d of the expected %d bytes\n",
-                    progname, fio->iodesc, fio->dir, filename, strerror(errno),
-                    fio->rw, rc, size);
+    pmsg_info("%s error %s %s: %s; %s %d of the expected %d bytes\n",
+      fio->iodesc, fio->dir, filename, strerror(errno), fio->rw, rc, size);
     return -1;
   }
 
@@ -1142,8 +1089,7 @@ static int fileio_imm(struct fioparms * fio,
 	    strtoul (p, &e, 0):
 	    strtoul (p + 2, &e, 2);
         if (*e != 0) {
-          msg_info("%s: invalid byte value (%s) specified for immediate mode\n",
-                          progname, p);
+          pmsg_info("invalid byte value (%s) specified for immediate mode\n", p);
           return -1;
         }
         mem->buf[loc] = b;
@@ -1154,21 +1100,17 @@ static int fileio_imm(struct fioparms * fio,
       break;
 
     case FIO_WRITE:
-      msg_info(
-                      "%s: Invalid file format 'immediate' for output\n",
-                      progname);
+      pmsg_info("invalid file format 'immediate' for output\n");
       return -1;
 
     default:
-      msg_info("%s: fileio: invalid operation=%d\n",
-              progname, fio->op);
+      pmsg_info("fileio: invalid operation=%d\n", fio->op);
       return -1;
   }
 
   if (rc < 0 || (fio->op == FIO_WRITE && rc < size)) {
-    msg_info("%s: %s error %s %s: %s; %s %d of the expected %d bytes\n",
-                    progname, fio->iodesc, fio->dir, filename, strerror(errno),
-                    fio->rw, rc, size);
+    pmsg_info("%s error %s %s: %s; %s %d of the expected %d bytes\n",
+      fio->iodesc, fio->dir, filename, strerror(errno), fio->rw, rc, size);
     return -1;
   }
 
@@ -1197,8 +1139,7 @@ static int fileio_ihex(struct fioparms * fio,
       break;
 
     default:
-      msg_info("%s: invalid Intel Hex file I/O operation=%d\n",
-              progname, fio->op);
+      pmsg_info("invalid Intel Hex file I/O operation=%d\n", fio->op);
       return -1;
       break;
   }
@@ -1227,9 +1168,7 @@ static int fileio_srec(struct fioparms * fio,
       break;
 
     default:
-      msg_info("%s: ERROR: invalid Motorola S-Records file I/O "
-              "operation=%d\n",
-              progname, fio->op);
+      pmsg_error("invalid Motorola S-Records file I/O operation=%d\n", fio->op);
       return -1;
       break;
   }
@@ -1247,9 +1186,7 @@ static int fileio_elf(struct fioparms * fio,
 
   switch (fio->op) {
     case FIO_WRITE:
-      msg_info("%s: ERROR: write operation not (yet) "
-              "supported for ELF\n",
-              progname);
+      pmsg_info("write operation not supported for ELF\n");
       return -1;
       break;
 
@@ -1258,9 +1195,7 @@ static int fileio_elf(struct fioparms * fio,
       return rc;
 
     default:
-      msg_info("%s: ERROR: invalid ELF file I/O "
-              "operation=%d\n",
-              progname, fio->op);
+      pmsg_info("invalid ELF file I/O operation=%d\n", fio->op);
       return -1;
       break;
   }
@@ -1310,14 +1245,11 @@ static int fileio_num(struct fioparms * fio,
       break;
 
     case FIO_READ:
-      msg_info(
-                      "%s: Invalid file format '%s' for input\n",
-                      progname, name);
+      pmsg_info("invalid file format '%s' for input\n", name);
       return -1;
 
     default:
-      msg_info("%s: fileio: invalid operation=%d\n",
-              progname, fio->op);
+      pmsg_info("fileio: invalid operation=%d\n", fio->op);
       return -1;
   }
 
@@ -1346,8 +1278,7 @@ static int fileio_num(struct fioparms * fio,
   return 0;
 
  writeerr:
-  msg_info("%s: error writing to %s: %s\n",
-	  progname, filename, strerror(errno));
+  pmsg_info("error writing to %s: %s\n", filename, strerror(errno));
   return -1;
 }
 
@@ -1373,8 +1304,7 @@ int fileio_setparms(int op, struct fioparms * fp,
       break;
 
     default:
-      msg_info("%s: invalid I/O operation %d\n",
-              progname, op);
+      pmsg_info("invalid I/O operation %d\n", op);
       return -1;
       break;
   }
@@ -1405,8 +1335,7 @@ int fileio_fmt_autodetect(const char * fname)
   f = fopen(fname, "rb");
 #endif
   if (f == NULL) {
-    msg_info("%s: error opening %s: %s\n",
-            progname, fname, strerror(errno));
+    pmsg_info("error opening %s: %s\n", fname, strerror(errno));
     return -1;
   }
 
@@ -1489,8 +1418,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
   op = oprwv == FIO_READ_FOR_VERIFY? FIO_READ: oprwv;
   mem = avr_locate_mem(p, memtype);
   if (mem == NULL) {
-    msg_info("fileio(): memory type \"%s\" not configured for device \"%s\"\n",
-                    memtype, p->desc);
+    msg_info("fileio(): memory type %s not configured for device %s\n", memtype, p->desc);
     return -1;
   }
 
@@ -1529,23 +1457,21 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     int format_detect;
 
     if (using_stdio) {
-      msg_info("%s: can't auto detect file format when using stdin/out.\n"
-                      "%s  Please specify a file format and try again.\n",
-                      progname, progbuf);
+      pmsg_info("can't auto detect file format when using stdin/out\n"
+        "%s  please specify a file format and try again\n", progbuf);
       return -1;
     }
 
     format_detect = fileio_fmt_autodetect(fname);
     if (format_detect < 0) {
-      msg_info("%s: can't determine file format for %s, specify explicitly\n",
-                      progname, fname);
+      pmsg_info("cannot determine file format for %s, specify explicitly\n", fname);
       return -1;
     }
     format = format_detect;
 
     if (quell_progress < 2) {
-      msg_notice("%s: %s file %s auto detected as %s\n",
-              progname, fio.iodesc, fname, fileio_fmtstr(format));
+      pmsg_notice("%s file %s auto detected as %s\n",
+        fio.iodesc, fname, fileio_fmtstr(format));
     }
   }
 
@@ -1568,8 +1494,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     if (!using_stdio) {
       f = fopen(fname, fio.mode);
       if (f == NULL) {
-        msg_info("%s: can't open %s file %s: %s\n",
-                progname, fio.iodesc, fname, strerror(errno));
+        pmsg_info("can't open %s file %s: %s\n", fio.iodesc, fname, strerror(errno));
         return -1;
       }
     }
@@ -1593,9 +1518,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
 #ifdef HAVE_LIBELF
       rc = fileio_elf(&fio, fname, f, mem, p, size);
 #else
-      msg_info("%s: can't handle ELF file %s, "
-                      "ELF file support was not compiled in\n",
-                      progname, fname);
+      pmsg_info("can't handle ELF file %s, ELF file support was not compiled in\n", fname);
       rc = -1;
 #endif
       break;
@@ -1612,8 +1535,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
       break;
 
     default:
-      msg_info("%s: invalid %s file format: %d\n",
-              progname, fio.iodesc, format);
+      pmsg_info("invalid %s file format: %d\n", fio.iodesc, format);
       return -1;
   }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1103,7 +1103,7 @@ static int fileio_imm(struct fioparms * fio,
       return -1;
 
     default:
-      pmsg_error("fileio: invalid operation=%d\n", fio->op);
+      pmsg_error("invalid operation=%d\n", fio->op);
       return -1;
   }
 
@@ -1248,7 +1248,7 @@ static int fileio_num(struct fioparms * fio,
       return -1;
 
     default:
-      pmsg_error("fileio: invalid operation=%d\n", fio->op);
+      pmsg_error("invalid operation=%d\n", fio->op);
       return -1;
   }
 
@@ -1417,7 +1417,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
   op = oprwv == FIO_READ_FOR_VERIFY? FIO_READ: oprwv;
   mem = avr_locate_mem(p, memtype);
   if (mem == NULL) {
-    pmsg_error("fileio(): memory type %s not configured for device %s\n", memtype, p->desc);
+    pmsg_error("memory type %s not configured for device %s\n", memtype, p->desc);
     return -1;
   }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1456,8 +1456,8 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     int format_detect;
 
     if (using_stdio) {
-      pmsg_error("cannot auto detect file format when using stdin/out\n"
-        "%s  please specify a file format and try again\n", progbuf);
+      pmsg_error("cannot auto detect file format when using stdin/out\n");
+      imsg_error("please specify a file format and try again\n");
       return -1;
     }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -126,7 +126,7 @@ static int b2ihex(unsigned char * inbuf, int bufsize,
   unsigned char cksum;
 
   if (recsize > 255) {
-    avrdude_message(MSG_INFO, "%s: recsize=%d, must be < 256\n",
+    msg_info("%s: recsize=%d, must be < 256\n",
               progname, recsize);
     return -1;
   }
@@ -319,21 +319,21 @@ static int ihex2b(char * infile, FILE * inf,
       continue;
     rc = ihex_readrec(&ihex, buffer);
     if (rc < 0) {
-      avrdude_message(MSG_INFO, "%s: invalid record at line %d of \"%s\"\n",
+      msg_info("%s: invalid record at line %d of \"%s\"\n",
               progname, lineno, infile);
       return -1;
     }
     else if (rc != ihex.cksum) {
       if(ffmt == FMT_IHEX) {
-        avrdude_message(MSG_INFO, "%s: ERROR: checksum mismatch at line %d of \"%s\"\n",
+        msg_info("%s: ERROR: checksum mismatch at line %d of \"%s\"\n",
                 progname, lineno, infile);
-        avrdude_message(MSG_INFO, "%s: checksum=0x%02x, computed checksum=0x%02x\n",
+        msg_info("%s: checksum=0x%02x, computed checksum=0x%02x\n",
                 progname, ihex.cksum, rc);
         return -1;
       } else {                  /* Just warn with more permissive format FMT_IHXC */
-        avrdude_message(MSG_NOTICE, "%s: warning: checksum mismatch at line %d of \"%s\"\n",
+        msg_notice("%s: warning: checksum mismatch at line %d of \"%s\"\n",
                 progname, lineno, infile);
-        avrdude_message(MSG_NOTICE, "%s: checksum=0x%02x, computed checksum=0x%02x\n",
+        msg_notice("%s: checksum=0x%02x, computed checksum=0x%02x\n",
                 progname, ihex.cksum, rc);
       }
     }
@@ -341,13 +341,13 @@ static int ihex2b(char * infile, FILE * inf,
     switch (ihex.rectyp) {
       case 0: /* data record */
         if (fileoffset != 0 && baseaddr < fileoffset) {
-          avrdude_message(MSG_INFO, "%s: ERROR: address 0x%04x out of range (below fileoffset 0x%x) at line %d of %s\n",
+          msg_info("%s: ERROR: address 0x%04x out of range (below fileoffset 0x%x) at line %d of %s\n",
                           progname, baseaddr, fileoffset, lineno, infile);
           return -1;
         }
         nextaddr = ihex.loadofs + baseaddr - fileoffset;
         if (nextaddr + ihex.reclen > (unsigned) bufsize) {
-          avrdude_message(MSG_INFO, "%s: ERROR: address 0x%04x out of range at line %d of %s\n",
+          msg_info("%s: ERROR: address 0x%04x out of range at line %d of %s\n",
                           progname, nextaddr+ihex.reclen, lineno, infile);
           return -1;
         }
@@ -380,7 +380,7 @@ static int ihex2b(char * infile, FILE * inf,
         break;
 
       default:
-        avrdude_message(MSG_INFO, "%s: don't know how to deal with rectype=%d "
+        msg_info("%s: don't know how to deal with rectype=%d "
                         "at line %d of %s\n",
                         progname, ihex.rectyp, lineno, infile);
         return -1;
@@ -390,14 +390,14 @@ static int ihex2b(char * infile, FILE * inf,
   } /* while */
 
   if (maxaddr == 0) {
-    avrdude_message(MSG_INFO, "%s: ERROR: No valid record found in Intel Hex "
+    msg_info("%s: ERROR: No valid record found in Intel Hex "
                     "file \"%s\"\n",
                     progname, infile);
 
     return -1;
   }
   else {
-    avrdude_message(MSG_INFO, "%s: WARNING: no end of file record found for Intel Hex "
+    msg_info("%s: WARNING: no end of file record found for Intel Hex "
                     "file \"%s\"\n",
                     progname, infile);
 
@@ -417,7 +417,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
   char * tmpl=0;
 
   if (recsize > 255) {
-    avrdude_message(MSG_INFO, "%s: ERROR: recsize=%d, must be < 256\n",
+    msg_info("%s: ERROR: recsize=%d, must be < 256\n",
             progname, recsize);
     return -1;
   }
@@ -450,7 +450,7 @@ static int b2srec(unsigned char * inbuf, int bufsize,
         tmpl="S3%02X%08X";
       }
       else {
-        avrdude_message(MSG_INFO, "%s: ERROR: address=%d, out of range\n",
+        msg_info("%s: ERROR: address=%d, out of range\n",
                 progname, nextaddr);
         return -1;
       }
@@ -615,14 +615,14 @@ static int srec2b(char * infile, FILE * inf,
     rc = srec_readrec(&srec, buffer);
 
     if (rc < 0) {
-      avrdude_message(MSG_INFO, "%s: ERROR: invalid record at line %d of \"%s\"\n",
+      msg_info("%s: ERROR: invalid record at line %d of \"%s\"\n",
               progname, lineno, infile);
       return -1;
     }
     else if (rc != srec.cksum) {
-      avrdude_message(MSG_INFO, "%s: ERROR: checksum mismatch at line %d of \"%s\"\n",
+      msg_info("%s: ERROR: checksum mismatch at line %d of \"%s\"\n",
               progname, lineno, infile);
-      avrdude_message(MSG_INFO, "%s: checksum=0x%02x, computed checksum=0x%02x\n",
+      msg_info("%s: checksum=0x%02x, computed checksum=0x%02x\n",
               progname, srec.cksum, rc);
       return -1;
     }
@@ -649,16 +649,16 @@ static int srec2b(char * infile, FILE * inf,
         break;
 
       case 0x34: /* S4 - symbol record (LSI extension) */
-        avrdude_message(MSG_INFO, "%s: ERROR: not supported record at line %d of %s\n",
+        msg_info("%s: ERROR: not supported record at line %d of %s\n",
                         progname, lineno, infile);
         return -1;
 
       case 0x35: /* S5 - count of S1,S2 and S3 records previously tx'd */
         if (srec.loadofs != reccount){
-          avrdude_message(MSG_INFO, "%s: ERROR: count of transmitted data records mismatch "
+          msg_info("%s: ERROR: count of transmitted data records mismatch "
                           "at line %d of \"%s\"\n",
                           progname, lineno, infile);
-          avrdude_message(MSG_INFO, "%s: transmitted data records= %d, expected "
+          msg_info("%s: transmitted data records= %d, expected "
                   "value= %d\n",
                   progname, reccount, srec.loadofs);
           return -1;
@@ -671,7 +671,7 @@ static int srec2b(char * infile, FILE * inf,
         return maxaddr;
 
       default:
-        avrdude_message(MSG_INFO, "%s: ERROR: don't know how to deal with rectype S%d "
+        msg_info("%s: ERROR: don't know how to deal with rectype S%d "
                         "at line %d of %s\n",
                         progname, srec.rectyp, lineno, infile);
         return -1;
@@ -680,14 +680,14 @@ static int srec2b(char * infile, FILE * inf,
     if (datarec == 1) {
       nextaddr = srec.loadofs;
       if (nextaddr < fileoffset) {
-        avrdude_message(MSG_INFO, msg, progname, nextaddr,
+        msg_info(msg, progname, nextaddr,
                 "(below fileoffset) ",
                 lineno, infile);
         return -1;
       }
       nextaddr -= fileoffset;
       if (nextaddr + srec.reclen > (unsigned) bufsize) {
-        avrdude_message(MSG_INFO, msg, progname, nextaddr+srec.reclen, "",
+        msg_info(msg, progname, nextaddr+srec.reclen, "",
                 lineno, infile);
         return -1;
       }
@@ -702,7 +702,7 @@ static int srec2b(char * infile, FILE * inf,
 
   }
 
-  avrdude_message(MSG_INFO, "%s: WARNING: no end of file record found for Motorola S-Records "
+  msg_info("%s: WARNING: no end of file record found for Motorola S-Records "
                   "file \"%s\"\n",
                   progname, infile);
 
@@ -747,7 +747,7 @@ static Elf_Scn *elf_get_scn(Elf *e, Elf32_Phdr *ph, Elf32_Shdr **shptr)
     Elf32_Shdr *sh;
     size_t ndx = elf_ndxscn(s);
     if ((sh = elf32_getshdr(s)) == NULL) {
-      avrdude_message(MSG_INFO, "%s: ERROR: Error reading section #%u header: %s\n",
+      msg_info("%s: ERROR: Error reading section #%u header: %s\n",
                       progname, (unsigned int)ndx, elf_errmsg(-1));
       continue;
     }
@@ -765,7 +765,7 @@ static Elf_Scn *elf_get_scn(Elf *e, Elf32_Phdr *ph, Elf32_Shdr **shptr)
     }
   }
 
-  avrdude_message(MSG_INFO, "%s: ERROR: Cannot find a matching section for "
+  msg_info("%s: ERROR: Cannot find a matching section for "
                   "program header entry @p_vaddr 0x%x\n",
                   progname, ph->p_vaddr);
   return NULL;
@@ -838,7 +838,7 @@ static int elf2b(char * infile, FILE * inf,
   unsigned int low, high, foff;
 
   if (elf_mem_limits(mem, p, &low, &high, &foff) != 0) {
-    avrdude_message(MSG_INFO, "%s: ERROR: Cannot handle \"%s\" memory region from ELF file\n",
+    msg_info("%s: ERROR: Cannot handle \"%s\" memory region from ELF file\n",
                     progname, mem->desc);
     return -1;
   }
@@ -856,7 +856,7 @@ static int elf2b(char * infile, FILE * inf,
        strcmp(mem->desc, "apptable") == 0)) {
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (flashmem == NULL) {
-      avrdude_message(MSG_INFO, "%s: ERROR: No \"flash\" memory region found, "
+      msg_info("%s: ERROR: No \"flash\" memory region found, "
                       "cannot compute bounds of \"%s\" sub-region.\n",
                       progname, mem->desc);
       return -1;
@@ -867,17 +867,17 @@ static int elf2b(char * infile, FILE * inf,
   }
 
   if (elf_version(EV_CURRENT) == EV_NONE) {
-    avrdude_message(MSG_INFO, "%s: ERROR: ELF library initialization failed: %s\n",
+    msg_info("%s: ERROR: ELF library initialization failed: %s\n",
                     progname, elf_errmsg(-1));
     return -1;
   }
   if ((e = elf_begin(fileno(inf), ELF_C_READ, NULL)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: ERROR: Cannot open \"%s\" as an ELF file: %s\n",
+    msg_info("%s: ERROR: Cannot open \"%s\" as an ELF file: %s\n",
                     progname, infile, elf_errmsg(-1));
     return -1;
   }
   if (elf_kind(e) != ELF_K_ELF) {
-    avrdude_message(MSG_INFO, "%s: ERROR: Cannot use \"%s\" as an ELF input file\n",
+    msg_info("%s: ERROR: Cannot use \"%s\" as an ELF input file\n",
                     progname, infile);
     goto done;
   }
@@ -886,7 +886,7 @@ static int elf2b(char * infile, FILE * inf,
   const char *id = elf_getident(e, &isize);
 
   if (id == NULL) {
-    avrdude_message(MSG_INFO, "%s: ERROR: Error reading ident area of \"%s\": %s\n",
+    msg_info("%s: ERROR: Error reading ident area of \"%s\": %s\n",
                     progname, infile, elf_errmsg(-1));
     goto done;
   }
@@ -902,7 +902,7 @@ static int elf2b(char * infile, FILE * inf,
   }
   if (id[EI_CLASS] != ELFCLASS32 ||
       id[EI_DATA] != endianess) {
-    avrdude_message(MSG_INFO, "%s: ERROR: ELF file \"%s\" is not a "
+    msg_info("%s: ERROR: ELF file \"%s\" is not a "
                     "32-bit, %s-endian file that was expected\n",
                     progname, infile, endianname);
     goto done;
@@ -910,13 +910,13 @@ static int elf2b(char * infile, FILE * inf,
 
   Elf32_Ehdr *eh;
   if ((eh = elf32_getehdr(e)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: ERROR: Error reading ehdr of \"%s\": %s\n",
+    msg_info("%s: ERROR: Error reading ehdr of \"%s\": %s\n",
                     progname, infile, elf_errmsg(-1));
     goto done;
   }
 
   if (eh->e_type != ET_EXEC) {
-    avrdude_message(MSG_INFO, "%s: ERROR: ELF file \"%s\" is not an executable file\n",
+    msg_info("%s: ERROR: ELF file \"%s\" is not an executable file\n",
                     progname, infile);
     goto done;
   }
@@ -931,12 +931,12 @@ static int elf2b(char * infile, FILE * inf,
     mname = "AVR";
   }
   if (eh->e_machine != machine) {
-    avrdude_message(MSG_INFO, "%s: ERROR: ELF file \"%s\" is not for machine %s\n",
+    msg_info("%s: ERROR: ELF file \"%s\" is not for machine %s\n",
                     progname, infile, mname);
     goto done;
   }
   if (eh->e_phnum == 0xffff /* PN_XNUM */) {
-    avrdude_message(MSG_INFO, "%s: ERROR: ELF file \"%s\" uses extended "
+    msg_info("%s: ERROR: ELF file \"%s\" uses extended "
                     "program header numbers which are not expected\n",
                     progname, infile);
     goto done;
@@ -944,14 +944,14 @@ static int elf2b(char * infile, FILE * inf,
 
   Elf32_Phdr *ph;
   if ((ph = elf32_getphdr(e)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: ERROR: Error reading program header table of \"%s\": %s\n",
+    msg_info("%s: ERROR: Error reading program header table of \"%s\": %s\n",
                     progname, infile, elf_errmsg(-1));
     goto done;
   }
 
   size_t sndx;
   if (elf_getshdrstrndx(e, &sndx) != 0) {
-    avrdude_message(MSG_INFO, "%s: ERROR: Error obtaining section name string table: %s\n",
+    msg_info("%s: ERROR: Error obtaining section name string table: %s\n",
                     progname, elf_errmsg(-1));
     sndx = 0;
   }
@@ -965,7 +965,7 @@ static int elf2b(char * infile, FILE * inf,
         ph[i].p_filesz == 0)
       continue;
 
-    avrdude_message(MSG_NOTICE2, "%s: Considering PT_LOAD program header entry #%d:\n"
+    msg_notice2("%s: Considering PT_LOAD program header entry #%d:\n"
                     "    p_vaddr 0x%x, p_paddr 0x%x, p_filesz %d\n",
                     progname, i, ph[i].p_vaddr, ph[i].p_paddr, ph[i].p_filesz);
 
@@ -986,14 +986,14 @@ static int elf2b(char * infile, FILE * inf,
       unsigned int lma;
       lma = ph[i].p_paddr + sh->sh_offset - ph[i].p_offset;
 
-      avrdude_message(MSG_NOTICE2, "%s: Found section \"%s\", LMA 0x%x, sh_size %u\n",
+      msg_notice2("%s: Found section \"%s\", LMA 0x%x, sh_size %u\n",
                       progname, sname, lma, sh->sh_size);
 
       if (lma >= low &&
           lma + sh->sh_size < high) {
         /* OK */
       } else {
-        avrdude_message(MSG_NOTICE2, "    => skipping, inappropriate for \"%s\" memory region\n",
+        msg_notice2("    => skipping, inappropriate for \"%s\" memory region\n",
                         mem->desc);
         continue;
       }
@@ -1006,7 +1006,7 @@ static int elf2b(char * infile, FILE * inf,
        * from it, using the "foff" offset obtained above.
        */
       if (mem->size != 1 && sh->sh_size > (unsigned) mem->size) {
-        avrdude_message(MSG_INFO, "%s: ERROR: section \"%s\" does not fit into \"%s\" memory:\n"
+        msg_info("%s: ERROR: section \"%s\" does not fit into \"%s\" memory:\n"
                         "    0x%x + %u > %u\n",
                         progname, sname, mem->desc,
                         lma, sh->sh_size, mem->size);
@@ -1015,17 +1015,17 @@ static int elf2b(char * infile, FILE * inf,
 
       Elf_Data *d = NULL;
       while ((d = elf_getdata(s, d)) != NULL) {
-        avrdude_message(MSG_NOTICE2, "    Data block: d_buf %p, d_off 0x%x, d_size %d\n",
+        msg_notice2("    Data block: d_buf %p, d_off 0x%x, d_size %d\n",
                         d->d_buf, (unsigned int)d->d_off, d->d_size);
         if (mem->size == 1) {
           if (d->d_off != 0) {
-            avrdude_message(MSG_INFO, "%s: ERROR: unexpected data block at offset != 0\n",
+            msg_info("%s: ERROR: unexpected data block at offset != 0\n",
                             progname);
           } else if (foff >= d->d_size) {
-            avrdude_message(MSG_INFO, "%s: ERROR: ELF file section does not contain byte at offset %d\n",
+            msg_info("%s: ERROR: ELF file section does not contain byte at offset %d\n",
                             progname, foff);
           } else {
-            avrdude_message(MSG_NOTICE2, "    Extracting one byte from file offset %d\n",
+            msg_notice2("    Extracting one byte from file offset %d\n",
                             foff);
             mem->buf[0] = ((unsigned char *)d->d_buf)[foff];
             mem->tags[0] = TAG_ALLOCATED;
@@ -1037,7 +1037,7 @@ static int elf2b(char * infile, FILE * inf,
           idx = lma - low + d->d_off;
           if ((int)(idx + d->d_size) > rv)
             rv = idx + d->d_size;
-          avrdude_message(MSG_DEBUG, "    Writing %d bytes to mem offset 0x%x\n",
+          msg_debug("    Writing %d bytes to mem offset 0x%x\n",
                           d->d_size, idx);
           memcpy(mem->buf + idx, d->d_buf, d->d_size);
           memset(mem->tags + idx, TAG_ALLOCATED, d->d_size);
@@ -1107,13 +1107,13 @@ static int fileio_rbin(struct fioparms * fio,
       rc = fwrite(buf, 1, size, f);
       break;
     default:
-      avrdude_message(MSG_INFO, "%s: fileio: invalid operation=%d\n",
+      msg_info("%s: fileio: invalid operation=%d\n",
               progname, fio->op);
       return -1;
   }
 
   if (rc < 0 || (fio->op == FIO_WRITE && rc < size)) {
-    avrdude_message(MSG_INFO, "%s: %s error %s %s: %s; %s %d of the expected %d bytes\n",
+    msg_info("%s: %s error %s %s: %s; %s %d of the expected %d bytes\n",
                     progname, fio->iodesc, fio->dir, filename, strerror(errno),
                     fio->rw, rc, size);
     return -1;
@@ -1142,7 +1142,7 @@ static int fileio_imm(struct fioparms * fio,
 	    strtoul (p, &e, 0):
 	    strtoul (p + 2, &e, 2);
         if (*e != 0) {
-          avrdude_message(MSG_INFO, "%s: invalid byte value (%s) specified for immediate mode\n",
+          msg_info("%s: invalid byte value (%s) specified for immediate mode\n",
                           progname, p);
           return -1;
         }
@@ -1154,19 +1154,19 @@ static int fileio_imm(struct fioparms * fio,
       break;
 
     case FIO_WRITE:
-      avrdude_message(MSG_INFO,
+      msg_info(
                       "%s: Invalid file format 'immediate' for output\n",
                       progname);
       return -1;
 
     default:
-      avrdude_message(MSG_INFO, "%s: fileio: invalid operation=%d\n",
+      msg_info("%s: fileio: invalid operation=%d\n",
               progname, fio->op);
       return -1;
   }
 
   if (rc < 0 || (fio->op == FIO_WRITE && rc < size)) {
-    avrdude_message(MSG_INFO, "%s: %s error %s %s: %s; %s %d of the expected %d bytes\n",
+    msg_info("%s: %s error %s %s: %s; %s %d of the expected %d bytes\n",
                     progname, fio->iodesc, fio->dir, filename, strerror(errno),
                     fio->rw, rc, size);
     return -1;
@@ -1197,7 +1197,7 @@ static int fileio_ihex(struct fioparms * fio,
       break;
 
     default:
-      avrdude_message(MSG_INFO, "%s: invalid Intel Hex file I/O operation=%d\n",
+      msg_info("%s: invalid Intel Hex file I/O operation=%d\n",
               progname, fio->op);
       return -1;
       break;
@@ -1227,7 +1227,7 @@ static int fileio_srec(struct fioparms * fio,
       break;
 
     default:
-      avrdude_message(MSG_INFO, "%s: ERROR: invalid Motorola S-Records file I/O "
+      msg_info("%s: ERROR: invalid Motorola S-Records file I/O "
               "operation=%d\n",
               progname, fio->op);
       return -1;
@@ -1247,7 +1247,7 @@ static int fileio_elf(struct fioparms * fio,
 
   switch (fio->op) {
     case FIO_WRITE:
-      avrdude_message(MSG_INFO, "%s: ERROR: write operation not (yet) "
+      msg_info("%s: ERROR: write operation not (yet) "
               "supported for ELF\n",
               progname);
       return -1;
@@ -1258,7 +1258,7 @@ static int fileio_elf(struct fioparms * fio,
       return rc;
 
     default:
-      avrdude_message(MSG_INFO, "%s: ERROR: invalid ELF file I/O "
+      msg_info("%s: ERROR: invalid ELF file I/O "
               "operation=%d\n",
               progname, fio->op);
       return -1;
@@ -1310,13 +1310,13 @@ static int fileio_num(struct fioparms * fio,
       break;
 
     case FIO_READ:
-      avrdude_message(MSG_INFO,
+      msg_info(
                       "%s: Invalid file format '%s' for input\n",
                       progname, name);
       return -1;
 
     default:
-      avrdude_message(MSG_INFO, "%s: fileio: invalid operation=%d\n",
+      msg_info("%s: fileio: invalid operation=%d\n",
               progname, fio->op);
       return -1;
   }
@@ -1346,7 +1346,7 @@ static int fileio_num(struct fioparms * fio,
   return 0;
 
  writeerr:
-  avrdude_message(MSG_INFO, "%s: error writing to %s: %s\n",
+  msg_info("%s: error writing to %s: %s\n",
 	  progname, filename, strerror(errno));
   return -1;
 }
@@ -1373,7 +1373,7 @@ int fileio_setparms(int op, struct fioparms * fp,
       break;
 
     default:
-      avrdude_message(MSG_INFO, "%s: invalid I/O operation %d\n",
+      msg_info("%s: invalid I/O operation %d\n",
               progname, op);
       return -1;
       break;
@@ -1405,7 +1405,7 @@ int fileio_fmt_autodetect(const char * fname)
   f = fopen(fname, "rb");
 #endif
   if (f == NULL) {
-    avrdude_message(MSG_INFO, "%s: error opening %s: %s\n",
+    msg_info("%s: error opening %s: %s\n",
             progname, fname, strerror(errno));
     return -1;
   }
@@ -1489,7 +1489,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
   op = oprwv == FIO_READ_FOR_VERIFY? FIO_READ: oprwv;
   mem = avr_locate_mem(p, memtype);
   if (mem == NULL) {
-    avrdude_message(MSG_INFO, "fileio(): memory type \"%s\" not configured for device \"%s\"\n",
+    msg_info("fileio(): memory type \"%s\" not configured for device \"%s\"\n",
                     memtype, p->desc);
     return -1;
   }
@@ -1529,7 +1529,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     int format_detect;
 
     if (using_stdio) {
-      avrdude_message(MSG_INFO, "%s: can't auto detect file format when using stdin/out.\n"
+      msg_info("%s: can't auto detect file format when using stdin/out.\n"
                       "%s  Please specify a file format and try again.\n",
                       progname, progbuf);
       return -1;
@@ -1537,14 +1537,14 @@ int fileio(int oprwv, char * filename, FILEFMT format,
 
     format_detect = fileio_fmt_autodetect(fname);
     if (format_detect < 0) {
-      avrdude_message(MSG_INFO, "%s: can't determine file format for %s, specify explicitly\n",
+      msg_info("%s: can't determine file format for %s, specify explicitly\n",
                       progname, fname);
       return -1;
     }
     format = format_detect;
 
     if (quell_progress < 2) {
-      avrdude_message(MSG_NOTICE, "%s: %s file %s auto detected as %s\n",
+      msg_notice("%s: %s file %s auto detected as %s\n",
               progname, fio.iodesc, fname, fileio_fmtstr(format));
     }
   }
@@ -1568,7 +1568,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
     if (!using_stdio) {
       f = fopen(fname, fio.mode);
       if (f == NULL) {
-        avrdude_message(MSG_INFO, "%s: can't open %s file %s: %s\n",
+        msg_info("%s: can't open %s file %s: %s\n",
                 progname, fio.iodesc, fname, strerror(errno));
         return -1;
       }
@@ -1593,7 +1593,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
 #ifdef HAVE_LIBELF
       rc = fileio_elf(&fio, fname, f, mem, p, size);
 #else
-      avrdude_message(MSG_INFO, "%s: can't handle ELF file %s, "
+      msg_info("%s: can't handle ELF file %s, "
                       "ELF file support was not compiled in\n",
                       progname, fname);
       rc = -1;
@@ -1612,7 +1612,7 @@ int fileio(int oprwv, char * filename, FILEFMT format,
       break;
 
     default:
-      avrdude_message(MSG_INFO, "%s: invalid %s file format: %d\n",
+      msg_info("%s: invalid %s file format: %d\n",
               progname, fio.iodesc, format);
       return -1;
   }

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -234,13 +234,13 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      avrdude_message(MSG_INFO, "%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
+      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
                       progname, pid);
   } else {
     pid = part->usbpid;
   }
   if (!ovsigck && (part->prog_modes & PM_PDI)) {
-    avrdude_message(MSG_INFO, "%s: \"flip1\" (FLIP protocol version 1) is for AT90USB* and ATmega*U* devices.\n"
+    msg_info("%s: \"flip1\" (FLIP protocol version 1) is for AT90USB* and ATmega*U* devices.\n"
                     "%s For Xmega devices, use \"flip2\".\n"
                     "%s (Use -F to bypass this check.)\n",
                     progname, progbuf, progbuf);
@@ -255,31 +255,31 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   /* Check if descriptor values are what we expect. */
 
   if (dfu->dev_desc.idVendor != vid)
-    avrdude_message(MSG_INFO, "%s: Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
+    msg_info("%s: Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
       progname, dfu->dev_desc.idVendor, vid);
 
   if (pid != 0 && dfu->dev_desc.idProduct != pid)
-    avrdude_message(MSG_INFO, "%s: Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
+    msg_info("%s: Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
       progname, dfu->dev_desc.idProduct, pid);
 
   if (dfu->dev_desc.bNumConfigurations != 1)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bNumConfigurations = %d (expected 1)\n",
+    msg_info("%s: Warning: USB bNumConfigurations = %d (expected 1)\n",
       progname, (int) dfu->dev_desc.bNumConfigurations);
 
   if (dfu->conf_desc.bNumInterfaces != 1)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bNumInterfaces = %d (expected 1)\n",
+    msg_info("%s: Warning: USB bNumInterfaces = %d (expected 1)\n",
       progname, (int) dfu->conf_desc.bNumInterfaces);
 
   if (dfu->dev_desc.bDeviceClass != 254)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bDeviceClass = %d (expected 254)\n",
+    msg_info("%s: Warning: USB bDeviceClass = %d (expected 254)\n",
       progname, (int) dfu->dev_desc.bDeviceClass);
 
   if (dfu->dev_desc.bDeviceSubClass != 1)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bDeviceSubClass = %d (expected 1)\n",
+    msg_info("%s: Warning: USB bDeviceSubClass = %d (expected 1)\n",
       progname, (int) dfu->dev_desc.bDeviceSubClass);
 
   if (dfu->dev_desc.bDeviceProtocol != 0)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bDeviceProtocol = %d (expected 0)\n",
+    msg_info("%s: Warning: USB bDeviceProtocol = %d (expected 0)\n",
       progname, (int) dfu->dev_desc.bDeviceProtocol);
 
   /*
@@ -290,20 +290,20 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
    */
   if (0) {
   if (dfu->intf_desc.bInterfaceClass != 254)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bInterfaceClass = %d (expected 254)\n",
+    msg_info("%s: Warning: USB bInterfaceClass = %d (expected 254)\n",
       progname, (int) dfu->intf_desc.bInterfaceClass);
 
   if (dfu->intf_desc.bInterfaceSubClass != 1)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bInterfaceSubClass = %d (expected 1)\n",
+    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 1)\n",
       progname, (int) dfu->intf_desc.bInterfaceSubClass);
 
   if (dfu->intf_desc.bInterfaceProtocol != 0)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
+    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
       progname, (int) dfu->intf_desc.bInterfaceProtocol);
   }
 
   if (dfu->dev_desc.bMaxPacketSize0 != 32)
-    avrdude_message(MSG_INFO, "%s: Warning: bMaxPacketSize0 (%d) != 32, things might go wrong\n",
+    msg_info("%s: Warning: bMaxPacketSize0 (%d) != 32, things might go wrong\n",
       progname, dfu->dev_desc.bMaxPacketSize0);
 
   if (verbose)
@@ -353,7 +353,7 @@ int flip1_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   int aux_result;
   unsigned int default_timeout = FLIP1(pgm)->dfu->timeout;
 
-  avrdude_message(MSG_NOTICE2, "%s: flip_chip_erase()\n", progname);
+  msg_notice2("%s: flip_chip_erase()\n", progname);
 
   struct flip1_cmd cmd = {
     FLIP1_CMD_WRITE_COMMAND, { 0, 0xff }
@@ -368,7 +368,7 @@ int flip1_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
     return -1;
 
   if (status.bStatus != DFU_STATUS_OK) {
-    avrdude_message(MSG_INFO, "%s: failed to send chip erase command: %s\n",
+    msg_info("%s: failed to send chip erase command: %s\n",
             progname, flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
       dfu_clrstatus(FLIP1(pgm)->dfu);
@@ -390,7 +390,7 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
     if (flip1_read_sig_bytes(pgm, part, mem) < 0)
       return -1;
     if (addr > mem->size) {
-      avrdude_message(MSG_INFO, "%s: flip1_read_byte(signature): address %lu out of range\n",
+      msg_info("%s: flip1_read_byte(signature): address %lu out of range\n",
               progname, addr);
       return -1;
     }
@@ -401,10 +401,10 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
-    avrdude_message(MSG_INFO, "\n");
+    msg_info("\n");
     return -1;
   }
 
@@ -426,10 +426,10 @@ int flip1_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
-    avrdude_message(MSG_INFO, "\n");
+    msg_info("\n");
     return -1;
   }
 
@@ -447,10 +447,10 @@ int flip1_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
-    avrdude_message(MSG_INFO, "\n");
+    msg_info("\n");
     return -1;
   }
 
@@ -473,16 +473,16 @@ int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
-    avrdude_message(MSG_INFO, "\n");
+    msg_info("\n");
     return -1;
   }
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    avrdude_message(MSG_INFO, "%s: Error: Attempting to read more than %d bytes\n",
+    msg_info("%s: Error: Attempting to read more than %d bytes\n",
       progname, INT_MAX);
     exit(1);
   }
@@ -494,13 +494,13 @@ int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
 }
 
 int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {
-  avrdude_message(MSG_NOTICE2, "%s: flip1_read_sig_bytes(): ", progname);
+  msg_notice2("%s: flip1_read_sig_bytes(): ", progname);
 
   if (FLIP1(pgm)->dfu == NULL)
     return -1;
 
   if (mem->size < sizeof(FLIP1(pgm)->part_sig)) {
-    avrdude_message(MSG_INFO, "%s: Error: Signature read must be at least %u bytes\n",
+    msg_info("%s: Error: Signature read must be at least %u bytes\n",
       progname, (unsigned int) sizeof(FLIP1(pgm)->part_sig));
     return -1;
   }
@@ -518,7 +518,7 @@ int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
       FLIP1_CMD_READ_COMMAND, FLIP1_READ_FAMILY_CODE
     };
 
-    avrdude_message(MSG_NOTICE2, "from device\n");
+    msg_notice2("from device\n");
 
     for (i = 0; i < 3; i++)
     {
@@ -535,7 +535,7 @@ int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
 
       if (status.bStatus != DFU_STATUS_OK)
       {
-        avrdude_message(MSG_INFO, "%s: failed to send cmd for signature byte %d: %s\n",
+        msg_info("%s: failed to send cmd for signature byte %d: %s\n",
                 progname, i, flip1_status_str(&status));
         if (status.bState == STATE_dfuERROR)
           dfu_clrstatus(FLIP1(pgm)->dfu);
@@ -550,7 +550,7 @@ int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
 
       if (status.bStatus != DFU_STATUS_OK)
       {
-        avrdude_message(MSG_INFO, "%s: failed to read signature byte %d: %s\n",
+        msg_info("%s: failed to read signature byte %d: %s\n",
                 progname, i, flip1_status_str(&status));
         if (status.bState == STATE_dfuERROR)
           dfu_clrstatus(FLIP1(pgm)->dfu);
@@ -560,7 +560,7 @@ int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
   }
   else
   {
-    avrdude_message(MSG_NOTICE2, "cached\n");
+    msg_notice2("cached\n");
   }
 
   memcpy(mem->buf, FLIP1(pgm)->part_sig, sizeof(FLIP1(pgm)->part_sig));
@@ -573,7 +573,7 @@ void flip1_setup(PROGRAMMER * pgm)
   pgm->cookie = calloc(1, sizeof(struct flip1));
 
   if (pgm->cookie == NULL) {
-    avrdude_message(MSG_INFO, "%s: Out of memory allocating private data structure\n",
+    msg_info("%s: Out of memory allocating private data structure\n",
             progname);
     exit(1);
   }
@@ -591,7 +591,7 @@ void flip1_teardown(PROGRAMMER * pgm)
 void flip1_show_info(struct flip1 *flip1)
 {
   dfu_show_info(flip1->dfu);
-  avrdude_message(MSG_INFO, "    USB max packet size : %hu\n",
+  msg_info("    USB max packet size : %hu\n",
     (unsigned short) flip1->dfu->dev_desc.bMaxPacketSize0);
 }
 
@@ -609,7 +609,7 @@ int flip1_read_memory(const PROGRAMMER *pgm,
   unsigned int default_timeout = dfu->timeout;
 
 
-  avrdude_message(MSG_NOTICE2, "%s: flip_read_memory(%s, 0x%04x, %d)\n",
+  msg_notice2("%s: flip_read_memory(%s, 0x%04x, %d)\n",
                   progname, flip1_mem_unit_str(mem_unit), addr, size);
 
   /*
@@ -640,7 +640,7 @@ int flip1_read_memory(const PROGRAMMER *pgm,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    avrdude_message(MSG_INFO, "%s: failed to read %u bytes of %s memory @%u: %s\n",
+    msg_info("%s: failed to read %u bytes of %s memory @%u: %s\n",
             progname, size, flip1_mem_unit_str(mem_unit), addr,
             flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
@@ -654,7 +654,7 @@ int flip1_read_memory(const PROGRAMMER *pgm,
   if (cmd_result < 0 && aux_result == 0 &&
       status.bStatus == DFU_STATUS_ERR_WRITE) {
     if (FLIP1(pgm)->security_mode_flag == 0)
-      avrdude_message(MSG_INFO, "\n%s:\n"
+      msg_info("\n%s:\n"
               "%s***********************************************************************\n"
               "%sMaybe the device is in ``security mode´´, and needs a chip erase first?\n"
               "%s***********************************************************************\n"
@@ -668,7 +668,7 @@ int flip1_read_memory(const PROGRAMMER *pgm,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    avrdude_message(MSG_INFO, "%s: failed to read %u bytes of %s memory @%u: %s\n",
+    msg_info("%s: failed to read %u bytes of %s memory @%u: %s\n",
             progname, size, flip1_mem_unit_str(mem_unit), addr,
             flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
@@ -702,13 +702,13 @@ int flip1_write_memory(struct dfu_dev *dfu,
   unsigned int default_timeout = dfu->timeout;
   unsigned char *buf;
 
-  avrdude_message(MSG_NOTICE2, "%s: flip_write_memory(%s, 0x%04x, %d)\n",
+  msg_notice2("%s: flip_write_memory(%s, 0x%04x, %d)\n",
                   progname, flip1_mem_unit_str(mem_unit), addr, size);
 
   if (size < 32) {
     /* presumably single-byte updates; must be padded to USB endpoint size */
     if ((addr + size - 1) / 32 != addr / 32) {
-      avrdude_message(MSG_INFO, "%s: flip_write_memory(): begin (0x%x) and end (0x%x) not within same 32-byte block\n",
+      msg_info("%s: flip_write_memory(): begin (0x%x) and end (0x%x) not within same 32-byte block\n",
                       progname, addr, addr + size - 1);
       return -1;
     }
@@ -720,7 +720,7 @@ int flip1_write_memory(struct dfu_dev *dfu,
   if ((buf = malloc(sizeof(struct flip1_cmd_header) +
                     write_size +
                     sizeof(struct flip1_prog_footer))) == 0) {
-    avrdude_message(MSG_INFO, "%s: Out of memory\n", progname);
+    msg_info("%s: Out of memory\n", progname);
     return -1;
   }
 
@@ -769,7 +769,7 @@ int flip1_write_memory(struct dfu_dev *dfu,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    avrdude_message(MSG_INFO, "%s: failed to write %u bytes of %s memory @%u: %s\n",
+    msg_info("%s: failed to write %u bytes of %s memory @%u: %s\n",
             progname, size, flip1_mem_unit_str(mem_unit), addr,
             flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
@@ -800,7 +800,7 @@ int flip1_set_mem_page(struct dfu_dev *dfu,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    avrdude_message(MSG_INFO, "%s: failed to set memory page: %s\n",
+    msg_info("%s: failed to set memory page: %s\n",
             progname, flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
       dfu_clrstatus(dfu);

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -239,9 +239,8 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
     pid = part->usbpid;
   }
   if (!ovsigck && (part->prog_modes & PM_PDI)) {
-    pmsg_error("flip1 (FLIP protocol version 1) is for AT90USB* and ATmega*U* devices\n"
-      "%s for Xmega devices, use flip2\n"
-      "%s (or use -F to bypass this check)\n", progbuf, progbuf);
+    pmsg_error("flip1 (FLIP protocol version 1) is for AT90USB* and ATmega*U* devices\n");
+    imsg_error("for Xmega devices, use flip2 (or use -F to bypass this check)\n");
     return -1;
   }
 
@@ -620,11 +619,11 @@ int flip1_read_memory(const PROGRAMMER *pgm,
       status.bStatus == DFU_STATUS_ERR_WRITE) {
     if (FLIP1(pgm)->security_mode_flag == 0)
       msg_error("\n");
-      pmsg_error("\n"
-        "%s***********************************************************************\n"
-        "%sMaybe the device is in ``security mode´´, and needs a chip erase first?\n"
-        "%s***********************************************************************\n"
-        "\n", progbuf, progbuf, progbuf);
+      pmsg_error("\n");
+      imsg_error("***********************************************************************\n");
+      imsg_error("Maybe the device is in ``security mode´´, and needs a chip erase first?\n");
+      imsg_error("***********************************************************************\n");
+      msg_error("\n");
     FLIP1(pgm)->security_mode_flag = 1;
   }
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -234,16 +234,14 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
-                      progname, pid);
+      pmsg_info("warning, using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
   } else {
     pid = part->usbpid;
   }
   if (!ovsigck && (part->prog_modes & PM_PDI)) {
-    msg_info("%s: \"flip1\" (FLIP protocol version 1) is for AT90USB* and ATmega*U* devices.\n"
-                    "%s For Xmega devices, use \"flip2\".\n"
-                    "%s (Use -F to bypass this check.)\n",
-                    progname, progbuf, progbuf);
+    pmsg_info("flip1 (FLIP protocol version 1) is for AT90USB* and ATmega*U* devices\n"
+      "%s for Xmega devices, use flip2\n"
+      "%s (or use -F to bypass this check)\n", progbuf, progbuf);
     return -1;
   }
 
@@ -255,32 +253,25 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   /* Check if descriptor values are what we expect. */
 
   if (dfu->dev_desc.idVendor != vid)
-    msg_info("%s: Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
-      progname, dfu->dev_desc.idVendor, vid);
+    pmsg_info("warning, USB idVendor = 0x%04X (expected 0x%04X)\n", dfu->dev_desc.idVendor, vid);
 
   if (pid != 0 && dfu->dev_desc.idProduct != pid)
-    msg_info("%s: Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
-      progname, dfu->dev_desc.idProduct, pid);
+    pmsg_info("warning, USB idProduct = 0x%04X (expected 0x%04X)\n", dfu->dev_desc.idProduct, pid);
 
   if (dfu->dev_desc.bNumConfigurations != 1)
-    msg_info("%s: Warning: USB bNumConfigurations = %d (expected 1)\n",
-      progname, (int) dfu->dev_desc.bNumConfigurations);
+    pmsg_info("warning, USB bNumConfigurations = %d (expected 1)\n", (int) dfu->dev_desc.bNumConfigurations);
 
   if (dfu->conf_desc.bNumInterfaces != 1)
-    msg_info("%s: Warning: USB bNumInterfaces = %d (expected 1)\n",
-      progname, (int) dfu->conf_desc.bNumInterfaces);
+    pmsg_info("warning, USB bNumInterfaces = %d (expected 1)\n", (int) dfu->conf_desc.bNumInterfaces);
 
   if (dfu->dev_desc.bDeviceClass != 254)
-    msg_info("%s: Warning: USB bDeviceClass = %d (expected 254)\n",
-      progname, (int) dfu->dev_desc.bDeviceClass);
+    pmsg_info("warning, USB bDeviceClass = %d (expected 254)\n", (int) dfu->dev_desc.bDeviceClass);
 
   if (dfu->dev_desc.bDeviceSubClass != 1)
-    msg_info("%s: Warning: USB bDeviceSubClass = %d (expected 1)\n",
-      progname, (int) dfu->dev_desc.bDeviceSubClass);
+    pmsg_info("warning, USB bDeviceSubClass = %d (expected 1)\n", (int) dfu->dev_desc.bDeviceSubClass);
 
   if (dfu->dev_desc.bDeviceProtocol != 0)
-    msg_info("%s: Warning: USB bDeviceProtocol = %d (expected 0)\n",
-      progname, (int) dfu->dev_desc.bDeviceProtocol);
+    pmsg_info("warning, USB bDeviceProtocol = %d (expected 0)\n", (int) dfu->dev_desc.bDeviceProtocol);
 
   /*
    * doc7618 claims an interface class of FEh and a subclas 01h.
@@ -290,21 +281,17 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
    */
   if (0) {
   if (dfu->intf_desc.bInterfaceClass != 254)
-    msg_info("%s: Warning: USB bInterfaceClass = %d (expected 254)\n",
-      progname, (int) dfu->intf_desc.bInterfaceClass);
+    pmsg_info("warning, USB bInterfaceClass = %d (expected 254)\n", (int) dfu->intf_desc.bInterfaceClass);
 
   if (dfu->intf_desc.bInterfaceSubClass != 1)
-    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 1)\n",
-      progname, (int) dfu->intf_desc.bInterfaceSubClass);
+    pmsg_info("warning, USB bInterfaceSubClass = %d (expected 1)\n", (int) dfu->intf_desc.bInterfaceSubClass);
 
   if (dfu->intf_desc.bInterfaceProtocol != 0)
-    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
-      progname, (int) dfu->intf_desc.bInterfaceProtocol);
+    pmsg_info("warning, USB bInterfaceSubClass = %d (expected 0)\n", (int) dfu->intf_desc.bInterfaceProtocol);
   }
 
   if (dfu->dev_desc.bMaxPacketSize0 != 32)
-    msg_info("%s: Warning: bMaxPacketSize0 (%d) != 32, things might go wrong\n",
-      progname, dfu->dev_desc.bMaxPacketSize0);
+    pmsg_info("warning, bMaxPacketSize0 (%d) != 32, things might go wrong\n", dfu->dev_desc.bMaxPacketSize0);
 
   if (verbose)
     flip1_show_info(FLIP1(pgm));
@@ -353,7 +340,7 @@ int flip1_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   int aux_result;
   unsigned int default_timeout = FLIP1(pgm)->dfu->timeout;
 
-  msg_notice2("%s: flip_chip_erase()\n", progname);
+  pmsg_notice2("flip_chip_erase()\n");
 
   struct flip1_cmd cmd = {
     FLIP1_CMD_WRITE_COMMAND, { 0, 0xff }
@@ -368,8 +355,7 @@ int flip1_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
     return -1;
 
   if (status.bStatus != DFU_STATUS_OK) {
-    msg_info("%s: failed to send chip erase command: %s\n",
-            progname, flip1_status_str(&status));
+    pmsg_info("failed to send chip erase command: %s\n", flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
       dfu_clrstatus(FLIP1(pgm)->dfu);
     return -1;
@@ -390,8 +376,7 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
     if (flip1_read_sig_bytes(pgm, part, mem) < 0)
       return -1;
     if (addr > mem->size) {
-      msg_info("%s: flip1_read_byte(signature): address %lu out of range\n",
-              progname, addr);
+      pmsg_info("flip1_read_byte(signature): address %lu out of range\n", addr);
       return -1;
     }
     *value = mem->buf[addr];
@@ -401,9 +386,7 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("error, %s memory not accessible using FLIP", mem->desc);
     msg_info("\n");
     return -1;
   }
@@ -426,9 +409,7 @@ int flip1_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("error, %s memory not accessible using FLIP", mem->desc);
     msg_info("\n");
     return -1;
   }
@@ -447,9 +428,7 @@ int flip1_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("error, %s memory not accessible using FLIP", mem->desc);
     msg_info("\n");
     return -1;
   }
@@ -473,17 +452,14 @@ int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
   mem_unit = flip1_mem_unit(mem->desc);
 
   if (mem_unit == FLIP1_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("error, %s memory not accessible using FLIP", mem->desc);
     msg_info("\n");
     return -1;
   }
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    msg_info("%s: Error: Attempting to read more than %d bytes\n",
-      progname, INT_MAX);
+    pmsg_info("error, attempting to read more than %d bytes\n", INT_MAX);
     exit(1);
   }
 
@@ -494,14 +470,13 @@ int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
 }
 
 int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {
-  msg_notice2("%s: flip1_read_sig_bytes(): ", progname);
+  pmsg_notice2("flip1_read_sig_bytes(): ");
 
   if (FLIP1(pgm)->dfu == NULL)
     return -1;
 
   if (mem->size < sizeof(FLIP1(pgm)->part_sig)) {
-    msg_info("%s: Error: Signature read must be at least %u bytes\n",
-      progname, (unsigned int) sizeof(FLIP1(pgm)->part_sig));
+    pmsg_info("error, signature read must be at least %u bytes\n", (unsigned int) sizeof(FLIP1(pgm)->part_sig));
     return -1;
   }
 
@@ -535,8 +510,7 @@ int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
 
       if (status.bStatus != DFU_STATUS_OK)
       {
-        msg_info("%s: failed to send cmd for signature byte %d: %s\n",
-                progname, i, flip1_status_str(&status));
+        pmsg_info("failed to send cmd for signature byte %d: %s\n", i, flip1_status_str(&status));
         if (status.bState == STATE_dfuERROR)
           dfu_clrstatus(FLIP1(pgm)->dfu);
         return -1;
@@ -550,8 +524,7 @@ int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
 
       if (status.bStatus != DFU_STATUS_OK)
       {
-        msg_info("%s: failed to read signature byte %d: %s\n",
-                progname, i, flip1_status_str(&status));
+        pmsg_info("failed to read signature byte %d: %s\n", i, flip1_status_str(&status));
         if (status.bState == STATE_dfuERROR)
           dfu_clrstatus(FLIP1(pgm)->dfu);
         return -1;
@@ -573,8 +546,7 @@ void flip1_setup(PROGRAMMER * pgm)
   pgm->cookie = calloc(1, sizeof(struct flip1));
 
   if (pgm->cookie == NULL) {
-    msg_info("%s: Out of memory allocating private data structure\n",
-            progname);
+    pmsg_info("out of memory allocating private data structure\n");
     exit(1);
   }
 }
@@ -609,8 +581,7 @@ int flip1_read_memory(const PROGRAMMER *pgm,
   unsigned int default_timeout = dfu->timeout;
 
 
-  msg_notice2("%s: flip_read_memory(%s, 0x%04x, %d)\n",
-                  progname, flip1_mem_unit_str(mem_unit), addr, size);
+  pmsg_notice2("flip_read_memory(%s, 0x%04x, %d)\n", flip1_mem_unit_str(mem_unit), addr, size);
 
   /*
    * As this function is called once per page, no need to handle 64
@@ -640,9 +611,8 @@ int flip1_read_memory(const PROGRAMMER *pgm,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    msg_info("%s: failed to read %u bytes of %s memory @%u: %s\n",
-            progname, size, flip1_mem_unit_str(mem_unit), addr,
-            flip1_status_str(&status));
+    pmsg_info("failed to read %u bytes of %s memory @%u: %s\n", size,
+      flip1_mem_unit_str(mem_unit), addr, flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
       dfu_clrstatus(dfu);
     return -1;
@@ -668,9 +638,8 @@ int flip1_read_memory(const PROGRAMMER *pgm,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    msg_info("%s: failed to read %u bytes of %s memory @%u: %s\n",
-            progname, size, flip1_mem_unit_str(mem_unit), addr,
-            flip1_status_str(&status));
+    pmsg_info("failed to read %u bytes of %s memory @%u: %s\n", size,
+      flip1_mem_unit_str(mem_unit), addr, flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
       dfu_clrstatus(dfu);
     return -1;
@@ -702,14 +671,14 @@ int flip1_write_memory(struct dfu_dev *dfu,
   unsigned int default_timeout = dfu->timeout;
   unsigned char *buf;
 
-  msg_notice2("%s: flip_write_memory(%s, 0x%04x, %d)\n",
-                  progname, flip1_mem_unit_str(mem_unit), addr, size);
+  pmsg_notice2("flip_write_memory(%s, 0x%04x, %d)\n",
+    flip1_mem_unit_str(mem_unit), addr, size);
 
   if (size < 32) {
     /* presumably single-byte updates; must be padded to USB endpoint size */
     if ((addr + size - 1) / 32 != addr / 32) {
-      msg_info("%s: flip_write_memory(): begin (0x%x) and end (0x%x) not within same 32-byte block\n",
-                      progname, addr, addr + size - 1);
+      pmsg_info("flip_write_memory(): begin 0x%x and end 0x%x not within same 32-byte block\n",
+        addr, addr + size - 1);
       return -1;
     }
     write_size = 32;
@@ -720,7 +689,7 @@ int flip1_write_memory(struct dfu_dev *dfu,
   if ((buf = malloc(sizeof(struct flip1_cmd_header) +
                     write_size +
                     sizeof(struct flip1_prog_footer))) == 0) {
-    msg_info("%s: Out of memory\n", progname);
+    pmsg_info("out of memory\n");
     return -1;
   }
 
@@ -769,9 +738,8 @@ int flip1_write_memory(struct dfu_dev *dfu,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    msg_info("%s: failed to write %u bytes of %s memory @%u: %s\n",
-            progname, size, flip1_mem_unit_str(mem_unit), addr,
-            flip1_status_str(&status));
+    pmsg_info("failed to write %u bytes of %s memory @%u: %s\n", size,
+      flip1_mem_unit_str(mem_unit), addr, flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
       dfu_clrstatus(dfu);
     return -1;
@@ -800,8 +768,7 @@ int flip1_set_mem_page(struct dfu_dev *dfu,
 
   if (status.bStatus != DFU_STATUS_OK)
   {
-    msg_info("%s: failed to set memory page: %s\n",
-            progname, flip1_status_str(&status));
+    pmsg_info("failed to set memory page: %s\n", flip1_status_str(&status));
     if (status.bState == STATE_dfuERROR)
       dfu_clrstatus(dfu);
     return -1;
@@ -855,8 +822,7 @@ enum flip1_mem_unit flip1_mem_unit(const char *name) {
 #else /* HAVE_LIBUSB */
 // Dummy functions
 int flip1_open(PROGRAMMER *pgm, const char *port_spec) {
-  fprintf(stderr, "%s: Error: No USB support in this compile of avrdude\n",
-    progname);
+  pmsg_info("no USB support compiled for avrdude\n");
   return -1;
 }
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -617,13 +617,14 @@ int flip1_read_memory(const PROGRAMMER *pgm,
 
   if (cmd_result < 0 && aux_result == 0 &&
       status.bStatus == DFU_STATUS_ERR_WRITE) {
-    if (FLIP1(pgm)->security_mode_flag == 0)
+    if (FLIP1(pgm)->security_mode_flag == 0) {
       msg_error("\n");
       pmsg_error("\n");
       imsg_error("***********************************************************************\n");
       imsg_error("Maybe the device is in ``security mode´´, and needs a chip erase first?\n");
       imsg_error("***********************************************************************\n");
       msg_error("\n");
+    }
     FLIP1(pgm)->security_mode_flag = 1;
   }
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -374,8 +374,8 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   if (strcmp(mem->desc, "signature") == 0) {
     if (flip1_read_sig_bytes(pgm, part, mem) < 0)
       return -1;
-    if (addr > mem->size) {
-      pmsg_error("flip1_read_byte(signature): address %lu out of range\n", addr);
+    if (addr >= mem->size) {
+      pmsg_error("signature address %lu out of range [0, %d]\n", addr, mem->size-1);
       return -1;
     }
     *value = mem->buf[addr];
@@ -671,7 +671,7 @@ int flip1_write_memory(struct dfu_dev *dfu,
   if (size < 32) {
     /* presumably single-byte updates; must be padded to USB endpoint size */
     if ((addr + size - 1) / 32 != addr / 32) {
-      pmsg_error("flip_write_memory(): begin 0x%x and end 0x%x not within same 32-byte block\n",
+      pmsg_error("begin 0x%x and end 0x%x not within same 32-byte block\n",
         addr, addr + size - 1);
       return -1;
     }

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -226,14 +226,14 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      avrdude_message(MSG_INFO, "%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
+      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
                       progname, pid);
   } else {
     pid = part->usbpid;
   }
 
   if (!ovsigck && !(part->prog_modes & PM_PDI)) {
-    avrdude_message(MSG_INFO, "%s: \"flip2\" (FLIP protocol version 2) is for Xmega devices.\n"
+    msg_info("%s: \"flip2\" (FLIP protocol version 2) is for Xmega devices.\n"
                     "%s For AT90USB* or ATmega*U* devices, use \"flip1\".\n"
                     "%s (Use -F to bypass this check.)\n",
                     progname, progbuf, progbuf);
@@ -248,43 +248,43 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   /* Check if descriptor values are what we expect. */
 
   if (dfu->dev_desc.idVendor != vid)
-    avrdude_message(MSG_INFO, "%s: Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
+    msg_info("%s: Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
       progname, dfu->dev_desc.idVendor, vid);
 
   if (pid != 0 && dfu->dev_desc.idProduct != pid)
-    avrdude_message(MSG_INFO, "%s: Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
+    msg_info("%s: Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
       progname, dfu->dev_desc.idProduct, pid);
 
   if (dfu->dev_desc.bNumConfigurations != 1)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bNumConfigurations = %d (expected 1)\n",
+    msg_info("%s: Warning: USB bNumConfigurations = %d (expected 1)\n",
       progname, (int) dfu->dev_desc.bNumConfigurations);
 
   if (dfu->conf_desc.bNumInterfaces != 1)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bNumInterfaces = %d (expected 1)\n",
+    msg_info("%s: Warning: USB bNumInterfaces = %d (expected 1)\n",
       progname, (int) dfu->conf_desc.bNumInterfaces);
 
   if (dfu->dev_desc.bDeviceClass != 0)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bDeviceClass = %d (expected 0)\n",
+    msg_info("%s: Warning: USB bDeviceClass = %d (expected 0)\n",
       progname, (int) dfu->dev_desc.bDeviceClass);
 
   if (dfu->dev_desc.bDeviceSubClass != 0)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bDeviceSubClass = %d (expected 0)\n",
+    msg_info("%s: Warning: USB bDeviceSubClass = %d (expected 0)\n",
       progname, (int) dfu->dev_desc.bDeviceSubClass);
 
   if (dfu->dev_desc.bDeviceProtocol != 0)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bDeviceProtocol = %d (expected 0)\n",
+    msg_info("%s: Warning: USB bDeviceProtocol = %d (expected 0)\n",
       progname, (int) dfu->dev_desc.bDeviceProtocol);
 
   if (dfu->intf_desc.bInterfaceClass != 0xFF)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bInterfaceClass = %d (expected 255)\n",
+    msg_info("%s: Warning: USB bInterfaceClass = %d (expected 255)\n",
       progname, (int) dfu->intf_desc.bInterfaceClass);
 
   if (dfu->intf_desc.bInterfaceSubClass != 0)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
+    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
       progname, (int) dfu->intf_desc.bInterfaceSubClass);
 
   if (dfu->intf_desc.bInterfaceProtocol != 0)
-    avrdude_message(MSG_INFO, "%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
+    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
       progname, (int) dfu->intf_desc.bInterfaceProtocol);
 
   result = flip2_read_memory(FLIP2(pgm)->dfu,
@@ -347,7 +347,7 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   int cmd_result = 0;
   int aux_result;
 
-  avrdude_message(MSG_NOTICE2, "%s: flip_chip_erase()\n", progname);
+  msg_notice2("%s: flip_chip_erase()\n", progname);
 
   struct flip2_cmd cmd = {
     FLIP2_CMD_GROUP_EXEC, FLIP2_CMD_CHIP_ERASE, { 0xFF, 0, 0, 0 }
@@ -366,7 +366,7 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
       {
         continue;
       } else
-        avrdude_message(MSG_INFO, "%s: Error: DFU status %s\n", progname,
+        msg_info("%s: Error: DFU status %s\n", progname,
           flip2_status_str(&status));
       dfu_clrstatus(FLIP2(pgm)->dfu);
     } else
@@ -377,7 +377,7 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
 }
 
 int flip2_start_app(const PROGRAMMER *pgm) {
-  avrdude_message(MSG_INFO, "%s: Starting application\n", progname);
+  msg_info("%s: Starting application\n", progname);
 
   struct flip2_cmd cmd = {
     FLIP2_CMD_GROUP_EXEC, FLIP2_CMD_START_APP, { 0x00, 0, 0, 0 }
@@ -403,12 +403,12 @@ int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      avrdude_message(MSG_INFO, " (did you mean \"application\"?)");
-    avrdude_message(MSG_INFO, "\n");
+      msg_info(" (did you mean \"application\"?)");
+    msg_info("\n");
     return -1;
   }
 
@@ -426,12 +426,12 @@ int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      avrdude_message(MSG_INFO, " (did you mean \"application\"?)");
-    avrdude_message(MSG_INFO, "\n");
+      msg_info(" (did you mean \"application\"?)");
+    msg_info("\n");
     return -1;
   }
 
@@ -450,18 +450,18 @@ int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      avrdude_message(MSG_INFO, " (did you mean \"application\"?)");
-    avrdude_message(MSG_INFO, "\n");
+      msg_info(" (did you mean \"application\"?)");
+    msg_info("\n");
     return -1;
   }
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    avrdude_message(MSG_INFO, "%s: Error: Attempting to read more than %d bytes\n",
+    msg_info("%s: Error: Attempting to read more than %d bytes\n",
       progname, INT_MAX);
     exit(1);
   }
@@ -484,18 +484,18 @@ int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    avrdude_message(MSG_INFO, "%s: Error: "
+    msg_info("%s: Error: "
       "\"%s\" memory not accessible using FLIP",
       progname, mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      avrdude_message(MSG_INFO, " (did you mean \"application\"?)");
-    avrdude_message(MSG_INFO, "\n");
+      msg_info(" (did you mean \"application\"?)");
+    msg_info("\n");
     return -1;
   }
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    avrdude_message(MSG_INFO, "%s: Error: Attempting to read more than %d bytes\n",
+    msg_info("%s: Error: Attempting to read more than %d bytes\n",
       progname, INT_MAX);
     exit(1);
   }
@@ -534,7 +534,7 @@ int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
     return -1;
 
   if (mem->size < sizeof(FLIP2(pgm)->part_sig)) {
-    avrdude_message(MSG_INFO, "%s: Error: Signature read must be at least %u bytes\n",
+    msg_info("%s: Error: Signature read must be at least %u bytes\n",
       progname, (unsigned int) sizeof(FLIP2(pgm)->part_sig));
     return -1;
   }
@@ -548,7 +548,7 @@ void flip2_setup(PROGRAMMER * pgm)
   pgm->cookie = calloc(1, sizeof(struct flip2));
 
   if (pgm->cookie == NULL) {
-    avrdude_message(MSG_INFO, "%s: Out of memory allocating private data structure\n",
+    msg_info("%s: Out of memory allocating private data structure\n",
             progname);
     exit(1);
   }
@@ -567,24 +567,24 @@ void flip2_show_info(struct flip2 *flip2)
 {
   dfu_show_info(flip2->dfu);
 
-  avrdude_message(MSG_INFO, "    Part signature      : 0x%02X%02X%02X\n",
+  msg_info("    Part signature      : 0x%02X%02X%02X\n",
     (int) flip2->part_sig[0],
     (int) flip2->part_sig[1],
     (int) flip2->part_sig[2]);
 
   if (flip2->part_rev < 26)
-    avrdude_message(MSG_INFO, "    Part revision       : %c\n",
+    msg_info("    Part revision       : %c\n",
       (char) (flip2->part_rev + 'A'));
   else
-    avrdude_message(MSG_INFO, "    Part revision       : %c%c\n",
+    msg_info("    Part revision       : %c%c\n",
       (char) (flip2->part_rev / 26 - 1 + 'A'),
       (char) (flip2->part_rev % 26 + 'A'));
 
-  avrdude_message(MSG_INFO, "    Bootloader version  : 2.%hu.%hu\n",
+  msg_info("    Bootloader version  : 2.%hu.%hu\n",
     ((unsigned short) flip2->boot_ver >> 4) & 0xF,
     ((unsigned short) flip2->boot_ver >> 0) & 0xF);
 
-  avrdude_message(MSG_INFO, "    USB max packet size : %hu\n",
+  msg_info("    USB max packet size : %hu\n",
     (unsigned short) flip2->dfu->dev_desc.bMaxPacketSize0);
 }
 
@@ -597,17 +597,17 @@ int flip2_read_memory(struct dfu_dev *dfu,
   int read_size;
   int result;
 
-  avrdude_message(MSG_NOTICE2, "%s: flip_read_memory(%s, 0x%04x, %d)\n",
+  msg_notice2("%s: flip_read_memory(%s, 0x%04x, %d)\n",
                   progname, flip2_mem_unit_str(mem_unit), addr, size);
 
   result = flip2_set_mem_unit(dfu, mem_unit);
 
   if (result != 0) {
     if ((mem_name = flip2_mem_unit_str(mem_unit)) != NULL)
-      avrdude_message(MSG_INFO, "%s: Error: Failed to set memory unit 0x%02X (%s)\n",
+      msg_info("%s: Error: Failed to set memory unit 0x%02X (%s)\n",
         progname, (int) mem_unit, mem_name);
     else
-      avrdude_message(MSG_INFO, "%s: Error: Failed to set memory unit 0x%02X\n",
+      msg_info("%s: Error: Failed to set memory unit 0x%02X\n",
         progname, (int) mem_unit);
     return -1;
   }
@@ -616,7 +616,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
   result = flip2_set_mem_page(dfu, page_addr);
 
   if (result != 0) {
-    avrdude_message(MSG_INFO, "%s: Error: Failed to set memory page 0x%04hX\n",
+    msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
         progname, page_addr);
     return -1;
   }
@@ -628,7 +628,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
     if (page_addr != prev_page_addr) {
       result = flip2_set_mem_page(dfu, page_addr);
       if (result != 0) {
-        avrdude_message(MSG_INFO, "%s: Error: Failed to set memory page 0x%04hX\n",
+        msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
             progname, page_addr);
         return -1;
       }
@@ -638,7 +638,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
     result = flip2_read_max1k(dfu, addr & 0xFFFF, ptr, read_size);
 
     if (result != 0) {
-      avrdude_message(MSG_INFO, "%s: Error: Failed to read 0x%04X bytes at 0x%04lX\n",
+      msg_info("%s: Error: Failed to read 0x%04X bytes at 0x%04lX\n",
           progname, read_size, (unsigned long) addr);
       return -1;
     }
@@ -660,17 +660,17 @@ int flip2_write_memory(struct dfu_dev *dfu,
   int write_size;
   int result;
 
-  avrdude_message(MSG_NOTICE2, "%s: flip_write_memory(%s, 0x%04x, %d)\n",
+  msg_notice2("%s: flip_write_memory(%s, 0x%04x, %d)\n",
                   progname, flip2_mem_unit_str(mem_unit), addr, size);
 
   result = flip2_set_mem_unit(dfu, mem_unit);
 
   if (result != 0) {
     if ((mem_name = flip2_mem_unit_str(mem_unit)) != NULL)
-      avrdude_message(MSG_INFO, "%s: Error: Failed to set memory unit 0x%02X (%s)\n",
+      msg_info("%s: Error: Failed to set memory unit 0x%02X (%s)\n",
         progname, (int) mem_unit, mem_name);
     else
-      avrdude_message(MSG_INFO, "%s: Error: Failed to set memory unit 0x%02X\n",
+      msg_info("%s: Error: Failed to set memory unit 0x%02X\n",
         progname, (int) mem_unit);
     return -1;
   }
@@ -679,7 +679,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
   result = flip2_set_mem_page(dfu, page_addr);
 
   if (result != 0) {
-    avrdude_message(MSG_INFO, "%s: Error: Failed to set memory page 0x%04hX\n",
+    msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
         progname, page_addr);
     return -1;
   }
@@ -691,7 +691,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
     if (page_addr != prev_page_addr) {
       result = flip2_set_mem_page(dfu, page_addr);
       if (result != 0) {
-        avrdude_message(MSG_INFO, "%s: Error: Failed to set memory page 0x%04hX\n",
+        msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
             progname, page_addr);
         return -1;
       }
@@ -701,7 +701,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
     result = flip2_write_max1k(dfu, addr & 0xFFFF, ptr, write_size);
 
     if (result != 0) {
-      avrdude_message(MSG_INFO, "%s: Error: Failed to write 0x%04X bytes at 0x%04lX\n",
+      msg_info("%s: Error: Failed to write 0x%04X bytes at 0x%04lX\n",
           progname, write_size, (unsigned long) addr);
       return -1;
     }
@@ -738,10 +738,10 @@ int flip2_set_mem_unit(struct dfu_dev *dfu, enum flip2_mem_unit mem_unit)
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      avrdude_message(MSG_INFO, "%s: Error: Unknown memory unit (0x%02x)\n",
+      msg_info("%s: Error: Unknown memory unit (0x%02x)\n",
         progname, (unsigned int) mem_unit);
     } else
-      avrdude_message(MSG_INFO, "%s: Error: DFU status %s\n", progname,
+      msg_info("%s: Error: DFU status %s\n", progname,
         flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
@@ -775,10 +775,10 @@ int flip2_set_mem_page(struct dfu_dev *dfu,
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      avrdude_message(MSG_INFO, "%s: Error: Page address out of range (0x%04hx)\n",
+      msg_info("%s: Error: Page address out of range (0x%04hx)\n",
         progname, page_addr);
     } else
-      avrdude_message(MSG_INFO, "%s: Error: DFU status %s\n", progname,
+      msg_info("%s: Error: DFU status %s\n", progname,
         flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
@@ -820,10 +820,10 @@ flip2_read_max1k_status:
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      avrdude_message(MSG_INFO, "%s: Error: Address out of range [0x%04hX,0x%04hX]\n",
+      msg_info("%s: Error: Address out of range [0x%04hX,0x%04hX]\n",
         progname, offset, offset+size-1);
     } else
-      avrdude_message(MSG_INFO, "%s: Error: DFU status %s\n", progname,
+      msg_info("%s: Error: DFU status %s\n", progname,
         flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
@@ -850,7 +850,7 @@ int flip2_write_max1k(struct dfu_dev *dfu,
   cmd.args[3] = ((offset+size-1) >> 0) & 0xFF;
 
   if (size > 0x400) {
-    avrdude_message(MSG_INFO, "%s: Error: Write block too large (%hu > 1024)\n",
+    msg_info("%s: Error: Write block too large (%hu > 1024)\n",
       progname, size);
     return -1;
   }
@@ -881,10 +881,10 @@ int flip2_write_max1k(struct dfu_dev *dfu,
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      avrdude_message(MSG_INFO, "%s: Error: Address out of range [0x%04hX,0x%04hX]\n",
+      msg_info("%s: Error: Address out of range [0x%04hX,0x%04hX]\n",
         progname, offset, offset+size-1);
     } else
-      avrdude_message(MSG_INFO, "%s: Error: DFU status %s\n", progname,
+      msg_info("%s: Error: DFU status %s\n", progname,
         flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
@@ -949,7 +949,7 @@ enum flip2_mem_unit flip2_mem_unit(const char *name) {
 
  // Give a proper error if we were not compiled with libusb
 static int flip2_nousb_open(PROGRAMMER* pgm, const char* name) {
-    avrdude_message(MSG_INFO, "%s: error, no USB support; please compile with libusb installed\n", progname);
+    msg_info("%s: error, no USB support; please compile with libusb installed\n", progname);
     return -1;
 }
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -226,15 +226,15 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      pmsg_info("Warning: using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
+      pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
   } else {
     pid = part->usbpid;
   }
 
   if (!ovsigck && !(part->prog_modes & PM_PDI)) {
-    pmsg_info("flip2 (FLIP protocol version 2) is for Xmega devices\n"
-                    "%s for AT90USB* or ATmega*U* devices, use flip1\n"
-                    "%s (or use -F to bypass this check)\n", progbuf, progbuf);
+    pmsg_error("flip2 (FLIP protocol version 2) is for Xmega devices\n"
+      "%s for AT90USB* or ATmega*U* devices, use flip1\n"
+      "%s (or use -F to bypass this check)\n", progbuf, progbuf);
     return -1;
   }
 
@@ -246,43 +246,43 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   /* Check if descriptor values are what we expect. */
 
   if (dfu->dev_desc.idVendor != vid)
-    pmsg_info("Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
+    pmsg_warning("USB idVendor = 0x%04X (expected 0x%04X)\n",
       dfu->dev_desc.idVendor, vid);
 
   if (pid != 0 && dfu->dev_desc.idProduct != pid)
-    pmsg_info("Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
+    pmsg_warning("USB idProduct = 0x%04X (expected 0x%04X)\n",
       dfu->dev_desc.idProduct, pid);
 
   if (dfu->dev_desc.bNumConfigurations != 1)
-    pmsg_info("USB bNumConfigurations = %d (expected 1)\n",
+    pmsg_error("USB bNumConfigurations = %d (expected 1)\n",
       (int) dfu->dev_desc.bNumConfigurations);
 
   if (dfu->conf_desc.bNumInterfaces != 1)
-    pmsg_info("USB bNumInterfaces = %d (expected 1)\n",
+    pmsg_error("USB bNumInterfaces = %d (expected 1)\n",
       (int) dfu->conf_desc.bNumInterfaces);
 
   if (dfu->dev_desc.bDeviceClass != 0)
-    pmsg_info("USB bDeviceClass = %d (expected 0)\n",
+    pmsg_error("USB bDeviceClass = %d (expected 0)\n",
       (int) dfu->dev_desc.bDeviceClass);
 
   if (dfu->dev_desc.bDeviceSubClass != 0)
-    pmsg_info("USB bDeviceSubClass = %d (expected 0)\n",
+    pmsg_error("USB bDeviceSubClass = %d (expected 0)\n",
       (int) dfu->dev_desc.bDeviceSubClass);
 
   if (dfu->dev_desc.bDeviceProtocol != 0)
-    pmsg_info("USB bDeviceProtocol = %d (expected 0)\n",
+    pmsg_error("USB bDeviceProtocol = %d (expected 0)\n",
       (int) dfu->dev_desc.bDeviceProtocol);
 
   if (dfu->intf_desc.bInterfaceClass != 0xFF)
-    pmsg_info("USB bInterfaceClass = %d (expected 255)\n",
+    pmsg_error("USB bInterfaceClass = %d (expected 255)\n",
       (int) dfu->intf_desc.bInterfaceClass);
 
   if (dfu->intf_desc.bInterfaceSubClass != 0)
-    pmsg_info("USB bInterfaceSubClass = %d (expected 0)\n",
+    pmsg_error("USB bInterfaceSubClass = %d (expected 0)\n",
       (int) dfu->intf_desc.bInterfaceSubClass);
 
   if (dfu->intf_desc.bInterfaceProtocol != 0)
-    pmsg_info("USB bInterfaceSubClass = %d (expected 0)\n",
+    pmsg_error("USB bInterfaceSubClass = %d (expected 0)\n",
       (int) dfu->intf_desc.bInterfaceProtocol);
 
   result = flip2_read_memory(FLIP2(pgm)->dfu,
@@ -364,7 +364,7 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
       {
         continue;
       } else
-        pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
+        pmsg_error("DFU status %s\n", flip2_status_str(&status));
         dfu_clrstatus(FLIP2(pgm)->dfu);
     } else
       break;
@@ -400,10 +400,10 @@ int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    pmsg_info("%s memory not accessible using FLIP", mem->desc);
+    pmsg_error("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      msg_info(" (did you mean \"application\"?)");
-    msg_info("\n");
+      msg_error(" (did you mean \"application\"?)");
+    msg_error("\n");
     return -1;
   }
 
@@ -421,10 +421,10 @@ int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    pmsg_info("%s memory not accessible using FLIP", mem->desc);
+    pmsg_error("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      msg_info(" (did you mean \"application\"?)");
-    msg_info("\n");
+      msg_error(" (did you mean \"application\"?)");
+    msg_error("\n");
     return -1;
   }
 
@@ -443,16 +443,16 @@ int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    pmsg_info("%s memory not accessible using FLIP", mem->desc);
+    pmsg_error("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      msg_info(" (did you mean \"application\"?)");
-    msg_info("\n");
+      msg_error(" (did you mean \"application\"?)");
+    msg_error("\n");
     return -1;
   }
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    pmsg_info("attempting to read more than %d bytes\n", INT_MAX);
+    pmsg_error("attempting to read more than %d bytes\n", INT_MAX);
     exit(1);
   }
 
@@ -474,16 +474,16 @@ int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    pmsg_info("%s memory not accessible using FLIP", mem->desc);
+    pmsg_error("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
-      msg_info(" (did you mean \"application\"?)");
-    msg_info("\n");
+      msg_error(" (did you mean \"application\"?)");
+    msg_error("\n");
     return -1;
   }
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    pmsg_info("attempting to read more than %d bytes\n", INT_MAX);
+    pmsg_error("attempting to read more than %d bytes\n", INT_MAX);
     exit(1);
   }
 
@@ -521,7 +521,7 @@ int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
     return -1;
 
   if (mem->size < sizeof(FLIP2(pgm)->part_sig)) {
-    pmsg_info("signature read must be at least %u bytes\n", (unsigned int) sizeof(FLIP2(pgm)->part_sig));
+    pmsg_error("signature read must be at least %u bytes\n", (unsigned int) sizeof(FLIP2(pgm)->part_sig));
     return -1;
   }
 
@@ -534,7 +534,7 @@ void flip2_setup(PROGRAMMER * pgm)
   pgm->cookie = calloc(1, sizeof(struct flip2));
 
   if (pgm->cookie == NULL) {
-    pmsg_info("out of memory allocating private data structure\n");
+    pmsg_error("out of memory allocating private data structure\n");
     exit(1);
   }
 }
@@ -588,9 +588,9 @@ int flip2_read_memory(struct dfu_dev *dfu,
 
   if (result != 0) {
     if ((mem_name = flip2_mem_unit_str(mem_unit)) != NULL)
-      pmsg_info("failed to set memory unit 0x%02X (%s)\n", (int) mem_unit, mem_name);
+      pmsg_error("unable to set memory unit 0x%02X (%s)\n", (int) mem_unit, mem_name);
     else
-      pmsg_info("failed to set memory unit 0x%02X\n", (int) mem_unit);
+      pmsg_error("unable to set memory unit 0x%02X\n", (int) mem_unit);
     return -1;
   }
 
@@ -598,7 +598,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
   result = flip2_set_mem_page(dfu, page_addr);
 
   if (result != 0) {
-    pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
+    pmsg_error("unable to set memory page 0x%04hX\n", page_addr);
     return -1;
   }
 
@@ -609,7 +609,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
     if (page_addr != prev_page_addr) {
       result = flip2_set_mem_page(dfu, page_addr);
       if (result != 0) {
-        pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
+        pmsg_error("unable to set memory page 0x%04hX\n", page_addr);
         return -1;
       }
     }
@@ -618,7 +618,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
     result = flip2_read_max1k(dfu, addr & 0xFFFF, ptr, read_size);
 
     if (result != 0) {
-      pmsg_info("failed to read 0x%04X bytes at 0x%04lX\n", read_size, (unsigned long) addr);
+      pmsg_error("unable to read 0x%04X bytes at 0x%04lX\n", read_size, (unsigned long) addr);
       return -1;
     }
 
@@ -645,9 +645,9 @@ int flip2_write_memory(struct dfu_dev *dfu,
 
   if (result != 0) {
     if ((mem_name = flip2_mem_unit_str(mem_unit)) != NULL)
-      pmsg_info("failed to set memory unit 0x%02X (%s)\n", (int) mem_unit, mem_name);
+      pmsg_error("unable to set memory unit 0x%02X (%s)\n", (int) mem_unit, mem_name);
     else
-      pmsg_info("failed to set memory unit 0x%02X\n", (int) mem_unit);
+      pmsg_error("unable to set memory unit 0x%02X\n", (int) mem_unit);
     return -1;
   }
 
@@ -655,7 +655,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
   result = flip2_set_mem_page(dfu, page_addr);
 
   if (result != 0) {
-    pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
+    pmsg_error("unable to set memory page 0x%04hX\n", page_addr);
     return -1;
   }
 
@@ -666,7 +666,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
     if (page_addr != prev_page_addr) {
       result = flip2_set_mem_page(dfu, page_addr);
       if (result != 0) {
-        pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
+        pmsg_error("unable to set memory page 0x%04hX\n", page_addr);
         return -1;
       }
     }
@@ -675,7 +675,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
     result = flip2_write_max1k(dfu, addr & 0xFFFF, ptr, write_size);
 
     if (result != 0) {
-      pmsg_info("failed to write 0x%04X bytes at 0x%04lX\n", write_size, (unsigned long) addr);
+      pmsg_error("unable to write 0x%04X bytes at 0x%04lX\n", write_size, (unsigned long) addr);
       return -1;
     }
 
@@ -711,9 +711,9 @@ int flip2_set_mem_unit(struct dfu_dev *dfu, enum flip2_mem_unit mem_unit)
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      pmsg_info("unknown memory unit (0x%02x)\n", (unsigned int) mem_unit);
+      pmsg_error("unknown memory unit (0x%02x)\n", (unsigned int) mem_unit);
     } else
-      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
+      pmsg_error("DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -746,9 +746,9 @@ int flip2_set_mem_page(struct dfu_dev *dfu,
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      pmsg_info("page address out of range (0x%04hx)\n", page_addr);
+      pmsg_error("page address out of range (0x%04hx)\n", page_addr);
     } else
-      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
+      pmsg_error("DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -789,9 +789,9 @@ flip2_read_max1k_status:
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      pmsg_info("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
+      pmsg_error("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
     } else
-      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
+      pmsg_error("DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -817,7 +817,7 @@ int flip2_write_max1k(struct dfu_dev *dfu,
   cmd.args[3] = ((offset+size-1) >> 0) & 0xFF;
 
   if (size > 0x400) {
-    pmsg_info("erite block too large (%hu > 1024)\n", size);
+    pmsg_error("erite block too large (%hu > 1024)\n", size);
     return -1;
   }
 
@@ -847,9 +847,9 @@ int flip2_write_max1k(struct dfu_dev *dfu,
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      pmsg_info("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
+      pmsg_error("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
     } else
-      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
+      pmsg_error("DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -913,7 +913,7 @@ enum flip2_mem_unit flip2_mem_unit(const char *name) {
 
  // Give a proper error if we were not compiled with libusb
 static int flip2_nousb_open(PROGRAMMER* pgm, const char* name) {
-    pmsg_info("error, no USB support; please compile with libusb installed\n");
+    pmsg_error("no USB support; please compile with libusb installed\n");
     return -1;
 }
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -232,9 +232,9 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   }
 
   if (!ovsigck && !(part->prog_modes & PM_PDI)) {
-    pmsg_error("flip2 (FLIP protocol version 2) is for Xmega devices\n"
-      "%s for AT90USB* or ATmega*U* devices, use flip1\n"
-      "%s (or use -F to bypass this check)\n", progbuf, progbuf);
+    pmsg_error("flip2 (FLIP protocol version 2) is for Xmega devices\n");
+    imsg_error("for AT90USB* or ATmega*U* devices, use flip1\n");
+    imsg_error("(or use -F to bypass this check)\n");
     return -1;
   }
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -363,9 +363,9 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
           status.bState == ((FLIP2_STATUS_ERASE_ONGOING >> 0) & 0xFF))
       {
         continue;
-      } else
-        pmsg_error("DFU status %s\n", flip2_status_str(&status));
-        dfu_clrstatus(FLIP2(pgm)->dfu);
+      }
+      pmsg_error("DFU status %s\n", flip2_status_str(&status));
+      dfu_clrstatus(FLIP2(pgm)->dfu);
     } else
       break;
   }

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -226,17 +226,15 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
-                      progname, pid);
+      pmsg_info("Warning: using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
   } else {
     pid = part->usbpid;
   }
 
   if (!ovsigck && !(part->prog_modes & PM_PDI)) {
-    msg_info("%s: \"flip2\" (FLIP protocol version 2) is for Xmega devices.\n"
-                    "%s For AT90USB* or ATmega*U* devices, use \"flip1\".\n"
-                    "%s (Use -F to bypass this check.)\n",
-                    progname, progbuf, progbuf);
+    pmsg_info("flip2 (FLIP protocol version 2) is for Xmega devices\n"
+                    "%s for AT90USB* or ATmega*U* devices, use flip1\n"
+                    "%s (or use -F to bypass this check)\n", progbuf, progbuf);
     return -1;
   }
 
@@ -248,44 +246,44 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   /* Check if descriptor values are what we expect. */
 
   if (dfu->dev_desc.idVendor != vid)
-    msg_info("%s: Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
-      progname, dfu->dev_desc.idVendor, vid);
+    pmsg_info("Warning: USB idVendor = 0x%04X (expected 0x%04X)\n",
+      dfu->dev_desc.idVendor, vid);
 
   if (pid != 0 && dfu->dev_desc.idProduct != pid)
-    msg_info("%s: Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
-      progname, dfu->dev_desc.idProduct, pid);
+    pmsg_info("Warning: USB idProduct = 0x%04X (expected 0x%04X)\n",
+      dfu->dev_desc.idProduct, pid);
 
   if (dfu->dev_desc.bNumConfigurations != 1)
-    msg_info("%s: Warning: USB bNumConfigurations = %d (expected 1)\n",
-      progname, (int) dfu->dev_desc.bNumConfigurations);
+    pmsg_info("USB bNumConfigurations = %d (expected 1)\n",
+      (int) dfu->dev_desc.bNumConfigurations);
 
   if (dfu->conf_desc.bNumInterfaces != 1)
-    msg_info("%s: Warning: USB bNumInterfaces = %d (expected 1)\n",
-      progname, (int) dfu->conf_desc.bNumInterfaces);
+    pmsg_info("USB bNumInterfaces = %d (expected 1)\n",
+      (int) dfu->conf_desc.bNumInterfaces);
 
   if (dfu->dev_desc.bDeviceClass != 0)
-    msg_info("%s: Warning: USB bDeviceClass = %d (expected 0)\n",
-      progname, (int) dfu->dev_desc.bDeviceClass);
+    pmsg_info("USB bDeviceClass = %d (expected 0)\n",
+      (int) dfu->dev_desc.bDeviceClass);
 
   if (dfu->dev_desc.bDeviceSubClass != 0)
-    msg_info("%s: Warning: USB bDeviceSubClass = %d (expected 0)\n",
-      progname, (int) dfu->dev_desc.bDeviceSubClass);
+    pmsg_info("USB bDeviceSubClass = %d (expected 0)\n",
+      (int) dfu->dev_desc.bDeviceSubClass);
 
   if (dfu->dev_desc.bDeviceProtocol != 0)
-    msg_info("%s: Warning: USB bDeviceProtocol = %d (expected 0)\n",
-      progname, (int) dfu->dev_desc.bDeviceProtocol);
+    pmsg_info("USB bDeviceProtocol = %d (expected 0)\n",
+      (int) dfu->dev_desc.bDeviceProtocol);
 
   if (dfu->intf_desc.bInterfaceClass != 0xFF)
-    msg_info("%s: Warning: USB bInterfaceClass = %d (expected 255)\n",
-      progname, (int) dfu->intf_desc.bInterfaceClass);
+    pmsg_info("USB bInterfaceClass = %d (expected 255)\n",
+      (int) dfu->intf_desc.bInterfaceClass);
 
   if (dfu->intf_desc.bInterfaceSubClass != 0)
-    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
-      progname, (int) dfu->intf_desc.bInterfaceSubClass);
+    pmsg_info("USB bInterfaceSubClass = %d (expected 0)\n",
+      (int) dfu->intf_desc.bInterfaceSubClass);
 
   if (dfu->intf_desc.bInterfaceProtocol != 0)
-    msg_info("%s: Warning: USB bInterfaceSubClass = %d (expected 0)\n",
-      progname, (int) dfu->intf_desc.bInterfaceProtocol);
+    pmsg_info("USB bInterfaceSubClass = %d (expected 0)\n",
+      (int) dfu->intf_desc.bInterfaceProtocol);
 
   result = flip2_read_memory(FLIP2(pgm)->dfu,
     FLIP2_MEM_UNIT_SIGNATURE, 0, FLIP2(pgm)->part_sig, 4);
@@ -347,7 +345,7 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
   int cmd_result = 0;
   int aux_result;
 
-  msg_notice2("%s: flip_chip_erase()\n", progname);
+  pmsg_notice2("flip_chip_erase()\n");
 
   struct flip2_cmd cmd = {
     FLIP2_CMD_GROUP_EXEC, FLIP2_CMD_CHIP_ERASE, { 0xFF, 0, 0, 0 }
@@ -366,9 +364,8 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
       {
         continue;
       } else
-        msg_info("%s: Error: DFU status %s\n", progname,
-          flip2_status_str(&status));
-      dfu_clrstatus(FLIP2(pgm)->dfu);
+        pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
+        dfu_clrstatus(FLIP2(pgm)->dfu);
     } else
       break;
   }
@@ -377,7 +374,7 @@ int flip2_chip_erase(const PROGRAMMER *pgm, const AVRPART *part) {
 }
 
 int flip2_start_app(const PROGRAMMER *pgm) {
-  msg_info("%s: Starting application\n", progname);
+  pmsg_info("starting application\n");
 
   struct flip2_cmd cmd = {
     FLIP2_CMD_GROUP_EXEC, FLIP2_CMD_START_APP, { 0x00, 0, 0, 0 }
@@ -403,9 +400,7 @@ int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
       msg_info(" (did you mean \"application\"?)");
     msg_info("\n");
@@ -426,9 +421,7 @@ int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
       msg_info(" (did you mean \"application\"?)");
     msg_info("\n");
@@ -450,9 +443,7 @@ int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
       msg_info(" (did you mean \"application\"?)");
     msg_info("\n");
@@ -461,8 +452,7 @@ int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    msg_info("%s: Error: Attempting to read more than %d bytes\n",
-      progname, INT_MAX);
+    pmsg_info("attempting to read more than %d bytes\n", INT_MAX);
     exit(1);
   }
 
@@ -484,9 +474,7 @@ int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
   mem_unit = flip2_mem_unit(mem->desc);
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
-    msg_info("%s: Error: "
-      "\"%s\" memory not accessible using FLIP",
-      progname, mem->desc);
+    pmsg_info("%s memory not accessible using FLIP", mem->desc);
     if (strcmp(mem->desc, "flash") == 0)
       msg_info(" (did you mean \"application\"?)");
     msg_info("\n");
@@ -495,8 +483,7 @@ int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
 
   if (n_bytes > INT_MAX) {
     /* This should never happen, unless the int type is only 16 bits. */
-    msg_info("%s: Error: Attempting to read more than %d bytes\n",
-      progname, INT_MAX);
+    pmsg_info("attempting to read more than %d bytes\n", INT_MAX);
     exit(1);
   }
 
@@ -534,8 +521,7 @@ int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
     return -1;
 
   if (mem->size < sizeof(FLIP2(pgm)->part_sig)) {
-    msg_info("%s: Error: Signature read must be at least %u bytes\n",
-      progname, (unsigned int) sizeof(FLIP2(pgm)->part_sig));
+    pmsg_info("signature read must be at least %u bytes\n", (unsigned int) sizeof(FLIP2(pgm)->part_sig));
     return -1;
   }
 
@@ -548,8 +534,7 @@ void flip2_setup(PROGRAMMER * pgm)
   pgm->cookie = calloc(1, sizeof(struct flip2));
 
   if (pgm->cookie == NULL) {
-    msg_info("%s: Out of memory allocating private data structure\n",
-            progname);
+    pmsg_info("out of memory allocating private data structure\n");
     exit(1);
   }
 }
@@ -597,18 +582,15 @@ int flip2_read_memory(struct dfu_dev *dfu,
   int read_size;
   int result;
 
-  msg_notice2("%s: flip_read_memory(%s, 0x%04x, %d)\n",
-                  progname, flip2_mem_unit_str(mem_unit), addr, size);
+  pmsg_notice2("flip_read_memory(%s, 0x%04x, %d)\n", flip2_mem_unit_str(mem_unit), addr, size);
 
   result = flip2_set_mem_unit(dfu, mem_unit);
 
   if (result != 0) {
     if ((mem_name = flip2_mem_unit_str(mem_unit)) != NULL)
-      msg_info("%s: Error: Failed to set memory unit 0x%02X (%s)\n",
-        progname, (int) mem_unit, mem_name);
+      pmsg_info("failed to set memory unit 0x%02X (%s)\n", (int) mem_unit, mem_name);
     else
-      msg_info("%s: Error: Failed to set memory unit 0x%02X\n",
-        progname, (int) mem_unit);
+      pmsg_info("failed to set memory unit 0x%02X\n", (int) mem_unit);
     return -1;
   }
 
@@ -616,8 +598,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
   result = flip2_set_mem_page(dfu, page_addr);
 
   if (result != 0) {
-    msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
-        progname, page_addr);
+    pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
     return -1;
   }
 
@@ -628,8 +609,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
     if (page_addr != prev_page_addr) {
       result = flip2_set_mem_page(dfu, page_addr);
       if (result != 0) {
-        msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
-            progname, page_addr);
+        pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
         return -1;
       }
     }
@@ -638,8 +618,7 @@ int flip2_read_memory(struct dfu_dev *dfu,
     result = flip2_read_max1k(dfu, addr & 0xFFFF, ptr, read_size);
 
     if (result != 0) {
-      msg_info("%s: Error: Failed to read 0x%04X bytes at 0x%04lX\n",
-          progname, read_size, (unsigned long) addr);
+      pmsg_info("failed to read 0x%04X bytes at 0x%04lX\n", read_size, (unsigned long) addr);
       return -1;
     }
 
@@ -660,18 +639,15 @@ int flip2_write_memory(struct dfu_dev *dfu,
   int write_size;
   int result;
 
-  msg_notice2("%s: flip_write_memory(%s, 0x%04x, %d)\n",
-                  progname, flip2_mem_unit_str(mem_unit), addr, size);
+  pmsg_notice2("flip_write_memory(%s, 0x%04x, %d)\n", flip2_mem_unit_str(mem_unit), addr, size);
 
   result = flip2_set_mem_unit(dfu, mem_unit);
 
   if (result != 0) {
     if ((mem_name = flip2_mem_unit_str(mem_unit)) != NULL)
-      msg_info("%s: Error: Failed to set memory unit 0x%02X (%s)\n",
-        progname, (int) mem_unit, mem_name);
+      pmsg_info("failed to set memory unit 0x%02X (%s)\n", (int) mem_unit, mem_name);
     else
-      msg_info("%s: Error: Failed to set memory unit 0x%02X\n",
-        progname, (int) mem_unit);
+      pmsg_info("failed to set memory unit 0x%02X\n", (int) mem_unit);
     return -1;
   }
 
@@ -679,8 +655,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
   result = flip2_set_mem_page(dfu, page_addr);
 
   if (result != 0) {
-    msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
-        progname, page_addr);
+    pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
     return -1;
   }
 
@@ -691,8 +666,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
     if (page_addr != prev_page_addr) {
       result = flip2_set_mem_page(dfu, page_addr);
       if (result != 0) {
-        msg_info("%s: Error: Failed to set memory page 0x%04hX\n",
-            progname, page_addr);
+        pmsg_info("failed to set memory page 0x%04hX\n", page_addr);
         return -1;
       }
     }
@@ -701,8 +675,7 @@ int flip2_write_memory(struct dfu_dev *dfu,
     result = flip2_write_max1k(dfu, addr & 0xFFFF, ptr, write_size);
 
     if (result != 0) {
-      msg_info("%s: Error: Failed to write 0x%04X bytes at 0x%04lX\n",
-          progname, write_size, (unsigned long) addr);
+      pmsg_info("failed to write 0x%04X bytes at 0x%04lX\n", write_size, (unsigned long) addr);
       return -1;
     }
 
@@ -738,11 +711,9 @@ int flip2_set_mem_unit(struct dfu_dev *dfu, enum flip2_mem_unit mem_unit)
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      msg_info("%s: Error: Unknown memory unit (0x%02x)\n",
-        progname, (unsigned int) mem_unit);
+      pmsg_info("unknown memory unit (0x%02x)\n", (unsigned int) mem_unit);
     } else
-      msg_info("%s: Error: DFU status %s\n", progname,
-        flip2_status_str(&status));
+      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -775,11 +746,9 @@ int flip2_set_mem_page(struct dfu_dev *dfu,
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      msg_info("%s: Error: Page address out of range (0x%04hx)\n",
-        progname, page_addr);
+      pmsg_info("page address out of range (0x%04hx)\n", page_addr);
     } else
-      msg_info("%s: Error: DFU status %s\n", progname,
-        flip2_status_str(&status));
+      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -820,11 +789,9 @@ flip2_read_max1k_status:
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      msg_info("%s: Error: Address out of range [0x%04hX,0x%04hX]\n",
-        progname, offset, offset+size-1);
+      pmsg_info("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
     } else
-      msg_info("%s: Error: DFU status %s\n", progname,
-        flip2_status_str(&status));
+      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -850,8 +817,7 @@ int flip2_write_max1k(struct dfu_dev *dfu,
   cmd.args[3] = ((offset+size-1) >> 0) & 0xFF;
 
   if (size > 0x400) {
-    msg_info("%s: Error: Write block too large (%hu > 1024)\n",
-      progname, size);
+    pmsg_info("erite block too large (%hu > 1024)\n", size);
     return -1;
   }
 
@@ -881,11 +847,9 @@ int flip2_write_max1k(struct dfu_dev *dfu,
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      msg_info("%s: Error: Address out of range [0x%04hX,0x%04hX]\n",
-        progname, offset, offset+size-1);
+      pmsg_info("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
     } else
-      msg_info("%s: Error: DFU status %s\n", progname,
-        flip2_status_str(&status));
+      pmsg_info("error, DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
   }
 
@@ -949,7 +913,7 @@ enum flip2_mem_unit flip2_mem_unit(const char *name) {
 
  // Give a proper error if we were not compiled with libusb
 static int flip2_nousb_open(PROGRAMMER* pgm, const char* name) {
-    msg_info("%s: error, no USB support; please compile with libusb installed\n", progname);
+    pmsg_info("error, no USB support; please compile with libusb installed\n");
     return -1;
 }
 

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -94,8 +94,7 @@
 #if defined(DO_NOT_BUILD_FT245R)
 
 static int ft245r_noftdi_open(PROGRAMMER *pgm, const char *name) {
-    msg_info("%s: error: no libftdi or libusb support. Install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again.\n",
-                    progname);
+    pmsg_info("no libftdi or libusb support; install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again\n");
 
     return -1;
 }
@@ -189,8 +188,7 @@ static int ft245r_fill(const PROGRAMMER *pgm) {
 	return -1;
     rx.pending -= nread;
 #if FT245R_DEBUG
-    msg_info("%s: read %d bytes (pending=%d)\n",
-		    __func__, nread, rx.pending);
+    msg_info("%s: read %d bytes (pending=%d)\n",  __func__, nread, rx.pending);
 #endif
     for (i = 0; i < nread; ++i)
 	ft245r_rx_buf_put(pgm, raw[i]);
@@ -223,9 +221,7 @@ static int ft245r_flush(const PROGRAMMER *pgm) {
 	if (avail <= 0) {
 	    avail = ft245r_fill(pgm);
 	    if (avail < 0) {
-		msg_info(
-				"%s: fill returned %d: %s\n",
-				__func__, avail, ftdi_get_error_string(handle));
+		msg_info("%s: fill returned %d: %s\n", __func__, avail, ftdi_get_error_string(handle));
 		return -1;
 	    }
 	}
@@ -237,9 +233,7 @@ static int ft245r_flush(const PROGRAMMER *pgm) {
 #endif
 	rv = ftdi_write_data(handle, src, avail);
 	if (rv != avail) {
-	    msg_info(
-			    "%s: write returned %d (expected %d): %s\n",
-			    __func__, rv, avail, ftdi_get_error_string(handle));
+	    msg_info("%s: write returned %d (expected %d): %s\n", __func__, rv, avail, ftdi_get_error_string(handle));
 	    return -1;
 	}
 	src += avail;
@@ -282,8 +276,7 @@ static int ft245r_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
     ft245r_fill(pgm);
 
 #if FT245R_DEBUG
-    msg_info("%s: discarding %d, consuming %zu bytes\n",
-        __func__, rx.discard, len);
+    msg_info("%s: discarding %d, consuming %zu bytes\n", __func__, rx.discard, len);
 #endif
     while (rx.discard > 0) {
         int result = ft245r_rx_buf_fill_and_get(pgm);
@@ -320,7 +313,7 @@ static int ft245r_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
 static int ft245r_drain(const PROGRAMMER *pgm, int display) {
     int r;
 
-    // flush the buffer in the chip by changing the mode.....
+    // flush the buffer in the chip by changing the mode ...
     r = ftdi_set_bitmode(handle, 0, BITMODE_RESET); 	// reset
     if (r) return -1;
     r = ftdi_set_bitmode(handle, ft245r_ddr, BITMODE_SYNCBB); // set Synchronuse BitBang
@@ -347,8 +340,7 @@ static int ft245r_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
       return avr_tpi_chip_erase(pgm, p);
 
     if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-        msg_info("chip erase instruction not defined for part \"%s\"\n",
-                p->desc);
+        msg_info("chip erase instruction not defined for part %s\n", p->desc);
         return -1;
     }
 
@@ -381,14 +373,12 @@ static int ft245r_set_bitclock(const PROGRAMMER *pgm) {
     ftdi_rate = rate;
 #endif
 
-    msg_notice2(
-		    "%s: bitclk %d -> FTDI rate %d, baud multiplier %d\n",
-		    __func__, rate, ftdi_rate, baud_multiplier);
+    msg_notice2("%s: bitclk %d -> FTDI rate %d, baud multiplier %d\n",
+      __func__, rate, ftdi_rate, baud_multiplier);
 
     r = ftdi_set_baudrate(handle, ftdi_rate);
     if (r) {
-        msg_info("Set baudrate (%d) failed with error '%s'.\n",
-                rate, ftdi_get_error_string (handle));
+        msg_info("set baudrate %d failed with error '%s'\n", rate, ftdi_get_error_string (handle));
         return -1;
     }
     return 0;
@@ -506,8 +496,7 @@ static int ft245r_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
       return avr_tpi_program_enable(pgm, p, TPIPCR_GT_0b);
 
     if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-        msg_info("%s: AVR_OP_PGM_ENABLE command not defined for %s\n",
-                        progname, p->desc);
+        pmsg_info("AVR_OP_PGM_ENABLE command not defined for %s\n", p->desc);
         fflush(stderr);
         return -1;
     }
@@ -520,8 +509,7 @@ static int ft245r_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
         if (res[p->pollindex-1] == p->pollvalue) return 0;
 
         if (FT245R_DEBUG) {
-            msg_notice("%s: Program enable command not successful. Retrying.\n",
-                            progname);
+            pmsg_notice("program enable command not successful, retrying\n");
             fflush(stderr);
         }
         set_pin(pgm, PIN_AVR_RESET, ON);
@@ -534,8 +522,7 @@ static int ft245r_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
         }
     }
 
-    msg_info("%s: Device is not responding to program enable. Check connection.\n",
-                    progname);
+    pmsg_info("device is not responding to program enable; check connection\n");
     fflush(stderr);
 
     return -1;
@@ -769,8 +756,7 @@ static int ft245r_tpi_rx(const PROGRAMMER *pgm, uint8_t *bytep) {
     while (m & res)
 	m <<= 1;
     if (m >= 0x10) {
-	msg_info("%s: start bit missing (res=0x%04x)\n",
-			__func__, res);
+	msg_info("%s: start bit missing (res=0x%04x)\n", __func__, res);
 	return -1;
     }
     byte = parity = 0;
@@ -845,19 +831,13 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
 
     // read device string cut after 8 chars (max. length of serial number)
     if ((sscanf(port, "usb:%8s", device) != 1)) {
-      msg_notice(
-          "%s: ft245r_open(): no device identifier in portname, using default\n",
-          progname);
+      pmsg_notice("ft245r_open(): no device identifier in portname, using default\n");
       pgm->usbsn = cache_string("");
       devnum = 0;
     } else {
       if (strlen(device) == 8 ){ // serial number
         if (verbose >= 2) {
-          msg_info(
-              "%s: ft245r_open(): serial number parsed as: "
-              "%s\n",
-              progname,
-              device);
+          pmsg_info("ft245r_open(): serial number parsed as: %s\n", device);
         }
         // copy serial number to pgm struct
         pgm->usbsn = cache_string(device);
@@ -871,18 +851,15 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
         if ((startptr==endptr) || (*endptr != '\0')) {
           devnum = -1;
         }
-        msg_info(
-            "%s: ft245r_open(): device number parsed as: "
+        pmsg_info("ft245r_open(): device number parsed as: "
             "%d\n",
-            progname,
             devnum);
       }
     }
 
     // if something went wrong before abort with helpful message
     if (devnum < 0) {
-      msg_info("%s: ft245r_open(): invalid portname '%s': use^ 'ft[0-9]+' or serial number\n",
-          progname,port);
+      pmsg_info("ft245r_open(): invalid portname '%s': use^ 'ft[0-9]+' or serial number\n", port);
       return -1;
     }
 
@@ -893,8 +870,7 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
     if (usbpid) {
       pid = *(int *)(ldata(usbpid));
       if (lnext(usbpid))
-	msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
-		progname, pid);
+	pmsg_info("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
     } else {
       pid = USB_DEVICE_FT245;
     }
@@ -905,8 +881,7 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
                                   pgm->usbsn[0]?pgm->usbsn:NULL,
                                   devnum);
     if (rv) {
-        msg_info("%s: can't open ftdi device: %s\n",
-                        progname, ftdi_get_error_string(handle));
+        pmsg_info("can't open ftdi device: %s\n", ftdi_get_error_string(handle));
         goto cleanup_no_usb;
     }
 
@@ -936,15 +911,13 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
 
     rv = ftdi_set_latency_timer(handle, 1);
     if (rv) {
-        msg_info("%s: unable to set latency timer to 1 (%s)\n",
-                        progname, ftdi_get_error_string(handle));
+        pmsg_info("unable to set latency timer to 1 (%s)\n", ftdi_get_error_string(handle));
         goto cleanup;
     }
 
     rv = ftdi_set_bitmode(handle, ft245r_ddr, BITMODE_SYNCBB); // set Synchronous BitBang
     if (rv) {
-        msg_info("%s: Synchronous BitBangMode is not supported (%s)\n",
-                        progname, ftdi_get_error_string(handle));
+        pmsg_info("synchronous BitBangMode is not supported (%s)\n", ftdi_get_error_string(handle));
         goto cleanup;
     }
 

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -960,7 +960,7 @@ static void ft245r_close(PROGRAMMER * pgm) {
 }
 
 static void ft245r_display(const PROGRAMMER *pgm, const char *p) {
-    msg_error("%sPin assignment  : 0..7 = DBUS0..7\n", p); // , 8..11 = GPIO0..3\n",p);
+    msg_info("%sPin assignment  : 0..7 = DBUS0..7\n", p); // , 8..11 = GPIO0..3\n",p);
     pgm_display_generic_mask(pgm, p, SHOW_ALL_PINS);
 }
 

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -563,9 +563,9 @@ static int ft245r_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 	set_pin(pgm, PIN_AVR_MOSI, 0);
 	if (get_pin(pgm, PIN_AVR_MISO) != 0) {
 	    io_link_ok = false;
-	    if(ovsigck) 
+	    if(ovsigck) {
 		pmsg_warning("MOSI->MISO 0 failed\n");
-	    else {
+	    } else {
 		pmsg_error("MOSI->MISO 0 failed\n");
 		return -1;
 	    }
@@ -573,9 +573,9 @@ static int ft245r_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 	set_pin(pgm, PIN_AVR_MOSI, 1);
 	if (get_pin(pgm, PIN_AVR_MISO) != 1) {
 	    io_link_ok = false;
-	    if(ovsigck) 
+	    if(ovsigck) {
 		pmsg_warning("MOSI->MISO 1 failed\n");
-	    else {
+	    } else {
 		pmsg_error("MOSI->MISO 1 failed\n");
 		return -1;
 	    }

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -221,7 +221,7 @@ static int ft245r_flush(const PROGRAMMER *pgm) {
 	if (avail <= 0) {
 	    avail = ft245r_fill(pgm);
 	    if (avail < 0) {
-		pmsg_error("%s: fill returned %d: %s\n", __func__, avail, ftdi_get_error_string(handle));
+		pmsg_error("fill returned %d: %s\n", avail, ftdi_get_error_string(handle));
 		return -1;
 	    }
 	}
@@ -233,7 +233,7 @@ static int ft245r_flush(const PROGRAMMER *pgm) {
 #endif
 	rv = ftdi_write_data(handle, src, avail);
 	if (rv != avail) {
-	    msg_error("%s: write returned %d (expected %d): %s\n", __func__, rv, avail, ftdi_get_error_string(handle));
+	    msg_error("write returned %d (expected %d): %s\n", rv, avail, ftdi_get_error_string(handle));
 	    return -1;
 	}
 	src += avail;
@@ -762,7 +762,7 @@ static int ft245r_tpi_rx(const PROGRAMMER *pgm, uint8_t *bytep) {
     while (m & res)
 	m <<= 1;
     if (m >= 0x10) {
-	pmsg_error("%s: start bit missing (res=0x%04x)\n", __func__, res);
+	pmsg_error("start bit missing (res=0x%04x)\n", res);
 	return -1;
     }
     byte = parity = 0;
@@ -774,11 +774,11 @@ static int ft245r_tpi_rx(const PROGRAMMER *pgm, uint8_t *bytep) {
     }
     m <<= 1;
     if (((res & m) != 0) != parity) {
-	pmsg_error("%s: parity bit wrong\n", __func__);
+	pmsg_error("parity bit wrong\n");
 	return -1;
     }
     if (((res & (m << 1)) == 0) || ((res & (m << 2))) == 0) {
-	pmsg_error("%s: stop bits wrong\n", __func__);
+	pmsg_error("stop bits wrong\n");
 	return -1;
     }
     *bytep = (uint8_t) byte;
@@ -861,7 +861,7 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
 
     // if something went wrong before abort with helpful message
     if (devnum < 0) {
-      pmsg_error("ft245r_open(): invalid portname '%s': use^ 'ft[0-9]+' or serial number\n", port);
+      pmsg_error("invalid portname '%s': use^ 'ft[0-9]+' or serial number\n", port);
       return -1;
     }
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -114,7 +114,7 @@ static unsigned int jtag3_memaddr(const PROGRAMMER *pgm, const AVRPART *p, const
 void jtag3_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("jtag3_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -423,7 +423,7 @@ int jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
 
   if ((buf = malloc(len + 4)) == NULL)
     {
-      pmsg_error("jtag3_send(): out of memory");
+      pmsg_error("out of memory");
       return -1;
     }
 
@@ -433,7 +433,7 @@ int jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   memcpy(buf + 4, data, len);
 
   if (serial_send(&pgm->fd, buf, len + 4) != 0) {
-    pmsg_error("jtag3_send(): unable to send command to serial port\n");
+    pmsg_error("unable to send command to serial port\n");
     free(buf);
     return -1;
   }
@@ -535,34 +535,34 @@ static int jtag3_edbg_prepare(const PROGRAMMER *pgm) {
   buf[0] = CMSISDAP_CMD_CONNECT;
   buf[1] = CMSISDAP_CONN_SWD;
   if (serial_send(&pgm->fd, buf, pgm->fd.usb.max_xfer) != 0) {
-    pmsg_error("jtag3_edbg_prepare(): unable to send command to serial port\n");
+    pmsg_error("unable to send command to serial port\n");
     return -1;
   }
   rv = serial_recv(&pgm->fd, status, pgm->fd.usb.max_xfer);
   if (rv != pgm->fd.usb.max_xfer) {
-    pmsg_error("jtag3_edbg_prepare(): unable to read from serial port (%d)\n", rv);
+    pmsg_error("unable to read from serial port (%d)\n", rv);
     return -1;
   }
   if (status[0] != CMSISDAP_CMD_CONNECT ||
       status[1] == 0)
-    pmsg_error("jtag3_edbg_prepare(): unexpected response 0x%02x, 0x%02x\n", status[0], status[1]);
+    pmsg_error("unexpected response 0x%02x, 0x%02x\n", status[0], status[1]);
   pmsg_notice2("jtag3_edbg_prepare(): connection status 0x%02x\n", status[1]);
 
   buf[0] = CMSISDAP_CMD_LED;
   buf[1] = CMSISDAP_LED_CONNECT;
   buf[2] = 1;
   if (serial_send(&pgm->fd, buf, pgm->fd.usb.max_xfer) != 0) {
-    pmsg_error("jtag3_edbg_prepare(): unable to send command to serial port\n");
+    pmsg_error("unable to send command to serial port\n");
     return -1;
   }
   rv = serial_recv(&pgm->fd, status, pgm->fd.usb.max_xfer);
   if (rv != pgm->fd.usb.max_xfer) {
-    pmsg_error("jtag3_edbg_prepare(): unable to read from serial port (%d)\n", rv);
+    pmsg_error("unable to read from serial port (%d)\n", rv);
     return -1;
   }
   if (status[0] != CMSISDAP_CMD_LED ||
       status[1] != 0)
-    pmsg_error("jtag3_edbg_prepare(): unexpected response 0x%02x, 0x%02x\n", status[0], status[1]);
+    pmsg_error("unexpected response 0x%02x, 0x%02x\n", status[0], status[1]);
 
   return 0;
 }
@@ -639,7 +639,7 @@ static int jtag3_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
   pmsg_trace("jtag3_recv():\n");
 
   if ((buf = malloc(pgm->fd.usb.max_xfer)) == NULL) {
-    pmsg_error("jtag3_recv(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
   if (verbose >= 4)
@@ -1036,7 +1036,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (conn == 0) {
-    pmsg_error("jtag3_initialize(): part %s has no %s interface\n", p->desc, ifname);
+    pmsg_error("part %s has no %s interface\n", p->desc, ifname);
     return -1;
   }
 
@@ -1362,7 +1362,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     AVRMEM *bootmem = avr_locate_mem(p, "boot");
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (bootmem == NULL || flashmem == NULL) {
-      pmsg_error("jtagmk3_initialize(): cannot locate flash or boot memories in description\n");
+      pmsg_error("cannot locate flash or boot memories in description\n");
     } else {
       PDATA(pgm)->boot_start = bootmem->offset - flashmem->offset;
     }
@@ -1371,11 +1371,11 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    pmsg_error("jtag3_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    pmsg_error("jtag3_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -1415,7 +1415,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       unsigned int ub, ua, bb, ba;
       if (sscanf(extended_param, "jtagchain=%u,%u,%u,%u", &ub, &ua, &bb, &ba)
           != 4) {
-        pmsg_error("jtag3_parseextparms(): invalid JTAG chain '%s'\n", extended_param);
+        pmsg_error("invalid JTAG chain '%s'\n", extended_param);
         rv = -1;
         continue;
       }
@@ -1436,7 +1436,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    pmsg_error("jtag3_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 
@@ -1454,7 +1454,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
 #endif
 
   if (!matches(port, "usb")) {
-    pmsg_error("jtag3_open_common(): JTAGICE3/EDBG port names must start with usb\n");
+    pmsg_error("JTAGICE3/EDBG port names must start with usb\n");
     return -1;
   }
 
@@ -1504,7 +1504,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
   }
 #endif
   if (rv < 0) {
-    pmsg_error("jtag3_open_common(): did not find any device matching VID 0x%04x and PID list: ",
+    pmsg_error("did not find any device matching VID 0x%04x and PID list: ",
       (unsigned) pinfo.usbinfo.vid);
     int notfirst = 0;
     for (usbpid = lfirst(pgm->usbpid); usbpid != NULL; usbpid = lnext(usbpid)) {
@@ -1628,7 +1628,7 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   pmsg_notice2("jtag3_page_erase(.., %s, 0x%x)\n", m->desc, addr);
 
   if (!(p->prog_modes & PM_PDI)) {
-    pmsg_error("jtag3_page_erase: not an Xmega device\n");
+    pmsg_error("not an Xmega device\n");
     return -1;
   }
 
@@ -1688,7 +1688,7 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   if (page_size == 0) page_size = 256;
 
   if ((cmd = malloc(page_size + 13)) == NULL) {
-    pmsg_error("jtag3_paged_write(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
 
@@ -2223,7 +2223,7 @@ int jtag3_setparm(const PROGRAMMER *pgm, unsigned char scope,
 
   if ((buf = malloc(6 + length)) == NULL)
   {
-    pmsg_error("jtag3_setparm(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
 
@@ -2273,7 +2273,7 @@ int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)(v * 1000);
 
   if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0) {
-    pmsg_warning("jtag3_set_vtarget(): cannot obtain V[target]\n");
+    pmsg_warning("cannot obtain V[target]\n");
   }
 
   uaref = b2_to_u16(buf);
@@ -2282,7 +2282,7 @@ int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
   pmsg_info("jtag3_set_vtarget(): changing V[target] from %.1f to %.1f\n", uaref / 1000.0, v);
 
   if (jtag3_setparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, sizeof(buf)) < 0) {
-    pmsg_error("jtag3_set_vtarget(): cannot confirm new V[target] value\n");
+    pmsg_error("cannot confirm new V[target] value\n");
     return -1;
   }
 
@@ -2314,7 +2314,7 @@ static void jtag3_display(const PROGRAMMER *pgm, const char *p) {
 
   c = resp[1];
   if (c != RSP3_INFO) {
-    pmsg_error("jtag3_display(): response is not RSP3_INFO\n");
+    pmsg_error("response is not RSP3_INFO\n");
     free(resp);
     return;
   }
@@ -2355,7 +2355,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x30)
-        pmsg_error("jtag3_print_parms1(): invalid PARM3_TSUP_VOLTAGE_MEAS data packet format\n");
+        pmsg_error("invalid PARM3_TSUP_VOLTAGE_MEAS data packet format\n");
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
@@ -2368,7 +2368,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x20)
-        pmsg_error("jtag3_print_parms1(): invalid PARM3_ANALOG_A_VOLTAGE data packet format\n");
+        pmsg_error("invalid PARM3_ANALOG_A_VOLTAGE data packet format\n");
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
@@ -2381,7 +2381,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = (buf[1] << 8) + buf[2];
       if (buf[0] != 0x90)
-        pmsg_error("jtag3_print_parms1(): invalid PARM3_ANALOG_A_CURRENT data packet format\n");
+        pmsg_error("invalid PARM3_ANALOG_A_CURRENT data packet format\n");
       else
         msg_info("%sCh A current    %s: %.3f mA\n", p,
           verbose? "": "             ", (float) analog_raw_data * 0.003472);
@@ -2391,7 +2391,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x10)
-        pmsg_error("jtag3_print_parms1(): invalid PARM3_ANALOG_B_VOLTAGE data packet format\n");
+        pmsg_error("invalid PARM3_ANALOG_B_VOLTAGE data packet format\n");
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
@@ -2404,7 +2404,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x00)
-        pmsg_error("jtag3_print_parms1(): invalid PARM3_ANALOG_B_CURRENT data packet format\n");
+        pmsg_error("invalid PARM3_ANALOG_B_CURRENT data packet format\n");
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -114,7 +114,7 @@ static unsigned int jtag3_memaddr(const PROGRAMMER *pgm, const AVRPART *p, const
 void jtag3_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_setup(): Out of memory allocating private data\n",
+    msg_info("%s: jtag3_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -178,7 +178,7 @@ static void jtag3_print_data(unsigned char *b, size_t s)
     return;
 
   for (i = 0; i < s; i++) {
-    avrdude_message(MSG_INFO, "0x%02x", b[i]);
+    msg_info("0x%02x", b[i]);
     if (i % 16 == 15)
       putc('\n', stderr);
     else
@@ -192,10 +192,10 @@ static void jtag3_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
   int i;
 
   if (verbose >= 4) {
-    avrdude_message(MSG_TRACE, "Raw message:\n");
+    msg_trace("Raw message:\n");
 
     for (i = 0; i < len; i++) {
-      avrdude_message(MSG_TRACE, "%02x ", data[i]);
+      msg_trace("%02x ", data[i]);
       if (i % 16 == 15)
 	putc('\n', stderr);
       else
@@ -207,34 +207,34 @@ static void jtag3_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
 
   switch (data[0]) {
     case SCOPE_INFO:
-      avrdude_message(MSG_INFO, "[info] ");
+      msg_info("[info] ");
       break;
 
     case SCOPE_GENERAL:
-      avrdude_message(MSG_INFO, "[general] ");
+      msg_info("[general] ");
       break;
 
     case SCOPE_AVR_ISP:
-      avrdude_message(MSG_INFO, "[AVRISP] ");
+      msg_info("[AVRISP] ");
       jtag3_print_data(data + 1, len - 1);
       return;
 
     case SCOPE_AVR:
-      avrdude_message(MSG_INFO, "[AVR] ");
+      msg_info("[AVR] ");
       break;
 
     default:
-      avrdude_message(MSG_INFO, "[scope 0x%02x] ", data[0]);
+      msg_info("[scope 0x%02x] ", data[0]);
       break;
   }
 
   switch (data[1]) {
     case RSP3_OK:
-      avrdude_message(MSG_INFO, "OK\n");
+      msg_info("OK\n");
       break;
 
     case RSP3_FAILED:
-      avrdude_message(MSG_INFO, "FAILED");
+      msg_info("FAILED");
       if (len > 3)
       {
 	char reason[50];
@@ -273,26 +273,26 @@ static void jtag3_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
 	    strcpy(reason, "debugWIRE communication failed");
 	    break;
 	}
-	avrdude_message(MSG_INFO, ", reason: %s\n", reason);
+	msg_info(", reason: %s\n", reason);
       }
       else
       {
-	avrdude_message(MSG_INFO, ", unspecified reason\n");
+	msg_info(", unspecified reason\n");
       }
       break;
 
     case RSP3_DATA:
-      avrdude_message(MSG_INFO, "Data returned:\n");
+      msg_info("Data returned:\n");
       jtag3_print_data(data + 2, len - 2);
       break;
 
     case RSP3_INFO:
-      avrdude_message(MSG_INFO, "Info returned:\n");
+      msg_info("Info returned:\n");
       for (i = 2; i < len; i++) {
 	if (isprint(data[i]))
 	  putc(data[i], stderr);
 	else
-	  avrdude_message(MSG_INFO, "\\%03o", data[i]);
+	  msg_info("\\%03o", data[i]);
       }
       putc('\n', stderr);
       break;
@@ -300,18 +300,18 @@ static void jtag3_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
     case RSP3_PC:
       if (len < 7)
       {
-	avrdude_message(MSG_INFO, "PC reply too short\n");
+	msg_info("PC reply too short\n");
       }
       else
       {
 	unsigned long pc = (data[6] << 24) | (data[5] << 16)
 	  | (data[4] << 8) | data[3];
-	avrdude_message(MSG_INFO, "PC 0x%0lx\n", pc);
+	msg_info("PC 0x%0lx\n", pc);
       }
       break;
 
   default:
-    avrdude_message(MSG_INFO, "unknown message 0x%02x\n", data[1]);
+    msg_info("unknown message 0x%02x\n", data[1]);
   }
 }
 
@@ -327,10 +327,10 @@ static void jtag3_prevent(const PROGRAMMER *pgm, unsigned char *data, size_t len
   int i;
 
   if (verbose >= 4) {
-    avrdude_message(MSG_TRACE, "Raw event:\n");
+    msg_trace("Raw event:\n");
 
     for (i = 0; i < len; i++) {
-      avrdude_message(MSG_TRACE, "%02x ", data[i]);
+      msg_trace("%02x ", data[i]);
       if (i % 16 == 15)
 	putc('\n', stderr);
       else
@@ -340,47 +340,47 @@ static void jtag3_prevent(const PROGRAMMER *pgm, unsigned char *data, size_t len
       putc('\n', stderr);
   }
 
-  avrdude_message(MSG_INFO, "Event serial 0x%04x, ",
+  msg_info("Event serial 0x%04x, ",
 	  (data[3] << 8) | data[2]);
 
   switch (data[4]) {
     case SCOPE_INFO:
-      avrdude_message(MSG_INFO, "[info] ");
+      msg_info("[info] ");
       break;
 
     case SCOPE_GENERAL:
-      avrdude_message(MSG_INFO, "[general] ");
+      msg_info("[general] ");
       break;
 
     case SCOPE_AVR:
-      avrdude_message(MSG_INFO, "[AVR] ");
+      msg_info("[AVR] ");
       break;
 
     default:
-      avrdude_message(MSG_INFO, "[scope 0x%02x] ", data[0]);
+      msg_info("[scope 0x%02x] ", data[0]);
       break;
   }
 
   switch (data[5]) {
   case EVT3_BREAK:
-    avrdude_message(MSG_INFO, "BREAK");
+    msg_info("BREAK");
     if (len >= 11) {
-      avrdude_message(MSG_INFO, ", PC = 0x%lx, reason ", b4_to_u32(data + 6));
+      msg_info(", PC = 0x%lx, reason ", b4_to_u32(data + 6));
       switch (data[10]) {
       case 0x00:
-	avrdude_message(MSG_INFO, "unspecified");
+	msg_info("unspecified");
 	break;
       case 0x01:
-	avrdude_message(MSG_INFO, "program break");
+	msg_info("program break");
 	break;
       case 0x02:
-	avrdude_message(MSG_INFO, "data break PDSB");
+	msg_info("data break PDSB");
 	break;
       case 0x03:
-	avrdude_message(MSG_INFO, "data break PDMSB");
+	msg_info("data break PDMSB");
 	break;
       default:
-	avrdude_message(MSG_INFO, "unknown: 0x%02x", data[10]);
+	msg_info("unknown: 0x%02x", data[10]);
       }
       /* There are two more bytes of data which always appear to be
        * 0x01, 0x00.  Purpose unknown. */
@@ -389,24 +389,24 @@ static void jtag3_prevent(const PROGRAMMER *pgm, unsigned char *data, size_t len
 
   case EVT3_SLEEP:
     if (len >= 8 && data[7] == 0)
-      avrdude_message(MSG_INFO, "sleeping");
+      msg_info("sleeping");
     else if (len >= 8 && data[7] == 1)
-      avrdude_message(MSG_INFO, "wakeup");
+      msg_info("wakeup");
     else
-      avrdude_message(MSG_INFO, "unknown SLEEP event");
+      msg_info("unknown SLEEP event");
     break;
 
   case EVT3_POWER:
     if (len >= 8 && data[7] == 0)
-      avrdude_message(MSG_INFO, "power-down");
+      msg_info("power-down");
     else if (len >= 8 && data[7] == 1)
-      avrdude_message(MSG_INFO, "power-up");
+      msg_info("power-up");
     else
-      avrdude_message(MSG_INFO, "unknown POWER event");
+      msg_info("unknown POWER event");
     break;
 
   default:
-    avrdude_message(MSG_INFO, "UNKNOWN 0x%02x", data[5]);
+    msg_info("UNKNOWN 0x%02x", data[5]);
     break;
   }
   putc('\n', stderr);
@@ -420,12 +420,12 @@ int jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   if (pgm->flag & PGM_FL_IS_EDBG)
     return jtag3_edbg_send(pgm, data, len);
 
-  avrdude_message(MSG_DEBUG, "\n%s: jtag3_send(): sending %lu bytes\n",
+  msg_debug("\n%s: jtag3_send(): sending %lu bytes\n",
 	    progname, (unsigned long)len);
 
   if ((buf = malloc(len + 4)) == NULL)
     {
-      avrdude_message(MSG_INFO, "%s: jtag3_send(): out of memory",
+      msg_info("%s: jtag3_send(): out of memory",
 	      progname);
       return -1;
     }
@@ -436,7 +436,7 @@ int jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   memcpy(buf + 4, data, len);
 
   if (serial_send(&pgm->fd, buf, len + 4) != 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_send(): failed to send command to serial port\n",
+    msg_info("%s: jtag3_send(): failed to send command to serial port\n",
                     progname);
     free(buf);
     return -1;
@@ -458,7 +458,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
       memset(status, 0, USBDEV_MAX_XFER_3);
     }
 
-  avrdude_message(MSG_DEBUG, "\n%s: jtag3_edbg_send(): sending %lu bytes\n",
+  msg_debug("\n%s: jtag3_edbg_send(): sending %lu bytes\n",
 	    progname, (unsigned long)len);
 
   /* 4 bytes overhead for CMD, fragment #, and length info */
@@ -466,7 +466,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
   int nfragments = (len + max_xfer - 1) / max_xfer;
   if (nfragments > 1)
     {
-      avrdude_message(MSG_DEBUG, "%s: jtag3_edbg_send(): fragmenting into %d packets\n",
+      msg_debug("%s: jtag3_edbg_send(): fragmenting into %d packets\n",
                       progname, nfragments);
     }
   int frag;
@@ -500,7 +500,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
         }
 
       if (serial_send(&pgm->fd, buf, max_xfer) != 0) {
-        avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_send(): failed to send command to serial port\n",
+        msg_notice("%s: jtag3_edbg_send(): failed to send command to serial port\n",
                         progname);
         return -1;
       }
@@ -508,7 +508,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
 
       if (rv < 0) {
         /* timeout in receive */
-        avrdude_message(MSG_NOTICE2, "%s: jtag3_edbg_send(): Timeout receiving packet\n",
+        msg_notice2("%s: jtag3_edbg_send(): Timeout receiving packet\n",
                         progname);
         return -1;
       }
@@ -516,7 +516,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
           (frag == nfragments - 1 && status[1] != 0x01))
         {
           /* what to do in this case? */
-          avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_send(): Unexpected response 0x%02x, 0x%02x\n",
+          msg_notice("%s: jtag3_edbg_send(): Unexpected response 0x%02x, 0x%02x\n",
                           progname, status[0], status[1]);
         }
       data += this_len;
@@ -534,7 +534,7 @@ static int jtag3_edbg_prepare(const PROGRAMMER *pgm) {
   unsigned char status[USBDEV_MAX_XFER_3];
   int rv;
 
-  avrdude_message(MSG_DEBUG, "\n%s: jtag3_edbg_prepare()\n",
+  msg_debug("\n%s: jtag3_edbg_prepare()\n",
 	    progname);
 
   if (verbose >= 4)
@@ -543,40 +543,40 @@ static int jtag3_edbg_prepare(const PROGRAMMER *pgm) {
   buf[0] = CMSISDAP_CMD_CONNECT;
   buf[1] = CMSISDAP_CONN_SWD;
   if (serial_send(&pgm->fd, buf, pgm->fd.usb.max_xfer) != 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_edbg_prepare(): failed to send command to serial port\n",
+    msg_info("%s: jtag3_edbg_prepare(): failed to send command to serial port\n",
                     progname);
     return -1;
   }
   rv = serial_recv(&pgm->fd, status, pgm->fd.usb.max_xfer);
   if (rv != pgm->fd.usb.max_xfer) {
-    avrdude_message(MSG_INFO, "%s: jtag3_edbg_prepare(): failed to read from serial port (%d)\n",
+    msg_info("%s: jtag3_edbg_prepare(): failed to read from serial port (%d)\n",
                     progname, rv);
     return -1;
   }
   if (status[0] != CMSISDAP_CMD_CONNECT ||
       status[1] == 0)
-    avrdude_message(MSG_INFO, "%s: jtag3_edbg_prepare(): unexpected response 0x%02x, 0x%02x\n",
+    msg_info("%s: jtag3_edbg_prepare(): unexpected response 0x%02x, 0x%02x\n",
                     progname, status[0], status[1]);
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_edbg_prepare(): connection status 0x%02x\n",
+  msg_notice2("%s: jtag3_edbg_prepare(): connection status 0x%02x\n",
                     progname, status[1]);
 
   buf[0] = CMSISDAP_CMD_LED;
   buf[1] = CMSISDAP_LED_CONNECT;
   buf[2] = 1;
   if (serial_send(&pgm->fd, buf, pgm->fd.usb.max_xfer) != 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_edbg_prepare(): failed to send command to serial port\n",
+    msg_info("%s: jtag3_edbg_prepare(): failed to send command to serial port\n",
                     progname);
     return -1;
   }
   rv = serial_recv(&pgm->fd, status, pgm->fd.usb.max_xfer);
   if (rv != pgm->fd.usb.max_xfer) {
-    avrdude_message(MSG_INFO, "%s: jtag3_edbg_prepare(): failed to read from serial port (%d)\n",
+    msg_info("%s: jtag3_edbg_prepare(): failed to read from serial port (%d)\n",
                     progname, rv);
     return -1;
   }
   if (status[0] != CMSISDAP_CMD_LED ||
       status[1] != 0)
-    avrdude_message(MSG_INFO, "%s: jtag3_edbg_prepare(): unexpected response 0x%02x, 0x%02x\n",
+    msg_info("%s: jtag3_edbg_prepare(): unexpected response 0x%02x, 0x%02x\n",
                     progname, status[0], status[1]);
 
   return 0;
@@ -591,7 +591,7 @@ static int jtag3_edbg_signoff(const PROGRAMMER *pgm) {
   unsigned char status[USBDEV_MAX_XFER_3];
   int rv;
 
-  avrdude_message(MSG_DEBUG, "\n%s: jtag3_edbg_signoff()\n",
+  msg_debug("\n%s: jtag3_edbg_signoff()\n",
 	    progname);
 
   if (verbose >= 4)
@@ -601,36 +601,36 @@ static int jtag3_edbg_signoff(const PROGRAMMER *pgm) {
   buf[1] = CMSISDAP_LED_CONNECT;
   buf[2] = 0;
   if (serial_send(&pgm->fd, buf, pgm->fd.usb.max_xfer) != 0) {
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_signoff(): failed to send command to serial port\n",
+    msg_notice("%s: jtag3_edbg_signoff(): failed to send command to serial port\n",
                     progname);
     return -1;
   }
   rv = serial_recv(&pgm->fd, status, pgm->fd.usb.max_xfer);
   if (rv != pgm->fd.usb.max_xfer) {
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_signoff(): failed to read from serial port (%d)\n",
+    msg_notice("%s: jtag3_edbg_signoff(): failed to read from serial port (%d)\n",
                     progname, rv);
     return -1;
   }
   if (status[0] != CMSISDAP_CMD_LED ||
       status[1] != 0)
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_signoff(): unexpected response 0x%02x, 0x%02x\n",
+    msg_notice("%s: jtag3_edbg_signoff(): unexpected response 0x%02x, 0x%02x\n",
                     progname, status[0], status[1]);
 
   buf[0] = CMSISDAP_CMD_DISCONNECT;
   if (serial_send(&pgm->fd, buf, pgm->fd.usb.max_xfer) != 0) {
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_signoff(): failed to send command to serial port\n",
+    msg_notice("%s: jtag3_edbg_signoff(): failed to send command to serial port\n",
                     progname);
     return -1;
   }
   rv = serial_recv(&pgm->fd, status, pgm->fd.usb.max_xfer);
   if (rv != pgm->fd.usb.max_xfer) {
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_signoff(): failed to read from serial port (%d)\n",
+    msg_notice("%s: jtag3_edbg_signoff(): failed to read from serial port (%d)\n",
                     progname, rv);
     return -1;
   }
   if (status[0] != CMSISDAP_CMD_DISCONNECT ||
       status[1] != 0)
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_signoff(): unexpected response 0x%02x, 0x%02x\n",
+    msg_notice("%s: jtag3_edbg_signoff(): unexpected response 0x%02x, 0x%02x\n",
                     progname, status[0], status[1]);
 
   return 0;
@@ -657,10 +657,10 @@ static int jtag3_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
   if (pgm->flag & PGM_FL_IS_EDBG)
     return jtag3_edbg_recv_frame(pgm, msg);
 
-  avrdude_message(MSG_TRACE, "%s: jtag3_recv():\n", progname);
+  msg_trace("%s: jtag3_recv():\n", progname);
 
   if ((buf = malloc(pgm->fd.usb.max_xfer)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtag3_recv(): out of memory\n",
+    msg_info("%s: jtag3_recv(): out of memory\n",
 	    progname);
     return -1;
   }
@@ -671,7 +671,7 @@ static int jtag3_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
 
   if (rv < 0) {
     /* timeout in receive */
-    avrdude_message(MSG_NOTICE2, "%s: jtag3_recv(): Timeout receiving packet\n",
+    msg_notice2("%s: jtag3_recv(): Timeout receiving packet\n",
                       progname);
     free(buf);
     return -1;
@@ -687,15 +687,15 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
   unsigned char *buf = NULL;
   unsigned char *request;
 
-  avrdude_message(MSG_TRACE, "%s: jtag3_edbg_recv():\n", progname);
+  msg_trace("%s: jtag3_edbg_recv():\n", progname);
 
   if ((buf = malloc(USBDEV_MAX_XFER_3)) == NULL) {
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_recv(): out of memory\n",
+    msg_notice("%s: jtag3_edbg_recv(): out of memory\n",
 	    progname);
     return -1;
   }
   if ((request = malloc(pgm->fd.usb.max_xfer)) == NULL) {
-    avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_recv(): out of memory\n",
+    msg_notice("%s: jtag3_edbg_recv(): out of memory\n",
 	    progname);
     free(buf);
     return -1;
@@ -710,7 +710,7 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
     request[0] = EDBG_VENDOR_AVR_RSP;
 
     if (serial_send(&pgm->fd, request, pgm->fd.usb.max_xfer) != 0) {
-      avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_recv(): error sending CMSIS-DAP vendor command\n",
+      msg_notice("%s: jtag3_edbg_recv(): error sending CMSIS-DAP vendor command\n",
                       progname);
       free(request);
       free(*msg);
@@ -721,7 +721,7 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
 
     if (rv < 0) {
       /* timeout in receive */
-      avrdude_message(MSG_NOTICE2, "%s: jtag3_edbg_recv(): Timeout receiving packet\n",
+      msg_notice2("%s: jtag3_edbg_recv(): Timeout receiving packet\n",
                       progname);
       free(*msg);
       free(request);
@@ -729,7 +729,7 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
     }
 
     if (buf[0] != EDBG_VENDOR_AVR_RSP) {
-      avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_recv(): Unexpected response 0x%02x\n",
+      msg_notice("%s: jtag3_edbg_recv(): Unexpected response 0x%02x\n",
                       progname, buf[0]);
       free(*msg);
       free(request);
@@ -740,7 +740,7 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
       // Documentation says:
       // "FragmentInfo 0x00 indicates that no response data is
       // available, and the rest of the packet is ignored."
-      avrdude_message(MSG_NOTICE,
+      msg_notice(
 		      "%s: jtag3_edbg_recv(): "
 		      "No response available\n",
 		      progname);
@@ -756,7 +756,7 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
       thisfrag = 1;
     } else {
       if (nfrags != (buf[1] & 0x0F)) {
-        avrdude_message(MSG_NOTICE,
+        msg_notice(
                         "%s: jtag3_edbg_recv(): "
                         "Inconsistent # of fragments; had %d, now %d\n",
                         progname, nfrags, (buf[1] & 0x0F));
@@ -766,7 +766,7 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
       }
     }
     if (thisfrag != ((buf[1] >> 4) & 0x0F)) {
-      avrdude_message(MSG_NOTICE,
+      msg_notice(
                       "%s: jtag3_edbg_recv(): "
                       "Inconsistent fragment number; expect %d, got %d\n",
                       progname, thisfrag, ((buf[1] >> 4) & 0x0F));
@@ -777,12 +777,12 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
 
     int thislen = (buf[2] << 8) | buf[3];
     if (thislen > rv + 4) {
-      avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_recv(): Unexpected length value (%d > %d)\n",
+      msg_notice("%s: jtag3_edbg_recv(): Unexpected length value (%d > %d)\n",
                       progname, thislen, rv + 4);
       thislen = rv + 4;
     }
     if (len + thislen > USBDEV_MAX_XFER_3) {
-      avrdude_message(MSG_NOTICE, "%s: jtag3_edbg_recv(): Length exceeds max size (%d > %d)\n",
+      msg_notice("%s: jtag3_edbg_recv(): Length exceeds max size (%d > %d)\n",
                       progname, len + thislen, USBDEV_MAX_XFER_3);
       thislen = USBDEV_MAX_XFER_3 - len;
     }
@@ -814,7 +814,7 @@ int jtag3_recv(const PROGRAMMER *pgm, unsigned char **msg) {
 
     rv &= USB_RECV_LENGTH_MASK;
     r_seqno = ((*msg)[2] << 8) | (*msg)[1];
-    avrdude_message(MSG_DEBUG, "%s: jtag3_recv(): "
+    msg_debug("%s: jtag3_recv(): "
 	      "Got message seqno %d (command_sequence == %d)\n",
 	      progname, r_seqno, PDATA(pgm)->command_sequence);
     if (r_seqno == PDATA(pgm)->command_sequence) {
@@ -830,7 +830,7 @@ int jtag3_recv(const PROGRAMMER *pgm, unsigned char **msg) {
 
       return rv;
     }
-    avrdude_message(MSG_NOTICE2, "%s: jtag3_recv(): "
+    msg_notice2("%s: jtag3_recv(): "
 	      "got wrong sequence number, %u != %u\n",
 	      progname, r_seqno, PDATA(pgm)->command_sequence);
 
@@ -844,7 +844,7 @@ int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen
   int status;
   unsigned char c;
 
-  avrdude_message(MSG_NOTICE2, "%s: Sending %s command: ",
+  msg_notice2("%s: Sending %s command: ",
 	    progname, descr);
   jtag3_send(pgm, cmd, cmdlen);
 
@@ -852,25 +852,25 @@ int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_NOTICE2, "%s: %s command: timeout/error communicating with programmer (status %d)\n",
+    msg_notice2("%s: %s command: timeout/error communicating with programmer (status %d)\n",
                     progname, descr, status);
     return LIBAVRDUDE_GENERAL_FAILURE;
   } else if (verbose >= 3) {
     putc('\n', stderr);
     jtag3_prmsg(pgm, *resp, status);
   } else {
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", (*resp)[1], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", (*resp)[1], status);
   }
 
   c = (*resp)[1] & RSP3_STATUS_MASK;
   if (c != RSP3_OK) {
     if ((c == RSP3_FAILED) && ((*resp)[3] == RSP3_FAIL_OCD_LOCKED ||
 			       (*resp)[3] == RSP3_FAIL_CRC_FAILURE)) {
-      avrdude_message(MSG_INFO,
+      msg_info(
 		      "%s: Device is locked! Chip erase required to unlock.\n",
 		      progname);
     } else {
-      avrdude_message(MSG_NOTICE, "%s: bad response to %s command: 0x%02x\n",
+      msg_notice("%s: bad response to %s command: 0x%02x\n",
 		      progname, descr, c);
     }
     status = (*resp)[3];
@@ -887,7 +887,7 @@ int jtag3_getsync(const PROGRAMMER *pgm, int mode) {
 
   unsigned char buf[3], *resp;
 
-  avrdude_message(MSG_DEBUG, "%s: jtag3_getsync()\n", progname);
+  msg_debug("%s: jtag3_getsync()\n", progname);
 
   /* XplainedMini boards do not need this, and early revisions had a
    * firmware bug where they complained about it. */
@@ -962,7 +962,7 @@ static int jtag3_unlock_erase_key(const PROGRAMMER *pgm, const AVRPART *p) {
  */
 static int jtag3_chip_erase_dw(const PROGRAMMER *pgm, const AVRPART *p) {
 
-  avrdude_message(MSG_INFO, "%s: Chip erase not supported in debugWire mode\n",
+  msg_info("%s: Chip erase not supported in debugWire mode\n",
 	  progname);
 
   return 0;
@@ -1052,10 +1052,10 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (jtag3_getparm(pgm, SCOPE_GENERAL, 0, PARM3_FW_MAJOR, parm, 2) < 0)
     return -1;
   if (pgm->fd.usb.max_xfer < USBDEV_MAX_XFER_3 && (pgm->flag & PGM_FL_IS_EDBG) == 0) {
-    avrdude_message(MSG_INFO, "%s: the JTAGICE3's firmware %d.%d is broken on USB 1.1 connections, sorry\n",
+    msg_info("%s: the JTAGICE3's firmware %d.%d is broken on USB 1.1 connections, sorry\n",
                     progname, parm[0], parm[1]);
     if (ovsigck) {
-      avrdude_message(MSG_INFO, "%s: forced to continue by option -F; THIS PUTS THE DEVICE'S DATA INTEGRITY AT RISK!\n",
+      msg_info("%s: forced to continue by option -F; THIS PUTS THE DEVICE'S DATA INTEGRITY AT RISK!\n",
                       progname);
     } else {
       return -1;
@@ -1081,7 +1081,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (conn == 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_initialize(): part %s has no %s interface\n",
+    msg_info("%s: jtag3_initialize(): part %s has no %s interface\n",
 	    progname, p->desc, ifname);
     return -1;
   }
@@ -1116,7 +1116,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (pgm->bitclock != 0.0 && PDATA(pgm)->set_sck != NULL)
   {
     unsigned int clock = 1E-3 / pgm->bitclock; /* kHz */
-    avrdude_message(MSG_NOTICE2, "%s: jtag3_initialize(): "
+    msg_notice2("%s: jtag3_initialize(): "
 	      "trying to set JTAG clock to %u kHz\n",
 	      progname, clock);
     parm[0] = clock & 0xff;
@@ -1127,7 +1127,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   jtag3_print_parms1(pgm, progbuf);
   if (conn == PARM3_CONN_JTAG)
   {
-    avrdude_message(MSG_NOTICE2, "%s: jtag3_initialize(): "
+    msg_notice2("%s: jtag3_initialize(): "
 	      "trying to set JTAG daisy-chain info to %d,%d,%d,%d\n",
 	      progname,
 	      PDATA(pgm)->jtagchain[0], PDATA(pgm)->jtagchain[1],
@@ -1253,13 +1253,13 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       parm[0] = PARM3_UPDI_HV_NONE;
       for (support = lfirst(pgm->hvupdi_support); support != NULL; support = lnext(support)) {
         if(*(int *) ldata(support) == p->hvupdi_variant) {
-          avrdude_message(MSG_NOTICE, "%s: Sending HV pulse to targets %s pin\n",
+          msg_notice("%s: Sending HV pulse to targets %s pin\n",
             progname, p->hvupdi_variant == HV_UPDI_VARIANT_0 ? "UPDI" : "RESET");
           parm[0] = PARM3_UPDI_HV_SIMPLE_PULSE;
           break;
         }
         if (parm[0] == PARM3_UPDI_HV_NONE) {
-          avrdude_message(MSG_INFO, "%s: %s does not support sending HV pulse to target %s\n",
+          msg_info("%s: %s does not support sending HV pulse to target %s\n",
             progname, pgm->desc, p->desc);
           return -1;
         }
@@ -1279,7 +1279,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     xd.syscfg_erase_mask_and = 0xFF;
     xd.syscfg_erase_mask_or = 0x00;
 
-    avrdude_message(MSG_NOTICE2, "UPDI SET: \n\t"
+    msg_notice2("UPDI SET: \n\t"
       "xd->prog_base_msb=%x\n\t"
       "xd->prog_base=%x %x\n\t"
       "xd->flash_page_size_msb=%x\n\t"
@@ -1338,7 +1338,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 	ocdrev = 4;
       else
 	ocdrev = 3;		/* many exceptions from that, actually */
-      avrdude_message(MSG_INFO, "%s: part definition for %s lacks \"ocdrev\"; guessing %d\n",
+      msg_info("%s: part definition for %s lacks \"ocdrev\"; guessing %d\n",
                       progname, p->desc, ocdrev);
       md.ocd_revision = ocdrev;
     } else {
@@ -1371,13 +1371,13 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if ((status = jtag3_command(pgm, cmd, 4, &resp, "AVR sign-on")) >= 0)
       break;
 
-    avrdude_message(MSG_NOTICE, "%s: retrying with external reset applied\n",
+    msg_notice("%s: retrying with external reset applied\n",
 		    progname);
   }
 
   if (use_ext_reset > 1) {
       if(strcmp(pgm->type, "JTAGICE3") == 0 && (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG)))
-        avrdude_message(MSG_INFO, "%s: JTAGEN fuse disabled?\n", progname);
+        msg_info("%s: JTAGEN fuse disabled?\n", progname);
       return -1;
   }
 
@@ -1396,12 +1396,12 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (resp[1] == RSP3_DATA && status >= 7) {
     if (p->prog_modes & PM_UPDI) {
       /* Partial Family_ID has been returned */
-      avrdude_message(MSG_NOTICE, "%s: Partial Family_ID returned: \"%c%c%c%c\"\n",
+      msg_notice("%s: Partial Family_ID returned: \"%c%c%c%c\"\n",
 	      progname, resp[3], resp[4], resp[5], resp[6]);
     }
     else
       /* JTAG ID has been returned */
-      avrdude_message(MSG_NOTICE, "%s: JTAG ID returned: 0x%02x 0x%02x 0x%02x 0x%02x\n",
+      msg_notice("%s: JTAG ID returned: 0x%02x 0x%02x 0x%02x 0x%02x\n",
 	      progname, resp[3], resp[4], resp[5], resp[6]);
   }
 
@@ -1413,7 +1413,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     AVRMEM *bootmem = avr_locate_mem(p, "boot");
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (bootmem == NULL || flashmem == NULL) {
-      avrdude_message(MSG_INFO, "%s: jtagmk3_initialize(): Cannot locate \"flash\" and \"boot\" memories in description\n",
+      msg_info("%s: jtagmk3_initialize(): Cannot locate \"flash\" and \"boot\" memories in description\n",
                       progname);
     } else {
       PDATA(pgm)->boot_start = bootmem->offset - flashmem->offset;
@@ -1423,12 +1423,12 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtag3_initialize(): Out of memory\n",
+    msg_info("%s: jtag3_initialize(): Out of memory\n",
 	    progname);
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtag3_initialize(): Out of memory\n",
+    msg_info("%s: jtag3_initialize(): Out of memory\n",
 	    progname);
     free(PDATA(pgm)->flash_pagecache);
     return -1;
@@ -1469,12 +1469,12 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       unsigned int ub, ua, bb, ba;
       if (sscanf(extended_param, "jtagchain=%u,%u,%u,%u", &ub, &ua, &bb, &ba)
           != 4) {
-        avrdude_message(MSG_INFO, "%s: jtag3_parseextparms(): invalid JTAG chain '%s'\n",
+        msg_info("%s: jtag3_parseextparms(): invalid JTAG chain '%s'\n",
                         progname, extended_param);
         rv = -1;
         continue;
       }
-      avrdude_message(MSG_NOTICE2, "%s: jtag3_parseextparms(): JTAG chain parsed as:\n"
+      msg_notice2("%s: jtag3_parseextparms(): JTAG chain parsed as:\n"
                         "%s %u units before, %u units after, %u bits before, %u bits after\n",
                         progname,
                         progbuf, ub, ua, bb, ba);
@@ -1492,7 +1492,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    avrdude_message(MSG_INFO, "%s: jtag3_parseextparms(): invalid extended parameter '%s'\n",
+    msg_info("%s: jtag3_parseextparms(): invalid extended parameter '%s'\n",
                     progname, extended_param);
     rv = -1;
   }
@@ -1506,12 +1506,12 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
   int rv = -1;
 
 #if !defined(HAVE_LIBUSB) && !defined(HAVE_LIBHIDAPI)
-  avrdude_message(MSG_INFO, "avrdude was compiled without USB or HIDAPI support.\n");
+  msg_info("avrdude was compiled without USB or HIDAPI support.\n");
   return -1;
 #endif
 
   if (!matches(port, "usb")) {
-    avrdude_message(MSG_INFO, "%s: jtag3_open_common(): JTAGICE3/EDBG port names must start with \"usb\"\n",
+    msg_info("%s: jtag3_open_common(): JTAGICE3/EDBG port names must start with \"usb\"\n",
                     progname);
     return -1;
   }
@@ -1562,13 +1562,13 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
   }
 #endif
   if (rv < 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_open_common(): Did not find any device matching VID 0x%04x and PID list: ",
+    msg_info("%s: jtag3_open_common(): Did not find any device matching VID 0x%04x and PID list: ",
                     progname, (unsigned)pinfo.usbinfo.vid);
     int notfirst = 0;
     for (usbpid = lfirst(pgm->usbpid); usbpid != NULL; usbpid = lnext(usbpid)) {
       if (notfirst)
-        avrdude_message(MSG_INFO, ", ");
-      avrdude_message(MSG_INFO, "0x%04x", (unsigned int)(*(int *)(ldata(usbpid))));
+        msg_info(", ");
+      msg_info("0x%04x", (unsigned int)(*(int *)(ldata(usbpid))));
       notfirst = 1;
     }
     fputc('\n', stderr);
@@ -1581,7 +1581,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
     /* The event EP has been deleted by usb_open(), so we are
        running on a CMSIS-DAP device, using EDBG protocol */
     pgm->flag |= PGM_FL_IS_EDBG;
-    avrdude_message(MSG_NOTICE, "%s: Found CMSIS-DAP compliant device, using EDBG protocol\n",
+    msg_notice("%s: Found CMSIS-DAP compliant device, using EDBG protocol\n",
                       progname);
   }
 
@@ -1596,7 +1596,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
 
 
 static int jtag3_open(PROGRAMMER *pgm, const char *port) {
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_open()\n", progname);
+  msg_notice2("%s: jtag3_open()\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
     return -1;
@@ -1608,7 +1608,7 @@ static int jtag3_open(PROGRAMMER *pgm, const char *port) {
 }
 
 static int jtag3_open_dw(PROGRAMMER *pgm, const char *port) {
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_open_dw()\n", progname);
+  msg_notice2("%s: jtag3_open_dw()\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
     return -1;
@@ -1620,7 +1620,7 @@ static int jtag3_open_dw(PROGRAMMER *pgm, const char *port) {
 }
 
 static int jtag3_open_pdi(PROGRAMMER *pgm, const char *port) {
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_open_pdi()\n", progname);
+  msg_notice2("%s: jtag3_open_pdi()\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
     return -1;
@@ -1632,13 +1632,13 @@ static int jtag3_open_pdi(PROGRAMMER *pgm, const char *port) {
 }
 
 static int jtag3_open_updi(PROGRAMMER *pgm, const char *port) {
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_open_updi()\n", progname);
+  msg_notice2("%s: jtag3_open_updi()\n", progname);
 
   LNODEID ln;
-  avrdude_message(MSG_NOTICE2, "%s: HV UPDI support:", progname);
+  msg_notice2("%s: HV UPDI support:", progname);
   for (ln = lfirst(pgm->hvupdi_support); ln; ln = lnext(ln))
-    avrdude_message(MSG_NOTICE2, " %d", *(int *) ldata(ln));
-  avrdude_message(MSG_NOTICE2, "\n", progname);
+    msg_notice2(" %d", *(int *) ldata(ln));
+  msg_notice2("\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
     return -1;
@@ -1653,7 +1653,7 @@ void jtag3_close(PROGRAMMER * pgm)
 {
   unsigned char buf[4], *resp;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_close()\n", progname);
+  msg_notice2("%s: jtag3_close()\n", progname);
 
   buf[0] = SCOPE_AVR;
   buf[1] = CMD3_SIGN_OFF;
@@ -1684,11 +1684,11 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
 {
   unsigned char cmd[8], *resp;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_page_erase(.., %s, 0x%x)\n",
+  msg_notice2("%s: jtag3_page_erase(.., %s, 0x%x)\n",
 	    progname, m->desc, addr);
 
   if (!(p->prog_modes & PM_PDI)) {
-    avrdude_message(MSG_INFO, "%s: jtag3_page_erase: not an Xmega device\n",
+    msg_info("%s: jtag3_page_erase: not an Xmega device\n",
 	    progname);
     return -1;
   }
@@ -1736,12 +1736,12 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   int status, dynamic_memtype = 0;
   long otimeout = serial_recv_timeout;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_paged_write(.., %s, %d, 0x%lx, %d)\n",
+  msg_notice2("%s: jtag3_paged_write(.., %s, %d, 0x%lx, %d)\n",
 	    progname, m->desc, page_size, addr, n_bytes);
 
   block_size = jtag3_memaddr(pgm, p, m, addr);
   if(block_size != addr)
-    avrdude_message(MSG_NOTICE2, "          mapped to address: 0x%lx\n", block_size);
+    msg_notice2("          mapped to address: 0x%lx\n", block_size);
   block_size = 0;
 
   if (!(pgm->flag & PGM_FL_IS_DW) && jtag3_program_enable(pgm) < 0)
@@ -1750,7 +1750,7 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   if (page_size == 0) page_size = 256;
 
   if ((cmd = malloc(page_size + 13)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtag3_paged_write(): Out of memory\n",
+    msg_info("%s: jtag3_paged_write(): Out of memory\n",
 	    progname);
     return -1;
   }
@@ -1798,7 +1798,7 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
       block_size = maxaddr - addr;
     else
       block_size = page_size;
-    avrdude_message(MSG_DEBUG, "%s: jtag3_paged_write(): "
+    msg_debug("%s: jtag3_paged_write(): "
 	      "block_size at addr %d is %d\n",
 	      progname, addr, block_size);
 
@@ -1846,12 +1846,12 @@ static int jtag3_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   int status, dynamic_memtype = 0;
   long otimeout = serial_recv_timeout;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_paged_load(.., %s, %d, 0x%lx, %d)\n",
+  msg_notice2("%s: jtag3_paged_load(.., %s, %d, 0x%lx, %d)\n",
 	    progname, m->desc, page_size, addr, n_bytes);
 
   block_size = jtag3_memaddr(pgm, p, m, addr);
   if(block_size != addr)
-    avrdude_message(MSG_NOTICE2, "          mapped to address: 0x%lx\n", block_size);
+    msg_notice2("          mapped to address: 0x%lx\n", block_size);
   block_size = 0;
 
   if (!(pgm->flag & PGM_FL_IS_DW) && jtag3_program_enable(pgm) < 0)
@@ -1892,7 +1892,7 @@ static int jtag3_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
       block_size = maxaddr - addr;
     else
       block_size = page_size;
-    avrdude_message(MSG_DEBUG, "%s: jtag3_paged_load(): "
+    msg_debug("%s: jtag3_paged_load(): "
 	      "block_size at addr %d is %d\n",
 	      progname, addr, block_size);
 
@@ -1907,7 +1907,7 @@ static int jtag3_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
 
     if (resp[1] != RSP3_DATA ||
 	status < block_size + 4) {
-      avrdude_message(MSG_INFO, "%s: wrong/short reply to read memory command\n",
+      msg_info("%s: wrong/short reply to read memory command\n",
 	      progname);
       serial_recv_timeout = otimeout;
       free(resp);
@@ -1930,12 +1930,12 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   unsigned long paddr = 0UL, *paddr_ptr = NULL;
   unsigned int pagesize = 0;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_read_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: jtag3_read_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   paddr = jtag3_memaddr(pgm, p, mem, addr);
   if(paddr != addr)
-    avrdude_message(MSG_NOTICE2, "          mapped to address: 0x%lx\n", paddr);
+    msg_notice2("          mapped to address: 0x%lx\n", paddr);
   paddr = 0;
 
   if (!(pgm->flag & PGM_FL_IS_DW))
@@ -2035,7 +2035,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
       return 0;
     } else {
       /* should not happen */
-      avrdude_message(MSG_INFO, "address out of range for signature memory: %lu\n", addr);
+      msg_info("address out of range for signature memory: %lu\n", addr);
       return -1;
     }
   }
@@ -2077,7 +2077,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
   if (resp[1] != RSP3_DATA ||
       status < (pagesize? pagesize: 1) + 4) {
-    avrdude_message(MSG_INFO, "%s: wrong/short reply to read memory command\n",
+    msg_info("%s: wrong/short reply to read memory command\n",
 	    progname);
     free(resp);
     return -1;
@@ -2104,12 +2104,12 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   unsigned int pagesize = 0;
   unsigned long mapped_addr;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_write_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: jtag3_write_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   mapped_addr = jtag3_memaddr(pgm, p, mem, addr);
   if(mapped_addr != addr)
-    avrdude_message(MSG_NOTICE2, "          mapped to address: 0x%lx\n", mapped_addr);
+    msg_notice2("          mapped to address: 0x%lx\n", mapped_addr);
 
   cmd[0] = SCOPE_AVR;
   cmd[1] = CMD3_WRITE_MEMORY;
@@ -2226,7 +2226,7 @@ static int jtag3_set_sck_period(const PROGRAMMER *pgm, double v) {
   parm[1] = (clock >> 8) & 0xff;
 
   if (PDATA(pgm)->set_sck == NULL) {
-    avrdude_message(MSG_INFO, "%s: No backend to set the SCK period for\n",
+    msg_info("%s: No backend to set the SCK period for\n",
 	    progname);
     return -1;
   }
@@ -2246,7 +2246,7 @@ int jtag3_getparm(const PROGRAMMER *pgm, unsigned char scope,
   unsigned char buf[6], *resp, c;
   char descr[60];
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_getparm()\n", progname);
+  msg_notice2("%s: jtag3_getparm()\n", progname);
 
   buf[0] = scope;
   buf[1] = CMD3_GET_PARAMETER;
@@ -2263,7 +2263,7 @@ int jtag3_getparm(const PROGRAMMER *pgm, unsigned char scope,
 
   c = resp[1];
   if (c != RSP3_DATA || status < 3) {
-    avrdude_message(MSG_NOTICE, "%s: jtag3_getparm(): "
+    msg_notice("%s: jtag3_getparm(): "
                     "bad response to %s\n",
                     progname, descr);
     free(resp);
@@ -2288,14 +2288,14 @@ int jtag3_setparm(const PROGRAMMER *pgm, unsigned char scope,
   unsigned char *buf, *resp;
   char descr[60];
 
-  avrdude_message(MSG_NOTICE2, "%s: jtag3_setparm()\n", progname);
+  msg_notice2("%s: jtag3_setparm()\n", progname);
 
   sprintf(descr, "set parameter (scope 0x%02x, section %d, parm %d)",
 	  scope, section, parm);
 
   if ((buf = malloc(6 + length)) == NULL)
   {
-    avrdude_message(MSG_INFO, "%s: jtag3_setparm(): Out of memory\n",
+    msg_info("%s: jtag3_setparm(): Out of memory\n",
 	    progname);
     return -1;
   }
@@ -2334,7 +2334,7 @@ int jtag3_read_sib(const PROGRAMMER *pgm, const AVRPART *p, char *sib) {
 
   memcpy(sib, resp+3, AVR_SIBLEN);
   sib[AVR_SIBLEN] = 0; // Zero terminate string
-  avrdude_message(MSG_DEBUG, "%s: jtag3_read_sib(): Received SIB: \"%s\"\n", progname, sib);
+  msg_debug("%s: jtag3_read_sib(): Received SIB: \"%s\"\n", progname, sib);
   free(resp);
   return 0;
 }
@@ -2346,18 +2346,18 @@ int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)(v * 1000);
 
   if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_set_vtarget(): cannot obtain V[target]\n",
+    msg_info("%s: jtag3_set_vtarget(): cannot obtain V[target]\n",
                     progname);
   }
 
   uaref = b2_to_u16(buf);
   u16_to_b2(buf, utarg);
 
-  avrdude_message(MSG_INFO, "%s: jtag3_set_vtarget(): changing V[target] from %.1f to %.1f\n",
+  msg_info("%s: jtag3_set_vtarget(): changing V[target] from %.1f to %.1f\n",
                   progname, uaref / 1000.0, v);
 
   if (jtag3_setparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, sizeof(buf)) < 0) {
-    avrdude_message(MSG_INFO, "%s: jtag3_set_vtarget(): cannot confirm new V[target] value\n",
+    msg_info("%s: jtag3_set_vtarget(): cannot confirm new V[target] value\n",
                     progname);
     return -1;
   }
@@ -2390,7 +2390,7 @@ static void jtag3_display(const PROGRAMMER *pgm, const char *p) {
 
   c = resp[1];
   if (c != RSP3_INFO) {
-    avrdude_message(MSG_INFO, "%s: jtag3_display(): response is not RSP3_INFO\n",
+    msg_info("%s: jtag3_display(): response is not RSP3_INFO\n",
                     progname);
     free(resp);
     return;
@@ -2398,11 +2398,11 @@ static void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   memmove(resp, resp + 3, status - 3);
   resp[status - 3] = 0;
 
-  avrdude_message(MSG_INFO, "%sICE HW version  : %d\n", p, parms[0]);
-  avrdude_message(MSG_INFO, "%sICE FW version  : %d.%02d (rel. %d)\n", p,
+  msg_info("%sICE HW version  : %d\n", p, parms[0]);
+  msg_info("%sICE FW version  : %d.%02d (rel. %d)\n", p,
 	  parms[1], parms[2],
 	  (parms[3] | (parms[4] << 8)));
-  avrdude_message(MSG_INFO, "%sSerial number   : %s", p, resp);
+  msg_info("%sSerial number   : %s", p, resp);
   free(resp);
 }
 
@@ -2412,7 +2412,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
 
   if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
     return;
-  avrdude_message(MSG_INFO, "%sVtarget         %s: %.2f V\n", p,
+  msg_info("%sVtarget         %s: %.2f V\n", p,
     verbose ? "" : "             ", b2_to_u16(buf) / 1000.0);
 
   // Print features unique to the Power Debugger
@@ -2424,7 +2424,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
         return;
       analog_raw_data = b2_to_u16(buf);
-      avrdude_message(MSG_INFO, "%sVout set        %s: %.2f V\n", p,
+      msg_info("%sVout set        %s: %.2f V\n", p,
         verbose ? "" : "             ", analog_raw_data / 1000.0);
 
       // Read measured generator voltage value (VOUT)
@@ -2432,11 +2432,11 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x30)
-        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_TSUP_VOLTAGE_MEAS data packet format\n", progname);
+        msg_info("%s: jtag3_print_parms1(): invalid PARM3_TSUP_VOLTAGE_MEAS data packet format\n", progname);
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        avrdude_message(MSG_INFO, "%sVout measured   %s: %.02f V\n", p,
+        msg_info("%sVout measured   %s: %.02f V\n", p,
           verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
       }
 
@@ -2445,11 +2445,11 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x20)
-        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_VOLTAGE data packet format\n", progname);
+        msg_info("%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_VOLTAGE data packet format\n", progname);
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        avrdude_message(MSG_INFO, "%sCh A voltage    %s: %.03f V\n", p,
+        msg_info("%sCh A voltage    %s: %.03f V\n", p,
           verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
       }
 
@@ -2458,9 +2458,9 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = (buf[1] << 8) + buf[2];
       if (buf[0] != 0x90)
-        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_CURRENT data packet format\n", progname);
+        msg_info("%s: jtag3_print_parms1(): invalid PARM3_ANALOG_A_CURRENT data packet format\n", progname);
       else
-        avrdude_message(MSG_INFO, "%sCh A current    %s: %.3f mA\n", p,
+        msg_info("%sCh A current    %s: %.3f mA\n", p,
           verbose ? "" : "             ", ((float)analog_raw_data * 0.003472));
 
       // Read channel B voltage
@@ -2468,11 +2468,11 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x10)
-        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_VOLTAGE data packet format\n", progname);
+        msg_info("%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_VOLTAGE data packet format\n", progname);
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        avrdude_message(MSG_INFO, "%sCh B voltage    %s: %.03f V\n", p,
+        msg_info("%sCh B voltage    %s: %.03f V\n", p,
           verbose ? "" : "             ", ((float)analog_raw_data / -200.0));
       }
 
@@ -2481,11 +2481,11 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
         return;
       analog_raw_data = ((buf[0] & 0x0F) << 8) + buf[1];
       if ((buf[0] & 0xF0) != 0x00)
-        avrdude_message(MSG_INFO, "%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_CURRENT data packet format\n", progname);
+        msg_info("%s: jtag3_print_parms1(): invalid PARM3_ANALOG_B_CURRENT data packet format\n", progname);
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        avrdude_message(MSG_INFO, "%sCh B current    %s: %.3f mA\n", p,
+        msg_info("%sCh B current    %s: %.3f mA\n", p,
           verbose ? "" : "             ", ((float)analog_raw_data * 0.555556));
       }
       break;
@@ -2496,7 +2496,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
     return;
 
   if (b2_to_u16(buf) > 0) {
-    avrdude_message(MSG_INFO, "%sJTAG clock megaAVR/program   : %u kHz\n", p,
+    msg_info("%sJTAG clock megaAVR/program   : %u kHz\n", p,
       b2_to_u16(buf));
   }
 
@@ -2504,7 +2504,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
     return;
 
   if (b2_to_u16(buf) > 0) {
-    avrdude_message(MSG_INFO, "%sJTAG clock megaAVR/debug     : %u kHz\n", p,
+    msg_info("%sJTAG clock megaAVR/debug     : %u kHz\n", p,
       b2_to_u16(buf));
   }
 
@@ -2512,7 +2512,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
     return;
 
   if (b2_to_u16(buf) > 0) {
-    avrdude_message(MSG_INFO, "%sJTAG clock Xmega             : %u kHz\n", p,
+    msg_info("%sJTAG clock Xmega             : %u kHz\n", p,
       b2_to_u16(buf));
   }
 
@@ -2520,7 +2520,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p) {
     return;
 
   if (b2_to_u16(buf) > 0) {
-    avrdude_message(MSG_INFO, "%sPDI/UPDI clock Xmega/megaAVR : %u kHz\n", p,
+    msg_info("%sPDI/UPDI clock Xmega/megaAVR : %u kHz\n", p,
       b2_to_u16(buf));
   }
 }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1010,7 +1010,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (pgm->fd.usb.max_xfer < USBDEV_MAX_XFER_3 && (pgm->flag & PGM_FL_IS_EDBG) == 0) {
     if (ovsigck) {
       pmsg_warning("JTAGICE3's firmware %d.%d is broken on USB 1.1 connections\n", parm[0], parm[1]);
-      pmsg_warning("forced to continue by option -F; THIS PUTS THE DEVICE'S DATA INTEGRITY AT RISK!\n");
+      imsg_warning("forced to continue by option -F; THIS PUTS THE DEVICE'S DATA INTEGRITY AT RISK!\n");
     } else {
       pmsg_error("JTAGICE3's firmware %d.%d is broken on USB 1.1 connections\n", parm[0], parm[1]);
       return -1;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1419,9 +1419,9 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
         rv = -1;
         continue;
       }
-      pmsg_notice2("jtag3_parseextparms(): JTAG chain parsed as:\n"
-        "%s %u units before, %u units after, %u bits before, %u bits after\n",
-        progbuf, ub, ua, bb, ba);
+      pmsg_notice2("jtag3_parseextparms(): JTAG chain parsed as:\n");
+      imsg_notice2("%u units before, %u units after, %u bits before, %u bits after\n",
+        ub, ua, bb, ba);
       PDATA(pgm)->jtagchain[0] = ub;
       PDATA(pgm)->jtagchain[1] = ua;
       PDATA(pgm)->jtagchain[2] = bb;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -111,8 +111,7 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon);
 static void jtagmkI_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: jtagmkI_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("jtagmkI_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -196,12 +195,11 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
   unsigned char *buf;
 
   msg_debug("\n%s: jtagmkI_send(): sending %u bytes\n",
-	    progname, (unsigned int)len);
+    progname, (unsigned int) len);
 
   if ((buf = malloc(len + 2)) == NULL)
     {
-      msg_info("%s: jtagmkI_send(): out of memory",
-	      progname);
+      pmsg_info("jtagmkI_send(): out of memory");
       exit(1);
     }
 
@@ -210,8 +208,7 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
   buf[len + 1] = ' ';		/* EOP */
 
   if (serial_send(&pgm->fd, buf, len + 2) != 0) {
-    msg_info("%s: jtagmkI_send(): failed to send command to serial port\n",
-                    progname);
+    pmsg_info("jtagmkI_send(): failed to send command to serial port\n");
     free(buf);
     return -1;
   }
@@ -223,8 +220,7 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
 
 static int jtagmkI_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
   if (serial_recv(&pgm->fd, buf, len) != 0) {
-    msg_info("\n%s: jtagmkI_recv(): failed to send command to serial port\n",
-                    progname);
+    msg_info("\n%s: jtagmkI_recv(): failed to send command to serial port\n", progname);
     return -1;
   }
   if (verbose >= 3) {
@@ -247,7 +243,7 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
 
   serial_recv_timeout = 200;
 
-  msg_trace("%s: jtagmkI_resync()\n", progname);
+  pmsg_trace("jtagmkI_resync()\n");
 
   jtagmkI_drain(pgm, 0);
 
@@ -255,12 +251,10 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
 
     /* Get the sign-on information. */
     buf[0] = CMD_GET_SYNC;
-    msg_notice2("%s: jtagmkI_resync(): Sending sync command: ",
-	      progname);
+    pmsg_notice2("jtagmkI_resync(): Sending sync command: ");
 
     if (serial_send(&pgm->fd, buf, 1) != 0) {
-      msg_info("\n%s: jtagmkI_resync(): failed to send command to serial port\n",
-                      progname);
+      msg_info("\n%s: jtagmkI_resync(): failed to send command to serial port\n", progname);
       serial_recv_timeout = otimeout;
       return -1;
     }
@@ -284,12 +278,10 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
       buf[1] = 'E';
       buf[2] = ' ';
       buf[3] = ' ';
-      msg_notice2("%s: jtagmkI_resync(): Sending sign-on command: ",
-		progname);
+      pmsg_notice2("jtagmkI_resync(): Sending sign-on command: ");
 
       if (serial_send(&pgm->fd, buf, 4) != 0) {
-	msg_info("\n%s: jtagmkI_resync(): failed to send command to serial port\n",
-                        progname);
+	msg_info("\n%s: jtagmkI_resync(): failed to send command to serial port\n", progname);
 	serial_recv_timeout = otimeout;
 	return -1;
       }
@@ -300,9 +292,8 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
     }
   }
   if (tries >= maxtries) {
-    msg_notice2("%s: jtagmkI_resync(): "
-                      "timeout/error communicating with programmer\n",
-                      progname);
+    pmsg_notice2("jtagmkI_resync(): "
+      "timeout/error communicating with programmer\n");
     serial_recv_timeout = otimeout;
     return -1;
   }
@@ -321,8 +312,7 @@ static int jtagmkI_getsync(const PROGRAMMER *pgm) {
 
   jtagmkI_drain(pgm, 0);
 
-  msg_notice2("%s: jtagmkI_getsync(): Sending sign-on command: ",
-	    progname);
+  pmsg_notice2("jtagmkI_getsync(): Sending sign-on command: ");
 
   buf[0] = CMD_GET_SIGNON;
   jtagmkI_send(pgm, buf, 1);
@@ -343,17 +333,15 @@ static int jtagmkI_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[1], resp[2];
 
   buf[0] = CMD_CHIP_ERASE;
-  msg_notice2("%s: jtagmkI_chip_erase(): Sending chip erase command: ",
-	    progname);
+  pmsg_notice2("jtagmkI_chip_erase(): Sending chip erase command: ");
   jtagmkI_send(pgm, buf, 1);
   if (jtagmkI_recv(pgm, resp, 2) < 0)
     return -1;
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_chip_erase(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_chip_erase(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     if (verbose == 2)
@@ -389,9 +377,8 @@ static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
 
-  msg_notice2("%s: jtagmkI_set_devdescr(): "
-	    "Sending set device descriptor command: ",
-	    progname);
+  pmsg_notice2("jtagmkI_set_devdescr(): "
+    "Sending set device descriptor command: ");
   jtagmkI_send(pgm, (unsigned char *)&sendbuf, sizeof(sendbuf));
 
   if (jtagmkI_recv(pgm, resp, 2) < 0)
@@ -399,9 +386,8 @@ static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_set_devdescr(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_set_devdescr(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
   } else {
     if (verbose == 2)
       msg_notice2("OK\n");
@@ -415,8 +401,7 @@ static int jtagmkI_reset(const PROGRAMMER *pgm) {
   unsigned char buf[1], resp[2];
 
   buf[0] = CMD_RESET;
-  msg_notice2("%s: jtagmkI_reset(): Sending reset command: ",
-	    progname);
+  pmsg_notice2("jtagmkI_reset(): Sending reset command: ");
   jtagmkI_send(pgm, buf, 1);
 
   if (jtagmkI_recv(pgm, resp, 2) < 0)
@@ -424,9 +409,8 @@ static int jtagmkI_reset(const PROGRAMMER *pgm) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_reset(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_reset(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     if (verbose == 2)
@@ -448,9 +432,8 @@ static int jtagmkI_program_enable(const PROGRAMMER *pgm) {
     return 0;
 
   buf[0] = CMD_ENTER_PROGMODE;
-  msg_notice2("%s: jtagmkI_program_enable(): "
-	    "Sending enter progmode command: ",
-	    progname);
+  pmsg_notice2("jtagmkI_program_enable(): "
+    "Sending enter progmode command: ");
   jtagmkI_send(pgm, buf, 1);
 
   if (jtagmkI_recv(pgm, resp, 2) < 0)
@@ -458,9 +441,8 @@ static int jtagmkI_program_enable(const PROGRAMMER *pgm) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_program_enable(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_program_enable(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     if (verbose == 2)
@@ -480,9 +462,7 @@ static int jtagmkI_program_disable(const PROGRAMMER *pgm) {
 
   if (pgm->fd.ifd != -1) {
     buf[0] = CMD_LEAVE_PROGMODE;
-    msg_notice2("%s: jtagmkI_program_disable(): "
-              "Sending leave progmode command: ",
-              progname);
+    pmsg_notice2("jtagmkI_program_disable(): sending leave progmode command: ");
     jtagmkI_send(pgm, buf, 1);
 
     if (jtagmkI_recv(pgm, resp, 2) < 0)
@@ -490,9 +470,8 @@ static int jtagmkI_program_disable(const PROGRAMMER *pgm) {
     if (resp[0] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      msg_info("%s: jtagmkI_program_disable(): "
-                      "timeout/error communicating with programmer (resp %c)\n",
-                      progname, resp[0]);
+      pmsg_info("jtagmkI_program_disable(): "
+        "timeout/error communicating with programmer (resp %c)\n", resp[0]);
       return -1;
     } else {
       if (verbose == 2)
@@ -524,24 +503,20 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char b;
 
   if (!(p->prog_modes & (PM_JTAGmkI | PM_JTAG))) {
-    msg_info("%s: jtagmkI_initialize(): part %s has no JTAG interface\n",
-	    progname, p->desc);
+    pmsg_info("jtagmkI_initialize(): part %s has no JTAG interface\n", p->desc);
     return -1;
   }
   if (!(p->prog_modes & PM_JTAGmkI))
-    msg_info("%s: jtagmkI_initialize(): warning part %s has JTAG interface, but may be too new\n",
-	    progname, p->desc);
+    pmsg_info("jtagmkI_initialize(): warning part %s has JTAG interface, but may be too new\n", p->desc);
 
   jtagmkI_drain(pgm, 0);
 
   if ((serdev->flags & SERDEV_FL_CANSETSPEED) && PDATA(pgm)->initial_baudrate != pgm->baudrate) {
     if ((b = jtagmkI_get_baud(pgm->baudrate)) == 0) {
-      msg_info("%s: jtagmkI_initialize(): unsupported baudrate %d\n",
-              progname, pgm->baudrate);
+      pmsg_info("jtagmkI_initialize(): unsupported baudrate %d\n", pgm->baudrate);
     } else {
-      msg_notice2("%s: jtagmkI_initialize(): "
-	      "trying to set baudrate to %d\n",
-                progname, pgm->baudrate);
+      pmsg_notice2("jtagmkI_initialize(): "
+	      "trying to set baudrate to %d\n", pgm->baudrate);
       if (jtagmkI_setparm(pgm, PARM_BITRATE, b) == 0) {
         PDATA(pgm)->initial_baudrate = pgm->baudrate; /* don't adjust again later */
         serial_setparams(&pgm->fd, pgm->baudrate, SERIAL_8N1);
@@ -550,9 +525,8 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (pgm->bitclock != 0.0) {
-    msg_notice2("%s: jtagmkI_initialize(): "
-	      "trying to set JTAG clock period to %.1f us\n",
-	      progname, pgm->bitclock);
+    pmsg_notice2("jtagmkI_initialize(): "
+      "trying to set JTAG clock period to %.1f us\n", pgm->bitclock);
     if (jtagmkI_set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -564,9 +538,8 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_initialize(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_initialize(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
   } else {
     if (verbose == 2)
       msg_notice2("OK\n");
@@ -584,13 +557,11 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    msg_info("%s: jtagmkI_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("jtagmkI_initialize(): Out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    msg_info("%s: jtagmkI_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("jtagmkI_initialize(): Out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -603,9 +574,8 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (jtagmkI_read_byte(pgm, p, &hfuse, 1, &b) < 0)
     return -1;
   if ((b & OCDEN) != 0)
-    msg_info("%s: jtagmkI_initialize(): warning: OCDEN fuse not programmed, "
-                    "single-byte EEPROM updates not possible\n",
-                    progname);
+    pmsg_info("jtagmkI_initialize(): warning: OCDEN fuse not programmed, "
+      "single-byte EEPROM updates not possible\n");
 
   return 0;
 }
@@ -630,7 +600,7 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
 {
   size_t i;
 
-  msg_notice2("%s: jtagmkI_open()\n", progname);
+  pmsg_notice2("jtagmkI_open()\n");
 
   strcpy(pgm->port, port);
   PDATA(pgm)->initial_baudrate = -1L;
@@ -639,8 +609,7 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
     union pinfo pinfo;
     pinfo.serialinfo.baud = baudtab[i].baud;
     pinfo.serialinfo.cflags = SERIAL_8N1;
-    msg_notice2("%s: jtagmkI_open(): trying to sync at baud rate %ld:\n",
-                      progname, pinfo.serialinfo.baud);
+    pmsg_notice2("jtagmkI_open(): trying to sync at baud rate %ld:\n", pinfo.serialinfo.baud);
     if (serial_open(port, pinfo, &pgm->fd)==-1) {
       return -1;
     }
@@ -652,15 +621,14 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
 
     if (jtagmkI_getsync(pgm) == 0) {
       PDATA(pgm)->initial_baudrate = baudtab[i].baud;
-      msg_notice2("%s: jtagmkI_open(): succeeded\n", progname);
+      pmsg_notice2("jtagmkI_open(): succeeded\n");
       return 0;
     }
 
     serial_close(&pgm->fd);
   }
 
-  msg_info("%s: jtagmkI_open(): failed to synchronize to ICE\n",
-                  progname);
+  pmsg_info("jtagmkI_open(): failed to synchronize to ICE\n");
   pgm->fd.ifd = -1;
 
   return -1;
@@ -671,7 +639,7 @@ static void jtagmkI_close(PROGRAMMER * pgm)
 {
   unsigned char b;
 
-  msg_notice2("%s: jtagmkI_close()\n", progname);
+  pmsg_notice2("jtagmkI_close()\n");
 
   /*
    * Revert baud rate to what it used to be when we started.  This
@@ -680,12 +648,10 @@ static void jtagmkI_close(PROGRAMMER * pgm)
    */
   if ((serdev->flags & SERDEV_FL_CANSETSPEED) && PDATA(pgm)->initial_baudrate != pgm->baudrate) {
     if ((b = jtagmkI_get_baud(PDATA(pgm)->initial_baudrate)) == 0) {
-      msg_info("%s: jtagmkI_close(): unsupported baudrate %d\n",
-              progname, PDATA(pgm)->initial_baudrate);
+      pmsg_info("jtagmkI_close(): unsupported baudrate %d\n", PDATA(pgm)->initial_baudrate);
     } else {
-      msg_notice2("%s: jtagmkI_close(): "
-                "trying to set baudrate to %d\n",
-                progname, PDATA(pgm)->initial_baudrate);
+      pmsg_notice2("jtagmkI_close(): "
+        "trying to set baudrate to %d\n", PDATA(pgm)->initial_baudrate);
       if (jtagmkI_setparm(pgm, PARM_BITRATE, b) == 0) {
         serial_setparams(&pgm->fd, pgm->baudrate, SERIAL_8N1);
       }
@@ -712,8 +678,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   long otimeout = serial_recv_timeout;
 #define MAXTRIES 3
 
-  msg_notice2("%s: jtagmkI_paged_write(.., %s, %d, %d)\n",
-	    progname, m->desc, page_size, n_bytes);
+  pmsg_notice2("jtagmkI_paged_write(.., %s, %d, %d)\n", m->desc, page_size, n_bytes);
 
   if (jtagmkI_program_enable(pgm) < 0)
     return -1;
@@ -721,14 +686,12 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if (page_size == 0) page_size = 256;
 
   if (page_size > 256) {
-    msg_info("%s: jtagmkI_paged_write(): page size %d too large\n",
-	    progname, page_size);
+    pmsg_info("jtagmkI_paged_write(): page size %d too large\n", page_size);
     return -1;
   }
 
   if ((datacmd = malloc(page_size + 1)) == NULL) {
-    msg_info("%s: jtagmkI_paged_write(): Out of memory\n",
-	    progname);
+    pmsg_info("jtagmkI_paged_write(): Out of memory\n");
     return -1;
   }
 
@@ -751,8 +714,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     again:
 
     if (tries != 0 && jtagmkI_resync(pgm, 2000, 0) < 0) {
-      msg_info("%s: jtagmkI_paged_write(): sync loss, retries exhausted\n",
-                      progname);
+      pmsg_info("jtagmkI_paged_write(): sync loss, retries exhausted\n");
       return -1;
     }
 
@@ -760,9 +722,8 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       block_size = n_bytes;
     else
       block_size = page_size;
-    msg_debug("%s: jtagmkI_paged_write(): "
-	      "block_size at addr %d is %d\n",
-	      progname, addr, block_size);
+    pmsg_debug("jtagmkI_paged_write(): "
+      "block_size at addr %d is %d\n", addr, block_size);
 
     /* We always write full pages. */
     send_size = page_size;
@@ -774,9 +735,8 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       u32_to_b3(cmd + 3, addr);
     }
 
-    msg_notice2("%s: jtagmkI_paged_write(): "
-	      "Sending write memory command: ",
-	      progname);
+    pmsg_notice2("jtagmkI_paged_write(): "
+      "sending write memory command: ");
 
     /* First part, send the write command. */
     jtagmkI_send(pgm, cmd, 6);
@@ -785,9 +745,8 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if (resp[0] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      msg_info("%s: jtagmkI_paged_write(): "
-                      "timeout/error communicating with programmer (resp %c)\n",
-                      progname, resp[0]);
+      pmsg_info("jtagmkI_paged_write(): "
+        "timeout/error communicating with programmer (resp %c)\n", resp[0]);
       if (tries++ < MAXTRIES)
 	goto again;
       serial_recv_timeout = otimeout;
@@ -814,9 +773,8 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if (resp[1] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      msg_info("%s: jtagmkI_paged_write(): "
-                      "timeout/error communicating with programmer (resp %c)\n",
-                      progname, resp[0]);
+      pmsg_info("jtagmkI_paged_write(): "
+        "timeout/error communicating with programmer (resp %c)\n", resp[0]);
       if (tries++ < MAXTRIES)
 	goto again;
       serial_recv_timeout = otimeout;
@@ -844,8 +802,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   long otimeout = serial_recv_timeout;
 #define MAXTRIES 3
 
-  msg_notice2("%s: jtagmkI_paged_load(.., %s, %d, %d)\n",
-	    progname, m->desc, page_size, n_bytes);
+  pmsg_notice2("jtagmkI_paged_load(.., %s, %d, %d)\n", m->desc, page_size, n_bytes);
 
   if (jtagmkI_program_enable(pgm) < 0)
     return -1;
@@ -861,8 +818,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   }
 
   if (page_size > (is_flash? 512: 256)) {
-    msg_info("%s: jtagmkI_paged_load(): page size %d too large\n",
-	    progname, page_size);
+    pmsg_info("jtagmkI_paged_load(): page size %d too large\n", page_size);
     return -1;
   }
 
@@ -871,8 +827,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     tries = 0;
     again:
     if (tries != 0 && jtagmkI_resync(pgm, 2000, 0) < 0) {
-      msg_info("%s: jtagmkI_paged_load(): sync loss, retries exhausted\n",
-                      progname);
+      pmsg_info("jtagmkI_paged_load(): sync loss, retries exhausted\n");
       return -1;
     }
 
@@ -880,9 +835,8 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       block_size = n_bytes;
     else
       block_size = page_size;
-    msg_debug("%s: jtagmkI_paged_load(): "
-	      "block_size at addr %d is %d\n",
-	      progname, addr, block_size);
+    pmsg_debug("jtagmkI_paged_load(): "
+      "block_size at addr %d is %d\n", addr, block_size);
 
     if (is_flash) {
       read_size = 2 * ((block_size + 1) / 2); /* round up */
@@ -894,8 +848,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       u32_to_b3(cmd + 3, addr);
     }
 
-    msg_notice2("%s: jtagmkI_paged_load(): Sending read memory command: ",
-	      progname);
+    pmsg_notice2("jtagmkI_paged_load(): Sending read memory command: ");
 
     jtagmkI_send(pgm, cmd, 6);
     if (jtagmkI_recv(pgm, resp, read_size + 3) < 0)
@@ -904,9 +857,8 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if (resp[read_size + 3 - 1] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      msg_info("%s: jtagmkI_paged_load(): "
-                      "timeout/error communicating with programmer (resp %c)\n",
-                      progname, resp[read_size + 3 - 1]);
+      pmsg_info("jtagmkI_paged_load(): "
+        "timeout/error communicating with programmer (resp %c)\n", resp[read_size + 3 - 1]);
       if (tries++ < MAXTRIES)
 	goto again;
 
@@ -935,8 +887,7 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   int respsize = 3 + 1;
   int is_flash = 0;
 
-  msg_notice2("%s: jtagmkI_read_byte(.., %s, 0x%lx, ...)\n",
-	    progname, mem->desc, addr);
+  pmsg_notice2("jtagmkI_read_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
   if (jtagmkI_program_enable(pgm) < 0)
     return -1;
@@ -1019,9 +970,8 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   if (resp[respsize - 1] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_read_byte(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[respsize - 1]);
+    pmsg_info("jtagmkI_read_byte(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[respsize - 1]);
     return -1;
   } else {
     if (verbose == 2)
@@ -1048,8 +998,7 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned char resp[1], writedata;
   int len, need_progmode = 1, need_dummy_read = 0;
 
-  msg_notice2("%s: jtagmkI_write_byte(.., %s, 0x%lx, ...)\n",
-	    progname, mem->desc, addr);
+  pmsg_notice2("jtagmkI_write_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
   writedata = data;
   cmd[0] = CMD_WRITE_MEM;
@@ -1096,7 +1045,7 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   if (cmd[1] == MTYPE_SPM) {
     /*
      * Flash is word-addressed, but we cannot handle flash anyway
-     * here, as it needs to be written one page at a time...
+     * here, as it needs to be written one page at a time ...
      */
     u32_to_b3(cmd + 3, addr / 2);
   } else {
@@ -1109,9 +1058,8 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_write_byte(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_write_byte(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     if (verbose == 2)
@@ -1139,9 +1087,8 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_write_byte(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_write_byte(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     if (verbose == 2)
@@ -1190,14 +1137,13 @@ static int jtagmkI_getparm(const PROGRAMMER *pgm, const unsigned char parm,
 {
   unsigned char buf[2], resp[3];
 
-  msg_notice2("%s: jtagmkI_getparm()\n", progname);
+  pmsg_notice2("jtagmkI_getparm()\n");
 
   buf[0] = CMD_GET_PARAM;
   buf[1] = parm;
   if (verbose >= 2)
-    msg_notice2("%s: jtagmkI_getparm(): "
-	    "Sending get parameter command (parm 0x%02x): ",
-	    progname, parm);
+    pmsg_notice2("jtagmkI_getparm(): "
+      "Sending get parameter command (parm 0x%02x): ", parm);
   jtagmkI_send(pgm, buf, 2);
 
   if (jtagmkI_recv(pgm, resp, 3) < 0)
@@ -1205,16 +1151,14 @@ static int jtagmkI_getparm(const PROGRAMMER *pgm, const unsigned char parm,
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_getparm(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_getparm(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else if (resp[2] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_getparm(): "
-                    "unknown parameter 0x%02x\n",
-                    progname, parm);
+    pmsg_info("jtagmkI_getparm(): "
+      "unknown parameter 0x%02x\n", parm);
     return -1;
   } else {
     if (verbose == 2)
@@ -1234,23 +1178,21 @@ static int jtagmkI_setparm(const PROGRAMMER *pgm, unsigned char parm,
 {
   unsigned char buf[3], resp[2];
 
-  msg_notice2("%s: jtagmkI_setparm()\n", progname);
+  pmsg_notice2("jtagmkI_setparm()\n");
 
   buf[0] = CMD_SET_PARAM;
   buf[1] = parm;
   buf[2] = value;
-  msg_notice2("%s: jtagmkI_setparm(): "
-	    "Sending set parameter command (parm 0x%02x): ",
-	    progname, parm);
+  pmsg_notice2("jtagmkI_setparm(): "
+    "Sending set parameter command (parm 0x%02x): ", parm);
   jtagmkI_send(pgm, buf, 3);
   if (jtagmkI_recv(pgm, resp, 2) < 0)
     return -1;
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    msg_info("%s: jtagmkI_setparm(): "
-                    "timeout/error communicating with programmer (resp %c)\n",
-                    progname, resp[0]);
+    pmsg_info("jtagmkI_setparm(): "
+      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     if (verbose == 2)

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -111,7 +111,7 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon);
 static void jtagmkI_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_setup(): Out of memory allocating private data\n",
+    msg_info("%s: jtagmkI_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -143,10 +143,10 @@ static void jtagmkI_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len
   int i;
 
   if (verbose >= 4) {
-    avrdude_message(MSG_TRACE, "Raw message:\n");
+    msg_trace("Raw message:\n");
 
     for (i = 0; i < len; i++) {
-      avrdude_message(MSG_TRACE, "0x%02x ", data[i]);
+      msg_trace("0x%02x ", data[i]);
       if (i % 16 == 15)
 	putc('\n', stderr);
       else
@@ -158,34 +158,34 @@ static void jtagmkI_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len
 
   switch (data[0]) {
   case RESP_OK:
-    avrdude_message(MSG_INFO, "OK\n");
+    msg_info("OK\n");
     break;
 
   case RESP_FAILED:
-    avrdude_message(MSG_INFO, "FAILED\n");
+    msg_info("FAILED\n");
     break;
 
   case RESP_BREAK:
-    avrdude_message(MSG_INFO, "breakpoint hit\n");
+    msg_info("breakpoint hit\n");
     break;
 
   case RESP_INFO:
-    avrdude_message(MSG_INFO, "IDR dirty\n");
+    msg_info("IDR dirty\n");
     break;
 
   case RESP_SYNC_ERROR:
-    avrdude_message(MSG_INFO, "Synchronization lost\n");
+    msg_info("Synchronization lost\n");
     break;
 
   case RESP_SLEEP:
-    avrdude_message(MSG_INFO, "sleep instruction hit\n");
+    msg_info("sleep instruction hit\n");
     break;
 
   case RESP_POWER:
-    avrdude_message(MSG_INFO, "target power lost\n");
+    msg_info("target power lost\n");
 
   default:
-    avrdude_message(MSG_INFO, "unknown message 0x%02x\n", data[0]);
+    msg_info("unknown message 0x%02x\n", data[0]);
   }
 
   putc('\n', stderr);
@@ -195,12 +195,12 @@ static void jtagmkI_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len
 static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   unsigned char *buf;
 
-  avrdude_message(MSG_DEBUG, "\n%s: jtagmkI_send(): sending %u bytes\n",
+  msg_debug("\n%s: jtagmkI_send(): sending %u bytes\n",
 	    progname, (unsigned int)len);
 
   if ((buf = malloc(len + 2)) == NULL)
     {
-      avrdude_message(MSG_INFO, "%s: jtagmkI_send(): out of memory",
+      msg_info("%s: jtagmkI_send(): out of memory",
 	      progname);
       exit(1);
     }
@@ -210,7 +210,7 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
   buf[len + 1] = ' ';		/* EOP */
 
   if (serial_send(&pgm->fd, buf, len + 2) != 0) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_send(): failed to send command to serial port\n",
+    msg_info("%s: jtagmkI_send(): failed to send command to serial port\n",
                     progname);
     free(buf);
     return -1;
@@ -223,7 +223,7 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
 
 static int jtagmkI_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
   if (serial_recv(&pgm->fd, buf, len) != 0) {
-    avrdude_message(MSG_INFO, "\n%s: jtagmkI_recv(): failed to send command to serial port\n",
+    msg_info("\n%s: jtagmkI_recv(): failed to send command to serial port\n",
                     progname);
     return -1;
   }
@@ -247,7 +247,7 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
 
   serial_recv_timeout = 200;
 
-  avrdude_message(MSG_TRACE, "%s: jtagmkI_resync()\n", progname);
+  msg_trace("%s: jtagmkI_resync()\n", progname);
 
   jtagmkI_drain(pgm, 0);
 
@@ -255,17 +255,17 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
 
     /* Get the sign-on information. */
     buf[0] = CMD_GET_SYNC;
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_resync(): Sending sync command: ",
+    msg_notice2("%s: jtagmkI_resync(): Sending sync command: ",
 	      progname);
 
     if (serial_send(&pgm->fd, buf, 1) != 0) {
-      avrdude_message(MSG_INFO, "\n%s: jtagmkI_resync(): failed to send command to serial port\n",
+      msg_info("\n%s: jtagmkI_resync(): failed to send command to serial port\n",
                       progname);
       serial_recv_timeout = otimeout;
       return -1;
     }
     if (serial_recv(&pgm->fd, resp, 1) == 0 && resp[0] == RESP_OK) {
-      avrdude_message(MSG_NOTICE2, "got RESP_OK\n");
+      msg_notice2("got RESP_OK\n");
       break;
     }
 
@@ -284,23 +284,23 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
       buf[1] = 'E';
       buf[2] = ' ';
       buf[3] = ' ';
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkI_resync(): Sending sign-on command: ",
+      msg_notice2("%s: jtagmkI_resync(): Sending sign-on command: ",
 		progname);
 
       if (serial_send(&pgm->fd, buf, 4) != 0) {
-	avrdude_message(MSG_INFO, "\n%s: jtagmkI_resync(): failed to send command to serial port\n",
+	msg_info("\n%s: jtagmkI_resync(): failed to send command to serial port\n",
                         progname);
 	serial_recv_timeout = otimeout;
 	return -1;
       }
       if (serial_recv(&pgm->fd, resp, 9) == 0 && resp[0] == RESP_OK) {
-        avrdude_message(MSG_NOTICE2, "got RESP_OK\n");
+        msg_notice2("got RESP_OK\n");
 	break;
       }
     }
   }
   if (tries >= maxtries) {
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_resync(): "
+    msg_notice2("%s: jtagmkI_resync(): "
                       "timeout/error communicating with programmer\n",
                       progname);
     serial_recv_timeout = otimeout;
@@ -321,7 +321,7 @@ static int jtagmkI_getsync(const PROGRAMMER *pgm) {
 
   jtagmkI_drain(pgm, 0);
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_getsync(): Sending sign-on command: ",
+  msg_notice2("%s: jtagmkI_getsync(): Sending sign-on command: ",
 	    progname);
 
   buf[0] = CMD_GET_SIGNON;
@@ -330,7 +330,7 @@ static int jtagmkI_getsync(const PROGRAMMER *pgm) {
     return -1;
   if (verbose >= 2) {
     resp[8] = '\0';
-    avrdude_message(MSG_NOTICE2, "got %s\n", resp + 1);
+    msg_notice2("got %s\n", resp + 1);
   }
 
   return 0;
@@ -343,7 +343,7 @@ static int jtagmkI_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[1], resp[2];
 
   buf[0] = CMD_CHIP_ERASE;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_chip_erase(): Sending chip erase command: ",
+  msg_notice2("%s: jtagmkI_chip_erase(): Sending chip erase command: ",
 	    progname);
   jtagmkI_send(pgm, buf, 1);
   if (jtagmkI_recv(pgm, resp, 2) < 0)
@@ -351,13 +351,13 @@ static int jtagmkI_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_chip_erase(): "
+    msg_info("%s: jtagmkI_chip_erase(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   pgm->initialize(pgm, p);
@@ -389,7 +389,7 @@ static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_set_devdescr(): "
+  msg_notice2("%s: jtagmkI_set_devdescr(): "
 	    "Sending set device descriptor command: ",
 	    progname);
   jtagmkI_send(pgm, (unsigned char *)&sendbuf, sizeof(sendbuf));
@@ -399,12 +399,12 @@ static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_set_devdescr(): "
+    msg_info("%s: jtagmkI_set_devdescr(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 }
 
@@ -415,7 +415,7 @@ static int jtagmkI_reset(const PROGRAMMER *pgm) {
   unsigned char buf[1], resp[2];
 
   buf[0] = CMD_RESET;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_reset(): Sending reset command: ",
+  msg_notice2("%s: jtagmkI_reset(): Sending reset command: ",
 	    progname);
   jtagmkI_send(pgm, buf, 1);
 
@@ -424,13 +424,13 @@ static int jtagmkI_reset(const PROGRAMMER *pgm) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_reset(): "
+    msg_info("%s: jtagmkI_reset(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   return 0;
@@ -448,7 +448,7 @@ static int jtagmkI_program_enable(const PROGRAMMER *pgm) {
     return 0;
 
   buf[0] = CMD_ENTER_PROGMODE;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_program_enable(): "
+  msg_notice2("%s: jtagmkI_program_enable(): "
 	    "Sending enter progmode command: ",
 	    progname);
   jtagmkI_send(pgm, buf, 1);
@@ -458,13 +458,13 @@ static int jtagmkI_program_enable(const PROGRAMMER *pgm) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_program_enable(): "
+    msg_info("%s: jtagmkI_program_enable(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   PDATA(pgm)->prog_enabled = 1;
@@ -480,7 +480,7 @@ static int jtagmkI_program_disable(const PROGRAMMER *pgm) {
 
   if (pgm->fd.ifd != -1) {
     buf[0] = CMD_LEAVE_PROGMODE;
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_program_disable(): "
+    msg_notice2("%s: jtagmkI_program_disable(): "
               "Sending leave progmode command: ",
               progname);
     jtagmkI_send(pgm, buf, 1);
@@ -490,13 +490,13 @@ static int jtagmkI_program_disable(const PROGRAMMER *pgm) {
     if (resp[0] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkI_program_disable(): "
+      msg_info("%s: jtagmkI_program_disable(): "
                       "timeout/error communicating with programmer (resp %c)\n",
                       progname, resp[0]);
       return -1;
     } else {
       if (verbose == 2)
-        avrdude_message(MSG_NOTICE2, "OK\n");
+        msg_notice2("OK\n");
     }
   }
   PDATA(pgm)->prog_enabled = 0;
@@ -524,22 +524,22 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char b;
 
   if (!(p->prog_modes & (PM_JTAGmkI | PM_JTAG))) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): part %s has no JTAG interface\n",
+    msg_info("%s: jtagmkI_initialize(): part %s has no JTAG interface\n",
 	    progname, p->desc);
     return -1;
   }
   if (!(p->prog_modes & PM_JTAGmkI))
-    avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): warning part %s has JTAG interface, but may be too new\n",
+    msg_info("%s: jtagmkI_initialize(): warning part %s has JTAG interface, but may be too new\n",
 	    progname, p->desc);
 
   jtagmkI_drain(pgm, 0);
 
   if ((serdev->flags & SERDEV_FL_CANSETSPEED) && PDATA(pgm)->initial_baudrate != pgm->baudrate) {
     if ((b = jtagmkI_get_baud(pgm->baudrate)) == 0) {
-      avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): unsupported baudrate %d\n",
+      msg_info("%s: jtagmkI_initialize(): unsupported baudrate %d\n",
               progname, pgm->baudrate);
     } else {
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkI_initialize(): "
+      msg_notice2("%s: jtagmkI_initialize(): "
 	      "trying to set baudrate to %d\n",
                 progname, pgm->baudrate);
       if (jtagmkI_setparm(pgm, PARM_BITRATE, b) == 0) {
@@ -550,7 +550,7 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (pgm->bitclock != 0.0) {
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_initialize(): "
+    msg_notice2("%s: jtagmkI_initialize(): "
 	      "trying to set JTAG clock period to %.1f us\n",
 	      progname, pgm->bitclock);
     if (jtagmkI_set_sck_period(pgm, pgm->bitclock) != 0)
@@ -564,12 +564,12 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): "
+    msg_info("%s: jtagmkI_initialize(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   /*
@@ -584,12 +584,12 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): Out of memory\n",
+    msg_info("%s: jtagmkI_initialize(): Out of memory\n",
 	    progname);
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): Out of memory\n",
+    msg_info("%s: jtagmkI_initialize(): Out of memory\n",
 	    progname);
     free(PDATA(pgm)->flash_pagecache);
     return -1;
@@ -603,7 +603,7 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (jtagmkI_read_byte(pgm, p, &hfuse, 1, &b) < 0)
     return -1;
   if ((b & OCDEN) != 0)
-    avrdude_message(MSG_INFO, "%s: jtagmkI_initialize(): warning: OCDEN fuse not programmed, "
+    msg_info("%s: jtagmkI_initialize(): warning: OCDEN fuse not programmed, "
                     "single-byte EEPROM updates not possible\n",
                     progname);
 
@@ -630,7 +630,7 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
 {
   size_t i;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_open()\n", progname);
+  msg_notice2("%s: jtagmkI_open()\n", progname);
 
   strcpy(pgm->port, port);
   PDATA(pgm)->initial_baudrate = -1L;
@@ -639,7 +639,7 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
     union pinfo pinfo;
     pinfo.serialinfo.baud = baudtab[i].baud;
     pinfo.serialinfo.cflags = SERIAL_8N1;
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_open(): trying to sync at baud rate %ld:\n",
+    msg_notice2("%s: jtagmkI_open(): trying to sync at baud rate %ld:\n",
                       progname, pinfo.serialinfo.baud);
     if (serial_open(port, pinfo, &pgm->fd)==-1) {
       return -1;
@@ -652,14 +652,14 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
 
     if (jtagmkI_getsync(pgm) == 0) {
       PDATA(pgm)->initial_baudrate = baudtab[i].baud;
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkI_open(): succeeded\n", progname);
+      msg_notice2("%s: jtagmkI_open(): succeeded\n", progname);
       return 0;
     }
 
     serial_close(&pgm->fd);
   }
 
-  avrdude_message(MSG_INFO, "%s: jtagmkI_open(): failed to synchronize to ICE\n",
+  msg_info("%s: jtagmkI_open(): failed to synchronize to ICE\n",
                   progname);
   pgm->fd.ifd = -1;
 
@@ -671,7 +671,7 @@ static void jtagmkI_close(PROGRAMMER * pgm)
 {
   unsigned char b;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_close()\n", progname);
+  msg_notice2("%s: jtagmkI_close()\n", progname);
 
   /*
    * Revert baud rate to what it used to be when we started.  This
@@ -680,10 +680,10 @@ static void jtagmkI_close(PROGRAMMER * pgm)
    */
   if ((serdev->flags & SERDEV_FL_CANSETSPEED) && PDATA(pgm)->initial_baudrate != pgm->baudrate) {
     if ((b = jtagmkI_get_baud(PDATA(pgm)->initial_baudrate)) == 0) {
-      avrdude_message(MSG_INFO, "%s: jtagmkI_close(): unsupported baudrate %d\n",
+      msg_info("%s: jtagmkI_close(): unsupported baudrate %d\n",
               progname, PDATA(pgm)->initial_baudrate);
     } else {
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkI_close(): "
+      msg_notice2("%s: jtagmkI_close(): "
                 "trying to set baudrate to %d\n",
                 progname, PDATA(pgm)->initial_baudrate);
       if (jtagmkI_setparm(pgm, PARM_BITRATE, b) == 0) {
@@ -712,7 +712,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   long otimeout = serial_recv_timeout;
 #define MAXTRIES 3
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_paged_write(.., %s, %d, %d)\n",
+  msg_notice2("%s: jtagmkI_paged_write(.., %s, %d, %d)\n",
 	    progname, m->desc, page_size, n_bytes);
 
   if (jtagmkI_program_enable(pgm) < 0)
@@ -721,13 +721,13 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if (page_size == 0) page_size = 256;
 
   if (page_size > 256) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_paged_write(): page size %d too large\n",
+    msg_info("%s: jtagmkI_paged_write(): page size %d too large\n",
 	    progname, page_size);
     return -1;
   }
 
   if ((datacmd = malloc(page_size + 1)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_paged_write(): Out of memory\n",
+    msg_info("%s: jtagmkI_paged_write(): Out of memory\n",
 	    progname);
     return -1;
   }
@@ -751,7 +751,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     again:
 
     if (tries != 0 && jtagmkI_resync(pgm, 2000, 0) < 0) {
-      avrdude_message(MSG_INFO, "%s: jtagmkI_paged_write(): sync loss, retries exhausted\n",
+      msg_info("%s: jtagmkI_paged_write(): sync loss, retries exhausted\n",
                       progname);
       return -1;
     }
@@ -760,7 +760,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       block_size = n_bytes;
     else
       block_size = page_size;
-    avrdude_message(MSG_DEBUG, "%s: jtagmkI_paged_write(): "
+    msg_debug("%s: jtagmkI_paged_write(): "
 	      "block_size at addr %d is %d\n",
 	      progname, addr, block_size);
 
@@ -774,7 +774,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       u32_to_b3(cmd + 3, addr);
     }
 
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_paged_write(): "
+    msg_notice2("%s: jtagmkI_paged_write(): "
 	      "Sending write memory command: ",
 	      progname);
 
@@ -785,7 +785,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if (resp[0] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkI_paged_write(): "
+      msg_info("%s: jtagmkI_paged_write(): "
                       "timeout/error communicating with programmer (resp %c)\n",
                       progname, resp[0]);
       if (tries++ < MAXTRIES)
@@ -794,7 +794,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       return -1;
     } else {
       if (verbose == 2)
-        avrdude_message(MSG_NOTICE2, "OK\n");
+        msg_notice2("OK\n");
     }
 
     /*
@@ -814,7 +814,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if (resp[1] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkI_paged_write(): "
+      msg_info("%s: jtagmkI_paged_write(): "
                       "timeout/error communicating with programmer (resp %c)\n",
                       progname, resp[0]);
       if (tries++ < MAXTRIES)
@@ -823,7 +823,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       return -1;
     } else {
       if (verbose == 2)
-        avrdude_message(MSG_NOTICE2, "OK\n");
+        msg_notice2("OK\n");
     }
   }
 
@@ -844,7 +844,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   long otimeout = serial_recv_timeout;
 #define MAXTRIES 3
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_paged_load(.., %s, %d, %d)\n",
+  msg_notice2("%s: jtagmkI_paged_load(.., %s, %d, %d)\n",
 	    progname, m->desc, page_size, n_bytes);
 
   if (jtagmkI_program_enable(pgm) < 0)
@@ -861,7 +861,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   }
 
   if (page_size > (is_flash? 512: 256)) {
-    avrdude_message(MSG_INFO, "%s: jtagmkI_paged_load(): page size %d too large\n",
+    msg_info("%s: jtagmkI_paged_load(): page size %d too large\n",
 	    progname, page_size);
     return -1;
   }
@@ -871,7 +871,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     tries = 0;
     again:
     if (tries != 0 && jtagmkI_resync(pgm, 2000, 0) < 0) {
-      avrdude_message(MSG_INFO, "%s: jtagmkI_paged_load(): sync loss, retries exhausted\n",
+      msg_info("%s: jtagmkI_paged_load(): sync loss, retries exhausted\n",
                       progname);
       return -1;
     }
@@ -880,7 +880,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       block_size = n_bytes;
     else
       block_size = page_size;
-    avrdude_message(MSG_DEBUG, "%s: jtagmkI_paged_load(): "
+    msg_debug("%s: jtagmkI_paged_load(): "
 	      "block_size at addr %d is %d\n",
 	      progname, addr, block_size);
 
@@ -894,7 +894,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       u32_to_b3(cmd + 3, addr);
     }
 
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_paged_load(): Sending read memory command: ",
+    msg_notice2("%s: jtagmkI_paged_load(): Sending read memory command: ",
 	      progname);
 
     jtagmkI_send(pgm, cmd, 6);
@@ -904,7 +904,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if (resp[read_size + 3 - 1] != RESP_OK) {
       if (verbose >= 2)
         putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkI_paged_load(): "
+      msg_info("%s: jtagmkI_paged_load(): "
                       "timeout/error communicating with programmer (resp %c)\n",
                       progname, resp[read_size + 3 - 1]);
       if (tries++ < MAXTRIES)
@@ -914,7 +914,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       return -1;
     } else {
       if (verbose == 2)
-        avrdude_message(MSG_NOTICE2, "OK\n");
+        msg_notice2("OK\n");
     }
 
     memcpy(m->buf + addr, resp + 1, block_size);
@@ -935,7 +935,7 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   int respsize = 3 + 1;
   int is_flash = 0;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_read_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: jtagmkI_read_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   if (jtagmkI_program_enable(pgm) < 0)
@@ -1019,13 +1019,13 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   if (resp[respsize - 1] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_read_byte(): "
+    msg_info("%s: jtagmkI_read_byte(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[respsize - 1]);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   if (pagesize) {
@@ -1048,7 +1048,7 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned char resp[1], writedata;
   int len, need_progmode = 1, need_dummy_read = 0;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_write_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: jtagmkI_write_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   writedata = data;
@@ -1109,13 +1109,13 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_write_byte(): "
+    msg_info("%s: jtagmkI_write_byte(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   /* Now, send the data buffer. */
@@ -1139,13 +1139,13 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_write_byte(): "
+    msg_info("%s: jtagmkI_write_byte(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   if(need_dummy_read)
@@ -1190,12 +1190,12 @@ static int jtagmkI_getparm(const PROGRAMMER *pgm, const unsigned char parm,
 {
   unsigned char buf[2], resp[3];
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_getparm()\n", progname);
+  msg_notice2("%s: jtagmkI_getparm()\n", progname);
 
   buf[0] = CMD_GET_PARAM;
   buf[1] = parm;
   if (verbose >= 2)
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkI_getparm(): "
+    msg_notice2("%s: jtagmkI_getparm(): "
 	    "Sending get parameter command (parm 0x%02x): ",
 	    progname, parm);
   jtagmkI_send(pgm, buf, 2);
@@ -1205,20 +1205,20 @@ static int jtagmkI_getparm(const PROGRAMMER *pgm, const unsigned char parm,
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_getparm(): "
+    msg_info("%s: jtagmkI_getparm(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
     return -1;
   } else if (resp[2] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_getparm(): "
+    msg_info("%s: jtagmkI_getparm(): "
                     "unknown parameter 0x%02x\n",
                     progname, parm);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK, value 0x%02x\n", resp[1]);
+      msg_notice2("OK, value 0x%02x\n", resp[1]);
   }
 
   *value = resp[1];
@@ -1234,12 +1234,12 @@ static int jtagmkI_setparm(const PROGRAMMER *pgm, unsigned char parm,
 {
   unsigned char buf[3], resp[2];
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_setparm()\n", progname);
+  msg_notice2("%s: jtagmkI_setparm()\n", progname);
 
   buf[0] = CMD_SET_PARAM;
   buf[1] = parm;
   buf[2] = value;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkI_setparm(): "
+  msg_notice2("%s: jtagmkI_setparm(): "
 	    "Sending set parameter command (parm 0x%02x): ",
 	    progname, parm);
   jtagmkI_send(pgm, buf, 3);
@@ -1248,13 +1248,13 @@ static int jtagmkI_setparm(const PROGRAMMER *pgm, unsigned char parm,
   if (resp[0] != RESP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkI_setparm(): "
+    msg_info("%s: jtagmkI_setparm(): "
                     "timeout/error communicating with programmer (resp %c)\n",
                     progname, resp[0]);
     return -1;
   } else {
     if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "OK\n");
+      msg_notice2("OK\n");
   }
 
   return 0;
@@ -1268,8 +1268,8 @@ static void jtagmkI_display(const PROGRAMMER *pgm, const char *p) {
       jtagmkI_getparm(pgm, PARM_SW_VERSION, &fw) < 0)
     return;
 
-  avrdude_message(MSG_INFO, "%sICE HW version: 0x%02x\n", p, hw);
-  avrdude_message(MSG_INFO, "%sICE FW version: 0x%02x\n", p, fw);
+  msg_info("%sICE HW version: 0x%02x\n", p, hw);
+  msg_info("%sICE FW version: 0x%02x\n", p, fw);
 
   jtagmkI_print_parms1(pgm, p);
 
@@ -1312,9 +1312,9 @@ static void jtagmkI_print_parms1(const PROGRAMMER *pgm, const char *p) {
     clk = 1e6;
   }
 
-  avrdude_message(MSG_INFO, "%sVtarget       : %.1f V\n", p,
+  msg_info("%sVtarget       : %.1f V\n", p,
 	  6.25 * (unsigned)vtarget / 255.0);
-  avrdude_message(MSG_INFO, "%sJTAG clock    : %s (%.1f us)\n", p, clkstr,
+  msg_info("%sJTAG clock    : %s (%.1f us)\n", p, clkstr,
 	  1.0e6 / clk);
 
   return;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -111,7 +111,7 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon);
 static void jtagmkI_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("jtagmkI_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -199,7 +199,7 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
 
   if ((buf = malloc(len + 2)) == NULL)
     {
-      pmsg_error("jtagmkI_send(): out of memory");
+      pmsg_error("out of memory");
       exit(1);
     }
 
@@ -208,7 +208,7 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
   buf[len + 1] = ' ';		/* EOP */
 
   if (serial_send(&pgm->fd, buf, len + 2) != 0) {
-    pmsg_error("jtagmkI_send(): unable to send command to serial port\n");
+    pmsg_error("unable to send command to serial port\n");
     free(buf);
     return -1;
   }
@@ -221,7 +221,7 @@ static int jtagmkI_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) 
 static int jtagmkI_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
   if (serial_recv(&pgm->fd, buf, len) != 0) {
     msg_error("\n");
-    pmsg_error("jtagmkI_recv(): unable to send command to serial port\n");
+    pmsg_error("unable to send command to serial port\n");
     return -1;
   }
   if (verbose >= 3) {
@@ -256,7 +256,7 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
 
     if (serial_send(&pgm->fd, buf, 1) != 0) {
       msg_error("\n");
-      pmsg_error("jtagmkI_resync(): unable to send command to serial port\n");
+      pmsg_error("unable to send command to serial port\n");
       serial_recv_timeout = otimeout;
       return -1;
     }
@@ -284,7 +284,7 @@ static int jtagmkI_resync(const PROGRAMMER *pgm, int maxtries, int signon) {
 
       if (serial_send(&pgm->fd, buf, 4) != 0) {
 	msg_error("\n");
-	pmsg_error("jtagmkI_resync(): unable to send command to serial port\n");
+	pmsg_error("unable to send command to serial port\n");
 	serial_recv_timeout = otimeout;
 	return -1;
       }
@@ -340,8 +340,7 @@ static int jtagmkI_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_chip_erase(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     msg_notice2("OK\n");
@@ -384,8 +383,7 @@ static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
     return;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_set_devdescr(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
   } else {
     msg_notice2("OK\n");
   }
@@ -405,8 +403,7 @@ static int jtagmkI_reset(const PROGRAMMER *pgm) {
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_reset(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
      msg_notice2("OK\n");
@@ -435,8 +432,7 @@ static int jtagmkI_program_enable(const PROGRAMMER *pgm) {
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_program_enable(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     msg_notice2("OK\n");
@@ -462,8 +458,7 @@ static int jtagmkI_program_disable(const PROGRAMMER *pgm) {
       return -1;
     if (resp[0] != RESP_OK) {
       msg_notice2("\n");
-      pmsg_error("jtagmkI_program_disable(): "
-        "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+      pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
       return -1;
     } else {
       msg_notice2("OK\n");
@@ -494,17 +489,17 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char b;
 
   if (!(p->prog_modes & (PM_JTAGmkI | PM_JTAG))) {
-    pmsg_error("jtagmkI_initialize(): part %s has no JTAG interface\n", p->desc);
+    pmsg_error("part %s has no JTAG interface\n", p->desc);
     return -1;
   }
   if (!(p->prog_modes & PM_JTAGmkI))
-    pmsg_warning("jtagmkI_initialize(): part %s has JTAG interface, but may be too new\n", p->desc);
+    pmsg_warning("part %s has JTAG interface, but may be too new\n", p->desc);
 
   jtagmkI_drain(pgm, 0);
 
   if ((serdev->flags & SERDEV_FL_CANSETSPEED) && PDATA(pgm)->initial_baudrate != pgm->baudrate) {
     if ((b = jtagmkI_get_baud(pgm->baudrate)) == 0) {
-      pmsg_error("jtagmkI_initialize(): unsupported baudrate %d\n", pgm->baudrate);
+      pmsg_error("unsupported baudrate %d\n", pgm->baudrate);
     } else {
       pmsg_notice2("jtagmkI_initialize(): "
 	      "trying to set baudrate to %d\n", pgm->baudrate);
@@ -528,8 +523,7 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_warning("jtagmkI_initialize(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_warning("timeout/error communicating with programmer (resp %c)\n", resp[0]);
   } else {
     msg_notice2("OK\n");
   }
@@ -546,11 +540,11 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    pmsg_error("jtagmkI_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    pmsg_error("jtagmkI_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -563,7 +557,7 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (jtagmkI_read_byte(pgm, p, &hfuse, 1, &b) < 0)
     return -1;
   if ((b & OCDEN) != 0)
-    pmsg_warning("jtagmkI_initialize(): OCDEN fuse not programmed, "
+    pmsg_warning("OCDEN fuse not programmed, "
       "single-byte EEPROM updates not possible\n");
 
   return 0;
@@ -617,7 +611,7 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port)
     serial_close(&pgm->fd);
   }
 
-  pmsg_error("jtagmkI_open(): unable to synchronize to ICE\n");
+  pmsg_error("unable to synchronize to ICE\n");
   pgm->fd.ifd = -1;
 
   return -1;
@@ -637,7 +631,7 @@ static void jtagmkI_close(PROGRAMMER * pgm)
    */
   if ((serdev->flags & SERDEV_FL_CANSETSPEED) && PDATA(pgm)->initial_baudrate != pgm->baudrate) {
     if ((b = jtagmkI_get_baud(PDATA(pgm)->initial_baudrate)) == 0) {
-      pmsg_error("jtagmkI_close(): unsupported baudrate %d\n", PDATA(pgm)->initial_baudrate);
+      pmsg_error("unsupported baudrate %d\n", PDATA(pgm)->initial_baudrate);
     } else {
       pmsg_notice2("jtagmkI_close(): "
         "trying to set baudrate to %d\n", PDATA(pgm)->initial_baudrate);
@@ -676,12 +670,12 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     page_size = 256;
 
   if (page_size > 256) {
-    pmsg_error("jtagmkI_paged_write(): page size %d too large\n", page_size);
+    pmsg_error("page size %d too large\n", page_size);
     return -1;
   }
 
   if ((datacmd = malloc(page_size + 1)) == NULL) {
-    pmsg_error("jtagmkI_paged_write(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
 
@@ -704,7 +698,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     again:
 
     if (tries != 0 && jtagmkI_resync(pgm, 2000, 0) < 0) {
-      pmsg_error("jtagmkI_paged_write(): sync loss, retries exhausted\n");
+      pmsg_error("sync loss, retries exhausted\n");
       return -1;
     }
 
@@ -734,8 +728,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       return -1;
     if (resp[0] != RESP_OK) {
       msg_notice2("\n");
-      pmsg_warning("jtagmkI_paged_write(): "
-        "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+      pmsg_warning("timeout/error communicating with programmer (resp %c)\n", resp[0]);
       if (tries++ < MAXTRIES)
 	goto again;
       serial_recv_timeout = otimeout;
@@ -760,8 +753,7 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
       return -1;
     if (resp[1] != RESP_OK) {
       msg_notice2("\n");
-      pmsg_warning("jtagmkI_paged_write(): "
-        "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+      pmsg_warning("timeout/error communicating with programmer (resp %c)\n", resp[0]);
       if (tries++ < MAXTRIES)
 	goto again;
       serial_recv_timeout = otimeout;
@@ -804,7 +796,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   }
 
   if (page_size > (is_flash? 512: 256)) {
-    pmsg_error("jtagmkI_paged_load(): page size %d too large\n", page_size);
+    pmsg_error("page size %d too large\n", page_size);
     return -1;
   }
 
@@ -813,7 +805,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     tries = 0;
     again:
     if (tries != 0 && jtagmkI_resync(pgm, 2000, 0) < 0) {
-      pmsg_error("jtagmkI_paged_load(): sync loss, retries exhausted\n");
+      pmsg_error("sync loss, retries exhausted\n");
       return -1;
     }
 
@@ -842,8 +834,7 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
     if (resp[read_size + 3 - 1] != RESP_OK) {
       msg_notice2("\n");
-      pmsg_warning("jtagmkI_paged_load(): "
-        "timeout/error communicating with programmer (resp %c)\n", resp[read_size + 3 - 1]);
+      pmsg_warning("timeout/error communicating with programmer (resp %c)\n", resp[read_size + 3 - 1]);
       if (tries++ < MAXTRIES)
 	goto again;
 
@@ -953,8 +944,7 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
   if (resp[respsize - 1] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_read_byte(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[respsize - 1]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[respsize - 1]);
     return -1;
   } else {
     msg_notice2("OK\n");
@@ -1039,8 +1029,7 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_write_byte(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     msg_notice2("OK\n");
@@ -1066,8 +1055,7 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_write_byte(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     msg_notice2("OK\n");
@@ -1127,13 +1115,11 @@ static int jtagmkI_getparm(const PROGRAMMER *pgm, const unsigned char parm,
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_getparm(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else if (resp[2] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_getparm(): "
-      "unknown parameter 0x%02x\n", parm);
+    pmsg_error("unknown parameter 0x%02x\n", parm);
     return -1;
   } else {
     msg_notice2("OK, value 0x%02x\n", resp[1]);
@@ -1164,8 +1150,7 @@ static int jtagmkI_setparm(const PROGRAMMER *pgm, unsigned char parm,
     return -1;
   if (resp[0] != RESP_OK) {
     msg_notice2("\n");
-    pmsg_error("jtagmkI_setparm(): "
-      "timeout/error communicating with programmer (resp %c)\n", resp[0]);
+    pmsg_error("timeout/error communicating with programmer (resp %c)\n", resp[0]);
     return -1;
   } else {
     msg_notice2("OK\n");

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -804,7 +804,7 @@ retry:
 	    return -1;
 	}
 	pmsg_warning("target prepared for ISP, signed off\n");
-        pmsg_warning("now retrying without power-cycling the target\n");
+        imsg_warning("now retrying without power-cycling the target\n");
         goto retry;
       }
     } else {

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1400,9 +1400,9 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         rv = -1;
         continue;
       }
-      pmsg_notice2("jtagmkII_parseextparms(): JTAG chain parsed as:\n"
-        "%s %u units before, %u units after, %u bits before, %u bits after\n",
-        progbuf, ub, ua, bb, ba);
+      pmsg_notice2("jtagmkII_parseextparms(): JTAG chain parsed as:\n");
+      imsg_notice2("%u units before, %u units after, %u bits before, %u bits after\n",
+        ub, ua, bb, ba);
       PDATA(pgm)->jtagchain[0] = ub;
       PDATA(pgm)->jtagchain[1] = ua;
       PDATA(pgm)->jtagchain[2] = bb;
@@ -3013,7 +3013,7 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
       pmsg_warning("expected signature for %s is %02X %02X %02X\n", p->desc,
         p->signature[0], p->signature[1], p->signature[2]);
       if (!ovsigck) {
-        msg_error("%sdouble check chip or use -F to override this check\n", progbuf);
+        imsg_error("double check chip or use -F to override this check\n");
         return -1;
       }
     }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2967,9 +2967,12 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
     resp[2] != p->signature[0] ||
     resp[3] != p->signature[1] ||
     resp[4] != p->signature[2]) {
-      pmsg_warning("expected signature for %s is %02X %02X %02X\n", p->desc,
-        p->signature[0], p->signature[1], p->signature[2]);
-      if (!ovsigck) {
+      if (ovsigck) {
+        pmsg_warning("expected signature for %s is %02X %02X %02X\n", p->desc,
+          p->signature[0], p->signature[1], p->signature[2]);
+      } else {
+        pmsg_error("expected signature for %s is %02X %02X %02X\n", p->desc,
+          p->signature[0], p->signature[1], p->signature[2]);
         imsg_error("double check chip or use -F to override this check\n");
         return -1;
       }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -267,7 +267,7 @@ static void jtagmkII_print_memory(unsigned char *b, size_t s)
     return;
 
   for (i = 0; i < s - 1; i++) {
-    avrdude_message(MSG_INFO, "0x%02x ", b[i + 1]);
+    msg_info("0x%02x ", b[i + 1]);
     if (i % 16 == 15)
       putc('\n', stderr);
     else
@@ -281,10 +281,10 @@ static void jtagmkII_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t le
   int i;
 
   if (verbose >= 4) {
-    avrdude_message(MSG_TRACE, "Raw message:\n");
+    msg_trace("Raw message:\n");
 
     for (i = 0; i < len; i++) {
-      avrdude_message(MSG_TRACE, "0x%02x", data[i]);
+      msg_trace("0x%02x", data[i]);
       if (i % 16 == 15)
 	putc('\n', stderr);
       else
@@ -296,121 +296,121 @@ static void jtagmkII_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t le
 
   switch (data[0]) {
   case RSP_OK:
-    avrdude_message(MSG_INFO, "OK\n");
+    msg_info("OK\n");
     break;
 
   case RSP_FAILED:
-    avrdude_message(MSG_INFO, "FAILED\n");
+    msg_info("FAILED\n");
     break;
 
   case RSP_ILLEGAL_BREAKPOINT:
-    avrdude_message(MSG_INFO, "Illegal breakpoint\n");
+    msg_info("Illegal breakpoint\n");
     break;
 
   case RSP_ILLEGAL_COMMAND:
-    avrdude_message(MSG_INFO, "Illegal command\n");
+    msg_info("Illegal command\n");
     break;
 
   case RSP_ILLEGAL_EMULATOR_MODE:
-    avrdude_message(MSG_INFO, "Illegal emulator mode");
+    msg_info("Illegal emulator mode");
     if (len > 1)
       switch (data[1]) {
-      case EMULATOR_MODE_DEBUGWIRE: avrdude_message(MSG_INFO, ": DebugWire"); break;
-      case EMULATOR_MODE_JTAG:      avrdude_message(MSG_INFO, ": JTAG"); break;
-      case EMULATOR_MODE_HV:        avrdude_message(MSG_INFO, ": HVSP/PP"); break;
-      case EMULATOR_MODE_SPI:       avrdude_message(MSG_INFO, ": SPI"); break;
-      case EMULATOR_MODE_JTAG_XMEGA: avrdude_message(MSG_INFO, ": JTAG/Xmega"); break;
+      case EMULATOR_MODE_DEBUGWIRE: msg_info(": DebugWire"); break;
+      case EMULATOR_MODE_JTAG:      msg_info(": JTAG"); break;
+      case EMULATOR_MODE_HV:        msg_info(": HVSP/PP"); break;
+      case EMULATOR_MODE_SPI:       msg_info(": SPI"); break;
+      case EMULATOR_MODE_JTAG_XMEGA: msg_info(": JTAG/Xmega"); break;
       }
     putc('\n', stderr);
     break;
 
   case RSP_ILLEGAL_JTAG_ID:
-    avrdude_message(MSG_INFO, "Illegal JTAG ID\n");
+    msg_info("Illegal JTAG ID\n");
     break;
 
   case RSP_ILLEGAL_MCU_STATE:
-    avrdude_message(MSG_INFO, "Illegal MCU state");
+    msg_info("Illegal MCU state");
     if (len > 1)
       switch (data[1]) {
-      case STOPPED:     avrdude_message(MSG_INFO, ": Stopped"); break;
-      case RUNNING:     avrdude_message(MSG_INFO, ": Running"); break;
-      case PROGRAMMING: avrdude_message(MSG_INFO, ": Programming"); break;
+      case STOPPED:     msg_info(": Stopped"); break;
+      case RUNNING:     msg_info(": Running"); break;
+      case PROGRAMMING: msg_info(": Programming"); break;
       }
     putc('\n', stderr);
     break;
 
   case RSP_ILLEGAL_MEMORY_TYPE:
-    avrdude_message(MSG_INFO, "Illegal memory type\n");
+    msg_info("Illegal memory type\n");
     break;
 
   case RSP_ILLEGAL_MEMORY_RANGE:
-    avrdude_message(MSG_INFO, "Illegal memory range\n");
+    msg_info("Illegal memory range\n");
     break;
 
   case RSP_ILLEGAL_PARAMETER:
-    avrdude_message(MSG_INFO, "Illegal parameter\n");
+    msg_info("Illegal parameter\n");
     break;
 
   case RSP_ILLEGAL_POWER_STATE:
-    avrdude_message(MSG_INFO, "Illegal power state\n");
+    msg_info("Illegal power state\n");
     break;
 
   case RSP_ILLEGAL_VALUE:
-    avrdude_message(MSG_INFO, "Illegal value\n");
+    msg_info("Illegal value\n");
     break;
 
   case RSP_NO_TARGET_POWER:
-    avrdude_message(MSG_INFO, "No target power\n");
+    msg_info("No target power\n");
     break;
 
   case RSP_SIGN_ON:
-    avrdude_message(MSG_INFO, "Sign-on succeeded\n");
+    msg_info("Sign-on succeeded\n");
     /* Sign-on data will be printed below anyway. */
     break;
 
   case RSP_MEMORY:
-    avrdude_message(MSG_INFO, "memory contents:\n");
+    msg_info("memory contents:\n");
     jtagmkII_print_memory(data, len);
     break;
 
   case RSP_PARAMETER:
-    avrdude_message(MSG_INFO, "parameter values:\n");
+    msg_info("parameter values:\n");
     jtagmkII_print_memory(data, len);
     break;
 
   case RSP_SPI_DATA:
-    avrdude_message(MSG_INFO, "SPI data returned:\n");
+    msg_info("SPI data returned:\n");
     for (i = 1; i < len; i++)
-      avrdude_message(MSG_INFO, "0x%02x ", data[i]);
+      msg_info("0x%02x ", data[i]);
     putc('\n', stderr);
     break;
 
   case EVT_BREAK:
-    avrdude_message(MSG_INFO, "BREAK event");
+    msg_info("BREAK event");
     if (len >= 6) {
-      avrdude_message(MSG_INFO, ", PC = 0x%lx, reason ", b4_to_u32(data + 1));
+      msg_info(", PC = 0x%lx, reason ", b4_to_u32(data + 1));
       switch (data[5]) {
       case 0x00:
-	avrdude_message(MSG_INFO, "unspecified");
+	msg_info("unspecified");
 	break;
       case 0x01:
-	avrdude_message(MSG_INFO, "program break");
+	msg_info("program break");
 	break;
       case 0x02:
-	avrdude_message(MSG_INFO, "data break PDSB");
+	msg_info("data break PDSB");
 	break;
       case 0x03:
-	avrdude_message(MSG_INFO, "data break PDMSB");
+	msg_info("data break PDMSB");
 	break;
       default:
-	avrdude_message(MSG_INFO, "unknown: 0x%02x", data[5]);
+	msg_info("unknown: 0x%02x", data[5]);
       }
     }
     putc('\n', stderr);
     break;
 
   default:
-    avrdude_message(MSG_INFO, "unknown message 0x%02x\n", data[0]);
+    msg_info("unknown message 0x%02x\n", data[0]);
   }
 
   putc('\n', stderr);
@@ -420,12 +420,12 @@ static void jtagmkII_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t le
 int jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   unsigned char *buf;
 
-  avrdude_message(MSG_DEBUG, "\n%s: jtagmkII_send(): sending %lu bytes\n",
+  msg_debug("\n%s: jtagmkII_send(): sending %lu bytes\n",
 	    progname, (unsigned long)len);
 
   if ((buf = malloc(len + 10)) == NULL)
     {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_send(): out of memory",
+      msg_info("%s: jtagmkII_send(): out of memory",
 	      progname);
       return -1;
     }
@@ -439,7 +439,7 @@ int jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   crcappend(buf, len + 8);
 
   if (serial_send(&pgm->fd, buf, len + 10) != 0) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_send(): failed to send command to serial port\n",
+    msg_info("%s: jtagmkII_send(): failed to send command to serial port\n",
                     progname);
     free(buf);
     return -1;
@@ -488,7 +488,7 @@ static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg,
   double timeoutval = 100;	/* seconds */
   double tstart, tnow;
 
-  avrdude_message(MSG_TRACE, "%s: jtagmkII_recv():\n", progname);
+  msg_trace("%s: jtagmkII_recv():\n", progname);
 
   gettimeofday(&tv, NULL);
   tstart = tv.tv_sec;
@@ -506,7 +506,7 @@ static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg,
       if (rv != 0) {
 	timedout:
 	/* timeout in receive */
-        avrdude_message(MSG_NOTICE2, "%s: jtagmkII_recv(): Timeout receiving packet\n",
+        msg_notice2("%s: jtagmkII_recv(): Timeout receiving packet\n",
                           progname);
 	free(buf);
 	return -1;
@@ -545,13 +545,13 @@ static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg,
         if (c == TOKEN) {
 	  state = sDATA;
 	  if (msglen > MAX_MESSAGE) {
-	    avrdude_message(MSG_INFO, "%s: jtagmkII_recv(): msglen %lu exceeds max message "
+	    msg_info("%s: jtagmkII_recv(): msglen %lu exceeds max message "
                             "size %u, ignoring message\n",
                             progname, msglen, MAX_MESSAGE);
 	    state = sSTART;
 	    headeridx = 0;
 	  } else if ((buf = malloc(msglen + 10)) == NULL) {
-	    avrdude_message(MSG_INFO, "%s: jtagmkII_recv(): out of memory\n",
+	    msg_info("%s: jtagmkII_recv(): out of memory\n",
 		    progname);
 	    ignorpkt++;
 	  } else {
@@ -573,11 +573,11 @@ static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg,
 	if (state == sCSUM2) {
 	  if (crcverify(buf, msglen + 10)) {
 	    if (verbose >= 9)
-	      avrdude_message(MSG_TRACE2, "%s: jtagmkII_recv(): CRC OK",
+	      msg_trace2("%s: jtagmkII_recv(): CRC OK",
 		      progname);
 	    state = sDONE;
 	  } else {
-	    avrdude_message(MSG_INFO, "%s: jtagmkII_recv(): checksum error\n",
+	    msg_info("%s: jtagmkII_recv(): checksum error\n",
 		    progname);
 	    free(buf);
 	    return -4;
@@ -586,7 +586,7 @@ static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg,
 	  state++;
         break;
       default:
-        avrdude_message(MSG_INFO, "%s: jtagmkII_recv(): unknown state\n",
+        msg_info("%s: jtagmkII_recv(): unknown state\n",
                 progname);
 	free(buf);
         return -5;
@@ -595,14 +595,14 @@ static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg,
      gettimeofday(&tv, NULL);
      tnow = tv.tv_sec;
      if (tnow - tstart > timeoutval) {
-       avrdude_message(MSG_INFO, "%s: jtagmkII_recv_frame(): timeout\n",
+       msg_info("%s: jtagmkII_recv_frame(): timeout\n",
                progname);
        free(buf);
        return -1;
      }
 
   }
-  avrdude_message(MSG_DEBUG, "\n");
+  msg_debug("\n");
 
   *seqno = r_seqno;
   *msg = buf;
@@ -617,7 +617,7 @@ int jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg) {
   for (;;) {
     if ((rv = jtagmkII_recv_frame(pgm, msg, &r_seqno)) <= 0)
       return rv;
-    avrdude_message(MSG_DEBUG, "%s: jtagmkII_recv(): "
+    msg_debug("%s: jtagmkII_recv(): "
 	      "Got message seqno %d (command_sequence == %d)\n",
 	      progname, r_seqno, PDATA(pgm)->command_sequence);
     if (r_seqno == PDATA(pgm)->command_sequence) {
@@ -634,30 +634,30 @@ int jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg) {
       {
           int i = rv;
           unsigned char *p = *msg;
-          avrdude_message(MSG_TRACE, "%s: Recv: ", progname);
+          msg_trace("%s: Recv: ", progname);
 
           while (i) {
             unsigned char c = *p;
             if (isprint(c)) {
-              avrdude_message(MSG_TRACE, "%c ", c);
+              msg_trace("%c ", c);
             }
             else {
-              avrdude_message(MSG_TRACE, ". ");
+              msg_trace(". ");
             }
-            avrdude_message(MSG_TRACE, "[%02x] ", c);
+            msg_trace("[%02x] ", c);
 
             p++;
             i--;
           }
-          avrdude_message(MSG_TRACE, "\n");
+          msg_trace("\n");
       }
       return rv;
     }
     if (r_seqno == 0xffff) {
-      avrdude_message(MSG_DEBUG, "%s: jtagmkII_recv(): got asynchronous event\n",
+      msg_debug("%s: jtagmkII_recv(): got asynchronous event\n",
 		progname);
     } else {
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkII_recv(): "
+      msg_notice2("%s: jtagmkII_recv(): "
 		"got wrong sequence number, %u != %u\n",
 		progname, r_seqno, PDATA(pgm)->command_sequence);
     }
@@ -674,14 +674,14 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
   unsigned int fwver, hwver;
   int is_dragon;
 
-  avrdude_message(MSG_DEBUG, "%s: jtagmkII_getsync()\n", progname);
+  msg_debug("%s: jtagmkII_getsync()\n", progname);
 
   if (strncmp(pgm->type, "JTAG", strlen("JTAG")) == 0) {
     is_dragon = 0;
   } else if (strncmp(pgm->type, "DRAGON", strlen("DRAGON")) == 0) {
     is_dragon = 1;
   } else {
-    avrdude_message(MSG_INFO, "%s: Programmer is neither JTAG ICE mkII nor AVR Dragon\n",
+    msg_info("%s: Programmer is neither JTAG ICE mkII nor AVR Dragon\n",
                     progname);
     return -1;
   }
@@ -689,19 +689,19 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
 
     /* Get the sign-on information. */
     buf[0] = CMND_GET_SIGN_ON;
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_getsync() attempt %d of %d: Sending sign-on command: ",
+    msg_notice2("%s: jtagmkII_getsync() attempt %d of %d: Sending sign-on command: ",
 	      progname, tries + 1, MAXTRIES);
     jtagmkII_send(pgm, buf, 1);
 
     status = jtagmkII_recv(pgm, &resp);
     if (status <= 0) {
-	    avrdude_message(MSG_INFO, "%s: jtagmkII_getsync() attempt %d of %d: sign-on command: status %d\n",
+	    msg_info("%s: jtagmkII_getsync() attempt %d of %d: sign-on command: status %d\n",
 		      progname, tries + 1, MAXTRIES, status);
     } else if (verbose >= 3) {
       putc('\n', stderr);
       jtagmkII_prmsg(pgm, resp, status);
     } else if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+      msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
 
     if (status > 0) {
       if ((c = resp[0]) == RSP_SIGN_ON) {
@@ -710,28 +710,28 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
 	hwver = (unsigned)resp[9];
 	memcpy(PDATA(pgm)->serno, resp + 10, 6);
 	if (status > 17) {
-	  avrdude_message(MSG_NOTICE, "JTAG ICE mkII sign-on message:\n");
-	  avrdude_message(MSG_NOTICE, "Communications protocol version: %u\n",
+	  msg_notice("JTAG ICE mkII sign-on message:\n");
+	  msg_notice("Communications protocol version: %u\n",
 		  (unsigned)resp[1]);
-	  avrdude_message(MSG_NOTICE, "M_MCU:\n");
-	  avrdude_message(MSG_NOTICE, "  boot-loader FW version:        %u\n",
+	  msg_notice("M_MCU:\n");
+	  msg_notice("  boot-loader FW version:        %u\n",
 		  (unsigned)resp[2]);
-	  avrdude_message(MSG_NOTICE, "  firmware version:              %u.%02u\n",
+	  msg_notice("  firmware version:              %u.%02u\n",
 		  (unsigned)resp[4], (unsigned)resp[3]);
-	  avrdude_message(MSG_NOTICE, "  hardware version:              %u\n",
+	  msg_notice("  hardware version:              %u\n",
 		  (unsigned)resp[5]);
-	  avrdude_message(MSG_NOTICE, "S_MCU:\n");
-	  avrdude_message(MSG_NOTICE, "  boot-loader FW version:        %u\n",
+	  msg_notice("S_MCU:\n");
+	  msg_notice("  boot-loader FW version:        %u\n",
 		  (unsigned)resp[6]);
-	  avrdude_message(MSG_NOTICE, "  firmware version:              %u.%02u\n",
+	  msg_notice("  firmware version:              %u.%02u\n",
 		  (unsigned)resp[8], (unsigned)resp[7]);
-	  avrdude_message(MSG_NOTICE, "  hardware version:              %u\n",
+	  msg_notice("  hardware version:              %u\n",
 		  (unsigned)resp[9]);
-	  avrdude_message(MSG_NOTICE, "Serial number:                   "
+	  msg_notice("Serial number:                   "
 		  "%02x:%02x:%02x:%02x:%02x:%02x\n",
 		  PDATA(pgm)->serno[0], PDATA(pgm)->serno[1], PDATA(pgm)->serno[2], PDATA(pgm)->serno[3], PDATA(pgm)->serno[4], PDATA(pgm)->serno[5]);
 	  resp[status - 1] = '\0';
-	  avrdude_message(MSG_NOTICE, "Device ID:                       %s\n",
+	  msg_notice("Device ID:                       %s\n",
 		  resp + 16);
 	}
 	free(resp);
@@ -742,11 +742,11 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
   }
   if (tries >= MAXTRIES) {
     if (status <= 0)
-      avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): "
+      msg_info("%s: jtagmkII_getsync(): "
                       "timeout/error communicating with programmer (status %d)\n",
                       progname, status);
     else
-      avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): "
+      msg_info("%s: jtagmkII_getsync(): "
                       "bad response to sign-on command: %s\n",
                       progname, jtagmkII_get_rc(c));
     return -1;
@@ -761,19 +761,19 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
 #define FWVER(maj, min) ((maj << 8) | (min))
   if (!is_dragon && fwver < FWVER(3, 16)) {
     PDATA(pgm)->device_descriptor_length -= 2;
-    avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): "
+    msg_info("%s: jtagmkII_getsync(): "
                     "S_MCU firmware version might be too old to work correctly\n",
                     progname);
   } else if (!is_dragon && fwver < FWVER(4, 0)) {
     PDATA(pgm)->device_descriptor_length -= 2;
   }
   if (mode != EMULATOR_MODE_SPI)
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_getsync(): Using a %u-byte device descriptor\n",
+    msg_notice2("%s: jtagmkII_getsync(): Using a %u-byte device descriptor\n",
                     progname, (unsigned)PDATA(pgm)->device_descriptor_length);
   if (mode == EMULATOR_MODE_SPI) {
     PDATA(pgm)->device_descriptor_length = 0;
     if (!is_dragon && fwver < FWVER(4, 14)) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): ISP functionality requires firmware "
+      msg_info("%s: jtagmkII_getsync(): ISP functionality requires firmware "
                       "version >= 4.14\n",
                       progname);
       return -1;
@@ -781,19 +781,19 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
   }
   if (mode == EMULATOR_MODE_PDI || mode == EMULATOR_MODE_JTAG_XMEGA) {
     if (!is_dragon && mode == EMULATOR_MODE_PDI && hwver < 1) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): Xmega PDI support requires hardware "
+      msg_info("%s: jtagmkII_getsync(): Xmega PDI support requires hardware "
                       "revision >= 1\n",
                       progname);
       return -1;
     }
     if (!is_dragon && fwver < FWVER(5, 37)) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): Xmega support requires firmware "
+      msg_info("%s: jtagmkII_getsync(): Xmega support requires firmware "
                       "version >= 5.37\n",
                       progname);
       return -1;
     }
     if (is_dragon && fwver < FWVER(6, 11)) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): Xmega support requires firmware "
+      msg_info("%s: jtagmkII_getsync(): Xmega support requires firmware "
                       "version >= 6.11\n",
                       progname);
       return -1;
@@ -809,7 +809,7 @@ retry:
   buf[0] = mode;
   if (jtagmkII_setparm(pgm, PAR_EMULATOR_MODE, buf) < 0) {
     if (mode == EMULATOR_MODE_SPI) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): "
+      msg_info("%s: jtagmkII_getsync(): "
                       "ISP activation failed, trying debugWire\n",
                       progname);
       buf[0] = EMULATOR_MODE_DEBUGWIRE;
@@ -829,11 +829,11 @@ retry:
 	 */
 	(void)jtagmkII_reset(pgm, 0x04);
 	if (tries++ > 3) {
-	    avrdude_message(MSG_INFO, "%s: Failed to return from debugWIRE to ISP.\n",
+	    msg_info("%s: Failed to return from debugWIRE to ISP.\n",
                             progname);
 	    return -1;
 	}
-	avrdude_message(MSG_INFO, "%s: Target prepared for ISP, signed off.\n"
+	msg_info("%s: Target prepared for ISP, signed off.\n"
                         "%s: Now retrying without power-cycling the target.\n",
                         progname, progname);
         goto retry;
@@ -845,7 +845,7 @@ retry:
 
   /* GET SYNC forces the target into STOPPED mode */
   buf[0] = CMND_GET_SYNC;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_getsync(): Sending get sync command: ",
+  msg_notice2("%s: jtagmkII_getsync(): Sending get sync command: ",
 	    progname);
   jtagmkII_send(pgm, buf, 1);
 
@@ -853,7 +853,7 @@ retry:
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): "
+    msg_info("%s: jtagmkII_getsync(): "
                     "timeout/error communicating with programmer (status %d)\n",
                     progname, status);
     return -1;
@@ -862,11 +862,11 @@ retry:
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_getsync(): "
+    msg_info("%s: jtagmkII_getsync(): "
                     "bad response to set parameter command: %s\n",
                     progname, jtagmkII_get_rc(c));
     return -1;
@@ -891,7 +891,7 @@ static int jtagmkII_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     buf[0] = CMND_CHIP_ERASE;
     len = 1;
   }
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_chip_erase(): Sending %schip erase command: ",
+  msg_notice2("%s: jtagmkII_chip_erase(): Sending %schip erase command: ",
                     progname,
                     p->prog_modes & (PM_PDI | PM_UPDI)? "Xmega ": "");
   jtagmkII_send(pgm, buf, len);
@@ -900,7 +900,7 @@ static int jtagmkII_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_chip_erase(): "
+    msg_info("%s: jtagmkII_chip_erase(): "
                     "timeout/error communicating with programmer (status %d)\n",
                     progname, status);
     return -1;
@@ -909,11 +909,11 @@ static int jtagmkII_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_chip_erase(): "
+    msg_info("%s: jtagmkII_chip_erase(): "
                     "bad response to chip erase command: %s\n",
                     progname, jtagmkII_get_rc(c));
     return -1;
@@ -930,7 +930,7 @@ static int jtagmkII_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
  */
 static int jtagmkII_chip_erase_dw(const PROGRAMMER *pgm, const AVRPART *p) {
 
-  avrdude_message(MSG_INFO, "%s: Chip erase not supported in debugWire mode\n",
+  msg_info("%s: Chip erase not supported in debugWire mode\n",
 	  progname);
 
   return 0;
@@ -977,7 +977,7 @@ static void jtagmkII_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   sendbuf.dd.ucCacheType =
     p->prog_modes & (PM_PDI | PM_UPDI)? 0x02 /* ATxmega */: 0x00;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_set_devdescr(): "
+  msg_notice2("%s: jtagmkII_set_devdescr(): "
 	    "Sending set device descriptor command: ",
 	    progname);
   jtagmkII_send(pgm, (unsigned char *)&sendbuf,
@@ -987,7 +987,7 @@ static void jtagmkII_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_set_devdescr(): "
+    msg_info("%s: jtagmkII_set_devdescr(): "
                     "timeout/error communicating with programmer (status %d)\n",
                     progname, status);
     return;
@@ -996,11 +996,11 @@ static void jtagmkII_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_set_devdescr(): "
+    msg_info("%s: jtagmkII_set_devdescr(): "
                     "bad response to set device descriptor command: %s\n",
                     progname, jtagmkII_get_rc(c));
   }
@@ -1055,7 +1055,7 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_set_xmega_params(): "
+  msg_notice2("%s: jtagmkII_set_xmega_params(): "
 	    "Sending set Xmega params command: ",
 	    progname);
   jtagmkII_send(pgm, (unsigned char *)&sendbuf, sizeof sendbuf);
@@ -1064,7 +1064,7 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_set_xmega_params(): "
+    msg_info("%s: jtagmkII_set_xmega_params(): "
                     "timeout/error communicating with programmer (status %d)\n",
                     progname, status);
     return;
@@ -1073,11 +1073,11 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_set_xmega_params(): "
+    msg_info("%s: jtagmkII_set_xmega_params(): "
                     "bad response to set device descriptor command: %s\n",
                     progname, jtagmkII_get_rc(c));
   }
@@ -1102,7 +1102,7 @@ static int jtagmkII_reset(const PROGRAMMER *pgm, unsigned char flags) {
 
   buf[0] = (pgm->flag & PGM_FL_IS_DW)? CMND_FORCED_STOP: CMND_RESET;
   buf[1] = (pgm->flag & PGM_FL_IS_DW)? 1: flags;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_reset(): Sending %s command: ",
+  msg_notice2("%s: jtagmkII_reset(): Sending %s command: ",
 	    progname, (pgm->flag & PGM_FL_IS_DW)? "stop": "reset");
   jtagmkII_send(pgm, buf, 2);
 
@@ -1110,7 +1110,7 @@ static int jtagmkII_reset(const PROGRAMMER *pgm, unsigned char flags) {
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_reset(): "
+    msg_info("%s: jtagmkII_reset(): "
                     "timeout/error communicating with programmer (status %d)\n",
                     progname, status);
     return -1;
@@ -1119,11 +1119,11 @@ static int jtagmkII_reset(const PROGRAMMER *pgm, unsigned char flags) {
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_reset(): "
+    msg_info("%s: jtagmkII_reset(): "
                     "bad response to reset command: %s\n",
                     progname, jtagmkII_get_rc(c));
     return -1;
@@ -1146,7 +1146,7 @@ static int jtagmkII_program_enable(const PROGRAMMER *pgm) {
 
   for (use_ext_reset = 0; use_ext_reset <= 1; use_ext_reset++) {
     buf[0] = CMND_ENTER_PROGMODE;
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_program_enable(): "
+    msg_notice2("%s: jtagmkII_program_enable(): "
 	      "Sending enter progmode command: ",
 	      progname);
     jtagmkII_send(pgm, buf, 1);
@@ -1155,7 +1155,7 @@ static int jtagmkII_program_enable(const PROGRAMMER *pgm) {
     if (status <= 0) {
       if (verbose >= 2)
 	putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkII_program_enable(): "
+      msg_info("%s: jtagmkII_program_enable(): "
                       "timeout/error communicating with programmer (status %d)\n",
                       progname, status);
       return -1;
@@ -1164,24 +1164,24 @@ static int jtagmkII_program_enable(const PROGRAMMER *pgm) {
       putc('\n', stderr);
       jtagmkII_prmsg(pgm, resp, status);
     } else if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+      msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
     c = resp[0];
     free(resp);
     if (c != RSP_OK) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_program_enable(): "
+      msg_info("%s: jtagmkII_program_enable(): "
                       "bad response to enter progmode command: %s\n",
                       progname, jtagmkII_get_rc(c));
       if (c == RSP_ILLEGAL_JTAG_ID) {
 	if (use_ext_reset == 0) {
 	  unsigned char parm[] = { 1};
-          avrdude_message(MSG_INFO, "%s: retrying with external reset applied\n",
+          msg_info("%s: retrying with external reset applied\n",
                             progname);
 
 	  (void)jtagmkII_setparm(pgm, PAR_EXTERNAL_RESET, parm);
 	  continue;
 	}
 
-	avrdude_message(MSG_INFO, "%s: JTAGEN fuse disabled?\n", progname);
+	msg_info("%s: JTAGEN fuse disabled?\n", progname);
 	return -1;
       }
     }
@@ -1199,7 +1199,7 @@ static int jtagmkII_program_disable(const PROGRAMMER *pgm) {
     return 0;
 
   buf[0] = CMND_LEAVE_PROGMODE;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_program_disable(): "
+  msg_notice2("%s: jtagmkII_program_disable(): "
 	    "Sending leave progmode command: ",
 	    progname);
   jtagmkII_send(pgm, buf, 1);
@@ -1208,7 +1208,7 @@ static int jtagmkII_program_disable(const PROGRAMMER *pgm) {
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_program_disable(): "
+    msg_info("%s: jtagmkII_program_disable(): "
                     "timeout/error communicating with programmer (status %d)\n",
                     progname, status);
     return -1;
@@ -1217,11 +1217,11 @@ static int jtagmkII_program_disable(const PROGRAMMER *pgm) {
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_program_disable(): "
+    msg_info("%s: jtagmkII_program_disable(): "
                     "bad response to leave progmode command: %s\n",
                     progname, jtagmkII_get_rc(c));
     return -1;
@@ -1292,7 +1292,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   /* Abort and print error if programmer does not support the target microcontroller */
   if ((strncmp(pgm->type, "JTAGMKII_UPDI", strlen("JTAGMKII_UPDI")) == 0 && !(p->prog_modes & PM_UPDI)) ||
       (strncmp(ldata(lfirst(pgm->id)), "jtagmkII", strlen("jtagmkII")) == 0 && (p->prog_modes & PM_UPDI))) {
-    avrdude_message(MSG_INFO, "ERROR: programmer %s does not support target %s\n\n",
+    msg_info("ERROR: programmer %s does not support target %s\n\n",
 	  ldata(lfirst(pgm->id)), p->desc);
     return -1;
   }
@@ -1313,17 +1313,17 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (!ok) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): part %s has no %s interface\n",
+    msg_info("%s: jtagmkII_initialize(): part %s has no %s interface\n",
 	    progname, p->desc, ifname);
     return -1;
   }
 
   if ((serdev->flags & SERDEV_FL_CANSETSPEED) && pgm->baudrate && pgm->baudrate != 19200) {
     if ((b = jtagmkII_get_baud(pgm->baudrate)) == 0) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): unsupported baudrate %d\n",
+      msg_info("%s: jtagmkII_initialize(): unsupported baudrate %d\n",
 	      progname, pgm->baudrate);
     } else {
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkII_initialize(): "
+      msg_notice2("%s: jtagmkII_initialize(): "
 		"trying to set baudrate to %d\n",
 		progname, pgm->baudrate);
       if (jtagmkII_setparm(pgm, PAR_BAUD_RATE, &b) == 0)
@@ -1331,7 +1331,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
   if ((pgm->flag & PGM_FL_IS_JTAG) && pgm->bitclock != 0.0) {
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_initialize(): "
+    msg_notice2("%s: jtagmkII_initialize(): "
 	      "trying to set JTAG clock period to %.1f us\n",
 	      progname, pgm->bitclock);
     if (jtagmkII_set_sck_period(pgm, pgm->bitclock) != 0)
@@ -1340,7 +1340,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   if ((pgm->flag & PGM_FL_IS_JTAG) &&
       jtagmkII_setparm(pgm, PAR_DAISY_CHAIN_INFO, PDATA(pgm)->jtagchain) < 0) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): Failed to setup JTAG chain\n",
+    msg_info("%s: jtagmkII_initialize(): Failed to setup JTAG chain\n",
             progname);
     return -1;
   }
@@ -1369,7 +1369,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (bootmem == NULL || flashmem == NULL) {
       if (strncmp(ldata(lfirst(pgm->id)), "jtagmkII", strlen("jtagmkII")) == 0) {
-        avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): Cannot locate \"flash\" and \"boot\" memories in description\n",
+        msg_info("%s: jtagmkII_initialize(): Cannot locate \"flash\" and \"boot\" memories in description\n",
           progname);
       }
     } else {
@@ -1390,12 +1390,12 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): Out of memory\n",
+    msg_info("%s: jtagmkII_initialize(): Out of memory\n",
 	    progname);
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): Out of memory\n",
+    msg_info("%s: jtagmkII_initialize(): Out of memory\n",
 	    progname);
     free(PDATA(pgm)->flash_pagecache);
     return -1;
@@ -1424,7 +1424,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if (jtagmkII_read_byte(pgm, p, &hfuse, 1, &b) < 0)
       return -1;
     if ((b & OCDEN) != 0)
-      avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): warning: OCDEN fuse not programmed, "
+      msg_info("%s: jtagmkII_initialize(): warning: OCDEN fuse not programmed, "
                       "single-byte EEPROM updates not possible\n",
                       progname);
   }
@@ -1463,12 +1463,12 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       unsigned int ub, ua, bb, ba;
       if (sscanf(extended_param, "jtagchain=%u,%u,%u,%u", &ub, &ua, &bb, &ba)
           != 4) {
-        avrdude_message(MSG_INFO, "%s: jtagmkII_parseextparms(): invalid JTAG chain '%s'\n",
+        msg_info("%s: jtagmkII_parseextparms(): invalid JTAG chain '%s'\n",
                         progname, extended_param);
         rv = -1;
         continue;
       }
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkII_parseextparms(): JTAG chain parsed as:\n"
+      msg_notice2("%s: jtagmkII_parseextparms(): JTAG chain parsed as:\n"
                         "%s %u units before, %u units after, %u bits before, %u bits after\n",
                         progname,
                         progbuf, ub, ua, bb, ba);
@@ -1480,7 +1480,7 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       continue;
     }
 
-    avrdude_message(MSG_INFO, "%s: jtagmkII_parseextparms(): invalid extended parameter '%s'\n",
+    msg_info("%s: jtagmkII_parseextparms(): invalid extended parameter '%s'\n",
                     progname, extended_param);
     rv = -1;
   }
@@ -1492,7 +1492,7 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
 static int jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_open()\n", progname);
+  msg_notice2("%s: jtagmkII_open()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -1520,7 +1520,7 @@ static int jtagmkII_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1544,7 +1544,7 @@ static int jtagmkII_open(PROGRAMMER *pgm, const char *port) {
 static int jtagmkII_open_dw(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_open_dw()\n", progname);
+  msg_notice2("%s: jtagmkII_open_dw()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -1572,7 +1572,7 @@ static int jtagmkII_open_dw(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1596,7 +1596,7 @@ static int jtagmkII_open_dw(PROGRAMMER *pgm, const char *port) {
 static int jtagmkII_open_pdi(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_open_pdi()\n", progname);
+  msg_notice2("%s: jtagmkII_open_pdi()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -1624,7 +1624,7 @@ static int jtagmkII_open_pdi(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1649,7 +1649,7 @@ static int jtagmkII_open_pdi(PROGRAMMER *pgm, const char *port) {
 static int jtagmkII_dragon_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_dragon_open()\n", progname);
+  msg_notice2("%s: jtagmkII_dragon_open()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -1677,7 +1677,7 @@ static int jtagmkII_dragon_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1702,7 +1702,7 @@ static int jtagmkII_dragon_open(PROGRAMMER *pgm, const char *port) {
 static int jtagmkII_dragon_open_dw(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_dragon_open_dw()\n", progname);
+  msg_notice2("%s: jtagmkII_dragon_open_dw()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -1730,7 +1730,7 @@ static int jtagmkII_dragon_open_dw(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1755,7 +1755,7 @@ static int jtagmkII_dragon_open_dw(PROGRAMMER *pgm, const char *port) {
 static int jtagmkII_dragon_open_pdi(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_dragon_open_pdi()\n", progname);
+  msg_notice2("%s: jtagmkII_dragon_open_pdi()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -1783,7 +1783,7 @@ static int jtagmkII_dragon_open_pdi(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1810,12 +1810,12 @@ void jtagmkII_close(PROGRAMMER * pgm)
   int status;
   unsigned char buf[1], *resp, c;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_close()\n", progname);
+  msg_notice2("%s: jtagmkII_close()\n", progname);
 
   if (pgm->flag & (PGM_FL_IS_PDI | PGM_FL_IS_JTAG)) {
     /* When in PDI or JTAG mode, restart target. */
     buf[0] = CMND_GO;
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_close(): Sending GO command: ",
+    msg_notice2("%s: jtagmkII_close(): Sending GO command: ",
 	      progname);
     jtagmkII_send(pgm, buf, 1);
 
@@ -1823,7 +1823,7 @@ void jtagmkII_close(PROGRAMMER * pgm)
     if (status <= 0) {
       if (verbose >= 2)
 	putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkII_close(): "
+      msg_info("%s: jtagmkII_close(): "
                       "timeout/error communicating with programmer (status %d)\n",
                       progname, status);
     } else {
@@ -1831,11 +1831,11 @@ void jtagmkII_close(PROGRAMMER * pgm)
 	putc('\n', stderr);
 	jtagmkII_prmsg(pgm, resp, status);
       } else if (verbose == 2)
-	avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+	msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
       c = resp[0];
       free(resp);
       if (c != RSP_OK) {
-	avrdude_message(MSG_INFO, "%s: jtagmkII_close(): "
+	msg_info("%s: jtagmkII_close(): "
                         "bad response to GO command: %s\n",
                         progname, jtagmkII_get_rc(c));
       }
@@ -1843,7 +1843,7 @@ void jtagmkII_close(PROGRAMMER * pgm)
   }
 
   buf[0] = CMND_SIGN_OFF;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_close(): Sending sign-off command: ",
+  msg_notice2("%s: jtagmkII_close(): Sending sign-off command: ",
 	    progname);
   jtagmkII_send(pgm, buf, 1);
 
@@ -1851,7 +1851,7 @@ void jtagmkII_close(PROGRAMMER * pgm)
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_close(): "
+    msg_info("%s: jtagmkII_close(): "
                     "timeout/error communicating with programmer (status %d)\n",
                     progname, status);
     return;
@@ -1860,11 +1860,11 @@ void jtagmkII_close(PROGRAMMER * pgm)
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_close(): "
+    msg_info("%s: jtagmkII_close(): "
                     "bad response to sign-off command: %s\n",
                     progname, jtagmkII_get_rc(c));
   }
@@ -1881,16 +1881,16 @@ static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AV
   int status, tries;
   long otimeout = serial_recv_timeout;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_page_erase(.., %s, 0x%x)\n",
+  msg_notice2("%s: jtagmkII_page_erase(.., %s, 0x%x)\n",
 	    progname, m->desc, addr);
 
   if (!(p->prog_modes & (PM_PDI | PM_UPDI))) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_page_erase: not an Xmega device\n",
+    msg_info("%s: jtagmkII_page_erase: not an Xmega device\n",
 	    progname);
     return -1;
   }
   if ((pgm->flag & PGM_FL_IS_DW)) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_page_erase: not applicable to debugWIRE\n",
+    msg_info("%s: jtagmkII_page_erase: not applicable to debugWIRE\n",
 	    progname);
     return -1;
   }
@@ -1927,7 +1927,7 @@ static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AV
   tries = 0;
 
   retry:
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_page_erase(): "
+    msg_notice2("%s: jtagmkII_page_erase(): "
             "Sending Xmega erase command: ",
             progname);
   jtagmkII_send(pgm, cmd, sizeof cmd);
@@ -1936,14 +1936,14 @@ static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_page_erase(): "
+    msg_info("%s: jtagmkII_page_erase(): "
                       "timeout/error communicating with programmer (status %d)\n",
                       progname, status);
     if (tries++ < 4) {
       serial_recv_timeout *= 2;
       goto retry;
     }
-    avrdude_message(MSG_INFO, "%s: jtagmkII_page_erase(): fatal timeout/"
+    msg_info("%s: jtagmkII_page_erase(): fatal timeout/"
                     "error communicating with programmer (status %d)\n",
                     progname, status);
     serial_recv_timeout = otimeout;
@@ -1953,9 +1953,9 @@ static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AV
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   if (resp[0] != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_page_erase(): "
+    msg_info("%s: jtagmkII_page_erase(): "
                     "bad response to xmega erase command: %s\n",
                     progname, jtagmkII_get_rc(resp[0]));
     free(resp);
@@ -1980,7 +1980,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   int status, tries, dynamic_memtype = 0;
   long otimeout = serial_recv_timeout;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_paged_write(.., %s, %d, %d)\n",
+  msg_notice2("%s: jtagmkII_paged_write(.., %s, %d, %d)\n",
 	    progname, m->desc, page_size, n_bytes);
 
   if (!(pgm->flag & PGM_FL_IS_DW) && jtagmkII_program_enable(pgm) < 0)
@@ -1990,7 +1990,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   else if (page_size > 256) page_size = 256;
 
   if ((cmd = malloc(page_size + 10)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_paged_write(): Out of memory\n",
+    msg_info("%s: jtagmkII_paged_write(): Out of memory\n",
 	    progname);
     return -1;
   }
@@ -2036,7 +2036,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
       block_size = maxaddr - addr;
     else
       block_size = page_size;
-    avrdude_message(MSG_DEBUG, "%s: jtagmkII_paged_write(): "
+    msg_debug("%s: jtagmkII_paged_write(): "
 	      "block_size at addr %d is %d\n",
 	      progname, addr, block_size);
 
@@ -2059,7 +2059,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     tries = 0;
 
     retry:
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkII_paged_write(): "
+      msg_notice2("%s: jtagmkII_paged_write(): "
 	      "Sending write memory command: ",
 	      progname);
     jtagmkII_send(pgm, cmd, page_size + 10);
@@ -2068,14 +2068,14 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     if (status <= 0) {
       if (verbose >= 2)
 	putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkII_paged_write(): "
+      msg_info("%s: jtagmkII_paged_write(): "
                         "timeout/error communicating with programmer (status %d)\n",
                         progname, status);
       if (tries++ < 4) {
 	serial_recv_timeout *= 2;
 	goto retry;
       }
-      avrdude_message(MSG_INFO, "%s: jtagmkII_paged_write(): fatal timeout/"
+      msg_info("%s: jtagmkII_paged_write(): fatal timeout/"
                       "error communicating with programmer (status %d)\n",
                       progname, status);
       free(cmd);
@@ -2086,9 +2086,9 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
       putc('\n', stderr);
       jtagmkII_prmsg(pgm, resp, status);
     } else if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+      msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
     if (resp[0] != RSP_OK) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_paged_write(): "
+      msg_info("%s: jtagmkII_paged_write(): "
                       "bad response to write memory command: %s\n",
                       progname, jtagmkII_get_rc(resp[0]));
       free(resp);
@@ -2116,7 +2116,7 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
   int status, tries, dynamic_memtype = 0;
   long otimeout = serial_recv_timeout;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_paged_load(.., %s, %d, %d)\n",
+  msg_notice2("%s: jtagmkII_paged_load(.., %s, %d, %d)\n",
 	    progname, m->desc, page_size, n_bytes);
 
   if (!(pgm->flag & PGM_FL_IS_DW) && jtagmkII_program_enable(pgm) < 0)
@@ -2152,7 +2152,7 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
       block_size = maxaddr - addr;
     else
       block_size = page_size;
-    avrdude_message(MSG_DEBUG, "%s: jtagmkII_paged_load(): "
+    msg_debug("%s: jtagmkII_paged_load(): "
 	      "block_size at addr %d is %d\n",
 	      progname, addr, block_size);
 
@@ -2165,7 +2165,7 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
     tries = 0;
 
     retry:
-      avrdude_message(MSG_NOTICE2, "%s: jtagmkII_paged_load(): Sending read memory command: ",
+      msg_notice2("%s: jtagmkII_paged_load(): Sending read memory command: ",
 	      progname);
     jtagmkII_send(pgm, cmd, 10);
 
@@ -2173,14 +2173,14 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if (status <= 0) {
       if (verbose >= 2)
 	putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkII_paged_load(): "
+      msg_info("%s: jtagmkII_paged_load(): "
                         "timeout/error communicating with programmer (status %d)\n",
                         progname, status);
       if (tries++ < 4) {
 	serial_recv_timeout *= 2;
 	goto retry;
       }
-      avrdude_message(MSG_INFO, "%s: jtagmkII_paged_load(): fatal timeout/"
+      msg_info("%s: jtagmkII_paged_load(): fatal timeout/"
                       "error communicating with programmer (status %d)\n",
                       progname, status);
       serial_recv_timeout = otimeout;
@@ -2190,9 +2190,9 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
       putc('\n', stderr);
       jtagmkII_prmsg(pgm, resp, status);
     } else if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+      msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
     if (resp[0] != RSP_MEMORY) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_paged_load(): "
+      msg_info("%s: jtagmkII_paged_load(): "
 	      "bad response to read memory command: %s\n",
 	      progname, jtagmkII_get_rc(resp[0]));
       free(resp);
@@ -2217,7 +2217,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned long paddr = 0UL, *paddr_ptr = NULL;
   unsigned int pagesize = 0;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_read_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: jtagmkII_read_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   if (!(pgm->flag & PGM_FL_IS_DW) && jtagmkII_program_enable(pgm) < 0)
@@ -2298,7 +2298,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 	break;
 
       default:
-	avrdude_message(MSG_INFO, "%s: illegal address %lu for signature memory\n",
+	msg_info("%s: illegal address %lu for signature memory\n",
 		progname, addr);
 	return -1;
       }
@@ -2340,7 +2340,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   tries = 0;
   retry:
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_read_byte(): Sending read memory command: ",
+    msg_notice2("%s: jtagmkII_read_byte(): Sending read memory command: ",
 	    progname);
   jtagmkII_send(pgm, cmd, 10);
 
@@ -2348,12 +2348,12 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_read_byte(): "
+    msg_info("%s: jtagmkII_read_byte(): "
 	      "timeout/error communicating with programmer (status %d)\n",
 	      progname, status);
     if (tries++ < 3)
       goto retry;
-    avrdude_message(MSG_INFO, "%s: jtagmkII_read_byte(): "
+    msg_info("%s: jtagmkII_read_byte(): "
 	    "fatal timeout/error communicating with programmer (status %d)\n",
 	    progname, status);
     if (status < 0)
@@ -2364,9 +2364,9 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   if (resp[0] != RSP_MEMORY) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_read_byte(): "
+    msg_info("%s: jtagmkII_read_byte(): "
 	    "bad response to read memory command: %s\n",
 	    progname, jtagmkII_get_rc(resp[0]));
     goto fail;
@@ -2394,7 +2394,7 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   unsigned char *resp = NULL, writedata, writedata2 = 0xFF;
   int status, tries, need_progmode = 1, unsupp = 0, writesize = 1;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_write_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: jtagmkII_write_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   addr += mem->offset;
@@ -2472,7 +2472,7 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   tries = 0;
   retry:
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_write_byte(): Sending write memory command: ",
+  msg_notice2("%s: jtagmkII_write_byte(): Sending write memory command: ",
 	    progname);
   jtagmkII_send(pgm, cmd, 10 + writesize);
 
@@ -2480,12 +2480,12 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_NOTICE2, "%s: jtagmkII_write_byte(): "
+    msg_notice2("%s: jtagmkII_write_byte(): "
 	      "timeout/error communicating with programmer (status %d)\n",
 	      progname, status);
     if (tries++ < 3)
       goto retry;
-    avrdude_message(MSG_INFO, "%s: jtagmkII_write_byte(): "
+    msg_info("%s: jtagmkII_write_byte(): "
 	    "fatal timeout/error communicating with programmer (status %d)\n",
 	    progname, status);
     goto fail;
@@ -2494,9 +2494,9 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   if (resp[0] != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_write_byte(): "
+    msg_info("%s: jtagmkII_write_byte(): "
 	    "bad response to write memory command: %s\n",
 	    progname, jtagmkII_get_rc(resp[0]));
     goto fail;
@@ -2548,11 +2548,11 @@ int jtagmkII_getparm(const PROGRAMMER *pgm, unsigned char parm,
   int status;
   unsigned char buf[2], *resp, c;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_getparm()\n", progname);
+  msg_notice2("%s: jtagmkII_getparm()\n", progname);
 
   buf[0] = CMND_GET_PARAMETER;
   buf[1] = parm;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_getparm(): "
+  msg_notice2("%s: jtagmkII_getparm(): "
 	    "Sending get parameter command (parm 0x%02x): ",
 	    progname, parm);
   jtagmkII_send(pgm, buf, 2);
@@ -2561,7 +2561,7 @@ int jtagmkII_getparm(const PROGRAMMER *pgm, unsigned char parm,
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_getparm(): "
+    msg_info("%s: jtagmkII_getparm(): "
 	    "timeout/error communicating with programmer (status %d)\n",
 	    progname, status);
     return -1;
@@ -2570,10 +2570,10 @@ int jtagmkII_getparm(const PROGRAMMER *pgm, unsigned char parm,
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   if (c != RSP_PARAMETER) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_getparm(): "
+    msg_info("%s: jtagmkII_getparm(): "
 	    "bad response to get parameter command: %s\n",
 	    progname, jtagmkII_get_rc(c));
     free(resp);
@@ -2600,7 +2600,7 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
   unsigned char buf[2 + 4], *resp, c;
   size_t size;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_setparm()\n", progname);
+  msg_notice2("%s: jtagmkII_setparm()\n", progname);
 
   switch (parm) {
   case PAR_HW_VERSION: size = 2; break;
@@ -2615,7 +2615,7 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
   case PAR_PDI_OFFSET_START:
   case PAR_PDI_OFFSET_END: size = 4; break;
   default:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_setparm(): unknown parameter 0x%02x\n",
+    msg_info("%s: jtagmkII_setparm(): unknown parameter 0x%02x\n",
 	    progname, parm);
     return -1;
   }
@@ -2623,7 +2623,7 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
   buf[0] = CMND_SET_PARAMETER;
   buf[1] = parm;
   memcpy(buf + 2, value, size);
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_setparm(): "
+  msg_notice2("%s: jtagmkII_setparm(): "
 	    "Sending set parameter command (parm 0x%02x, %u bytes): ",
 	    progname, parm, (unsigned)size);
   jtagmkII_send(pgm, buf, size + 2);
@@ -2632,7 +2632,7 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_setparm(): "
+    msg_info("%s: jtagmkII_setparm(): "
 	    "timeout/error communicating with programmer (status %d)\n",
 	    progname, status);
     return -1;
@@ -2641,11 +2641,11 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_setparm(): "
+    msg_info("%s: jtagmkII_setparm(): "
 	    "bad response to set parameter command: %s\n",
 	    progname, jtagmkII_get_rc(c));
     return -1;
@@ -2662,11 +2662,11 @@ static void jtagmkII_display(const PROGRAMMER *pgm, const char *p) {
       jtagmkII_getparm(pgm, PAR_FW_VERSION, fw) < 0)
     return;
 
-  avrdude_message(MSG_INFO, "%sM_MCU HW version: %d\n", p, hw[0]);
-  avrdude_message(MSG_INFO, "%sM_MCU FW version: %d.%02d\n", p, fw[1], fw[0]);
-  avrdude_message(MSG_INFO, "%sS_MCU HW version: %d\n", p, hw[1]);
-  avrdude_message(MSG_INFO, "%sS_MCU FW version: %d.%02d\n", p, fw[3], fw[2]);
-  avrdude_message(MSG_INFO, "%sSerial number   : %02x:%02x:%02x:%02x:%02x:%02x\n",
+  msg_info("%sM_MCU HW version: %d\n", p, hw[0]);
+  msg_info("%sM_MCU FW version: %d.%02d\n", p, fw[1], fw[0]);
+  msg_info("%sS_MCU HW version: %d\n", p, hw[1]);
+  msg_info("%sS_MCU FW version: %d.%02d\n", p, fw[3], fw[2]);
+  msg_info("%sSerial number   : %02x:%02x:%02x:%02x:%02x:%02x\n",
 	  p, PDATA(pgm)->serno[0], PDATA(pgm)->serno[1], PDATA(pgm)->serno[2], PDATA(pgm)->serno[3], PDATA(pgm)->serno[4], PDATA(pgm)->serno[5]);
 
   jtagmkII_print_parms1(pgm, p);
@@ -2683,7 +2683,7 @@ static void jtagmkII_print_parms1(const PROGRAMMER *pgm, const char *p) {
   if (jtagmkII_getparm(pgm, PAR_OCD_VTARGET, vtarget) < 0)
     return;
 
-  avrdude_message(MSG_INFO, "%sVtarget         : %.1f V\n", p,
+  msg_info("%sVtarget         : %.1f V\n", p,
 	  b2_to_u16(vtarget) / 1000.0);
 
   if ((pgm->flag & PGM_FL_IS_JTAG)) {
@@ -2703,7 +2703,7 @@ static void jtagmkII_print_parms1(const PROGRAMMER *pgm, const char *p) {
       sprintf(clkbuf, "%.1f kHz", 5.35e3 / (double)jtag_clock[0]);
       clk = 5.35e6 / (double)jtag_clock[0];
 
-      avrdude_message(MSG_INFO, "%sJTAG clock      : %s (%.1f us)\n", p, clkbuf,
+      msg_info("%sJTAG clock      : %s (%.1f us)\n", p, clkbuf,
 	      1.0e6 / clk);
     }
   }
@@ -2761,7 +2761,7 @@ static int jtagmkII_avr32_reset(const PROGRAMMER *pgm, unsigned char val,
   int status;
   unsigned char buf[3], *resp;
 
-  avrdude_message(MSG_NOTICE, "%s: jtagmkII_avr32_reset(%2.2x)\n",
+  msg_notice("%s: jtagmkII_avr32_reset(%2.2x)\n",
           progname, val);
 
   buf[0] = CMND_GET_IR;
@@ -2771,7 +2771,7 @@ static int jtagmkII_avr32_reset(const PROGRAMMER *pgm, unsigned char val,
 
   status = jtagmkII_recv(pgm, &resp);
   if (status != 2 || resp[0] != 0x87 || resp[1] != ret1) {
-    avrdude_message(MSG_NOTICE, "%s: jtagmkII_avr32_reset(): "
+    msg_notice("%s: jtagmkII_avr32_reset(): "
 	      "Get_IR, expecting %2.2x but got %2.2x\n",
 	      progname, ret1, resp[1]);
 
@@ -2786,7 +2786,7 @@ static int jtagmkII_avr32_reset(const PROGRAMMER *pgm, unsigned char val,
 
   status = jtagmkII_recv(pgm, &resp);
   if (status != 2 || resp[0] != 0x87 || resp[1] != ret2) {
-    avrdude_message(MSG_NOTICE, "%s: jtagmkII_avr32_reset(): "
+    msg_notice("%s: jtagmkII_avr32_reset(): "
 	      "Get_XXX, expecting %2.2x but got %2.2x\n",
 	      progname, ret2, resp[1]);
     //return -1;
@@ -2801,7 +2801,7 @@ static int jtagmkII_reset32(const PROGRAMMER *pgm, unsigned short flags) {
   unsigned char *resp, buf[3];
   unsigned long val=0;
 
-  avrdude_message(MSG_NOTICE, "%s: jtagmkII_reset32(%2.2x)\n",
+  msg_notice("%s: jtagmkII_reset32(%2.2x)\n",
           progname, flags);
 
   status = -1;
@@ -2979,7 +2979,7 @@ static int jtagmkII_reset32(const PROGRAMMER *pgm, unsigned short flags) {
   return 0;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_reset32(): "
+    msg_info("%s: jtagmkII_reset32(): "
 	    "failed at line %d (status=%x val=%lx)\n",
 	    progname, lineno, status, val);
     return -1;
@@ -3077,7 +3077,7 @@ static int jtagmkII_smc_init32(const PROGRAMMER *pgm) {
   return 0;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_smc_init32(): "
+    msg_info("%s: jtagmkII_smc_init32(): "
 	    "failed at line %d\n",
 	    progname, lineno);
     return -1;
@@ -3092,7 +3092,7 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[6], *resp;
 
   if (jtagmkII_setparm(pgm, PAR_DAISY_CHAIN_INFO, PDATA(pgm)->jtagchain) < 0) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): Failed to setup JTAG chain\n",
+    msg_info("%s: jtagmkII_initialize(): Failed to setup JTAG chain\n",
             progname);
     return -1;
   }
@@ -3100,12 +3100,12 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_initialize(): Out of memory\n",
+    msg_info("%s: jtagmkII_initialize(): Out of memory\n",
 	    progname);
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_initialize32(): Out of memory\n",
+    msg_info("%s: jtagmkII_initialize32(): Out of memory\n",
 	    progname);
     free(PDATA(pgm)->flash_pagecache);
     return -1;
@@ -3121,7 +3121,7 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
     if(status <= 0 || resp[0] != 0x87) {
       if (verbose >= 2)
         putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkII_initialize32(): "
+      msg_info("%s: jtagmkII_initialize32(): "
                 "timeout/error communicating with programmer (status %d)\n",
                 progname, status);
       return -1;
@@ -3137,7 +3137,7 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
     if(status <= 0 || resp[0] != 0x87) {
       if (verbose >= 2)
         putc('\n', stderr);
-      avrdude_message(MSG_INFO, "%s: jtagmkII_initialize32(): "
+      msg_info("%s: jtagmkII_initialize32(): "
                 "timeout/error communicating with programmer (status %d)\n",
                 progname, status);
       return -1;
@@ -3147,11 +3147,11 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
     resp[2] != p->signature[0] ||
     resp[3] != p->signature[1] ||
     resp[4] != p->signature[2]) {
-      avrdude_message(MSG_INFO, "%s: Expected signature for %s is %02X %02X %02X\n",
+      msg_info("%s: Expected signature for %s is %02X %02X %02X\n",
           progname, p->desc,
           p->signature[0], p->signature[1], p->signature[2]);
       if (!ovsigck) {
-        avrdude_message(MSG_INFO, "%sDouble check chip, "
+        msg_info("%sDouble check chip, "
         "or use -F to override this check.\n",
                 progbuf);
         return -1;
@@ -3169,7 +3169,7 @@ static int jtagmkII_chip_erase32(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned long val=0;
   unsigned int lineno;
 
-  avrdude_message(MSG_NOTICE, "%s: jtagmkII_chip_erase32()\n",
+  msg_notice("%s: jtagmkII_chip_erase32()\n",
           progname);
 
   status = jtagmkII_reset32(pgm, AVR32_RESET_CHIP_ERASE);
@@ -3217,7 +3217,7 @@ static int jtagmkII_chip_erase32(const PROGRAMMER *pgm, const AVRPART *p) {
   return 0;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_reset32(): "
+    msg_info("%s: jtagmkII_reset32(): "
 	    "failed at line %d (status=%x val=%lx)\n",
 	    progname, lineno, status, val);
     return -1;
@@ -3244,19 +3244,19 @@ static unsigned long jtagmkII_read_SABaddr(const PROGRAMMER *pgm, unsigned long 
   if(status <= 0 || resp[0] != 0x87) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_read_SABaddr(): "
+    msg_info("%s: jtagmkII_read_SABaddr(): "
 	      "timeout/error communicating with programmer (status %d) resp=%x\n",
 	      progname, status, resp[0]);
     serial_recv_timeout = otimeout;
 
     if(status > 0) {
       int i;
-      avrdude_message(MSG_INFO, "Cmd: ");
-      for(i=0; i<6; ++i) avrdude_message(MSG_INFO, "%2.2x ", buf[i]);
-      avrdude_message(MSG_INFO, "\n");
-      avrdude_message(MSG_INFO, "Data: ");
-      for(i=0; i<status; ++i) avrdude_message(MSG_INFO, "%2.2x ", resp[i]);
-      avrdude_message(MSG_INFO, "\n");
+      msg_info("Cmd: ");
+      for(i=0; i<6; ++i) msg_info("%2.2x ", buf[i]);
+      msg_info("\n");
+      msg_info("Data: ");
+      for(i=0; i<status; ++i) msg_info("%2.2x ", resp[i]);
+      msg_info("\n");
     }
     return ERROR_SAB;
   }
@@ -3264,7 +3264,7 @@ static unsigned long jtagmkII_read_SABaddr(const PROGRAMMER *pgm, unsigned long 
   if(status != 5) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_read_SABaddr(): "
+    msg_info("%s: jtagmkII_read_SABaddr(): "
 	      "wrong number of bytes (status %d)\n",
 	      progname, status);
     serial_recv_timeout = otimeout;
@@ -3277,7 +3277,7 @@ static unsigned long jtagmkII_read_SABaddr(const PROGRAMMER *pgm, unsigned long 
   if (verbose) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_read_SABaddr(): "
+    msg_info("%s: jtagmkII_read_SABaddr(): "
 	      "OCD Register %lx -> %4.4lx\n",
 	      progname, addr, val);
   }
@@ -3303,7 +3303,7 @@ static int jtagmkII_write_SABaddr(const PROGRAMMER *pgm, unsigned long addr,
   if(status <= 0 || resp[0] != RSP_OK) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_write_SABaddr(): "
+    msg_info("%s: jtagmkII_write_SABaddr(): "
 	      "timeout/error communicating with programmer (status %d)\n",
 	      progname, status);
     return -1;
@@ -3313,7 +3313,7 @@ static int jtagmkII_write_SABaddr(const PROGRAMMER *pgm, unsigned long addr,
   if (verbose) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_write_SABaddr(): "
+    msg_info("%s: jtagmkII_write_SABaddr(): "
 	      "OCD Register %lx -> %4.4lx\n",
 	      progname, addr, val);
   }
@@ -3325,7 +3325,7 @@ static int jtagmkII_open32(PROGRAMMER *pgm, const char *port) {
   unsigned char buf[6], *resp;
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_open32()\n", progname);
+  msg_notice2("%s: jtagmkII_open32()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -3353,7 +3353,7 @@ static int jtagmkII_open32(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -3406,7 +3406,7 @@ static void jtagmkII_close32(PROGRAMMER * pgm)
   unsigned char *resp, buf[3], c;
   unsigned long val=0;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_close32()\n", progname);
+  msg_notice2("%s: jtagmkII_close32()\n", progname);
 
   // AVR32 "special"
   buf[0] = CMND_SET_PARAMETER;
@@ -3418,7 +3418,7 @@ static void jtagmkII_close32(PROGRAMMER * pgm)
   free(resp);
 
   buf[0] = CMND_SIGN_OFF;
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_close(): Sending sign-off command: ",
+  msg_notice2("%s: jtagmkII_close(): Sending sign-off command: ",
 	    progname);
   jtagmkII_send(pgm, buf, 1);
 
@@ -3426,7 +3426,7 @@ static void jtagmkII_close32(PROGRAMMER * pgm)
   if (status <= 0) {
     if (verbose >= 2)
       putc('\n', stderr);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_close(): "
+    msg_info("%s: jtagmkII_close(): "
 	    "timeout/error communicating with programmer (status %d)\n",
 	    progname, status);
     return;
@@ -3435,11 +3435,11 @@ static void jtagmkII_close32(PROGRAMMER * pgm)
     putc('\n', stderr);
     jtagmkII_prmsg(pgm, resp, status);
   } else if (verbose == 2)
-    avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+    msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_close(): "
+    msg_info("%s: jtagmkII_close(): "
 	    "bad response to sign-off command: %s\n",
 	    progname, jtagmkII_get_rc(c));
   }
@@ -3450,7 +3450,7 @@ static void jtagmkII_close32(PROGRAMMER * pgm)
     return;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_reset32(): "
+    msg_info("%s: jtagmkII_reset32(): "
 	    "failed at line %d (status=%x val=%lx)\n",
 	    progname, lineno, status, val);
     goto ret;
@@ -3468,7 +3468,7 @@ static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p, const 
   unsigned long val=0;
   long otimeout = serial_recv_timeout;
 
-  avrdude_message(MSG_NOTICE2, "%s: jtagmkII_paged_load32(.., %s, %d, %d)\n",
+  msg_notice2("%s: jtagmkII_paged_load32(.., %s, %d, %d)\n",
 	    progname, m->desc, page_size, n_bytes);
 
   serial_recv_timeout = 256;
@@ -3485,7 +3485,7 @@ static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p, const 
     PDATA(pgm)->flags32 |= FLAGS32_INIT_SMC;
   }
 
-  //avrdude_message(MSG_INFO, "\n pageSize=%d bytes=%d pages=%d m->offset=0x%x pgm->page_size %d\n",
+  //msg_info("\n pageSize=%d bytes=%d pages=%d m->offset=0x%x pgm->page_size %d\n",
   //        page_size, n_bytes, pages, m->offset, pgm->page_size);
 
   cmd[0] = CMND_READ_MEMORY32;
@@ -3494,7 +3494,7 @@ static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p, const 
 
   for (; addr < maxaddr; addr += block_size) {
     block_size = ((maxaddr-addr) < pgm->page_size) ? (maxaddr - addr) : pgm->page_size;
-    avrdude_message(MSG_DEBUG, "%s: jtagmkII_paged_load32(): "
+    msg_debug("%s: jtagmkII_paged_load32(): "
               "block_size at addr %d is %d\n",
               progname, addr, block_size);
 
@@ -3509,9 +3509,9 @@ static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p, const 
       putc('\n', stderr);
       jtagmkII_prmsg(pgm, resp, status);
     } else if (verbose == 2)
-      avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+      msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
     if (resp[0] != 0x87) {
-      avrdude_message(MSG_INFO, "%s: jtagmkII_paged_load32(): "
+      msg_info("%s: jtagmkII_paged_load32(): "
               "bad response to write memory command: %s\n",
               progname, jtagmkII_get_rc(resp[0]));
       free(resp);
@@ -3531,7 +3531,7 @@ static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p, const 
 
   eRR:
     serial_recv_timeout = otimeout;
-    avrdude_message(MSG_INFO, "%s: jtagmkII_paged_load32(): "
+    msg_info("%s: jtagmkII_paged_load32(): "
 	    "failed at line %d (status=%x val=%lx)\n",
 	    progname, lineno, status, val);
     return -1;
@@ -3559,12 +3559,12 @@ static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p, const
 
   pages = (n_bytes - addr - 1)/page_size + 1;
   sPageNum = addr/page_size;
-  //avrdude_message(MSG_INFO, "\n pageSize=%d bytes=%d pages=%d m->offset=0x%x pgm->page_size %d\n",
+  //msg_info("\n pageSize=%d bytes=%d pages=%d m->offset=0x%x pgm->page_size %d\n",
   //        page_size, n_bytes, pages, m->offset, pgm->page_size);
 
   // Before any errors can happen
   if ((cmd = malloc(pgm->page_size + 10)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: jtagmkII_paged_write32(): Out of memory\n", progname);
+    msg_info("%s: jtagmkII_paged_write32(): Out of memory\n", progname);
     return -1;
   }
 
@@ -3598,7 +3598,7 @@ static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p, const
 
     for(blocks=0; blocks<2; ++blocks) {
       block_size = ((maxaddr-addr) < pgm->page_size) ? (maxaddr - addr) : pgm->page_size;
-      avrdude_message(MSG_DEBUG, "%s: jtagmkII_paged_write32(): "
+      msg_debug("%s: jtagmkII_paged_write32(): "
                 "block_size at addr %d is %d\n",
                 progname, addr, block_size);
 
@@ -3615,9 +3615,9 @@ static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p, const
         putc('\n', stderr);
         jtagmkII_prmsg(pgm, resp, status);
       } else if (verbose == 2)
-        avrdude_message(MSG_NOTICE2, "0x%02x (%d bytes msg)\n", resp[0], status);
+        msg_notice2("0x%02x (%d bytes msg)\n", resp[0], status);
       if (resp[0] != RSP_OK) {
-        avrdude_message(MSG_INFO, "%s: jtagmkII_paged_write32(): "
+        msg_info("%s: jtagmkII_paged_write32(): "
                 "bad response to write memory command: %s\n",
                 progname, jtagmkII_get_rc(resp[0]));
         free(resp);
@@ -3644,7 +3644,7 @@ static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p, const
   eRR:
     serial_recv_timeout = otimeout;
     free(cmd);
-    avrdude_message(MSG_INFO, "%s: jtagmkII_paged_write32(): "
+    msg_info("%s: jtagmkII_paged_write32(): "
 	    "failed at line %d (status=%x val=%lx)\n",
 	    progname, lineno, status, val);
     return -1;
@@ -3671,7 +3671,7 @@ static int jtagmkII_flash_lock32(const PROGRAMMER *pgm, unsigned char lock, unsi
   return 0;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_flash_lock32(): "
+    msg_info("%s: jtagmkII_flash_lock32(): "
 	    "failed at line %d page %d cmd %8.8lx\n",
 	    progname, lineno, page, cmd);
     return -1;
@@ -3694,7 +3694,7 @@ static int jtagmkII_flash_erase32(const PROGRAMMER *pgm, unsigned int page) {
   status = jtagmkII_write_SABaddr(pgm, AVR32_FLASHC_FCMD, 0x05, cmd);
   if (status < 0) {lineno = __LINE__; goto eRR;}
 
-//avrdude_message(MSG_INFO, "ERASE %x -> %x\n", cmd, AVR32_FLASHC_FCMD);
+//msg_info("ERASE %x -> %x\n", cmd, AVR32_FLASHC_FCMD);
 
   err = 0;
   for(i=0; i<256; ++i) {
@@ -3710,7 +3710,7 @@ static int jtagmkII_flash_erase32(const PROGRAMMER *pgm, unsigned int page) {
   return 0;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_flash_erase32(): "
+    msg_info("%s: jtagmkII_flash_erase32(): "
 	    "failed at line %d page %d cmd %8.8lx val %lx\n",
 	    progname, lineno, page, cmd, val);
     return -1;
@@ -3739,7 +3739,7 @@ static int jtagmkII_flash_write_page32(const PROGRAMMER *pgm, unsigned int page)
   return 0;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_flash_write_page32(): "
+    msg_info("%s: jtagmkII_flash_write_page32(): "
 	    "failed at line %d page %d cmd %8.8lx val %lx\n",
 	    progname, lineno, page, cmd, val);
     return -1;
@@ -3767,7 +3767,7 @@ static int jtagmkII_flash_clear_pagebuffer32(const PROGRAMMER *pgm) {
   return 0;
 
   eRR:
-    avrdude_message(MSG_INFO, "%s: jtagmkII_flash_clear_pagebuffer32(): "
+    msg_info("%s: jtagmkII_flash_clear_pagebuffer32(): "
 	    "failed at line %d cmd %8.8lx val %lx\n",
 	    progname, lineno, cmd, val);
     return -1;

--- a/src/linux_ppdev.h
+++ b/src/linux_ppdev.h
@@ -33,7 +33,7 @@
 
 #define ppi_claim(fd)                                        \
   if (ioctl(fd, PPCLAIM)) {                                  \
-    avrdude_message(MSG_INFO, "%s: can't claim device \"%s\": %s\n\n", \
+    msg_info("%s: can't claim device \"%s\": %s\n\n", \
             progname, port, strerror(errno));                \
     close(fd);                                               \
     return;                                                  \
@@ -41,7 +41,7 @@
 
 #define ppi_release(fd)                                      \
   if (ioctl(fd, PPRELEASE)) {                                \
-    avrdude_message(MSG_INFO, "%s: can't release device: %s\n\n", \
+    msg_info("%s: can't release device: %s\n\n", \
             progname, strerror(errno));                      \
   }
 

--- a/src/linux_ppdev.h
+++ b/src/linux_ppdev.h
@@ -31,18 +31,18 @@
 
 #include <stdlib.h>
 
-#define ppi_claim(fd)                             \
-  if (ioctl(fd, PPCLAIM)) {                       \
-    pmsg_info("cannot claim port %s: %s\n\n",     \
-      port, strerror(errno));                     \
-    close(fd);                                    \
-    return;                                       \
+#define ppi_claim(fd)                               \
+  if (ioctl(fd, PPCLAIM)) {                         \
+    pmsg_ext_error("cannot claim port %s: %s\n\n",  \
+      port, strerror(errno));                       \
+    close(fd);                                      \
+    return;                                         \
   }
 
-#define ppi_release(fd)                           \
-  if (ioctl(fd, PPRELEASE)) {                     \
-    pmsg_info("cannot release device: %s\n\n",    \
-      strerror(errno));                           \
+#define ppi_release(fd)                             \
+  if (ioctl(fd, PPRELEASE)) {                       \
+    pmsg_ext_error("cannot release device: %s\n\n", \
+      strerror(errno));                             \
   }
 
 #define DO_PPI_READ(fd, reg, valp) \

--- a/src/linux_ppdev.h
+++ b/src/linux_ppdev.h
@@ -31,18 +31,18 @@
 
 #include <stdlib.h>
 
-#define ppi_claim(fd)                                        \
-  if (ioctl(fd, PPCLAIM)) {                                  \
-    msg_info("%s: can't claim device \"%s\": %s\n\n", \
-            progname, port, strerror(errno));                \
-    close(fd);                                               \
-    return;                                                  \
+#define ppi_claim(fd)                             \
+  if (ioctl(fd, PPCLAIM)) {                       \
+    pmsg_info("cannot claim port %s: %s\n\n",     \
+      port, strerror(errno));                     \
+    close(fd);                                    \
+    return;                                       \
   }
 
-#define ppi_release(fd)                                      \
-  if (ioctl(fd, PPRELEASE)) {                                \
-    msg_info("%s: can't release device: %s\n\n", \
-            progname, strerror(errno));                      \
+#define ppi_release(fd)                           \
+  if (ioctl(fd, PPRELEASE)) {                     \
+    pmsg_info("cannot release device: %s\n\n",    \
+      strerror(errno));                           \
   }
 
 #define DO_PPI_READ(fd, reg, valp) \

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -220,7 +220,7 @@ static int linuxgpio_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
 
 
 static void linuxgpio_display(const PROGRAMMER *pgm, const char *p) {
-    avrdude_message(MSG_INFO, "%sPin assignment  : /sys/class/gpio/gpio{n}\n",p);
+    msg_info("%sPin assignment  : /sys/class/gpio/gpio{n}\n",p);
     pgm_display_generic_mask(pgm, p, SHOW_AVR_PINS);
 }
 
@@ -267,7 +267,7 @@ static int linuxgpio_open(PROGRAMMER *pgm, const char *port) {
          i == PIN_AVR_MISO ) {
         pin = pgm->pinno[i] & PIN_MASK;
         if ((r=linuxgpio_export(pin)) < 0) {
-            avrdude_message(MSG_INFO, "Can't export GPIO %d, already exported/busy?: %s",
+            msg_info("Can't export GPIO %d, already exported/busy?: %s",
                     pin, strerror(errno));
             return r;
         }
@@ -306,7 +306,7 @@ static int linuxgpio_open(PROGRAMMER *pgm, const char *port) {
         }
 
         if (retry_count)
-            avrdude_message(MSG_NOTICE2, "%s: needed %d retr%s for linuxgpio_dir_%s(%s)\n",
+            msg_notice2("%s: needed %d retr%s for linuxgpio_dir_%s(%s)\n",
                 progname, retry_count, retry_count > 1? "ies": "y",
                 i == PIN_AVR_MISO? "in": "out", avr_pin_name(pin));
 
@@ -379,7 +379,7 @@ const char linuxgpio_desc[] = "GPIO bitbanging using the Linux sysfs interface";
 #else  /* !HAVE_LINUXGPIO */
 
 void linuxgpio_initpgm(PROGRAMMER *pgm) {
-  avrdude_message(MSG_INFO, "%s: Linux sysfs GPIO support not available in this configuration\n",
+  msg_info("%s: Linux sysfs GPIO support not available in this configuration\n",
                   progname);
 }
 

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -306,9 +306,9 @@ static int linuxgpio_open(PROGRAMMER *pgm, const char *port) {
         }
 
         if (retry_count)
-            msg_notice2("%s: needed %d retr%s for linuxgpio_dir_%s(%s)\n",
-                progname, retry_count, retry_count > 1? "ies": "y",
-                i == PIN_AVR_MISO? "in": "out", avr_pin_name(pin));
+            pmsg_notice2("needed %d retr%s for linuxgpio_dir_%s(%s)\n",
+              retry_count, retry_count > 1? "ies": "y",
+              i == PIN_AVR_MISO? "in": "out", avr_pin_name(pin));
 
         if (r < 0) {
             linuxgpio_unexport(pin);
@@ -379,8 +379,7 @@ const char linuxgpio_desc[] = "GPIO bitbanging using the Linux sysfs interface";
 #else  /* !HAVE_LINUXGPIO */
 
 void linuxgpio_initpgm(PROGRAMMER *pgm) {
-  msg_info("%s: Linux sysfs GPIO support not available in this configuration\n",
-                  progname);
+  pmsg_info("Linux sysfs GPIO support not available in this configuration\n");
 }
 
 const char linuxgpio_desc[] = "GPIO bitbanging using the Linux sysfs interface (not available)";

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -63,7 +63,7 @@ static int linuxgpio_export(unsigned int gpio)
 
   fd = open("/sys/class/gpio/export", O_WRONLY);
   if (fd < 0) {
-    perror("Can't open /sys/class/gpio/export");
+    pmsg_ext_error("cannot open /sys/class/gpio/export: %s\n", strerror(errno));
     return fd;
   }
 
@@ -81,7 +81,7 @@ static int linuxgpio_unexport(unsigned int gpio)
 
   fd = open("/sys/class/gpio/unexport", O_WRONLY);
   if (fd < 0) {
-    perror("Can't open /sys/class/gpio/unexport");
+    pmsg_ext_error("cannot open /sys/class/gpio/unexport: %s\n", strerror(errno));
     return fd;
   }
 
@@ -109,8 +109,7 @@ static int linuxgpio_dir(unsigned int gpio, unsigned int dir)
 
   fd = open(buf, O_WRONLY);
   if (fd < 0) {
-    snprintf(buf, sizeof(buf), "Can't open gpio%u/direction", gpio);
-    perror(buf);
+    pmsg_ext_error("cannot open %s: %s\n", buf, strerror(errno));
     return fd;
   }
 
@@ -267,7 +266,7 @@ static int linuxgpio_open(PROGRAMMER *pgm, const char *port) {
          i == PIN_AVR_MISO ) {
         pin = pgm->pinno[i] & PIN_MASK;
         if ((r=linuxgpio_export(pin)) < 0) {
-            msg_info("Can't export GPIO %d, already exported/busy?: %s",
+            pmsg_ext_error("cannot export GPIO %d, already exported/busy?: %s",
                     pin, strerror(errno));
             return r;
         }
@@ -379,7 +378,7 @@ const char linuxgpio_desc[] = "GPIO bitbanging using the Linux sysfs interface";
 #else  /* !HAVE_LINUXGPIO */
 
 void linuxgpio_initpgm(PROGRAMMER *pgm) {
-  pmsg_info("Linux sysfs GPIO support not available in this configuration\n");
+  pmsg_error("Linux sysfs GPIO support not available in this configuration\n");
 }
 
 const char linuxgpio_desc[] = "GPIO bitbanging using the Linux sysfs interface (not available)";

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -133,8 +133,7 @@ static int linuxspi_reset_mcu(const PROGRAMMER *pgm, bool active) {
 #endif
     if (ret == -1) {
         ret = -errno;
-        msg_info("%s: unable to set GPIO line %d value. %s\n",
-            progname, pgm->pinno[PIN_AVR_RESET] & ~PIN_INVERSE, strerror(errno));
+        pmsg_info("unable to set GPIO line %d value. %s\n", pgm->pinno[PIN_AVR_RESET] & ~PIN_INVERSE, strerror(errno));
         return ret;
     }
 
@@ -143,7 +142,7 @@ static int linuxspi_reset_mcu(const PROGRAMMER *pgm, bool active) {
 
 static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
     const char *port_error =
-      "%s: error, unknown port specification; "
+      "error, unknown port specification; "
       "please use the format /dev/spidev:/dev/gpiochip[:resetno]\n";
     char port_default[] = "/dev/spidev0.0:/dev/gpiochip0";
     char *spidev, *gpiochip, *reset_pin;
@@ -157,13 +156,13 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
 
     spidev = strtok(port, ":");
     if (!spidev) {
-        msg_info(port_error, progname);
+        pmsg_info(port_error);
         return -1;
     }
 
     gpiochip = strtok(NULL, ":");
     if (!gpiochip) {
-        msg_info(port_error, progname);
+        pmsg_info(port_error);
         return -1;
     }
 
@@ -187,10 +186,9 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
     ret = ioctl(fd_spidev, SPI_IOC_WR_MODE32, &mode);
     if (ret == -1) {
         int ioctl_errno = errno;
-        msg_info("%s: unable to set SPI mode %02X on %s. %s\n",
-            progname, mode, spidev, strerror(errno));
+        pmsg_info("unable to set SPI mode %02X on %s. %s\n", mode, spidev, strerror(errno));
         if(ioctl_errno == EINVAL && !PDATA(pgm)->disable_no_cs)
-            msg_info("%s: try -x disable_no_cs\n", progname);
+            pmsg_info("try -x disable_no_cs\n");
         goto close_spidev;
     }
     fd_gpiochip = open(gpiochip, 0);
@@ -231,8 +229,7 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
 #endif
     if (ret == -1) {
         ret = -errno;
-        msg_info("%s: unable to get GPIO line %d. %s\n",
-            progname, pgm->pinno[PIN_AVR_RESET] & ~PIN_INVERSE, strerror(errno));
+        pmsg_info("unable to get GPIO line %d. %s\n", pgm->pinno[PIN_AVR_RESET] & ~PIN_INVERSE, strerror(errno));
         goto close_gpiochip;
     }
 
@@ -241,14 +238,11 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
         goto close_out;
 
     if (pgm->baudrate != 0) {
-        msg_info(
-            "%s: obsolete use of -b <clock> option for bit clock; use -B <clock>\n",
-            progname);
+        pmsg_info("obsolete use of -b <clock> option for bit clock; use -B <clock>\n");
       pgm->bitclock = 1.0 / pgm->baudrate;
     }
     if (pgm->bitclock == 0) {
-        msg_notice(
-            "%s: defaulting bit clock to 200 kHz\n", progname);
+        pmsg_notice("defaulting bit clock to 200 kHz\n");
         pgm->bitclock = 5E-6; // 200 kHz - 5 µs
     }
 
@@ -296,7 +290,7 @@ static int linuxspi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->prog_modes & PM_TPI) {
         /* We do not support TPI. This is a dedicated SPI thing */
-        msg_info("%s: error, programmer " LINUXSPI " does not support TPI\n", progname);
+        pmsg_info("error, programmer " LINUXSPI " does not support TPI\n");
         return -1;
     }
 
@@ -310,7 +304,7 @@ static int linuxspi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     } while(tries++ < 65);
 
     if (ret)
-        msg_info("%s: error, AVR device not responding\n", progname);
+        pmsg_info("error, AVR device not responding\n");
 
     return ret;
 }
@@ -324,7 +318,7 @@ static int linuxspi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     unsigned char cmd[4], res[4];
 
     if (!p->op[AVR_OP_PGM_ENABLE]) {
-        msg_info("%s: error, program enable instruction not defined for part %s\n", progname, p->desc);
+        pmsg_info("error, program enable instruction not defined for part %s\n", p->desc);
         return -1;
     }
 
@@ -367,7 +361,7 @@ static int linuxspi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     unsigned char cmd[4], res[4];
 
     if (!p->op[AVR_OP_CHIP_ERASE]) {
-        msg_info("%s: error, chip erase instruction not defined for part %s\n", progname, p->desc);
+        pmsg_info("error, chip erase instruction not defined for part %s\n", p->desc);
         return -1;
     }
 
@@ -415,8 +409,7 @@ static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
       continue;
     }
 
-    msg_info("%s: linuxspi_parseextparams(): "
-        "invalid extended parameter '%s'\n", progname, extended_param);
+    pmsg_info("linuxspi_parseextparams(): invalid extended parameter '%s'\n", extended_param);
     rc = -1;
   }
 
@@ -453,7 +446,7 @@ const char linuxspi_desc[] = "SPI using Linux spidev driver";
 #else /* !HAVE_LINUXSPI */
 
 void linuxspi_initpgm(PROGRAMMER *pgm) {
-  msg_info("%s: Linux SPI driver not available in this configuration\n", progname);
+  pmsg_info("Linux SPI driver not available in this configuration\n");
 }
 
 const char linuxspi_desc[] = "SPI using Linux spidev driver (not available)";

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -143,7 +143,7 @@ static int linuxspi_reset_mcu(const PROGRAMMER *pgm, bool active) {
 
 static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
     const char *port_error =
-      "unknown port specification; "
+      "unknown port specification, "
       "please use the format /dev/spidev:/dev/gpiochip[:resetno]\n";
     char port_default[] = "/dev/spidev0.0:/dev/gpiochip0";
     char *spidev, *gpiochip, *reset_pin;
@@ -157,13 +157,13 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
 
     spidev = strtok(port, ":");
     if (!spidev) {
-        pmsg_error(port_error);
+        pmsg_error("%s", port_error);
         return -1;
     }
 
     gpiochip = strtok(NULL, ":");
     if (!gpiochip) {
-        pmsg_error(port_error);
+        pmsg_error("%s", port_error);
         return -1;
     }
 

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -97,7 +97,7 @@ static int linuxspi_spi_duplex(const PROGRAMMER *pgm, const unsigned char *tx, u
         msg_error("\n");
         pmsg_error("unable to send SPI message");
         if (ioctl_errno)
-            msg_error(": %s", strerror(ioctl_errno));
+            msg_error("%s", strerror(ioctl_errno));
         msg_error("\n");
     }
 
@@ -408,7 +408,7 @@ static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
       continue;
     }
 
-    pmsg_error("linuxspi_parseextparams(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
     rc = -1;
   }
 

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -94,10 +94,10 @@ static int linuxspi_spi_duplex(const PROGRAMMER *pgm, const unsigned char *tx, u
     ret = ioctl(fd_spidev, SPI_IOC_MESSAGE(1), &tr);
     if (ret != len) {
         int ioctl_errno = errno;
-        avrdude_message(MSG_INFO, "\n%s: unable to send SPI message", progname);
+        msg_info("\n%s: unable to send SPI message", progname);
         if (ioctl_errno)
-            avrdude_message(MSG_INFO, ". %s", strerror(ioctl_errno));
-        avrdude_message(MSG_INFO, "\n");
+            msg_info(". %s", strerror(ioctl_errno));
+        msg_info("\n");
     }
 
     return ret == -1? -1: 0;
@@ -133,7 +133,7 @@ static int linuxspi_reset_mcu(const PROGRAMMER *pgm, bool active) {
 #endif
     if (ret == -1) {
         ret = -errno;
-        avrdude_message(MSG_INFO, "%s: unable to set GPIO line %d value. %s\n",
+        msg_info("%s: unable to set GPIO line %d value. %s\n",
             progname, pgm->pinno[PIN_AVR_RESET] & ~PIN_INVERSE, strerror(errno));
         return ret;
     }
@@ -157,13 +157,13 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
 
     spidev = strtok(port, ":");
     if (!spidev) {
-        avrdude_message(MSG_INFO, port_error, progname);
+        msg_info(port_error, progname);
         return -1;
     }
 
     gpiochip = strtok(NULL, ":");
     if (!gpiochip) {
-        avrdude_message(MSG_INFO, port_error, progname);
+        msg_info(port_error, progname);
         return -1;
     }
 
@@ -175,7 +175,7 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
     strcpy(pgm->port, port);
     fd_spidev = open(pgm->port, O_RDWR);
     if (fd_spidev < 0) {
-        avrdude_message(MSG_INFO, "\n%s: unable to open the spidev device %s. %s",
+        msg_info("\n%s: unable to open the spidev device %s. %s",
             progname, pgm->port, strerror(errno));
         return -1;
     }
@@ -187,15 +187,15 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
     ret = ioctl(fd_spidev, SPI_IOC_WR_MODE32, &mode);
     if (ret == -1) {
         int ioctl_errno = errno;
-        avrdude_message(MSG_INFO, "%s: unable to set SPI mode %02X on %s. %s\n",
+        msg_info("%s: unable to set SPI mode %02X on %s. %s\n",
             progname, mode, spidev, strerror(errno));
         if(ioctl_errno == EINVAL && !PDATA(pgm)->disable_no_cs)
-            avrdude_message(MSG_INFO, "%s: try -x disable_no_cs\n", progname);
+            msg_info("%s: try -x disable_no_cs\n", progname);
         goto close_spidev;
     }
     fd_gpiochip = open(gpiochip, 0);
     if (fd_gpiochip < 0) {
-        avrdude_message(MSG_INFO, "\n%s: unable to open the gpiochip %s. %s\n",
+        msg_info("\n%s: unable to open the gpiochip %s. %s\n",
             progname, gpiochip, strerror(errno));
         ret = -1;
         goto close_spidev;
@@ -231,7 +231,7 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
 #endif
     if (ret == -1) {
         ret = -errno;
-        avrdude_message(MSG_INFO, "%s: unable to get GPIO line %d. %s\n",
+        msg_info("%s: unable to get GPIO line %d. %s\n",
             progname, pgm->pinno[PIN_AVR_RESET] & ~PIN_INVERSE, strerror(errno));
         goto close_gpiochip;
     }
@@ -241,13 +241,13 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
         goto close_out;
 
     if (pgm->baudrate != 0) {
-        avrdude_message(MSG_INFO,
+        msg_info(
             "%s: obsolete use of -b <clock> option for bit clock; use -B <clock>\n",
             progname);
       pgm->bitclock = 1.0 / pgm->baudrate;
     }
     if (pgm->bitclock == 0) {
-        avrdude_message(MSG_NOTICE,
+        msg_notice(
             "%s: defaulting bit clock to 200 kHz\n", progname);
         pgm->bitclock = 5E-6; // 200 kHz - 5 µs
     }
@@ -296,7 +296,7 @@ static int linuxspi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->prog_modes & PM_TPI) {
         /* We do not support TPI. This is a dedicated SPI thing */
-        avrdude_message(MSG_INFO, "%s: error, programmer " LINUXSPI " does not support TPI\n", progname);
+        msg_info("%s: error, programmer " LINUXSPI " does not support TPI\n", progname);
         return -1;
     }
 
@@ -310,7 +310,7 @@ static int linuxspi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     } while(tries++ < 65);
 
     if (ret)
-        avrdude_message(MSG_INFO, "%s: error, AVR device not responding\n", progname);
+        msg_info("%s: error, AVR device not responding\n", progname);
 
     return ret;
 }
@@ -324,7 +324,7 @@ static int linuxspi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     unsigned char cmd[4], res[4];
 
     if (!p->op[AVR_OP_PGM_ENABLE]) {
-        avrdude_message(MSG_INFO, "%s: error, program enable instruction not defined for part %s\n", progname, p->desc);
+        msg_info("%s: error, program enable instruction not defined for part %s\n", progname, p->desc);
         return -1;
     }
 
@@ -367,7 +367,7 @@ static int linuxspi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     unsigned char cmd[4], res[4];
 
     if (!p->op[AVR_OP_CHIP_ERASE]) {
-        avrdude_message(MSG_INFO, "%s: error, chip erase instruction not defined for part %s\n", progname, p->desc);
+        msg_info("%s: error, chip erase instruction not defined for part %s\n", progname, p->desc);
         return -1;
     }
 
@@ -415,7 +415,7 @@ static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
       continue;
     }
 
-    avrdude_message(MSG_INFO, "%s: linuxspi_parseextparams(): "
+    msg_info("%s: linuxspi_parseextparams(): "
         "invalid extended parameter '%s'\n", progname, extended_param);
     rc = -1;
   }
@@ -453,7 +453,7 @@ const char linuxspi_desc[] = "SPI using Linux spidev driver";
 #else /* !HAVE_LINUXSPI */
 
 void linuxspi_initpgm(PROGRAMMER *pgm) {
-  avrdude_message(MSG_INFO, "%s: Linux SPI driver not available in this configuration\n", progname);
+  msg_info("%s: Linux SPI driver not available in this configuration\n", progname);
 }
 
 const char linuxspi_desc[] = "SPI using Linux spidev driver (not available)";

--- a/src/main.c
+++ b/src/main.c
@@ -398,9 +398,10 @@ static void exit_programmer_not_found(const char *programmer) {
   msg_error("\n");
   if(programmer && *programmer)
     pmsg_error("cannot find programmer id %s\n", programmer);
-  else
+  else {
     pmsg_error("no programmer has been specified on the command line or in the\n");
     imsg_error("config file(s); specify one using the -c option and try again\n");
+  }
 
   msg_error("\nValid programmers are:\n");
   list_programmers(stderr, "  ", programmers, ~0);
@@ -1301,9 +1302,12 @@ int main(int argc, char * argv [])
       }
 
       if (!signature_matches) {
-        pmsg_error("expected signature for %s is %02X %02X %02X\n", p->desc,
-          p->signature[0], p->signature[1], p->signature[2]);
-        if (!ovsigck) {
+        if (ovsigck) {
+          pmsg_warning("expected signature for %s is %02X %02X %02X\n", p->desc,
+            p->signature[0], p->signature[1], p->signature[2]);
+        } else {
+          pmsg_error("expected signature for %s is %02X %02X %02X\n", p->desc,
+            p->signature[0], p->signature[1], p->signature[2]);
           imsg_error("double check chip or use -F to override this check\n");
           exitrc = 1;
           goto main_exit;

--- a/src/main.c
+++ b/src/main.c
@@ -102,7 +102,7 @@ int    ovsigck;     /* 1=override sig check, 0=don't */
  */
 static void usage(void)
 {
-  avrdude_message(MSG_INFO,
+  msg_info(
  "Usage: %s [options]\n"
  "Options:\n"
  "  -p <partno>                Required. Specify AVR device.\n"
@@ -349,28 +349,28 @@ static int dev_opt(char *str) {
 
 static void exit_programmer_not_found(const char *programmer) {
   if(programmer && *programmer)
-    avrdude_message(MSG_INFO, "\n%s: cannot find programmer id %s\n", progname, programmer);
+    msg_info("\n%s: cannot find programmer id %s\n", progname, programmer);
   else
-    avrdude_message(MSG_INFO, "\n%s: no programmer has been specified on the command line "
+    msg_info("\n%s: no programmer has been specified on the command line "
       "or in the\n%sconfig file; specify one using the -c option and try again\n",
         progname, progbuf);
 
-  avrdude_message(MSG_INFO, "\nValid programmers are:\n");
+  msg_info("\nValid programmers are:\n");
   list_programmers(stderr, "  ", programmers, ~0);
-  avrdude_message(MSG_INFO, "\n");
+  msg_info("\n");
 
   exit(1);
 }
 
 static void exit_part_not_found(const char *partdesc) {
   if(partdesc && *partdesc)
-    avrdude_message(MSG_INFO, "\n%s: AVR part %s not found\n", progname, partdesc);
+    msg_info("\n%s: AVR part %s not found\n", progname, partdesc);
   else
-    avrdude_message(MSG_INFO, "\n%s: no AVR part has been specified; use -p part\n", progname);
+    msg_info("\n%s: no AVR part has been specified; use -p part\n", progname);
 
-  avrdude_message(MSG_INFO, "\nValid parts are:\n");
+  msg_info("\nValid parts are:\n");
   list_parts(stderr, "  ", part_list, ~0);
-  avrdude_message(MSG_INFO, "\n");
+  msg_info("\n");
 
   exit(1);
 }
@@ -457,19 +457,19 @@ int main(int argc, char * argv [])
 
   updates = lcreat(NULL, 0);
   if (updates == NULL) {
-    avrdude_message(MSG_INFO, "%s: cannot initialize updater list\n", progname);
+    msg_info("%s: cannot initialize updater list\n", progname);
     exit(1);
   }
 
   extended_params = lcreat(NULL, 0);
   if (extended_params == NULL) {
-    avrdude_message(MSG_INFO, "%s: cannot initialize extended parameter list\n", progname);
+    msg_info("%s: cannot initialize extended parameter list\n", progname);
     exit(1);
   }
 
   additional_config_files = lcreat(NULL, 0);
   if (additional_config_files == NULL) {
-    avrdude_message(MSG_INFO, "%s: cannot initialize additional config files list\n", progname);
+    msg_info("%s: cannot initialize additional config files list\n", progname);
     exit(1);
   }
 
@@ -514,7 +514,7 @@ int main(int argc, char * argv [])
       case 'b': /* override default programmer baud rate */
         baudrate = strtol(optarg, &e, 0);
         if ((e == optarg) || (*e != 0)) {
-          avrdude_message(MSG_INFO, "%s: invalid baud rate specified '%s'\n",
+          msg_info("%s: invalid baud rate specified '%s'\n",
                   progname, optarg);
           exit(1);
         }
@@ -560,11 +560,11 @@ int main(int argc, char * argv [])
 	    break;
 	  }
 	  if (bitclock == 0.0)
-	    avrdude_message(MSG_INFO, "%s: invalid bit clock unit of measure '%s'\n",
+	    msg_info("%s: invalid bit clock unit of measure '%s'\n",
 			    progname, e);
 	}
 	if ((e == optarg) || bitclock == 0.0) {
-	  avrdude_message(MSG_INFO, "%s: invalid bit clock period specified '%s'\n",
+	  msg_info("%s: invalid bit clock period specified '%s'\n",
                   progname, optarg);
           exit(1);
         }
@@ -573,7 +573,7 @@ int main(int argc, char * argv [])
       case 'i':	/* specify isp clock delay */
 	ispdelay = strtol(optarg, &e,10);
 	if ((e == optarg) || (*e != 0) || ispdelay == 0) {
-	  avrdude_message(MSG_INFO, "%s: invalid isp clock delay specified '%s'\n",
+	  msg_info("%s: invalid isp clock delay specified '%s'\n",
                   progname, optarg);
           exit(1);
         }
@@ -643,14 +643,14 @@ int main(int argc, char * argv [])
 
       case 's':
       case 'u':
-        avrdude_message(MSG_INFO, "%s: \"safemode\" feature no longer supported\n",
+        msg_info("%s: \"safemode\" feature no longer supported\n",
                 progname);
         break;
 
       case 'U':
         upd = parse_op(optarg);
         if (upd == NULL) {
-          avrdude_message(MSG_INFO, "%s: error parsing update operation '%s'\n",
+          msg_info("%s: error parsing update operation '%s'\n",
                   progname, optarg);
           exit(1);
         }
@@ -670,12 +670,12 @@ int main(int argc, char * argv [])
         break;
 
       case 'y':
-        avrdude_message(MSG_INFO, "%s: erase cycle counter no longer supported\n",
+        msg_info("%s: erase cycle counter no longer supported\n",
                 progname);
         break;
 
       case 'Y':
-        avrdude_message(MSG_INFO, "%s: erase cycle counter no longer supported\n",
+        msg_info("%s: erase cycle counter no longer supported\n",
                 progname);
         break;
 
@@ -685,7 +685,7 @@ int main(int argc, char * argv [])
         break;
 
       default:
-        avrdude_message(MSG_INFO, "%s: invalid option -%c\n\n", progname, ch);
+        msg_info("%s: invalid option -%c\n\n", progname, ch);
         usage();
         exit(1);
         break;
@@ -737,10 +737,10 @@ int main(int argc, char * argv [])
       executable_dirpath[executable_dirpath_len] = '\0';
 
       // Debug output
-      avrdude_message(MSG_DEBUG, "executable_abspath = %s\n", executable_abspath);
-      avrdude_message(MSG_DEBUG, "executable_abspath_len = %i\n", executable_abspath_len);
-      avrdude_message(MSG_DEBUG, "executable_dirpath = %s\n", executable_dirpath);
-      avrdude_message(MSG_DEBUG, "executable_dirpath_len = %i\n", executable_dirpath_len);
+      msg_debug("executable_abspath = %s\n", executable_abspath);
+      msg_debug("executable_abspath_len = %i\n", executable_abspath_len);
+      msg_debug("executable_dirpath = %s\n", executable_dirpath);
+      msg_debug("executable_dirpath_len = %i\n", executable_dirpath_len);
     }
 
     /*
@@ -796,9 +796,9 @@ int main(int argc, char * argv [])
     }
   }
   // Debug output
-  avrdude_message(MSG_DEBUG, "sys_config = %s\n", sys_config);
-  avrdude_message(MSG_DEBUG, "sys_config_found = %s\n", sys_config_found ? "true" : "false");
-  avrdude_message(MSG_DEBUG, "\n");
+  msg_debug("sys_config = %s\n", sys_config);
+  msg_debug("sys_config_found = %s\n", sys_config_found ? "true" : "false");
+  msg_debug("\n");
 
   /*
    * USER CONFIG
@@ -826,34 +826,34 @@ int main(int argc, char * argv [])
    * Print out an identifying string so folks can tell what version
    * they are running
    */
-  avrdude_message(MSG_NOTICE, "\n%s: Version %s\n"
+  msg_notice("\n%s: Version %s\n"
                     "%sCopyright (c) Brian Dean, http://www.bdmicro.com/\n"
                     "%sCopyright (c) Joerg Wunsch\n\n",
                     progname, version, progbuf, progbuf);
-  avrdude_message(MSG_NOTICE, "%sSystem wide configuration file is \"%s\"\n",
+  msg_notice("%sSystem wide configuration file is \"%s\"\n",
             progbuf, sys_config);
 
   rc = read_config(sys_config);
   if (rc) {
-    avrdude_message(MSG_INFO, "%s: error reading system wide configuration file \"%s\"\n",
+    msg_info("%s: error reading system wide configuration file \"%s\"\n",
                     progname, sys_config);
     exit(1);
   }
 
   if (usr_config[0] != 0) {
-    avrdude_message(MSG_NOTICE, "%sUser configuration file is \"%s\"\n",
+    msg_notice("%sUser configuration file is \"%s\"\n",
               progbuf, usr_config);
 
     rc = stat(usr_config, &sb);
     if ((rc < 0) || ((sb.st_mode & S_IFREG) == 0)) {
-      avrdude_message(MSG_NOTICE, "%sUser configuration file does not exist or is not a "
+      msg_notice("%sUser configuration file does not exist or is not a "
                       "regular file, skipping\n",
                       progbuf);
     }
     else {
       rc = read_config(usr_config);
       if (rc) {
-        avrdude_message(MSG_INFO, "%s: error reading user configuration file \"%s\"\n",
+        msg_info("%s: error reading user configuration file \"%s\"\n",
                 progname, usr_config);
         exit(1);
       }
@@ -866,12 +866,12 @@ int main(int argc, char * argv [])
 
     for (ln1=lfirst(additional_config_files); ln1; ln1=lnext(ln1)) {
       p = ldata(ln1);
-      avrdude_message(MSG_NOTICE, "%sAdditional configuration file is \"%s\"\n",
+      msg_notice("%sAdditional configuration file is \"%s\"\n",
                       progbuf, p);
 
       rc = read_config(p);
       if (rc) {
-        avrdude_message(MSG_INFO, "%s: error reading additional configuration file \"%s\"\n",
+        msg_info("%s: error reading additional configuration file \"%s\"\n",
                         progname, p);
         exit(1);
       }
@@ -898,7 +898,7 @@ int main(int argc, char * argv [])
       PROGRAMMER *pgm = ldata(ln2);
       int pm = pgm->prog_modes & p->prog_modes;
       if(pm & (pm-1))
-        avrdude_message(MSG_INFO, "%s warning: %s and %s share multiple modes (%s)\n",
+        msg_info("%s warning: %s and %s share multiple modes (%s)\n",
           progname, pgm->id? ldata(lfirst(pgm->id)): "???", p->desc, via_prog_modes(pm));
     }
   }
@@ -909,13 +909,13 @@ int main(int argc, char * argv [])
         PROGRAMMER *pgm = locate_programmer(programmers, programmer);
         if(!pgm)
           exit_programmer_not_found(programmer);
-        avrdude_message(MSG_INFO, "\nValid parts for programmer %s are:\n", programmer);
+        msg_info("\nValid parts for programmer %s are:\n", programmer);
         list_parts(stderr, "  ", part_list, pgm->prog_modes);
       } else {
-        avrdude_message(MSG_INFO, "\nValid parts are:\n");
+        msg_info("\nValid parts are:\n");
         list_parts(stderr, "  ", part_list, ~0);
       }
-      avrdude_message(MSG_INFO, "\n");
+      msg_info("\n");
       exit(1);
     }
   }
@@ -926,25 +926,25 @@ int main(int argc, char * argv [])
         AVRPART *p = locate_part(part_list, partdesc);
         if(!p)
           exit_part_not_found(partdesc);
-        avrdude_message(MSG_INFO, "\nValid programmers for part %s are:\n", p->desc);
+        msg_info("\nValid programmers for part %s are:\n", p->desc);
         list_programmers(stderr, "  ", programmers, p->prog_modes);
       }  else {
-        avrdude_message(MSG_INFO, "\nValid programmers are:\n");
+        msg_info("\nValid programmers are:\n");
         list_programmers(stderr, "  ", programmers, ~0);
       }
-      avrdude_message(MSG_INFO, "\n");
+      msg_info("\n");
       exit(1);
     }
 
     if (strcmp(programmer, "?type") == 0) {
-      avrdude_message(MSG_INFO, "\nValid programmer types are:\n");
+      msg_info("\nValid programmer types are:\n");
       list_programmer_types(stderr, "  ");
-      avrdude_message(MSG_INFO, "\n");
+      msg_info("\n");
       exit(1);
     }
   }
 
-  avrdude_message(MSG_NOTICE, "\n");
+  msg_notice("\n");
 
   if (!programmer || !*programmer)
     exit_programmer_not_found(NULL);
@@ -956,7 +956,7 @@ int main(int argc, char * argv [])
   if (pgm->initpgm) {
     pgm->initpgm(pgm);
   } else {
-    avrdude_message(MSG_INFO, "\n%s: cannot initialize the programmer\n\n", progname);
+    msg_info("\n%s: cannot initialize the programmer\n\n", progname);
     exit(1);
   }
 
@@ -969,12 +969,12 @@ int main(int argc, char * argv [])
 
   if (lsize(extended_params) > 0) {
     if (pgm->parseextparams == NULL) {
-      avrdude_message(MSG_INFO, "%s: WARNING: Programmer doesn't support extended parameters,"
+      msg_info("%s: WARNING: Programmer doesn't support extended parameters,"
                       " -x option(s) ignored\n",
                       progname);
     } else {
       if (pgm->parseextparams(pgm, extended_params) < 0) {
-        avrdude_message(MSG_INFO, "%s: Error parsing extended parameter list\n",
+        msg_info("%s: Error parsing extended parameter list\n",
                         progname);
         exit(1);
       }
@@ -1014,7 +1014,7 @@ int main(int argc, char * argv [])
 
   if (exitspecs != NULL) {
     if (pgm->parseexitspecs == NULL) {
-      avrdude_message(MSG_INFO, "%s: WARNING: -E option not supported by this programmer type\n",
+      msg_info("%s: WARNING: -E option not supported by this programmer type\n",
                       progname);
       exitspecs = NULL;
     }
@@ -1025,7 +1025,7 @@ int main(int argc, char * argv [])
   }
 
   if (avr_initmem(p) != 0) {
-    avrdude_message(MSG_INFO, "\n%s: failed to initialize memories\n",
+    msg_info("\n%s: failed to initialize memories\n",
       progname);
     exit(1);
   }
@@ -1042,7 +1042,7 @@ int main(int argc, char * argv [])
     upd = ldata(ln);
     if (upd->memtype == NULL) {
       const char *mtype = p->prog_modes & PM_PDI? "application": "flash";
-      avrdude_message(MSG_NOTICE2, "%s: defaulting memtype in -U %c:%s option to \"%s\"\n",
+      msg_notice2("%s: defaulting memtype in -U %c:%s option to \"%s\"\n",
                       progname,
                       (upd->op == DEVICE_READ)? 'r': (upd->op == DEVICE_WRITE)? 'w': 'v',
                       upd->filename, mtype);
@@ -1060,42 +1060,42 @@ int main(int argc, char * argv [])
    * open the programmer
    */
   if (port[0] == 0) {
-    avrdude_message(MSG_INFO, "\n%s: no port has been specified on the command line "
+    msg_info("\n%s: no port has been specified on the command line "
             "or in the config file\n",
             progname);
-    avrdude_message(MSG_INFO, "%sSpecify a port using the -P option and try again\n\n",
+    msg_info("%sSpecify a port using the -P option and try again\n\n",
             progbuf);
     exit(1);
   }
 
   if (verbose) {
-    avrdude_message(MSG_NOTICE, "%sUsing Port                    : %s\n", progbuf, port);
-    avrdude_message(MSG_NOTICE, "%sUsing Programmer              : %s\n", progbuf, programmer);
+    msg_notice("%sUsing Port                    : %s\n", progbuf, port);
+    msg_notice("%sUsing Programmer              : %s\n", progbuf, programmer);
     if ((strcmp(pgm->type, "avr910") == 0)) {
-	  avrdude_message(MSG_NOTICE, "%savr910_devcode (avrdude.conf) : ", progbuf);
-      if(p->avr910_devcode)avrdude_message(MSG_INFO, "0x%x\n", p->avr910_devcode);
-	  else avrdude_message(MSG_NOTICE, "none\n");
+	  msg_notice("%savr910_devcode (avrdude.conf) : ", progbuf);
+      if(p->avr910_devcode)msg_info("0x%x\n", p->avr910_devcode);
+	  else msg_notice("none\n");
     }
   }
 
   if (baudrate != 0) {
-    avrdude_message(MSG_NOTICE, "%sOverriding Baud Rate          : %d\n", progbuf, baudrate);
+    msg_notice("%sOverriding Baud Rate          : %d\n", progbuf, baudrate);
     pgm->baudrate = baudrate;
   }
 
   if (bitclock != 0.0) {
-    avrdude_message(MSG_NOTICE, "%sSetting bit clk period        : %.1f\n", progbuf, bitclock);
+    msg_notice("%sSetting bit clk period        : %.1f\n", progbuf, bitclock);
     pgm->bitclock = bitclock * 1e-6;
   }
 
   if (ispdelay != 0) {
-    avrdude_message(MSG_NOTICE, "%sSetting isp clock delay        : %3i\n", progbuf, ispdelay);
+    msg_notice("%sSetting isp clock delay        : %3i\n", progbuf, ispdelay);
     pgm->ispdelay = ispdelay;
   }
 
   rc = pgm->open(pgm, port);
   if (rc < 0) {
-    avrdude_message(MSG_INFO,
+    msg_info(
                     "%s: opening programmer \"%s\" on port \"%s\" failed\n",
                     progname, programmer, port);
     exitrc = 1;
@@ -1110,15 +1110,15 @@ int main(int argc, char * argv [])
      * as outlined in appnote AVR053
      */
     if (pgm->perform_osccal == 0) {
-      avrdude_message(MSG_INFO, "%s: programmer does not support RC oscillator calibration\n",
+      msg_info("%s: programmer does not support RC oscillator calibration\n",
                       progname);
       exitrc = 1;
     } else {
-      avrdude_message(MSG_INFO, "%s: performing RC oscillator calibration\n", progname);
+      msg_info("%s: performing RC oscillator calibration\n", progname);
       exitrc = pgm->perform_osccal(pgm);
     }
     if (exitrc == 0 && quell_progress < 2) {
-      avrdude_message(MSG_INFO, "%s: calibration value is now stored in EEPROM at address 0\n",
+      msg_info("%s: calibration value is now stored in EEPROM at address 0\n",
                       progname);
     }
     goto main_exit;
@@ -1126,12 +1126,12 @@ int main(int argc, char * argv [])
 
   if (verbose) {
     avr_display(stderr, p, progbuf, verbose);
-    avrdude_message(MSG_NOTICE, "\n");
+    msg_notice("\n");
     programmer_display(pgm, progbuf);
   }
 
   if (quell_progress < 2) {
-    avrdude_message(MSG_INFO, "\n");
+    msg_info("\n");
   }
 
   exitrc = 0;
@@ -1154,9 +1154,9 @@ int main(int argc, char * argv [])
    */
   init_ok = (rc = pgm->initialize(pgm, p)) >= 0;
   if (!init_ok) {
-    avrdude_message(MSG_INFO, "%s: initialization failed, rc=%d\n", progname, rc);
+    msg_info("%s: initialization failed, rc=%d\n", progname, rc);
     if (!ovsigck) {
-      avrdude_message(MSG_INFO, "%sDouble check connections and try again, "
+      msg_info("%sDouble check connections and try again, "
               "or use -F to override\n"
               "%sthis check.\n\n",
               progbuf, progbuf);
@@ -1169,7 +1169,7 @@ int main(int argc, char * argv [])
   pgm->rdy_led(pgm, ON);
 
   if (quell_progress < 2) {
-    avrdude_message(MSG_INFO, "%s: AVR device initialized and ready to accept instructions\n",
+    msg_info("%s: AVR device initialized and ready to accept instructions\n",
                     progname);
   }
 
@@ -1194,15 +1194,15 @@ int main(int argc, char * argv [])
              // Read SIB and compare FamilyID
              char sib[AVR_SIBLEN + 1];
              pgm->read_sib(pgm, p, sib);
-             avrdude_message(MSG_NOTICE, "%s: System Information Block: \"%s\"\n",
+             msg_notice("%s: System Information Block: \"%s\"\n",
                              progname, sib);
             if (quell_progress < 2)
-              avrdude_message(MSG_INFO, "%s: Received FamilyID: \"%.*s\"\n", progname, AVR_FAMILYIDLEN, sib);
+              msg_info("%s: Received FamilyID: \"%.*s\"\n", progname, AVR_FAMILYIDLEN, sib);
 
             if (strncmp(p->family_id, sib, AVR_FAMILYIDLEN)) {
-              avrdude_message(MSG_INFO, "%s: Expected FamilyID: \"%s\"\n", progname, p->family_id);
+              msg_info("%s: Expected FamilyID: \"%s\"\n", progname, p->family_id);
               if (!ovsigck) {
-                avrdude_message(MSG_INFO, "%sDouble check chip, "
+                msg_info("%sDouble check chip, "
                         "or use -F to override this check.\n",
                         progbuf);
                 exitrc = 1;
@@ -1213,18 +1213,18 @@ int main(int argc, char * argv [])
           if(erase) {
             erase = 0;
             if (uflags & UF_NOWRITE) {
-              avrdude_message(MSG_INFO, "%s: conflicting -e and -n options specified, NOT erasing chip\n",
+              msg_info("%s: conflicting -e and -n options specified, NOT erasing chip\n",
                               progname);
             } else {
               if (quell_progress < 2)
-                avrdude_message(MSG_INFO, "%s: erasing chip\n", progname);
+                msg_info("%s: erasing chip\n", progname);
               exitrc = avr_unlock(pgm, p);
               if(exitrc) goto main_exit;
               goto sig_again;
             }
           }
         }
-        avrdude_message(MSG_INFO, "%s: error reading signature data, rc=%d\n",
+        msg_info("%s: error reading signature data, rc=%d\n",
           progname, rc);
         exitrc = 1;
         goto main_exit;
@@ -1233,7 +1233,7 @@ int main(int argc, char * argv [])
 
     sig = avr_locate_mem(p, "signature");
     if (sig == NULL) {
-      avrdude_message(MSG_INFO, "%s: WARNING: signature data not defined for device \"%s\"\n",
+      msg_info("%s: WARNING: signature data not defined for device \"%s\"\n",
                       progname, p->desc);
     }
 
@@ -1241,12 +1241,12 @@ int main(int argc, char * argv [])
       int ff, zz;
 
       if (quell_progress < 2) {
-        avrdude_message(MSG_INFO, "%s: Device signature = 0x", progname);
+        msg_info("%s: Device signature = 0x", progname);
       }
       ff = zz = 1;
       for (i=0; i<sig->size; i++) {
         if (quell_progress < 2) {
-          avrdude_message(MSG_INFO, "%02x", sig->buf[i]);
+          msg_info("%02x", sig->buf[i]);
         }
         if (sig->buf[i] != 0xff)
           ff = 0;
@@ -1265,23 +1265,23 @@ int main(int argc, char * argv [])
 
         part = locate_part_by_signature(part_list, sig->buf, sig->size);
         if (part) {
-          avrdude_message(MSG_INFO, " (probably %s)", signature_matches ? p->id : part->id);
+          msg_info(" (probably %s)", signature_matches ? p->id : part->id);
         }
       }
       if (ff || zz) {
         if (++attempt < 3) {
           waittime *= 5;
           if (quell_progress < 2) {
-              avrdude_message(MSG_INFO, " (retrying)\n");
+              msg_info(" (retrying)\n");
           }
           goto sig_again;
         }
         if (quell_progress < 2) {
-            avrdude_message(MSG_INFO, "\n");
+            msg_info("\n");
         }
-        avrdude_message(MSG_INFO, "%s: Yikes!  Invalid device signature.\n", progname);
+        msg_info("%s: Yikes!  Invalid device signature.\n", progname);
         if (!ovsigck) {
-          avrdude_message(MSG_INFO, "%sDouble check connections and try again, "
+          msg_info("%sDouble check connections and try again, "
                   "or use -F to override\n"
                   "%sthis check.\n\n",
                   progbuf, progbuf);
@@ -1290,16 +1290,16 @@ int main(int argc, char * argv [])
         }
       } else {
         if (quell_progress < 2) {
-          avrdude_message(MSG_INFO, "\n");
+          msg_info("\n");
         }
       }
 
       if (!signature_matches) {
-        avrdude_message(MSG_INFO, "%s: Expected signature for %s is %02X %02X %02X\n",
+        msg_info("%s: Expected signature for %s is %02X %02X %02X\n",
                         progname, p->desc,
                         p->signature[0], p->signature[1], p->signature[2]);
         if (!ovsigck) {
-          avrdude_message(MSG_INFO, "%sDouble check chip, "
+          msg_info("%sDouble check chip, "
                   "or use -F to override this check.\n",
                   progbuf);
           exitrc = 1;
@@ -1312,7 +1312,7 @@ int main(int argc, char * argv [])
   if (uflags & UF_AUTO_ERASE) {
     if ((p->prog_modes & PM_PDI) && pgm->page_erase && lsize(updates) > 0) {
       if (quell_progress < 2) {
-        avrdude_message(MSG_INFO, "%s: NOTE: Programmer supports page erase for Xmega devices.\n"
+        msg_info("%s: NOTE: Programmer supports page erase for Xmega devices.\n"
                         "%sEach page will be erased before programming it, but no chip erase is performed.\n"
                         "%sTo disable page erases, specify the -D option; for a chip-erase, use the -e option.\n",
                         progname, progbuf, progbuf);
@@ -1330,7 +1330,7 @@ int main(int argc, char * argv [])
         if ((strcmp(m->desc, memname) == 0) && (upd->op == DEVICE_WRITE)) {
           erase = 1;
           if (quell_progress < 2) {
-            avrdude_message(MSG_INFO, "%s: NOTE: \"%s\" memory has been specified, an erase cycle "
+            msg_info("%s: NOTE: \"%s\" memory has been specified, an erase cycle "
                             "will be performed\n"
                             "%sTo disable this feature, specify the -D option.\n",
                             progname, memname, progbuf);
@@ -1347,11 +1347,11 @@ int main(int argc, char * argv [])
      * before the chip can accept new programming
      */
     if (uflags & UF_NOWRITE) {
-      avrdude_message(MSG_INFO, "%s: conflicting -e and -n options specified, NOT erasing chip\n",
+      msg_info("%s: conflicting -e and -n options specified, NOT erasing chip\n",
                       progname);
     } else {
       if (quell_progress < 2)
-      	avrdude_message(MSG_INFO, "%s: erasing chip\n", progname);
+      	msg_info("%s: erasing chip\n", progname);
       exitrc = avr_chip_erase(pgm, p);
       if(exitrc) goto main_exit;
     }
@@ -1399,7 +1399,7 @@ main_exit:
   }
 
   if (quell_progress < 2) {
-    avrdude_message(MSG_INFO, "\n%s done.  Thank you.\n\n", progname);
+    msg_info("\n%s done.  Thank you.\n\n", progname);
   }
 
   return exitrc;

--- a/src/main.c
+++ b/src/main.c
@@ -96,7 +96,8 @@ int avrdude_message2(const char *fname, int msgmode, int msglvl, const char *for
         fflush(stderr);
     }
  
-    if (verbose >= msglvl) {
+    // Reduce effective verbosity level by number of -q above one
+    if ((quell_progress < 2? verbose: verbose+1-quell_progress) >= msglvl) {
         if(msgmode & MSG2_PROGNAME) {
           fprintf(stderr, "%s", progname);
           if(verbose >= MSG_NOTICE && (msgmode & MSG2_FUNCTION))
@@ -1159,7 +1160,7 @@ int main(int argc, char * argv [])
     goto main_exit;
   }
 
-  if (verbose) {
+  if (verbose && quell_progress < 2) {
     avr_display(stderr, p, progbuf, verbose);
     msg_notice("\n");
     programmer_display(pgm, progbuf);

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@
 
 #include "avrdude.h"
 #include "libavrdude.h"
-
+#include "config.h"
 #include "term.h"
 #include "developer_opts.h"
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -550,7 +550,7 @@ static void micronucleus_setup(PROGRAMMER* pgm)
 
     if ((pgm->cookie = malloc(sizeof(pdata_t))) == 0)
     {
-        pmsg_error("micronucleus_setup(): out of memory allocating private data\n");
+        pmsg_error("out of memory allocating private data\n");
         exit(1);
     }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -164,7 +164,7 @@ static int micronucleus_reconnect(pdata_t* pdata)
 
     for (int i = 0; i < 25; i++)
     {
-        avrdude_message(MSG_NOTICE, "%s: Trying to reconnect...\n", progname);
+        msg_notice("%s: Trying to reconnect...\n", progname);
 
         pdata->usb_handle = usb_open(device);
         if (pdata->usb_handle != NULL)
@@ -188,13 +188,13 @@ static int micronucleus_get_bootloader_info_v1(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        avrdude_message(MSG_INFO, "%s: WARNING: Failed to get bootloader info block: %s\n",
+        msg_info("%s: WARNING: Failed to get bootloader info block: %s\n",
             progname, usb_strerror());
         return result;
     }
     else if (result < sizeof(buffer))
     {
-        avrdude_message(MSG_INFO, "%s: WARNING: Received invalid bootloader info block size: %d\n",
+        msg_info("%s: WARNING: Received invalid bootloader info block size: %d\n",
             progname, result);
         return -1;
     }
@@ -257,13 +257,13 @@ static int micronucleus_get_bootloader_info_v2(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        avrdude_message(MSG_INFO, "%s: WARNING: Failed to get bootloader info block: %s\n",
+        msg_info("%s: WARNING: Failed to get bootloader info block: %s\n",
             progname, usb_strerror());
         return result;
     }
     else if (result < sizeof(buffer))
     {
-        avrdude_message(MSG_INFO, "%s: WARNING: Received invalid bootloader info block size: %d\n",
+        msg_info("%s: WARNING: Received invalid bootloader info block size: %d\n",
             progname, result);
         return -1;
     }
@@ -302,19 +302,19 @@ static int micronucleus_get_bootloader_info(pdata_t* pdata)
 
 static void micronucleus_dump_device_info(pdata_t* pdata)
 {
-    avrdude_message(MSG_NOTICE, "%s: Bootloader version: %d.%d\n", progname, pdata->major_version, pdata->minor_version);
-    avrdude_message(MSG_NOTICE, "%s: Available flash size: %u\n", progname, pdata->flash_size);
-    avrdude_message(MSG_NOTICE, "%s: Page size: %u\n", progname, pdata->page_size);
-    avrdude_message(MSG_NOTICE, "%s: Bootloader start: 0x%04X\n", progname, pdata->bootloader_start);
-    avrdude_message(MSG_NOTICE, "%s: Write sleep: %ums\n", progname, pdata->write_sleep);
-    avrdude_message(MSG_NOTICE, "%s: Erase sleep: %ums\n", progname, pdata->erase_sleep);
-    avrdude_message(MSG_NOTICE, "%s: Signature1: 0x%02X\n", progname, pdata->signature1);
-    avrdude_message(MSG_NOTICE, "%s: Signature2: 0x%02X\n", progname, pdata->signature2);
+    msg_notice("%s: Bootloader version: %d.%d\n", progname, pdata->major_version, pdata->minor_version);
+    msg_notice("%s: Available flash size: %u\n", progname, pdata->flash_size);
+    msg_notice("%s: Page size: %u\n", progname, pdata->page_size);
+    msg_notice("%s: Bootloader start: 0x%04X\n", progname, pdata->bootloader_start);
+    msg_notice("%s: Write sleep: %ums\n", progname, pdata->write_sleep);
+    msg_notice("%s: Erase sleep: %ums\n", progname, pdata->erase_sleep);
+    msg_notice("%s: Signature1: 0x%02X\n", progname, pdata->signature1);
+    msg_notice("%s: Signature2: 0x%02X\n", progname, pdata->signature2);
 }
 
 static int micronucleus_erase_device(pdata_t* pdata)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_erase_device()\n", progname);
+    msg_debug("%s: micronucleus_erase_device()\n", progname);
 
     int result = usb_control_msg(
         pdata->usb_handle,
@@ -329,10 +329,10 @@ static int micronucleus_erase_device(pdata_t* pdata)
         {
         case -EIO:
         case -EPIPE:
-            avrdude_message(MSG_NOTICE, "%s: Ignoring last error of erase command: %s\n", progname, usb_strerror());
+            msg_notice("%s: Ignoring last error of erase command: %s\n", progname, usb_strerror());
             break;
         default:
-            avrdude_message(MSG_INFO, "%s: WARNING: Failed is issue erase command, code %d: %s\n", progname, result, usb_strerror());
+            msg_info("%s: WARNING: Failed is issue erase command, code %d: %s\n", progname, result, usb_strerror());
             return result;
         }
     }
@@ -342,12 +342,12 @@ static int micronucleus_erase_device(pdata_t* pdata)
     result = micronucleus_check_connection(pdata);
     if (result < 0)
     {
-        avrdude_message(MSG_NOTICE, "%s: Connection dropped, trying to reconnect...\n", progname);
+        msg_notice("%s: Connection dropped, trying to reconnect...\n", progname);
 
         result = micronucleus_reconnect(pdata);
         if (result < 0)
         {
-            avrdude_message(MSG_INFO, "%s: WARNING: Failed to reconnect USB device: %s\n", progname, usb_strerror());
+            msg_info("%s: WARNING: Failed to reconnect USB device: %s\n", progname, usb_strerror());
             return result;
         }
     }
@@ -373,7 +373,7 @@ static int micronucleus_patch_reset_vector(pdata_t* pdata, uint8_t* buffer)
     }
     else
     {
-        avrdude_message(MSG_INFO, "%s: The reset vector of the user program does not contain a branch instruction.\n", progname);
+        msg_info("%s: The reset vector of the user program does not contain a branch instruction.\n", progname);
         return -1;
     }
 
@@ -431,7 +431,7 @@ static int micronucleus_write_page_v1(pdata_t* pdata, uint32_t address, uint8_t*
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        avrdude_message(MSG_INFO, "%s: Failed to transfer page: %s\n", progname, usb_strerror());
+        msg_info("%s: Failed to transfer page: %s\n", progname, usb_strerror());
         return result;
     }
 
@@ -449,7 +449,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        avrdude_message(MSG_INFO, "%s: Failed to transfer page: %s\n", progname, usb_strerror());
+        msg_info("%s: Failed to transfer page: %s\n", progname, usb_strerror());
         return result;
     }
 
@@ -466,7 +466,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
             MICRONUCLEUS_DEFAULT_TIMEOUT);
         if (result < 0)
         {
-            avrdude_message(MSG_INFO, "%s: Failed to transfer page: %s\n", progname, usb_strerror());
+            msg_info("%s: Failed to transfer page: %s\n", progname, usb_strerror());
             return result;
         }
     }
@@ -476,7 +476,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
 
 static int micronucleus_write_page(pdata_t* pdata, uint32_t address, uint8_t* buffer, uint32_t size)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_write_page(address=0x%04X, size=%d)\n", progname, address, size);
+    msg_debug("%s: micronucleus_write_page(address=0x%04X, size=%d)\n", progname, address, size);
 
     if (address == 0)
     {
@@ -528,7 +528,7 @@ static int micronucleus_write_page(pdata_t* pdata, uint32_t address, uint8_t* bu
 
 static int micronucleus_start(pdata_t* pdata)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_start()\n", progname);
+    msg_debug("%s: micronucleus_start()\n", progname);
 
     int result = usb_control_msg(
         pdata->usb_handle,
@@ -539,7 +539,7 @@ static int micronucleus_start(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        avrdude_message(MSG_INFO, "%s: WARNING: Failed is issue start command: %s\n", progname, usb_strerror());
+        msg_info("%s: WARNING: Failed is issue start command: %s\n", progname, usb_strerror());
         return result;
     }
 
@@ -550,11 +550,11 @@ static int micronucleus_start(pdata_t* pdata)
 
 static void micronucleus_setup(PROGRAMMER* pgm)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_setup()\n", progname);
+    msg_debug("%s: micronucleus_setup()\n", progname);
 
     if ((pgm->cookie = malloc(sizeof(pdata_t))) == 0)
     {
-        avrdude_message(MSG_INFO, "%s: micronucleus_setup(): Out of memory allocating private data\n", progname);
+        msg_info("%s: micronucleus_setup(): Out of memory allocating private data\n", progname);
         exit(1);
     }
 
@@ -563,12 +563,12 @@ static void micronucleus_setup(PROGRAMMER* pgm)
 
 static void micronucleus_teardown(PROGRAMMER* pgm)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_teardown()\n", progname);
+    msg_debug("%s: micronucleus_teardown()\n", progname);
     free(pgm->cookie);
 }
 
 static int micronucleus_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_initialize()\n", progname);
+    msg_debug("%s: micronucleus_initialize()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -582,15 +582,15 @@ static int micronucleus_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static void micronucleus_display(const PROGRAMMER *pgm, const char *prefix) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_display()\n", progname);
+    msg_debug("%s: micronucleus_display()\n", progname);
 }
 
 static void micronucleus_powerup(const PROGRAMMER *pgm) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_powerup()\n", progname);
+    msg_debug("%s: micronucleus_powerup()\n", progname);
 }
 
 static void micronucleus_powerdown(const PROGRAMMER *pgm) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_powerdown()\n", progname);
+    msg_debug("%s: micronucleus_powerdown()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
     if (pdata->write_last_page)
@@ -615,24 +615,24 @@ static void micronucleus_powerdown(const PROGRAMMER *pgm) {
 }
 
 static void micronucleus_enable(PROGRAMMER *pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_enable()\n", progname);
+    msg_debug("%s: micronucleus_enable()\n", progname);
 }
 
 static void micronucleus_disable(const PROGRAMMER *pgm) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_disable()\n", progname);
+    msg_debug("%s: micronucleus_disable()\n", progname);
 }
 
 static int micronucleus_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_program_enable()\n", progname);
+    msg_debug("%s: micronucleus_program_enable()\n", progname);
     return 0;
 }
 
 static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_read_sig_bytes()\n", progname);
+    msg_debug("%s: micronucleus_read_sig_bytes()\n", progname);
 
     if (mem->size < 3)
     {
-        avrdude_message(MSG_INFO, "%s: memory size too small for read_sig_bytes", progname);
+        msg_info("%s: memory size too small for read_sig_bytes", progname);
         return -1;
     }
 
@@ -644,14 +644,14 @@ static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, 
 }
 
 static int micronucleus_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_chip_erase()\n", progname);
+    msg_debug("%s: micronucleus_chip_erase()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
     return micronucleus_erase_device(pdata);
 }
 
 static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_open(\"%s\")\n", progname, port);
+    msg_debug("%s: micronucleus_open(\"%s\")\n", progname, port);
 
     pdata_t* pdata = PDATA(pgm);
     const char *bus_name = NULL;
@@ -679,8 +679,8 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
     if (port != NULL && dev_name == NULL)
     {
-        avrdude_message(MSG_INFO, "%s: ERROR: Invalid -P value: '%s'\n", progname, port);
-        avrdude_message(MSG_INFO, "%sUse -P usb:bus:device\n", progbuf);
+        msg_info("%s: ERROR: Invalid -P value: '%s'\n", progname, port);
+        msg_info("%sUse -P usb:bus:device\n", progbuf);
         return -1;
     }
 
@@ -694,7 +694,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
         pid = *(int*)(ldata(usbpid));
         if (lnext(usbpid))
         {
-            avrdude_message(MSG_INFO, "%s: WARNING: using PID 0x%04x, ignoring remaining PIDs in list\n",
+            msg_info("%s: WARNING: using PID 0x%04x, ignoring remaining PIDs in list\n",
                 progname, pid);
         }
     }
@@ -728,7 +728,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                     {
                         if (show_unresponsive_device_message)
                         {
-                            avrdude_message(MSG_INFO, "%s: WARNING: Unresponsive Micronucleus device detected, please reconnect...\n",
+                            msg_info("%s: WARNING: Unresponsive Micronucleus device detected, please reconnect...\n",
                                 progname);
 
                             show_unresponsive_device_message = false;
@@ -737,7 +737,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                         continue;
                     }
 
-                    avrdude_message(MSG_NOTICE, "%s: Found device with Micronucleus V%d.%d, bus:device: %s:%s\n",
+                    msg_notice("%s: Found device with Micronucleus V%d.%d, bus:device: %s:%s\n",
                         progname,
                         pdata->major_version, pdata->minor_version,
                         bus->dirname, device->filename);
@@ -753,7 +753,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
                     if (pdata->major_version > MICRONUCLEUS_MAX_MAJOR_VERSION)
                     {
-                        avrdude_message(MSG_INFO, "%s: WARNING: device with unsupported version (V%d.%d) of Micronucleus detected.\n",
+                        msg_info("%s: WARNING: device with unsupported version (V%d.%d) of Micronucleus detected.\n",
                             progname,
                             pdata->major_version, pdata->minor_version);
                         continue;
@@ -762,7 +762,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                     pdata->usb_handle = usb_open(device);
                     if (pdata->usb_handle == NULL)
                     {
-                        avrdude_message(MSG_INFO, "%s: ERROR: Failed to open USB device: %s\n", progname, usb_strerror());
+                        msg_info("%s: ERROR: Failed to open USB device: %s\n", progname, usb_strerror());
                     }
                 }
             }
@@ -774,16 +774,16 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
             {
                 if (pdata->wait_timout < 0)
                 {
-                    avrdude_message(MSG_INFO, "%s: No device found, waiting for device to be plugged in...\n", progname);
+                    msg_info("%s: No device found, waiting for device to be plugged in...\n", progname);
                 }
                 else
                 {
-                    avrdude_message(MSG_INFO, "%s: No device found, waiting %d seconds for device to be plugged in...\n",
+                    msg_info("%s: No device found, waiting %d seconds for device to be plugged in...\n",
                         progname,
                         pdata->wait_timout);
                 }
 
-                avrdude_message(MSG_INFO, "%s: Press CTRL-C to terminate.\n", progname);
+                msg_info("%s: Press CTRL-C to terminate.\n", progname);
                 show_retry_message = false;
             }
 
@@ -799,7 +799,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
     if (!pdata->usb_handle)
     {
-        avrdude_message(MSG_INFO, "%s: ERROR: Could not find device with Micronucleus bootloader (%04X:%04X)\n",
+        msg_info("%s: ERROR: Could not find device with Micronucleus bootloader (%04X:%04X)\n",
             progname, vid, pid);
         return -1;
     }
@@ -809,7 +809,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
 static void micronucleus_close(PROGRAMMER* pgm)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_close()\n", progname);
+    msg_debug("%s: micronucleus_close()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
     if (pdata->usb_handle != NULL)
@@ -822,7 +822,7 @@ static void micronucleus_close(PROGRAMMER* pgm)
 static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char* value)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_read_byte(desc=%s, addr=0x%0X)\n",
+    msg_debug("%s: micronucleus_read_byte(desc=%s, addr=0x%0X)\n",
         progname, mem->desc, addr);
 
     if (strcmp(mem->desc, "lfuse") == 0 ||
@@ -835,7 +835,7 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
     }
     else
     {
-        avrdude_message(MSG_INFO, "%s: Unsupported memory type: %s\n", progname, mem->desc);
+        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
         return -1;
     }
 }
@@ -843,7 +843,7 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
 static int micronucleus_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char value)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_write_byte(desc=%s, addr=0x%0X)\n",
+    msg_debug("%s: micronucleus_write_byte(desc=%s, addr=0x%0X)\n",
         progname, mem->desc, addr);
     return -1;
 }
@@ -852,7 +852,7 @@ static int micronucleus_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
+    msg_debug("%s: micronucleus_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
         progname, page_size, addr, n_bytes);
     return -1;
 }
@@ -861,7 +861,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
+    msg_debug("%s: micronucleus_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
         progname, page_size, addr, n_bytes);
 
     if (strcmp(mem->desc, "flash") == 0)
@@ -870,20 +870,20 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 
         if (n_bytes > page_size)
         {
-            avrdude_message(MSG_INFO, "%s: Buffer size (%u) exceeds page size (%u)\n", progname, n_bytes, page_size);
+            msg_info("%s: Buffer size (%u) exceeds page size (%u)\n", progname, n_bytes, page_size);
             return -1;
         }
 
         if (addr + n_bytes > pdata->flash_size)
         {
-            avrdude_message(MSG_INFO, "%s: Program size (%u) exceeds flash size (%u)\n", progname, addr + n_bytes, pdata->flash_size);
+            msg_info("%s: Program size (%u) exceeds flash size (%u)\n", progname, addr + n_bytes, pdata->flash_size);
             return -1;
         }
 
         uint8_t* page_buffer = (uint8_t*)malloc(pdata->page_size);
         if (page_buffer == NULL)
         {
-            avrdude_message(MSG_INFO, "%s: Failed to allocate memory\n", progname);
+            msg_info("%s: Failed to allocate memory\n", progname);
             return -1;
         }
 
@@ -911,13 +911,13 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     }
     else
     {
-        avrdude_message(MSG_INFO, "%s: Unsupported memory type: %s\n", progname, mem->desc);
+        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
         return -1;
     }
 }
 
 static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
-    avrdude_message(MSG_DEBUG, "%s: micronucleus_parseextparams()\n", progname);
+    msg_debug("%s: micronucleus_parseextparams()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
     for (LNODEID node = lfirst(xparams); node != NULL; node = lnext(node))
@@ -936,7 +936,7 @@ static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xpara
         }
         else
         {
-            avrdude_message(MSG_INFO, "%s: Invalid extended parameter '%s'\n", progname, param);
+            msg_info("%s: Invalid extended parameter '%s'\n", progname, param);
             return -1;
         }
     }
@@ -972,7 +972,7 @@ void micronucleus_initpgm(PROGRAMMER *pgm) {
 
  // Give a proper error if we were not compiled with libusb
 static int micronucleus_nousb_open(PROGRAMMER* pgm, const char* name) {
-    avrdude_message(MSG_INFO, "%s: error: No usb support. Please compile again with libusb installed.\n", progname);
+    msg_info("%s: error: No usb support. Please compile again with libusb installed.\n", progname);
     return -1;
 }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -188,12 +188,12 @@ static int micronucleus_get_bootloader_info_v1(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        pmsg_info("WARNING: Failed to get bootloader info block: %s\n", usb_strerror());
+        pmsg_warning("unable to get bootloader info block: %s\n", usb_strerror());
         return result;
     }
     else if (result < sizeof(buffer))
     {
-        pmsg_info("warning, received invalid bootloader info block size: %d\n", result);
+        pmsg_warning("received invalid bootloader info block size: %d\n", result);
         return -1;
     }
 
@@ -255,12 +255,12 @@ static int micronucleus_get_bootloader_info_v2(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        pmsg_info("warning, failed to get bootloader info block: %s\n", usb_strerror());
+        pmsg_warning("unable to get bootloader info block: %s\n", usb_strerror());
         return result;
     }
     else if (result < sizeof(buffer))
     {
-        pmsg_info("warning, received invalid bootloader info block size: %d\n", result);
+        pmsg_warning("received invalid bootloader info block size: %d\n", result);
         return -1;
     }
 
@@ -325,10 +325,10 @@ static int micronucleus_erase_device(pdata_t* pdata)
         {
         case -EIO:
         case -EPIPE:
-            pmsg_notice("Ignoring last error of erase command: %s\n", usb_strerror());
+            pmsg_notice("ignoring last error of erase command: %s\n", usb_strerror());
             break;
         default:
-            pmsg_info("warning, failed is issue erase command, code %d: %s\n", result, usb_strerror());
+            pmsg_warning("erase command failed, code %d: %s\n", result, usb_strerror());
             return result;
         }
     }
@@ -343,7 +343,7 @@ static int micronucleus_erase_device(pdata_t* pdata)
         result = micronucleus_reconnect(pdata);
         if (result < 0)
         {
-            pmsg_info("warning, failed to reconnect USB device: %s\n", usb_strerror());
+            pmsg_warning("unable to reconnect USB device: %s\n", usb_strerror());
             return result;
         }
     }
@@ -369,7 +369,7 @@ static int micronucleus_patch_reset_vector(pdata_t* pdata, uint8_t* buffer)
     }
     else
     {
-        pmsg_info("the reset vector of the user program does not contain a branch instruction\n");
+        pmsg_error("the reset vector of the user program does not contain a branch instruction\n");
         return -1;
     }
 
@@ -427,7 +427,7 @@ static int micronucleus_write_page_v1(pdata_t* pdata, uint32_t address, uint8_t*
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        pmsg_info("failed to transfer page: %s\n", usb_strerror());
+        pmsg_error("unable to transfer page: %s\n", usb_strerror());
         return result;
     }
 
@@ -445,7 +445,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        pmsg_info("failed to transfer page: %s\n", usb_strerror());
+        pmsg_error("unable to transfer page: %s\n", usb_strerror());
         return result;
     }
 
@@ -462,7 +462,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
             MICRONUCLEUS_DEFAULT_TIMEOUT);
         if (result < 0)
         {
-            pmsg_info("Failed to transfer page: %s\n", usb_strerror());
+            pmsg_error("unable to transfer page: %s\n", usb_strerror());
             return result;
         }
     }
@@ -535,7 +535,7 @@ static int micronucleus_start(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        pmsg_info("warning, failed is issue start command: %s\n", usb_strerror());
+        pmsg_warning("start command failed: %s\n", usb_strerror());
         return result;
     }
 
@@ -550,7 +550,7 @@ static void micronucleus_setup(PROGRAMMER* pgm)
 
     if ((pgm->cookie = malloc(sizeof(pdata_t))) == 0)
     {
-        pmsg_info("micronucleus_setup(): Out of memory allocating private data\n");
+        pmsg_error("micronucleus_setup(): out of memory allocating private data\n");
         exit(1);
     }
 
@@ -628,7 +628,7 @@ static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, 
 
     if (mem->size < 3)
     {
-        pmsg_info("memory size too small for read_sig_bytes");
+        pmsg_error("memory size %d < 3 too small for read_sig_bytes", mem->size);
         return -1;
     }
 
@@ -675,8 +675,8 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
     if (port != NULL && dev_name == NULL)
     {
-        pmsg_info("error, invalid -P value %s\n", port);
-        msg_info("%sUse -P usb:bus:device\n", progbuf);
+        pmsg_error("invalid -P value %s\n", port);
+        msg_error("%sUse -P usb:bus:device\n", progbuf);
         return -1;
     }
 
@@ -690,7 +690,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
         pid = *(int*)(ldata(usbpid));
         if (lnext(usbpid))
         {
-            pmsg_info("warning, using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
+            pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
         }
     }
 
@@ -723,7 +723,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                     {
                         if (show_unresponsive_device_message)
                         {
-                            pmsg_info("warning, unresponsive Micronucleus device detected, please reconnect ...\n");
+                            pmsg_warning("unresponsive Micronucleus device detected, please reconnect ...\n");
 
                             show_unresponsive_device_message = false;
                         }
@@ -746,7 +746,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
                     if (pdata->major_version > MICRONUCLEUS_MAX_MAJOR_VERSION)
                     {
-                        pmsg_info("warning, device with unsupported version (V%d.%d) of Micronucleus detected\n",
+                        pmsg_warning("device with unsupported Micronucleus version V%d.%d\n",
                             pdata->major_version, pdata->minor_version);
                         continue;
                     }
@@ -754,7 +754,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                     pdata->usb_handle = usb_open(device);
                     if (pdata->usb_handle == NULL)
                     {
-                        pmsg_info("error, failed to open USB device: %s\n", usb_strerror());
+                        pmsg_error("unable to open USB device: %s\n", usb_strerror());
                     }
                 }
             }
@@ -766,15 +766,15 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
             {
                 if (pdata->wait_timout < 0)
                 {
-                    pmsg_info("no device found, waiting for device to be plugged in ...\n");
+                    pmsg_error("no device found, waiting for device to be plugged in ...\n");
                 }
                 else
                 {
-                    pmsg_info("no device found, waiting %d seconds for device to be plugged in ...\n",
+                    pmsg_error("no device found, waiting %d seconds for device to be plugged in ...\n",
                         pdata->wait_timout);
                 }
 
-                pmsg_info("press CTRL-C to terminate\n");
+                pmsg_error("press CTRL-C to terminate\n");
                 show_retry_message = false;
             }
 
@@ -790,7 +790,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
     if (!pdata->usb_handle)
     {
-        pmsg_info("error, could not find device with Micronucleus bootloader (%04X:%04X)\n", vid, pid);
+        pmsg_error("cannot find device with Micronucleus bootloader (%04X:%04X)\n", vid, pid);
         return -1;
     }
 
@@ -824,7 +824,7 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
     }
     else
     {
-        pmsg_info("unsupported memory type %s\n", mem->desc);
+        pmsg_error("unsupported memory type %s\n", mem->desc);
         return -1;
     }
 }
@@ -856,20 +856,20 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 
         if (n_bytes > page_size)
         {
-            pmsg_info("buffer size %u exceeds page size %u\n", n_bytes, page_size);
+            pmsg_error("buffer size %u exceeds page size %u\n", n_bytes, page_size);
             return -1;
         }
 
         if (addr + n_bytes > pdata->flash_size)
         {
-            pmsg_info("program size %u exceeds flash size %u\n", addr + n_bytes, pdata->flash_size);
+            pmsg_error("program size %u exceeds flash size %u\n", addr + n_bytes, pdata->flash_size);
             return -1;
         }
 
         uint8_t* page_buffer = (uint8_t*)malloc(pdata->page_size);
         if (page_buffer == NULL)
         {
-            pmsg_info("failed to allocate memory\n");
+            pmsg_error("unable to allocate memory\n");
             return -1;
         }
 
@@ -897,7 +897,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     }
     else
     {
-        pmsg_info("unsupported memory type: %s\n", mem->desc);
+        pmsg_error("unsupported memory type: %s\n", mem->desc);
         return -1;
     }
 }
@@ -922,7 +922,7 @@ static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xpara
         }
         else
         {
-            pmsg_info("invalid extended parameter '%s'\n", param);
+            pmsg_error("invalid extended parameter '%s'\n", param);
             return -1;
         }
     }
@@ -958,7 +958,7 @@ void micronucleus_initpgm(PROGRAMMER *pgm) {
 
  // Give a proper error if we were not compiled with libusb
 static int micronucleus_nousb_open(PROGRAMMER* pgm, const char* name) {
-    pmsg_info("no usb support; please compile again with libusb installed\n");
+    pmsg_error("no usb support; please compile again with libusb installed\n");
     return -1;
 }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -164,7 +164,7 @@ static int micronucleus_reconnect(pdata_t* pdata)
 
     for (int i = 0; i < 25; i++)
     {
-        msg_notice("%s: Trying to reconnect...\n", progname);
+        pmsg_notice("trying to reconnect ...\n");
 
         pdata->usb_handle = usb_open(device);
         if (pdata->usb_handle != NULL)
@@ -188,14 +188,12 @@ static int micronucleus_get_bootloader_info_v1(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        msg_info("%s: WARNING: Failed to get bootloader info block: %s\n",
-            progname, usb_strerror());
+        pmsg_info("WARNING: Failed to get bootloader info block: %s\n", usb_strerror());
         return result;
     }
     else if (result < sizeof(buffer))
     {
-        msg_info("%s: WARNING: Received invalid bootloader info block size: %d\n",
-            progname, result);
+        pmsg_info("warning, received invalid bootloader info block size: %d\n", result);
         return -1;
     }
 
@@ -257,14 +255,12 @@ static int micronucleus_get_bootloader_info_v2(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        msg_info("%s: WARNING: Failed to get bootloader info block: %s\n",
-            progname, usb_strerror());
+        pmsg_info("warning, failed to get bootloader info block: %s\n", usb_strerror());
         return result;
     }
     else if (result < sizeof(buffer))
     {
-        msg_info("%s: WARNING: Received invalid bootloader info block size: %d\n",
-            progname, result);
+        pmsg_info("warning, received invalid bootloader info block size: %d\n", result);
         return -1;
     }
 
@@ -302,19 +298,19 @@ static int micronucleus_get_bootloader_info(pdata_t* pdata)
 
 static void micronucleus_dump_device_info(pdata_t* pdata)
 {
-    msg_notice("%s: Bootloader version: %d.%d\n", progname, pdata->major_version, pdata->minor_version);
-    msg_notice("%s: Available flash size: %u\n", progname, pdata->flash_size);
-    msg_notice("%s: Page size: %u\n", progname, pdata->page_size);
-    msg_notice("%s: Bootloader start: 0x%04X\n", progname, pdata->bootloader_start);
-    msg_notice("%s: Write sleep: %ums\n", progname, pdata->write_sleep);
-    msg_notice("%s: Erase sleep: %ums\n", progname, pdata->erase_sleep);
-    msg_notice("%s: Signature1: 0x%02X\n", progname, pdata->signature1);
-    msg_notice("%s: Signature2: 0x%02X\n", progname, pdata->signature2);
+    pmsg_notice("Bootloader version: %d.%d\n", pdata->major_version, pdata->minor_version);
+    pmsg_notice("Available flash size: %u\n", pdata->flash_size);
+    pmsg_notice("Page size: %u\n", pdata->page_size);
+    pmsg_notice("Bootloader start: 0x%04X\n", pdata->bootloader_start);
+    pmsg_notice("Write sleep: %ums\n", pdata->write_sleep);
+    pmsg_notice("Erase sleep: %ums\n", pdata->erase_sleep);
+    pmsg_notice("Signature1: 0x%02X\n", pdata->signature1);
+    pmsg_notice("Signature2: 0x%02X\n", pdata->signature2);
 }
 
 static int micronucleus_erase_device(pdata_t* pdata)
 {
-    msg_debug("%s: micronucleus_erase_device()\n", progname);
+    pmsg_debug("micronucleus_erase_device()\n");
 
     int result = usb_control_msg(
         pdata->usb_handle,
@@ -329,10 +325,10 @@ static int micronucleus_erase_device(pdata_t* pdata)
         {
         case -EIO:
         case -EPIPE:
-            msg_notice("%s: Ignoring last error of erase command: %s\n", progname, usb_strerror());
+            pmsg_notice("Ignoring last error of erase command: %s\n", usb_strerror());
             break;
         default:
-            msg_info("%s: WARNING: Failed is issue erase command, code %d: %s\n", progname, result, usb_strerror());
+            pmsg_info("warning, failed is issue erase command, code %d: %s\n", result, usb_strerror());
             return result;
         }
     }
@@ -342,12 +338,12 @@ static int micronucleus_erase_device(pdata_t* pdata)
     result = micronucleus_check_connection(pdata);
     if (result < 0)
     {
-        msg_notice("%s: Connection dropped, trying to reconnect...\n", progname);
+        pmsg_notice("connection dropped, trying to reconnect ...\n");
 
         result = micronucleus_reconnect(pdata);
         if (result < 0)
         {
-            msg_info("%s: WARNING: Failed to reconnect USB device: %s\n", progname, usb_strerror());
+            pmsg_info("warning, failed to reconnect USB device: %s\n", usb_strerror());
             return result;
         }
     }
@@ -373,7 +369,7 @@ static int micronucleus_patch_reset_vector(pdata_t* pdata, uint8_t* buffer)
     }
     else
     {
-        msg_info("%s: The reset vector of the user program does not contain a branch instruction.\n", progname);
+        pmsg_info("the reset vector of the user program does not contain a branch instruction\n");
         return -1;
     }
 
@@ -431,7 +427,7 @@ static int micronucleus_write_page_v1(pdata_t* pdata, uint32_t address, uint8_t*
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        msg_info("%s: Failed to transfer page: %s\n", progname, usb_strerror());
+        pmsg_info("failed to transfer page: %s\n", usb_strerror());
         return result;
     }
 
@@ -449,7 +445,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        msg_info("%s: Failed to transfer page: %s\n", progname, usb_strerror());
+        pmsg_info("failed to transfer page: %s\n", usb_strerror());
         return result;
     }
 
@@ -466,7 +462,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
             MICRONUCLEUS_DEFAULT_TIMEOUT);
         if (result < 0)
         {
-            msg_info("%s: Failed to transfer page: %s\n", progname, usb_strerror());
+            pmsg_info("Failed to transfer page: %s\n", usb_strerror());
             return result;
         }
     }
@@ -476,7 +472,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
 
 static int micronucleus_write_page(pdata_t* pdata, uint32_t address, uint8_t* buffer, uint32_t size)
 {
-    msg_debug("%s: micronucleus_write_page(address=0x%04X, size=%d)\n", progname, address, size);
+    pmsg_debug("micronucleus_write_page(address=0x%04X, size=%d)\n", address, size);
 
     if (address == 0)
     {
@@ -528,7 +524,7 @@ static int micronucleus_write_page(pdata_t* pdata, uint32_t address, uint8_t* bu
 
 static int micronucleus_start(pdata_t* pdata)
 {
-    msg_debug("%s: micronucleus_start()\n", progname);
+    pmsg_debug("micronucleus_start()\n");
 
     int result = usb_control_msg(
         pdata->usb_handle,
@@ -539,7 +535,7 @@ static int micronucleus_start(pdata_t* pdata)
         MICRONUCLEUS_DEFAULT_TIMEOUT);
     if (result < 0)
     {
-        msg_info("%s: WARNING: Failed is issue start command: %s\n", progname, usb_strerror());
+        pmsg_info("warning, failed is issue start command: %s\n", usb_strerror());
         return result;
     }
 
@@ -550,11 +546,11 @@ static int micronucleus_start(pdata_t* pdata)
 
 static void micronucleus_setup(PROGRAMMER* pgm)
 {
-    msg_debug("%s: micronucleus_setup()\n", progname);
+    pmsg_debug("micronucleus_setup()\n");
 
     if ((pgm->cookie = malloc(sizeof(pdata_t))) == 0)
     {
-        msg_info("%s: micronucleus_setup(): Out of memory allocating private data\n", progname);
+        pmsg_info("micronucleus_setup(): Out of memory allocating private data\n");
         exit(1);
     }
 
@@ -563,12 +559,12 @@ static void micronucleus_setup(PROGRAMMER* pgm)
 
 static void micronucleus_teardown(PROGRAMMER* pgm)
 {
-    msg_debug("%s: micronucleus_teardown()\n", progname);
+    pmsg_debug("micronucleus_teardown()\n");
     free(pgm->cookie);
 }
 
 static int micronucleus_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
-    msg_debug("%s: micronucleus_initialize()\n", progname);
+    pmsg_debug("micronucleus_initialize()\n");
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -582,15 +578,15 @@ static int micronucleus_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static void micronucleus_display(const PROGRAMMER *pgm, const char *prefix) {
-    msg_debug("%s: micronucleus_display()\n", progname);
+    pmsg_debug("micronucleus_display()\n");
 }
 
 static void micronucleus_powerup(const PROGRAMMER *pgm) {
-    msg_debug("%s: micronucleus_powerup()\n", progname);
+    pmsg_debug("micronucleus_powerup()\n");
 }
 
 static void micronucleus_powerdown(const PROGRAMMER *pgm) {
-    msg_debug("%s: micronucleus_powerdown()\n", progname);
+    pmsg_debug("micronucleus_powerdown()\n");
 
     pdata_t* pdata = PDATA(pgm);
     if (pdata->write_last_page)
@@ -615,24 +611,24 @@ static void micronucleus_powerdown(const PROGRAMMER *pgm) {
 }
 
 static void micronucleus_enable(PROGRAMMER *pgm, const AVRPART *p) {
-    msg_debug("%s: micronucleus_enable()\n", progname);
+    pmsg_debug("micronucleus_enable()\n");
 }
 
 static void micronucleus_disable(const PROGRAMMER *pgm) {
-    msg_debug("%s: micronucleus_disable()\n", progname);
+    pmsg_debug("micronucleus_disable()\n");
 }
 
 static int micronucleus_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-    msg_debug("%s: micronucleus_program_enable()\n", progname);
+    pmsg_debug("micronucleus_program_enable()\n");
     return 0;
 }
 
 static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
-    msg_debug("%s: micronucleus_read_sig_bytes()\n", progname);
+    pmsg_debug("micronucleus_read_sig_bytes()\n");
 
     if (mem->size < 3)
     {
-        msg_info("%s: memory size too small for read_sig_bytes", progname);
+        pmsg_info("memory size too small for read_sig_bytes");
         return -1;
     }
 
@@ -644,14 +640,14 @@ static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, 
 }
 
 static int micronucleus_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
-    msg_debug("%s: micronucleus_chip_erase()\n", progname);
+    pmsg_debug("micronucleus_chip_erase()\n");
 
     pdata_t* pdata = PDATA(pgm);
     return micronucleus_erase_device(pdata);
 }
 
 static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
-    msg_debug("%s: micronucleus_open(\"%s\")\n", progname, port);
+    pmsg_debug("micronucleus_open(\"%s\")\n", port);
 
     pdata_t* pdata = PDATA(pgm);
     const char *bus_name = NULL;
@@ -679,7 +675,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
     if (port != NULL && dev_name == NULL)
     {
-        msg_info("%s: ERROR: Invalid -P value: '%s'\n", progname, port);
+        pmsg_info("error, invalid -P value %s\n", port);
         msg_info("%sUse -P usb:bus:device\n", progbuf);
         return -1;
     }
@@ -694,8 +690,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
         pid = *(int*)(ldata(usbpid));
         if (lnext(usbpid))
         {
-            msg_info("%s: WARNING: using PID 0x%04x, ignoring remaining PIDs in list\n",
-                progname, pid);
+            pmsg_info("warning, using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
         }
     }
 
@@ -728,8 +723,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                     {
                         if (show_unresponsive_device_message)
                         {
-                            msg_info("%s: WARNING: Unresponsive Micronucleus device detected, please reconnect...\n",
-                                progname);
+                            pmsg_info("warning, unresponsive Micronucleus device detected, please reconnect ...\n");
 
                             show_unresponsive_device_message = false;
                         }
@@ -737,8 +731,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                         continue;
                     }
 
-                    msg_notice("%s: Found device with Micronucleus V%d.%d, bus:device: %s:%s\n",
-                        progname,
+                    pmsg_notice("found device with Micronucleus V%d.%d, bus:device: %s:%s\n",
                         pdata->major_version, pdata->minor_version,
                         bus->dirname, device->filename);
 
@@ -753,8 +746,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
                     if (pdata->major_version > MICRONUCLEUS_MAX_MAJOR_VERSION)
                     {
-                        msg_info("%s: WARNING: device with unsupported version (V%d.%d) of Micronucleus detected.\n",
-                            progname,
+                        pmsg_info("warning, device with unsupported version (V%d.%d) of Micronucleus detected\n",
                             pdata->major_version, pdata->minor_version);
                         continue;
                     }
@@ -762,7 +754,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                     pdata->usb_handle = usb_open(device);
                     if (pdata->usb_handle == NULL)
                     {
-                        msg_info("%s: ERROR: Failed to open USB device: %s\n", progname, usb_strerror());
+                        pmsg_info("error, failed to open USB device: %s\n", usb_strerror());
                     }
                 }
             }
@@ -774,16 +766,15 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
             {
                 if (pdata->wait_timout < 0)
                 {
-                    msg_info("%s: No device found, waiting for device to be plugged in...\n", progname);
+                    pmsg_info("no device found, waiting for device to be plugged in ...\n");
                 }
                 else
                 {
-                    msg_info("%s: No device found, waiting %d seconds for device to be plugged in...\n",
-                        progname,
+                    pmsg_info("no device found, waiting %d seconds for device to be plugged in ...\n",
                         pdata->wait_timout);
                 }
 
-                msg_info("%s: Press CTRL-C to terminate.\n", progname);
+                pmsg_info("press CTRL-C to terminate\n");
                 show_retry_message = false;
             }
 
@@ -799,8 +790,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
     if (!pdata->usb_handle)
     {
-        msg_info("%s: ERROR: Could not find device with Micronucleus bootloader (%04X:%04X)\n",
-            progname, vid, pid);
+        pmsg_info("error, could not find device with Micronucleus bootloader (%04X:%04X)\n", vid, pid);
         return -1;
     }
 
@@ -809,7 +799,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
 
 static void micronucleus_close(PROGRAMMER* pgm)
 {
-    msg_debug("%s: micronucleus_close()\n", progname);
+    pmsg_debug("micronucleus_close()\n");
 
     pdata_t* pdata = PDATA(pgm);
     if (pdata->usb_handle != NULL)
@@ -822,8 +812,7 @@ static void micronucleus_close(PROGRAMMER* pgm)
 static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char* value)
 {
-    msg_debug("%s: micronucleus_read_byte(desc=%s, addr=0x%0X)\n",
-        progname, mem->desc, addr);
+    pmsg_debug("micronucleus_read_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
 
     if (strcmp(mem->desc, "lfuse") == 0 ||
         strcmp(mem->desc, "hfuse") == 0 ||
@@ -835,7 +824,7 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
     }
     else
     {
-        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
+        pmsg_info("unsupported memory type %s\n", mem->desc);
         return -1;
     }
 }
@@ -843,8 +832,7 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
 static int micronucleus_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char value)
 {
-    msg_debug("%s: micronucleus_write_byte(desc=%s, addr=0x%0X)\n",
-        progname, mem->desc, addr);
+    pmsg_debug("micronucleus_write_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
     return -1;
 }
 
@@ -852,8 +840,7 @@ static int micronucleus_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    msg_debug("%s: micronucleus_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
-        progname, page_size, addr, n_bytes);
+    pmsg_debug("micronucleus_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
     return -1;
 }
 
@@ -861,8 +848,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    msg_debug("%s: micronucleus_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
-        progname, page_size, addr, n_bytes);
+    pmsg_debug("micronucleus_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
 
     if (strcmp(mem->desc, "flash") == 0)
     {
@@ -870,20 +856,20 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 
         if (n_bytes > page_size)
         {
-            msg_info("%s: Buffer size (%u) exceeds page size (%u)\n", progname, n_bytes, page_size);
+            pmsg_info("buffer size %u exceeds page size %u\n", n_bytes, page_size);
             return -1;
         }
 
         if (addr + n_bytes > pdata->flash_size)
         {
-            msg_info("%s: Program size (%u) exceeds flash size (%u)\n", progname, addr + n_bytes, pdata->flash_size);
+            pmsg_info("program size %u exceeds flash size %u\n", addr + n_bytes, pdata->flash_size);
             return -1;
         }
 
         uint8_t* page_buffer = (uint8_t*)malloc(pdata->page_size);
         if (page_buffer == NULL)
         {
-            msg_info("%s: Failed to allocate memory\n", progname);
+            pmsg_info("failed to allocate memory\n");
             return -1;
         }
 
@@ -911,13 +897,13 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     }
     else
     {
-        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
+        pmsg_info("unsupported memory type: %s\n", mem->desc);
         return -1;
     }
 }
 
 static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
-    msg_debug("%s: micronucleus_parseextparams()\n", progname);
+    pmsg_debug("micronucleus_parseextparams()\n");
 
     pdata_t* pdata = PDATA(pgm);
     for (LNODEID node = lfirst(xparams); node != NULL; node = lnext(node))
@@ -936,7 +922,7 @@ static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xpara
         }
         else
         {
-            msg_info("%s: Invalid extended parameter '%s'\n", progname, param);
+            pmsg_info("invalid extended parameter '%s'\n", param);
             return -1;
         }
     }
@@ -972,7 +958,7 @@ void micronucleus_initpgm(PROGRAMMER *pgm) {
 
  // Give a proper error if we were not compiled with libusb
 static int micronucleus_nousb_open(PROGRAMMER* pgm, const char* name) {
-    msg_info("%s: error: No usb support. Please compile again with libusb installed.\n", progname);
+    pmsg_info("no usb support; please compile again with libusb installed\n");
     return -1;
 }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -676,7 +676,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
     if (port != NULL && dev_name == NULL)
     {
         pmsg_error("invalid -P value %s\n", port);
-        msg_error("%sUse -P usb:bus:device\n", progbuf);
+        imsg_error("use -P usb:bus:device\n");
         return -1;
     }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -299,13 +299,13 @@ static int micronucleus_get_bootloader_info(pdata_t* pdata)
 static void micronucleus_dump_device_info(pdata_t* pdata)
 {
     pmsg_notice("Bootloader version: %d.%d\n", pdata->major_version, pdata->minor_version);
-    pmsg_notice("Available flash size: %u\n", pdata->flash_size);
-    pmsg_notice("Page size: %u\n", pdata->page_size);
-    pmsg_notice("Bootloader start: 0x%04X\n", pdata->bootloader_start);
-    pmsg_notice("Write sleep: %ums\n", pdata->write_sleep);
-    pmsg_notice("Erase sleep: %ums\n", pdata->erase_sleep);
-    pmsg_notice("Signature1: 0x%02X\n", pdata->signature1);
-    pmsg_notice("Signature2: 0x%02X\n", pdata->signature2);
+    imsg_notice("Available flash size: %u\n", pdata->flash_size);
+    imsg_notice("Page size: %u\n", pdata->page_size);
+    imsg_notice("Bootloader start: 0x%04X\n", pdata->bootloader_start);
+    imsg_notice("Write sleep: %ums\n", pdata->write_sleep);
+    imsg_notice("Erase sleep: %ums\n", pdata->erase_sleep);
+    imsg_notice("Signature1: 0x%02X\n", pdata->signature1);
+    imsg_notice("Signature2: 0x%02X\n", pdata->signature2);
 }
 
 static int micronucleus_erase_device(pdata_t* pdata)

--- a/src/par.c
+++ b/src/par.c
@@ -231,7 +231,7 @@ static int par_open(PROGRAMMER *pgm, const char *port) {
 
   ppi_open(port, &pgm->fd);
   if (pgm->fd.ifd < 0) {
-    avrdude_message(MSG_INFO, "%s: failed to open parallel port \"%s\"\n\n",
+    msg_info("%s: failed to open parallel port \"%s\"\n\n",
             progname, port);
     return -1;
   }
@@ -241,14 +241,14 @@ static int par_open(PROGRAMMER *pgm, const char *port) {
    */
   rc = ppi_getall(&pgm->fd, PPIDATA);
   if (rc < 0) {
-    avrdude_message(MSG_INFO, "%s: error reading status of ppi data port\n", progname);
+    msg_info("%s: error reading status of ppi data port\n", progname);
     return -1;
   }
   pgm->ppidata = rc;
 
   rc = ppi_getall(&pgm->fd, PPICTRL);
   if (rc < 0) {
-    avrdude_message(MSG_INFO, "%s: error reading status of ppi ctrl port\n", progname);
+    msg_info("%s: error reading status of ppi ctrl port\n", progname);
     return -1;
   }
   pgm->ppictrl = rc;
@@ -391,7 +391,7 @@ void par_initpgm(PROGRAMMER *pgm) {
 #else  /* !HAVE_PARPORT */
 
 void par_initpgm(PROGRAMMER *pgm) {
-  avrdude_message(MSG_INFO, "%s: parallel port access not available in this configuration\n", progname);
+  msg_info("%s: parallel port access not available in this configuration\n", progname);
 }
 
 #endif /* HAVE_PARPORT */

--- a/src/par.c
+++ b/src/par.c
@@ -231,8 +231,7 @@ static int par_open(PROGRAMMER *pgm, const char *port) {
 
   ppi_open(port, &pgm->fd);
   if (pgm->fd.ifd < 0) {
-    msg_info("%s: failed to open parallel port \"%s\"\n\n",
-            progname, port);
+    pmsg_info("failed to open parallel port %s\n\n", port);
     return -1;
   }
 
@@ -241,14 +240,14 @@ static int par_open(PROGRAMMER *pgm, const char *port) {
    */
   rc = ppi_getall(&pgm->fd, PPIDATA);
   if (rc < 0) {
-    msg_info("%s: error reading status of ppi data port\n", progname);
+    pmsg_info("error reading status of ppi data port\n");
     return -1;
   }
   pgm->ppidata = rc;
 
   rc = ppi_getall(&pgm->fd, PPICTRL);
   if (rc < 0) {
-    msg_info("%s: error reading status of ppi ctrl port\n", progname);
+    pmsg_info("error reading status of ppi ctrl port\n");
     return -1;
   }
   pgm->ppictrl = rc;
@@ -391,7 +390,7 @@ void par_initpgm(PROGRAMMER *pgm) {
 #else  /* !HAVE_PARPORT */
 
 void par_initpgm(PROGRAMMER *pgm) {
-  msg_info("%s: parallel port access not available in this configuration\n", progname);
+  pmsg_info("parallel port access not available in this configuration\n");
 }
 
 #endif /* HAVE_PARPORT */

--- a/src/par.c
+++ b/src/par.c
@@ -231,7 +231,7 @@ static int par_open(PROGRAMMER *pgm, const char *port) {
 
   ppi_open(port, &pgm->fd);
   if (pgm->fd.ifd < 0) {
-    pmsg_info("failed to open parallel port %s\n\n", port);
+    pmsg_error("unable to open parallel port %s\n\n", port);
     return -1;
   }
 
@@ -240,14 +240,14 @@ static int par_open(PROGRAMMER *pgm, const char *port) {
    */
   rc = ppi_getall(&pgm->fd, PPIDATA);
   if (rc < 0) {
-    pmsg_info("error reading status of ppi data port\n");
+    pmsg_error("unable to read status of ppi data port\n");
     return -1;
   }
   pgm->ppidata = rc;
 
   rc = ppi_getall(&pgm->fd, PPICTRL);
   if (rc < 0) {
-    pmsg_info("error reading status of ppi ctrl port\n");
+    pmsg_error("unable to read status of ppi ctrl port\n");
     return -1;
   }
   pgm->ppictrl = rc;
@@ -390,7 +390,7 @@ void par_initpgm(PROGRAMMER *pgm) {
 #else  /* !HAVE_PARPORT */
 
 void par_initpgm(PROGRAMMER *pgm) {
-  pmsg_info("parallel port access not available in this configuration\n");
+  pmsg_error("parallel port access not available in this configuration\n");
 }
 
 #endif /* HAVE_PARPORT */

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -39,7 +39,7 @@ static void pgm_default_6(const PROGRAMMER *, const char *);
 
 
 static int pgm_default_open(PROGRAMMER *pgm, const char *name) {
-  avrdude_message(MSG_INFO, "\n%s: programmer does not support open()", progname);
+  msg_info("\n%s: programmer does not support open()", progname);
   return -1;
 }
 
@@ -220,7 +220,7 @@ PROGRAMMER *pgm_dup(const PROGRAMMER *src) {
 
 
 static void pgm_default(void) {
-  avrdude_message(MSG_INFO, "%s: programmer operation not supported\n", progname);
+  msg_info("%s: programmer operation not supported\n", progname);
 }
 
 
@@ -251,8 +251,8 @@ static void pgm_default_6 (const PROGRAMMER *pgm, const char *p) {
 
 
 void programmer_display(PROGRAMMER *pgm, const char * p) {
-  avrdude_message(MSG_INFO, "%sProgrammer Type : %s\n", p, pgm->type);
-  avrdude_message(MSG_INFO, "%sDescription     : %s\n", p, pgm->desc);
+  msg_info("%sProgrammer Type : %s\n", p, pgm->type);
+  msg_info("%sDescription     : %s\n", p, pgm->desc);
 
   pgm->display(pgm, p);
 }
@@ -260,25 +260,25 @@ void programmer_display(PROGRAMMER *pgm, const char * p) {
 
 void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int show) {
   if(show & (1<<PPI_AVR_VCC)) 
-    avrdude_message(MSG_INFO, "%s  VCC     = %s\n", p, pins_to_str(&pgm->pin[PPI_AVR_VCC]));
+    msg_info("%s  VCC     = %s\n", p, pins_to_str(&pgm->pin[PPI_AVR_VCC]));
   if(show & (1<<PPI_AVR_BUFF))
-    avrdude_message(MSG_INFO, "%s  BUFF    = %s\n", p, pins_to_str(&pgm->pin[PPI_AVR_BUFF]));
+    msg_info("%s  BUFF    = %s\n", p, pins_to_str(&pgm->pin[PPI_AVR_BUFF]));
   if(show & (1<<PIN_AVR_RESET))
-    avrdude_message(MSG_INFO, "%s  RESET   = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_RESET]));
+    msg_info("%s  RESET   = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_RESET]));
   if(show & (1<<PIN_AVR_SCK))
-    avrdude_message(MSG_INFO, "%s  SCK     = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_SCK]));
+    msg_info("%s  SCK     = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_SCK]));
   if(show & (1<<PIN_AVR_MOSI))
-    avrdude_message(MSG_INFO, "%s  MOSI    = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_MOSI]));
+    msg_info("%s  MOSI    = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_MOSI]));
   if(show & (1<<PIN_AVR_MISO))
-    avrdude_message(MSG_INFO, "%s  MISO    = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_MISO]));
+    msg_info("%s  MISO    = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_MISO]));
   if(show & (1<<PIN_LED_ERR))
-    avrdude_message(MSG_INFO, "%s  ERR LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_ERR]));
+    msg_info("%s  ERR LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_ERR]));
   if(show & (1<<PIN_LED_RDY))
-    avrdude_message(MSG_INFO, "%s  RDY LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_RDY]));
+    msg_info("%s  RDY LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_RDY]));
   if(show & (1<<PIN_LED_PGM))
-    avrdude_message(MSG_INFO, "%s  PGM LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_PGM]));
+    msg_info("%s  PGM LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_PGM]));
   if(show & (1<<PIN_LED_VFY))
-    avrdude_message(MSG_INFO, "%s  VFY LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_VFY]));
+    msg_info("%s  VFY LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_VFY]));
 }
 
 void pgm_display_generic(const PROGRAMMER *pgm, const char *p) {

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -220,7 +220,7 @@ PROGRAMMER *pgm_dup(const PROGRAMMER *src) {
 
 
 static void pgm_default(void) {
-  msg_info("%s: programmer operation not supported\n", progname);
+  pmsg_info("programmer operation not supported\n");
 }
 
 

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -39,7 +39,7 @@ static void pgm_default_6(const PROGRAMMER *, const char *);
 
 
 static int pgm_default_open(PROGRAMMER *pgm, const char *name) {
-  msg_info("\n%s: programmer does not support open()", progname);
+  pmsg_error("programmer does not support open()");
   return -1;
 }
 
@@ -220,7 +220,7 @@ PROGRAMMER *pgm_dup(const PROGRAMMER *src) {
 
 
 static void pgm_default(void) {
-  pmsg_info("programmer operation not supported\n");
+  pmsg_error("programmer operation not supported\n");
 }
 
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -164,8 +164,7 @@ static void pickit2_setup(PROGRAMMER * pgm)
 {
     if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0)
     {
-        msg_info("%s: pickit2_setup(): Out of memory allocating private data\n",
-                        progname);
+        pmsg_info("pickit2_setup(): Out of memory allocating private data\n");
         exit(1);
     }
     memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -186,8 +185,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     if (PDATA(pgm)->usb_handle == INVALID_HANDLE_VALUE)
     {
         /* no PICkit2 found */
-        msg_info("%s: error: could not find PICkit2 with vid=0x%x pid=0x%x\n",
-                        progname, PICKIT2_VID, PICKIT2_PID);
+        pmsg_info("error: could not find PICkit2 with vid=0x%x pid=0x%x\n", PICKIT2_VID, PICKIT2_PID);
         return -1;
     }
     else
@@ -209,8 +207,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     if (usb_open_device(&(PDATA(pgm)->usb_handle), PICKIT2_VID, PICKIT2_PID) < 0)
     {
         /* no PICkit2 found */
-        msg_info("%s: error: could not find PICkit2 with vid=0x%x pid=0x%x\n",
-                        progname, PICKIT2_VID, PICKIT2_PID);
+        pmsg_info("error: could not find PICkit2 with vid=0x%x pid=0x%x\n", PICKIT2_VID, PICKIT2_PID);
         return -1;
     }
 #endif
@@ -258,7 +255,7 @@ static int pickit2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         //memset(report, 0, sizeof(report));
         if ((errorCode = pickit2_read_report(pgm, report)) >= 4)
         {
-            msg_notice("%s: %s firmware version %d.%d.%d\n", progname, pgm->desc, (int)report[1], (int)report[2], (int)report[3]);
+            pmsg_notice("%s firmware version %d.%d.%d\n", pgm->desc, (int)report[1], (int)report[2], (int)report[3]);
 
             // set the pins, apply reset,
             // TO DO: apply vtarget (if requested though -x option)
@@ -341,7 +338,7 @@ static void pickit2_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static void pickit2_display(const PROGRAMMER *pgm, const char *p) {
-    DEBUG( "%s: Found \"%s\" version %d.%d.%d\n", progname, p, 1, 1, 1);
+    DEBUG("%s: found %s version %d.%d.%d\n", progname, p, 1, 1, 1);
     return;
 }
 
@@ -408,8 +405,7 @@ static int  pickit2_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->op[AVR_OP_PGM_ENABLE] == NULL)
     {
-        msg_info("program enable instruction not defined for part \"%s\"\n",
-                p->desc);
+        msg_info("program enable instruction not defined for part %s\n", p->desc);
         return -1;
     }
 
@@ -441,8 +437,7 @@ static int  pickit2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->op[AVR_OP_CHIP_ERASE] == NULL)
     {
-        msg_info("chip erase instruction not defined for part \"%s\"\n",
-                p->desc);
+        msg_info("chip erase instruction not defined for part %s\n", p->desc);
         return -1;
     }
 
@@ -561,8 +556,7 @@ static int pickit2_commit_page(const PROGRAMMER *pgm, const AVRPART *p, const AV
     wp = mem->op[AVR_OP_WRITEPAGE];
     if (wp == NULL)
     {
-        msg_info("pickit2_commit_page(): memory \"%s\" not configured for page writes\n",
-                        mem->desc);
+        msg_info("pickit2_commit_page(): memory %s not configured for page writes\n", mem->desc);
         return -1;
     }
 
@@ -1129,19 +1123,20 @@ static int usb_open_device(struct usb_dev_handle **device, int vendor, int produ
                 if (handle == NULL)
                 {
                     errorCode = USB_ERROR_ACCESS;
-                    msg_info("%s: Warning: cannot open USB device: %s\n", progname, usb_strerror());
+                    pmsg_info("Warning: cannot open USB device: %s\n", usb_strerror());
                     continue;
                 }
 
                 // return with opened device handle
                 else
                 {
-                    msg_notice("Device %p seemed to open OK.\n", handle);
+                    msg_notice("device %p seemed to open OK\n", handle);
 
                     if ((errorCode = usb_set_configuration(handle, 1)) < 0)
                     {
-                        msg_info("Could not set configuration. Error code %d, %s.\n"
-                                "You may need to run avrdude as root or set up correct usb port permissions.", errorCode, usb_strerror());
+                        msg_info("could not set configuration; error code %d, %s\n"
+                          "you may need to run avrdude as root or set up correct usb port permissions",
+                          errorCode, usb_strerror());
                     }
 
                     if ((errorCode = usb_claim_interface(handle, 0)) < 0)
@@ -1186,8 +1181,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int clock_rate;
             if (sscanf(extended_param, "clockrate=%i", &clock_rate) != 1 || clock_rate <= 0)
             {
-                msg_info("%s: pickit2_parseextparms(): invalid clockrate '%s'\n",
-                                progname, extended_param);
+                pmsg_info("pickit2_parseextparms(): invalid clockrate '%s'\n", extended_param);
                 rv = -1;
                 continue;
             }
@@ -1195,8 +1189,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int clock_period = MIN(1000000 / clock_rate, 255);    // max period is 255
             clock_rate = (int)(1000000 / (clock_period + 5e-7));    // assume highest speed is 2MHz - should probably check this
 
-            msg_notice2("%s: pickit2_parseextparms(): clockrate set to 0x%02x\n",
-                                progname, clock_rate);
+            pmsg_notice2("pickit2_parseextparms(): clockrate set to 0x%02x\n", clock_rate);
             PDATA(pgm)->clock_period = clock_period;
 
             continue;
@@ -1207,21 +1200,18 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int timeout;
             if (sscanf(extended_param, "timeout=%i", &timeout) != 1 || timeout <= 0)
             {
-                msg_info("%s: pickit2_parseextparms(): invalid timeout '%s'\n",
-                                progname, extended_param);
+                pmsg_info("pickit2_parseextparms(): invalid timeout '%s'\n", extended_param);
                 rv = -1;
                 continue;
             }
 
-            msg_notice2("%s: pickit2_parseextparms(): usb timeout set to 0x%02x\n",
-                                progname, timeout);
+            pmsg_notice2("pickit2_parseextparms(): usb timeout set to 0x%02x\n", timeout);
             PDATA(pgm)->transaction_timeout = timeout;
 
             continue;
         }
 
-        msg_info("%s: pickit2_parseextparms(): invalid extended parameter '%s'\n",
-                        progname, extended_param);
+        pmsg_info("pickit2_parseextparms(): invalid extended parameter '%s'\n", extended_param);
         rv = -1;
     }
 
@@ -1279,19 +1269,19 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
 
     pgm->setup          = pickit2_setup;
     pgm->teardown       = pickit2_teardown;
-    // pgm->page_size      = 256;        // not sure what this does... maybe the max page size that the page read/write function can handle
+    // pgm->page_size      = 256;        // not sure what this does ... maybe the max page size that the page read/write function can handle
 
     strncpy(pgm->type, "pickit2", sizeof(pgm->type));
 }
 #else
 static int pickit2_nousb_open(PROGRAMMER *pgm, const char *name) {
-    msg_info(
+    pmsg_info(
 #ifdef WIN32
-            "%s: error: no usb or hid support. Please compile again with libusb or HID support from Win32 DDK installed.\n",
+            "no usb or hid support; please compile again with libusb or HID support from Win32 DDK installed\n",
 #else
-            "%s: error: no usb support. Please compile again with libusb installed.\n",
+            "no usb support; please compile again with libusb installed\n",
 #endif
-            progname);
+     );
 
     return -1;
 }

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -164,7 +164,7 @@ static void pickit2_setup(PROGRAMMER * pgm)
 {
     if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0)
     {
-        pmsg_error("pickit2_setup(): out of memory allocating private data\n");
+        pmsg_error("out of memory allocating private data\n");
         exit(1);
     }
     memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -556,7 +556,7 @@ static int pickit2_commit_page(const PROGRAMMER *pgm, const AVRPART *p, const AV
     wp = mem->op[AVR_OP_WRITEPAGE];
     if (wp == NULL)
     {
-        pmsg_error("pickit2_commit_page(): memory %s not configured for page writes\n", mem->desc);
+        pmsg_error("memory %s not configured for page writes\n", mem->desc);
         return -1;
     }
 
@@ -1182,7 +1182,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int clock_rate;
             if (sscanf(extended_param, "clockrate=%i", &clock_rate) != 1 || clock_rate <= 0)
             {
-                pmsg_error("pickit2_parseextparms(): invalid clockrate '%s'\n", extended_param);
+                pmsg_error("invalid clockrate '%s'\n", extended_param);
                 rv = -1;
                 continue;
             }
@@ -1201,7 +1201,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int timeout;
             if (sscanf(extended_param, "timeout=%i", &timeout) != 1 || timeout <= 0)
             {
-                pmsg_error("pickit2_parseextparms(): invalid timeout '%s'\n", extended_param);
+                pmsg_error("invalid timeout '%s'\n", extended_param);
                 rv = -1;
                 continue;
             }
@@ -1212,7 +1212,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             continue;
         }
 
-        pmsg_error("pickit2_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+        pmsg_error("invalid extended parameter '%s'\n", extended_param);
         rv = -1;
     }
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1278,9 +1278,9 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
 static int pickit2_nousb_open(PROGRAMMER *pgm, const char *name) {
     pmsg_error(
 #ifdef WIN32
-            "no usb or hid support; please compile again with libusb or HID support from Win32 DDK installed\n",
+            "no usb or hid support; please compile again with libusb or HID support from Win32 DDK installed\n"
 #else
-            "no usb support; please compile again with libusb installed\n",
+            "no usb support; please compile again with libusb installed\n"
 #endif
      );
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -72,13 +72,13 @@
 #endif
 
 #if 0
-#define DEBUG(...) do { avrdude_message(MSG_DEBUG, __VA_ARGS__); } while(0) 
+#define DEBUG(...) do { msg_debug(__VA_ARGS__); } while(0)
 #else
 #define DEBUG(...) ((void)0)
 #endif
 
 #if 0
-#define DEBUGRECV(...) do { avrdude_message(MSG_DEBUG, __VA_ARGS__); } while(0) 
+#define DEBUGRECV(...) do { msg_debug(__VA_ARGS__); } while(0)
 #else
 #define DEBUGRECV(...) ((void)0)
 #endif
@@ -164,7 +164,7 @@ static void pickit2_setup(PROGRAMMER * pgm)
 {
     if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0)
     {
-        avrdude_message(MSG_INFO, "%s: pickit2_setup(): Out of memory allocating private data\n",
+        msg_info("%s: pickit2_setup(): Out of memory allocating private data\n",
                         progname);
         exit(1);
     }
@@ -186,7 +186,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     if (PDATA(pgm)->usb_handle == INVALID_HANDLE_VALUE)
     {
         /* no PICkit2 found */
-        avrdude_message(MSG_INFO, "%s: error: could not find PICkit2 with vid=0x%x pid=0x%x\n",
+        msg_info("%s: error: could not find PICkit2 with vid=0x%x pid=0x%x\n",
                         progname, PICKIT2_VID, PICKIT2_PID);
         return -1;
     }
@@ -209,7 +209,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     if (usb_open_device(&(PDATA(pgm)->usb_handle), PICKIT2_VID, PICKIT2_PID) < 0)
     {
         /* no PICkit2 found */
-        avrdude_message(MSG_INFO, "%s: error: could not find PICkit2 with vid=0x%x pid=0x%x\n",
+        msg_info("%s: error: could not find PICkit2 with vid=0x%x pid=0x%x\n",
                         progname, PICKIT2_VID, PICKIT2_PID);
         return -1;
     }
@@ -258,7 +258,7 @@ static int pickit2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         //memset(report, 0, sizeof(report));
         if ((errorCode = pickit2_read_report(pgm, report)) >= 4)
         {
-            avrdude_message(MSG_NOTICE, "%s: %s firmware version %d.%d.%d\n", progname, pgm->desc, (int)report[1], (int)report[2], (int)report[3]);
+            msg_notice("%s: %s firmware version %d.%d.%d\n", progname, pgm->desc, (int)report[1], (int)report[2], (int)report[3]);
 
             // set the pins, apply reset,
             // TO DO: apply vtarget (if requested though -x option)
@@ -293,19 +293,19 @@ static int pickit2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
             if (pickit2_write_report(pgm, report) < 0)
             {
-                avrdude_message(MSG_INFO, "pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
+                msg_info("pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
                 return -1;
             }
         }
         else
         {
-            avrdude_message(MSG_INFO, "pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
+            msg_info("pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
             return -1;
         }
     }
     else
     {
-        avrdude_message(MSG_INFO, "pickit2_write_report failed (ec %d). %s\n", errorCode, usb_strerror());
+        msg_info("pickit2_write_report failed (ec %d). %s\n", errorCode, usb_strerror());
         return -1;
     }
 
@@ -408,7 +408,7 @@ static int  pickit2_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->op[AVR_OP_PGM_ENABLE] == NULL)
     {
-        avrdude_message(MSG_INFO, "program enable instruction not defined for part \"%s\"\n",
+        msg_info("program enable instruction not defined for part \"%s\"\n",
                 p->desc);
         return -1;
     }
@@ -419,13 +419,13 @@ static int  pickit2_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 
     {
         int i;
-        avrdude_message(MSG_DEBUG, "program_enable(): sending command. Resp = ");
+        msg_debug("program_enable(): sending command. Resp = ");
 
         for (i = 0; i < 4; i++)
         {
-            avrdude_message(MSG_DEBUG, "%x ", (int)res[i]);
+            msg_debug("%x ", (int)res[i]);
         }
-        avrdude_message(MSG_DEBUG, "\n");
+        msg_debug("\n");
     }
 
     // check for sync character
@@ -441,7 +441,7 @@ static int  pickit2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->op[AVR_OP_CHIP_ERASE] == NULL)
     {
-        avrdude_message(MSG_INFO, "chip erase instruction not defined for part \"%s\"\n",
+        msg_info("chip erase instruction not defined for part \"%s\"\n",
                 p->desc);
         return -1;
     }
@@ -515,7 +515,7 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
             }
             else
             {
-                avrdude_message(MSG_INFO, "no read command specified\n");
+                msg_info("no read command specified\n");
                 return -1;
             }
 
@@ -527,7 +527,7 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
         if (bytes_read < 0)
         {
-            avrdude_message(MSG_INFO, "Failed @ pgm->spi()\n");
+            msg_info("Failed @ pgm->spi()\n");
             pgm->err_led(pgm, ON);
             return -1;
         }
@@ -561,7 +561,7 @@ static int pickit2_commit_page(const PROGRAMMER *pgm, const AVRPART *p, const AV
     wp = mem->op[AVR_OP_WRITEPAGE];
     if (wp == NULL)
     {
-        avrdude_message(MSG_INFO, "pickit2_commit_page(): memory \"%s\" not configured for page writes\n",
+        msg_info("pickit2_commit_page(): memory \"%s\" not configured for page writes\n",
                         mem->desc);
         return -1;
     }
@@ -609,7 +609,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     // only paged write for flash implemented
     if (strcmp(mem->desc, "flash") != 0 && strcmp(mem->desc, "eeprom") != 0)
     {
-        avrdude_message(MSG_INFO, "Part does not support %d paged write of %s\n", page_size, mem->desc);
+        msg_info("Part does not support %d paged write of %s\n", page_size, mem->desc);
         return -1;
     }
 
@@ -666,7 +666,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
                 writeop = mem->op[AVR_OP_WRITE_LO];
                 caddr = addr;       // maybe this should divide by 2 & use the write_high opcode also
 
-                avrdude_message(MSG_INFO, "Error AVR_OP_WRITE_LO defined only (where's the HIGH command?)\n");
+                msg_info("Error AVR_OP_WRITE_LO defined only (where's the HIGH command?)\n");
                 return -1;
             }
             else
@@ -691,7 +691,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
         if (bytes_read < 0)
         {
-            avrdude_message(MSG_INFO, "Failed @ pgm->spi()\n");
+            msg_info("Failed @ pgm->spi()\n");
             pgm->err_led(pgm, ON);
             return -1;
         }
@@ -1129,24 +1129,24 @@ static int usb_open_device(struct usb_dev_handle **device, int vendor, int produ
                 if (handle == NULL)
                 {
                     errorCode = USB_ERROR_ACCESS;
-                    avrdude_message(MSG_INFO, "%s: Warning: cannot open USB device: %s\n", progname, usb_strerror());
+                    msg_info("%s: Warning: cannot open USB device: %s\n", progname, usb_strerror());
                     continue;
                 }
 
                 // return with opened device handle
                 else
                 {
-                    avrdude_message(MSG_NOTICE, "Device %p seemed to open OK.\n", handle);
+                    msg_notice("Device %p seemed to open OK.\n", handle);
 
                     if ((errorCode = usb_set_configuration(handle, 1)) < 0)
                     {
-                        avrdude_message(MSG_INFO, "Could not set configuration. Error code %d, %s.\n"
+                        msg_info("Could not set configuration. Error code %d, %s.\n"
                                 "You may need to run avrdude as root or set up correct usb port permissions.", errorCode, usb_strerror());
                     }
 
                     if ((errorCode = usb_claim_interface(handle, 0)) < 0)
                     {
-                        avrdude_message(MSG_INFO, "Could not claim interface. Error code %d, %s\n"
+                        msg_info("Could not claim interface. Error code %d, %s\n"
                                 "You may need to run avrdude as root or set up correct usb port permissions.", errorCode, usb_strerror());
                     }
 
@@ -1186,7 +1186,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int clock_rate;
             if (sscanf(extended_param, "clockrate=%i", &clock_rate) != 1 || clock_rate <= 0)
             {
-                avrdude_message(MSG_INFO, "%s: pickit2_parseextparms(): invalid clockrate '%s'\n",
+                msg_info("%s: pickit2_parseextparms(): invalid clockrate '%s'\n",
                                 progname, extended_param);
                 rv = -1;
                 continue;
@@ -1195,7 +1195,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int clock_period = MIN(1000000 / clock_rate, 255);    // max period is 255
             clock_rate = (int)(1000000 / (clock_period + 5e-7));    // assume highest speed is 2MHz - should probably check this
 
-            avrdude_message(MSG_NOTICE2, "%s: pickit2_parseextparms(): clockrate set to 0x%02x\n",
+            msg_notice2("%s: pickit2_parseextparms(): clockrate set to 0x%02x\n",
                                 progname, clock_rate);
             PDATA(pgm)->clock_period = clock_period;
 
@@ -1207,20 +1207,20 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int timeout;
             if (sscanf(extended_param, "timeout=%i", &timeout) != 1 || timeout <= 0)
             {
-                avrdude_message(MSG_INFO, "%s: pickit2_parseextparms(): invalid timeout '%s'\n",
+                msg_info("%s: pickit2_parseextparms(): invalid timeout '%s'\n",
                                 progname, extended_param);
                 rv = -1;
                 continue;
             }
 
-            avrdude_message(MSG_NOTICE2, "%s: pickit2_parseextparms(): usb timeout set to 0x%02x\n",
+            msg_notice2("%s: pickit2_parseextparms(): usb timeout set to 0x%02x\n",
                                 progname, timeout);
             PDATA(pgm)->transaction_timeout = timeout;
 
             continue;
         }
 
-        avrdude_message(MSG_INFO, "%s: pickit2_parseextparms(): invalid extended parameter '%s'\n",
+        msg_info("%s: pickit2_parseextparms(): invalid extended parameter '%s'\n",
                         progname, extended_param);
         rv = -1;
     }
@@ -1285,7 +1285,7 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
 }
 #else
 static int pickit2_nousb_open(PROGRAMMER *pgm, const char *name) {
-    avrdude_message(MSG_INFO, 
+    msg_info(
 #ifdef WIN32
             "%s: error: no usb or hid support. Please compile again with libusb or HID support from Win32 DDK installed.\n",
 #else

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -164,7 +164,7 @@ static void pickit2_setup(PROGRAMMER * pgm)
 {
     if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0)
     {
-        pmsg_info("pickit2_setup(): Out of memory allocating private data\n");
+        pmsg_error("pickit2_setup(): out of memory allocating private data\n");
         exit(1);
     }
     memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -185,7 +185,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     if (PDATA(pgm)->usb_handle == INVALID_HANDLE_VALUE)
     {
         /* no PICkit2 found */
-        pmsg_info("error: could not find PICkit2 with vid=0x%x pid=0x%x\n", PICKIT2_VID, PICKIT2_PID);
+        pmsg_error("cannot find PICkit2 with vid=0x%x pid=0x%x\n", PICKIT2_VID, PICKIT2_PID);
         return -1;
     }
     else
@@ -207,7 +207,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     if (usb_open_device(&(PDATA(pgm)->usb_handle), PICKIT2_VID, PICKIT2_PID) < 0)
     {
         /* no PICkit2 found */
-        pmsg_info("error: could not find PICkit2 with vid=0x%x pid=0x%x\n", PICKIT2_VID, PICKIT2_PID);
+        pmsg_error("cannot find PICkit2 with vid=0x%x pid=0x%x\n", PICKIT2_VID, PICKIT2_PID);
         return -1;
     }
 #endif
@@ -290,19 +290,19 @@ static int pickit2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
             if (pickit2_write_report(pgm, report) < 0)
             {
-                msg_info("pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
+                pmsg_error("pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
                 return -1;
             }
         }
         else
         {
-            msg_info("pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
+            pmsg_error("pickit2_read_report failed (ec %d). %s\n", errorCode, usb_strerror());
             return -1;
         }
     }
     else
     {
-        msg_info("pickit2_write_report failed (ec %d). %s\n", errorCode, usb_strerror());
+        pmsg_error("pickit2_write_report failed (ec %d). %s\n", errorCode, usb_strerror());
         return -1;
     }
 
@@ -405,7 +405,7 @@ static int  pickit2_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->op[AVR_OP_PGM_ENABLE] == NULL)
     {
-        msg_info("program enable instruction not defined for part %s\n", p->desc);
+        pmsg_error("program enable instruction not defined for part %s\n", p->desc);
         return -1;
     }
 
@@ -437,7 +437,7 @@ static int  pickit2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->op[AVR_OP_CHIP_ERASE] == NULL)
     {
-        msg_info("chip erase instruction not defined for part %s\n", p->desc);
+        pmsg_error("chip erase instruction not defined for part %s\n", p->desc);
         return -1;
     }
 
@@ -510,7 +510,7 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
             }
             else
             {
-                msg_info("no read command specified\n");
+                pmsg_error("no read command specified\n");
                 return -1;
             }
 
@@ -522,7 +522,7 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
         if (bytes_read < 0)
         {
-            msg_info("Failed @ pgm->spi()\n");
+            pmsg_error("failed @ pgm->spi()\n");
             pgm->err_led(pgm, ON);
             return -1;
         }
@@ -556,7 +556,7 @@ static int pickit2_commit_page(const PROGRAMMER *pgm, const AVRPART *p, const AV
     wp = mem->op[AVR_OP_WRITEPAGE];
     if (wp == NULL)
     {
-        msg_info("pickit2_commit_page(): memory %s not configured for page writes\n", mem->desc);
+        pmsg_error("pickit2_commit_page(): memory %s not configured for page writes\n", mem->desc);
         return -1;
     }
 
@@ -603,7 +603,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     // only paged write for flash implemented
     if (strcmp(mem->desc, "flash") != 0 && strcmp(mem->desc, "eeprom") != 0)
     {
-        msg_info("Part does not support %d paged write of %s\n", page_size, mem->desc);
+        pmsg_error("part does not support %d paged write of %s\n", page_size, mem->desc);
         return -1;
     }
 
@@ -660,7 +660,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
                 writeop = mem->op[AVR_OP_WRITE_LO];
                 caddr = addr;       // maybe this should divide by 2 & use the write_high opcode also
 
-                msg_info("Error AVR_OP_WRITE_LO defined only (where's the HIGH command?)\n");
+                pmsg_error("%s AVR_OP_WRITE_LO defined only (where is the HIGH command?)\n", mem->desc);
                 return -1;
             }
             else
@@ -685,7 +685,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
         if (bytes_read < 0)
         {
-            msg_info("Failed @ pgm->spi()\n");
+            pmsg_error("failed @ pgm->spi()\n");
             pgm->err_led(pgm, ON);
             return -1;
         }
@@ -1123,7 +1123,7 @@ static int usb_open_device(struct usb_dev_handle **device, int vendor, int produ
                 if (handle == NULL)
                 {
                     errorCode = USB_ERROR_ACCESS;
-                    pmsg_info("Warning: cannot open USB device: %s\n", usb_strerror());
+                    pmsg_warning("cannot open USB device: %s\n", usb_strerror());
                     continue;
                 }
 
@@ -1134,15 +1134,16 @@ static int usb_open_device(struct usb_dev_handle **device, int vendor, int produ
 
                     if ((errorCode = usb_set_configuration(handle, 1)) < 0)
                     {
-                        msg_info("could not set configuration; error code %d, %s\n"
+                        pmsg_ext_error("cannot set configuration, error code %d, %s\n"
                           "you may need to run avrdude as root or set up correct usb port permissions",
                           errorCode, usb_strerror());
                     }
 
                     if ((errorCode = usb_claim_interface(handle, 0)) < 0)
                     {
-                        msg_info("Could not claim interface. Error code %d, %s\n"
-                                "You may need to run avrdude as root or set up correct usb port permissions.", errorCode, usb_strerror());
+                        pmsg_ext_error("cannot claim interface, error code %d, %s\n"
+                           "You may need to run avrdude as root or set up correct usb port permissions.",
+                           errorCode, usb_strerror());
                     }
 
                     errorCode = 0;
@@ -1181,7 +1182,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int clock_rate;
             if (sscanf(extended_param, "clockrate=%i", &clock_rate) != 1 || clock_rate <= 0)
             {
-                pmsg_info("pickit2_parseextparms(): invalid clockrate '%s'\n", extended_param);
+                pmsg_error("pickit2_parseextparms(): invalid clockrate '%s'\n", extended_param);
                 rv = -1;
                 continue;
             }
@@ -1200,7 +1201,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int timeout;
             if (sscanf(extended_param, "timeout=%i", &timeout) != 1 || timeout <= 0)
             {
-                pmsg_info("pickit2_parseextparms(): invalid timeout '%s'\n", extended_param);
+                pmsg_error("pickit2_parseextparms(): invalid timeout '%s'\n", extended_param);
                 rv = -1;
                 continue;
             }
@@ -1211,7 +1212,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             continue;
         }
 
-        pmsg_info("pickit2_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+        pmsg_error("pickit2_parseextparms(): invalid extended parameter '%s'\n", extended_param);
         rv = -1;
     }
 
@@ -1275,7 +1276,7 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
 }
 #else
 static int pickit2_nousb_open(PROGRAMMER *pgm, const char *name) {
-    pmsg_info(
+    pmsg_error(
 #ifdef WIN32
             "no usb or hid support; please compile again with libusb or HID support from Win32 DDK installed\n",
 #else

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -64,7 +64,7 @@ static int pin_fill_old_pinno(const struct pindef_t * const pindef, unsigned int
   for(i = 0; i < PIN_MAX; i++) {
     if(pindef->mask[i / PIN_FIELD_ELEMENT_SIZE] & (1 << (i % PIN_FIELD_ELEMENT_SIZE))) {
       if(found) {
-        avrdude_message(MSG_INFO, "Multiple pins found\n"); //TODO
+        msg_info("Multiple pins found\n"); //TODO
         return -1;
       }
       found = true;
@@ -89,7 +89,7 @@ static int pin_fill_old_pinlist(const struct pindef_t * const pindef, unsigned i
   for(i = 0; i < PIN_FIELD_SIZE; i++) {
     if(i == 0) {
       if((pindef->mask[i] & ~PIN_MASK) != 0) {
-        avrdude_message(MSG_INFO, "Pins of higher index than max field size for old pinno found\n");
+        msg_info("Pins of higher index than max field size for old pinno found\n");
         return -1;
       }
       if (pindef->mask[i] == 0) {
@@ -101,11 +101,11 @@ static int pin_fill_old_pinlist(const struct pindef_t * const pindef, unsigned i
       } else if(pindef->mask[i] == ((~pindef->inverse[i]) & pindef->mask[i])) {  /* all set bits in mask are cleared in inverse */
         *pinno = pindef->mask[i];
       } else {
-        avrdude_message(MSG_INFO, "pins have different polarity set\n");
+        msg_info("pins have different polarity set\n");
         return -1;
       }
     } else if(pindef->mask[i] != 0) {
-      avrdude_message(MSG_INFO, "Pins have higher number than fit in old format\n");
+      msg_info("Pins have higher number than fit in old format\n");
       return -1;
     }
   }
@@ -271,32 +271,32 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     }
     if(invalid) {
       if(output) {
-        avrdude_message(MSG_INFO, "%s: %s: Following pins are not valid pins for this function: %s\n",
+        msg_info("%s: %s: Following pins are not valid pins for this function: %s\n",
                         progname, avr_pin_name(pinname), pinmask_to_str(invalid_used));
-        avrdude_message(MSG_NOTICE2, "%s: %s: Valid pins for this function are: %s\n",
+        msg_notice2("%s: %s: Valid pins for this function are: %s\n",
                   progname, avr_pin_name(pinname), pinmask_to_str(valid_pins->mask));
       }
       is_ok = false;
     }
     if(inverse) {
       if(output) {
-        avrdude_message(MSG_INFO, "%s: %s: Following pins are not usable as inverse pins for this function: %s\n",
+        msg_info("%s: %s: Following pins are not usable as inverse pins for this function: %s\n",
                         progname, avr_pin_name(pinname), pinmask_to_str(inverse_used));
-        avrdude_message(MSG_NOTICE2, "%s: %s: Valid inverse pins for this function are: %s\n",
+        msg_notice2("%s: %s: Valid inverse pins for this function are: %s\n",
                           progname, avr_pin_name(pinname), pinmask_to_str(valid_pins->inverse));
       }
       is_ok = false;
     }
     if(used) {
       if(output) {
-        avrdude_message(MSG_INFO, "%s: %s: Following pins are set for other functions too: %s\n",
+        msg_info("%s: %s: Following pins are set for other functions too: %s\n",
                         progname, avr_pin_name(pinname), pinmask_to_str(already_used));
         is_ok = false;
       }
     }
     if(!mandatory_used && is_mandatory && !invalid) {
       if(output) {
-        avrdude_message(MSG_INFO, "%s: %s: Mandatory pin is not defined.\n",
+        msg_info("%s: %s: Mandatory pin is not defined.\n",
                         progname, avr_pin_name(pinname));
       }
       is_ok = false;
@@ -304,7 +304,7 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     if(!is_ok) {
       rv = -1;
     } else if(output) {
-      avrdude_message(MSG_DEBUG, "%s: %s: Pin is ok.\n",
+      msg_debug("%s: %s: Pin is ok.\n",
                       progname, avr_pin_name(pinname));
     }
   }

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -64,7 +64,7 @@ static int pin_fill_old_pinno(const struct pindef_t * const pindef, unsigned int
   for(i = 0; i < PIN_MAX; i++) {
     if(pindef->mask[i / PIN_FIELD_ELEMENT_SIZE] & (1 << (i % PIN_FIELD_ELEMENT_SIZE))) {
       if(found) {
-        msg_info("Multiple pins found\n"); //TODO
+        pmsg_error("multiple pins found\n"); // TODO
         return -1;
       }
       found = true;
@@ -89,7 +89,7 @@ static int pin_fill_old_pinlist(const struct pindef_t * const pindef, unsigned i
   for(i = 0; i < PIN_FIELD_SIZE; i++) {
     if(i == 0) {
       if((pindef->mask[i] & ~PIN_MASK) != 0) {
-        msg_info("Pins of higher index than max field size for old pinno found\n");
+        pmsg_error("pins of higher index than max field size for old pinno found\n");
         return -1;
       }
       if (pindef->mask[i] == 0) {
@@ -101,11 +101,11 @@ static int pin_fill_old_pinlist(const struct pindef_t * const pindef, unsigned i
       } else if(pindef->mask[i] == ((~pindef->inverse[i]) & pindef->mask[i])) {  /* all set bits in mask are cleared in inverse */
         *pinno = pindef->mask[i];
       } else {
-        msg_info("pins have different polarity set\n");
+        pmsg_error("pins have different polarity set\n");
         return -1;
       }
     } else if(pindef->mask[i] != 0) {
-      msg_info("Pins have higher number than fit in old format\n");
+      pmsg_error("pins have higher number than fit in old format\n");
       return -1;
     }
   }
@@ -271,32 +271,32 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     }
     if(invalid) {
       if(output) {
-        pmsg_info("%s: Following pins are not valid pins for this function: %s\n",
+        pmsg_error("%s: these pins are not valid pins for this function: %s\n",
           avr_pin_name(pinname), pinmask_to_str(invalid_used));
-        pmsg_notice2("%s: Valid pins for this function are: %s\n",
+        pmsg_notice("%s: valid pins for this function are: %s\n",
           avr_pin_name(pinname), pinmask_to_str(valid_pins->mask));
       }
       is_ok = false;
     }
     if(inverse) {
       if(output) {
-        pmsg_info("%s: Following pins are not usable as inverse pins for this function: %s\n",
+        pmsg_error("%s: these pins are not usable as inverse pins for this function: %s\n",
           avr_pin_name(pinname), pinmask_to_str(inverse_used));
-        pmsg_notice2("%s: Valid inverse pins for this function are: %s\n",
+        pmsg_notice("%s: valid inverse pins for this function are: %s\n",
           avr_pin_name(pinname), pinmask_to_str(valid_pins->inverse));
       }
       is_ok = false;
     }
     if(used) {
       if(output) {
-        pmsg_info("%s: Following pins are set for other functions too: %s\n",
+        pmsg_error("%s: these pins are set for other functions too: %s\n",
           avr_pin_name(pinname), pinmask_to_str(already_used));
         is_ok = false;
       }
     }
     if(!mandatory_used && is_mandatory && !invalid) {
       if(output) {
-        pmsg_info("%s: mandatory pin is not defined\n", avr_pin_name(pinname));
+        pmsg_error("%s: mandatory pin is not defined\n", avr_pin_name(pinname));
       }
       is_ok = false;
     }

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -271,41 +271,39 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     }
     if(invalid) {
       if(output) {
-        msg_info("%s: %s: Following pins are not valid pins for this function: %s\n",
-                        progname, avr_pin_name(pinname), pinmask_to_str(invalid_used));
-        msg_notice2("%s: %s: Valid pins for this function are: %s\n",
-                  progname, avr_pin_name(pinname), pinmask_to_str(valid_pins->mask));
+        pmsg_info("%s: Following pins are not valid pins for this function: %s\n",
+          avr_pin_name(pinname), pinmask_to_str(invalid_used));
+        pmsg_notice2("%s: Valid pins for this function are: %s\n",
+          avr_pin_name(pinname), pinmask_to_str(valid_pins->mask));
       }
       is_ok = false;
     }
     if(inverse) {
       if(output) {
-        msg_info("%s: %s: Following pins are not usable as inverse pins for this function: %s\n",
-                        progname, avr_pin_name(pinname), pinmask_to_str(inverse_used));
-        msg_notice2("%s: %s: Valid inverse pins for this function are: %s\n",
-                          progname, avr_pin_name(pinname), pinmask_to_str(valid_pins->inverse));
+        pmsg_info("%s: Following pins are not usable as inverse pins for this function: %s\n",
+          avr_pin_name(pinname), pinmask_to_str(inverse_used));
+        pmsg_notice2("%s: Valid inverse pins for this function are: %s\n",
+          avr_pin_name(pinname), pinmask_to_str(valid_pins->inverse));
       }
       is_ok = false;
     }
     if(used) {
       if(output) {
-        msg_info("%s: %s: Following pins are set for other functions too: %s\n",
-                        progname, avr_pin_name(pinname), pinmask_to_str(already_used));
+        pmsg_info("%s: Following pins are set for other functions too: %s\n",
+          avr_pin_name(pinname), pinmask_to_str(already_used));
         is_ok = false;
       }
     }
     if(!mandatory_used && is_mandatory && !invalid) {
       if(output) {
-        msg_info("%s: %s: Mandatory pin is not defined.\n",
-                        progname, avr_pin_name(pinname));
+        pmsg_info("%s: mandatory pin is not defined\n", avr_pin_name(pinname));
       }
       is_ok = false;
     }
     if(!is_ok) {
       rv = -1;
     } else if(output) {
-      msg_debug("%s: %s: Pin is ok.\n",
-                      progname, avr_pin_name(pinname));
+      pmsg_debug("%s: pin is OK\n", avr_pin_name(pinname));
     }
   }
   return rv;

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -68,7 +68,7 @@ static int ppi_shadow_access(const union filedescriptor *fdp, int reg,
       shadow_num = 2;
       break;
     default:
-      pmsg_error("avr_set(): invalid register=%d\n", reg);
+      pmsg_error("invalid register=%d\n", reg);
       return -1;
       break;
   }

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -68,7 +68,7 @@ static int ppi_shadow_access(const union filedescriptor *fdp, int reg,
       shadow_num = 2;
       break;
     default:
-      avrdude_message(MSG_INFO, "%s: avr_set(): invalid register=%d\n",
+      msg_info("%s: avr_set(): invalid register=%d\n",
               progname, reg);
       return -1;
       break;
@@ -198,7 +198,7 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 
   fd = open(port, O_RDWR);
   if (fd < 0) {
-    avrdude_message(MSG_INFO, "%s: can't open device \"%s\": %s\n",
+    msg_info("%s: can't open device \"%s\": %s\n",
               progname, port, strerror(errno));
     fdp->ifd = -1;
     return;

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -68,8 +68,7 @@ static int ppi_shadow_access(const union filedescriptor *fdp, int reg,
       shadow_num = 2;
       break;
     default:
-      msg_info("%s: avr_set(): invalid register=%d\n",
-              progname, reg);
+      pmsg_info("avr_set(): invalid register=%d\n", reg);
       return -1;
       break;
   }
@@ -198,8 +197,7 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 
   fd = open(port, O_RDWR);
   if (fd < 0) {
-    msg_info("%s: can't open device \"%s\": %s\n",
-              progname, port, strerror(errno));
+    pmsg_info("cannot open port %s: %s\n", port, strerror(errno));
     fdp->ifd = -1;
     return;
   }

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -68,7 +68,7 @@ static int ppi_shadow_access(const union filedescriptor *fdp, int reg,
       shadow_num = 2;
       break;
     default:
-      pmsg_info("avr_set(): invalid register=%d\n", reg);
+      pmsg_error("avr_set(): invalid register=%d\n", reg);
       return -1;
       break;
   }
@@ -197,7 +197,7 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 
   fd = open(port, O_RDWR);
   if (fd < 0) {
-    pmsg_info("cannot open port %s: %s\n", port, strerror(errno));
+    pmsg_ext_error("cannot open port %s: %s\n", port, strerror(errno));
     fdp->ifd = -1;
     return;
   }

--- a/src/ppiwin.c
+++ b/src/ppiwin.c
@@ -92,7 +92,7 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 
     if(fd < 0)
     {
-        msg_info("%s: can't open device \"giveio\"\n\n", progname);
+        pmsg_info("can't open device \"giveio\"\n\n"); // giveio???
         fdp->ifd = -1;
         return;
     }
@@ -120,14 +120,13 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 	fd = strtol(port, &cp, 0);
 	if(*port == '\0' || *cp != '\0')
 	{
-	    msg_info("%s: port name \"%s\" is neither lpt1/2/3 nor valid number\n",
-                            progname, port);
+	    pmsg_info("port %s is neither lpt1/2/3 nor valid number\n", port);
 	    fd = -1;
 	}
     }
     if(fd < 0)
     {
-        msg_info("%s: can't open device \"%s\"\n\n", progname, port);
+        pmsg_info("can't open port %s\n\n", port);
         fdp->ifd = -1;
         return;
     }

--- a/src/ppiwin.c
+++ b/src/ppiwin.c
@@ -92,7 +92,7 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 
     if(fd < 0)
     {
-        avrdude_message(MSG_INFO, "%s: can't open device \"giveio\"\n\n", progname);
+        msg_info("%s: can't open device \"giveio\"\n\n", progname);
         fdp->ifd = -1;
         return;
     }
@@ -120,14 +120,14 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 	fd = strtol(port, &cp, 0);
 	if(*port == '\0' || *cp != '\0')
 	{
-	    avrdude_message(MSG_INFO, "%s: port name \"%s\" is neither lpt1/2/3 nor valid number\n",
+	    msg_info("%s: port name \"%s\" is neither lpt1/2/3 nor valid number\n",
                             progname, port);
 	    fd = -1;
 	}
     }
     if(fd < 0)
     {
-        avrdude_message(MSG_INFO, "%s: can't open device \"%s\"\n\n", progname, port);
+        msg_info("%s: can't open device \"%s\"\n\n", progname, port);
         fdp->ifd = -1;
         return;
     }

--- a/src/ppiwin.c
+++ b/src/ppiwin.c
@@ -92,7 +92,7 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 
     if(fd < 0)
     {
-        pmsg_info("can't open device \"giveio\"\n\n"); // giveio???
+        pmsg_ext_error("cannot open device \"giveio\"\n\n"); // giveio?!? FIXME!
         fdp->ifd = -1;
         return;
     }
@@ -120,13 +120,13 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
 	fd = strtol(port, &cp, 0);
 	if(*port == '\0' || *cp != '\0')
 	{
-	    pmsg_info("port %s is neither lpt1/2/3 nor valid number\n", port);
+	    pmsg_error("port %s is neither lpt1/2/3 nor valid number\n", port);
 	    fd = -1;
 	}
     }
     if(fd < 0)
     {
-        pmsg_info("can't open port %s\n\n", port);
+        pmsg_ext_error("cannot open port %s\n\n", port);
         fdp->ifd = -1;
         return;
     }

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -73,7 +73,7 @@ static int usbOpenDevice(union filedescriptor *fdp, int vendor, const char *vend
     dev = hid_open(vendor, product, NULL);
     if (dev == NULL)
     {
-      avrdude_message(MSG_INFO, "%s: usbOpenDevice(): No device found\n",
+      msg_info("%s: usbOpenDevice(): No device found\n",
 		    progname);
       return USB_ERROR_NOTFOUND;
     }
@@ -113,7 +113,7 @@ static int usbSetReport(const union filedescriptor *fdp, int reportType, char *b
 
   if(bytesSent != len){
       if(bytesSent < 0)
-          avrdude_message(MSG_INFO, "Error sending message: %s\n", hid_error(udev));
+          msg_info("Error sending message: %s\n", hid_error(udev));
       return USB_ERROR_IO;
   }
   return USB_ERROR_NONE;
@@ -138,7 +138,7 @@ static int usbGetReport(const union filedescriptor *fdp, int reportType, int rep
       break;
   }
   if(bytesReceived < 0){
-      avrdude_message(MSG_INFO, "Error sending message: %s\n", hid_error(udev));
+      msg_info("Error sending message: %s\n", hid_error(udev));
       return USB_ERROR_IO;
   }
   *len = bytesReceived;
@@ -160,11 +160,11 @@ static void dumpBlock(const char *prefix, const unsigned char *buf, int len)
     int i;
 
     if(len <= 8){   /* more compact format for short blocks */
-        avrdude_message(MSG_INFO, "%s: %d bytes: ", prefix, len);
+        msg_info("%s: %d bytes: ", prefix, len);
         for(i = 0; i < len; i++){
-            avrdude_message(MSG_INFO, "%02x ", buf[i]);
+            msg_info("%02x ", buf[i]);
         }
-        avrdude_message(MSG_INFO, " \"");
+        msg_info(" \"");
         for(i = 0; i < len; i++){
             if(buf[i] >= 0x20 && buf[i] < 0x7f){
                 fputc(buf[i], stderr);
@@ -172,20 +172,20 @@ static void dumpBlock(const char *prefix, const unsigned char *buf, int len)
                 fputc('.', stderr);
             }
         }
-        avrdude_message(MSG_INFO, "\"\n");
+        msg_info("\"\n");
     }else{
-        avrdude_message(MSG_INFO, "%s: %d bytes:\n", prefix, len);
+        msg_info("%s: %d bytes:\n", prefix, len);
         while(len > 0){
             for(i = 0; i < 16; i++){
                 if(i < len){
-                    avrdude_message(MSG_INFO, "%02x ", buf[i]);
+                    msg_info("%02x ", buf[i]);
                 }else{
-                    avrdude_message(MSG_INFO, "   ");
+                    msg_info("   ");
                 }
                 if(i == 7)
                     fputc(' ', stderr);
             }
-            avrdude_message(MSG_INFO, "  \"");
+            msg_info("  \"");
             for(i = 0; i < 16; i++){
                 if(i < len){
                     if(buf[i] >= 0x20 && buf[i] < 0x7f){
@@ -195,7 +195,7 @@ static void dumpBlock(const char *prefix, const unsigned char *buf, int len)
                     }
                 }
             }
-            avrdude_message(MSG_INFO, "\"\n");
+            msg_info("\"\n");
             buf += 16;
             len -= 16;
         }
@@ -228,7 +228,7 @@ static int avrdoper_open(const char *port, union pinfo pinfo, union filedescript
 
     rval = usbOpenDevice(fdp, USB_VENDOR_ID, vname, USB_PRODUCT_ID, devname, 1);
     if(rval != 0){
-        avrdude_message(MSG_INFO, "%s: avrdoper_open(): %s\n", progname, usbErrorText(rval));
+        msg_info("%s: avrdoper_open(): %s\n", progname, usbErrorText(rval));
         return -1;
     }
     return 0;
@@ -266,11 +266,11 @@ static int avrdoper_send(const union filedescriptor *fdp, const unsigned char *b
         buffer[0] = lenIndex + 1;   /* report ID */
         buffer[1] = thisLen;
         memcpy(buffer + 2, buf, thisLen);
-        avrdude_message(MSG_TRACE, "Sending %d bytes data chunk\n", thisLen);
+        msg_trace("Sending %d bytes data chunk\n", thisLen);
         rval = usbSetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, (char *)buffer,
 			    reportDataSizes[lenIndex] + 2);
         if(rval != 0){
-            avrdude_message(MSG_INFO, "%s: avrdoper_send(): %s\n", progname, usbErrorText(rval));
+            msg_info("%s: avrdoper_send(): %s\n", progname, usbErrorText(rval));
             return -1;
         }
         buflen -= thisLen;
@@ -295,16 +295,16 @@ static int avrdoperFillBuffer(const union filedescriptor *fdp) {
         usbErr = usbGetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, lenIndex + 1,
 			      (char *)buffer, &len);
         if(usbErr != 0){
-            avrdude_message(MSG_INFO, "%s: avrdoperFillBuffer(): %s\n", progname, usbErrorText(usbErr));
+            msg_info("%s: avrdoperFillBuffer(): %s\n", progname, usbErrorText(usbErr));
             return -1;
         }
-        avrdude_message(MSG_TRACE, "Received %d bytes data chunk of total %d\n", len - 2, buffer[1]);
+        msg_trace("Received %d bytes data chunk of total %d\n", len - 2, buffer[1]);
         len -= 2;   /* compensate for report ID and length byte */
         bytesPending = buffer[1] - len; /* amount still buffered */
         if(len > buffer[1])             /* cut away padding */
             len = buffer[1];
         if(avrdoperRxLength + len > sizeof(avrdoperRxBuffer)){
-            avrdude_message(MSG_INFO, "%s: avrdoperFillBuffer(): internal error: buffer overflow\n",
+            msg_info("%s: avrdoperFillBuffer(): internal error: buffer overflow\n",
                             progname);
             return -1;
         }
@@ -352,7 +352,7 @@ static int avrdoper_drain(const union filedescriptor *fdp, int display)
 
 static int avrdoper_set_dtr_rts(const union filedescriptor *fdp, int is_on)
 {
-	avrdude_message(MSG_INFO, "%s: AVR-Doper doesn't support DTR/RTS setting\n", progname);
+	msg_info("%s: AVR-Doper doesn't support DTR/RTS setting\n", progname);
     return -1;
 }
 

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -73,7 +73,7 @@ static int usbOpenDevice(union filedescriptor *fdp, int vendor, const char *vend
     dev = hid_open(vendor, product, NULL);
     if (dev == NULL)
     {
-      pmsg_ext_error("usbOpenDevice(): no device found\n");
+      pmsg_ext_error("no device found\n");
       return USB_ERROR_NOTFOUND;
     }
     fdp->usb.handle = dev;
@@ -215,7 +215,7 @@ static int avrdoper_open(const char *port, union pinfo pinfo, union filedescript
 
     rval = usbOpenDevice(fdp, USB_VENDOR_ID, vname, USB_PRODUCT_ID, devname, 1);
     if(rval != 0){
-        pmsg_ext_error("avrdoper_open(): %s\n", usbErrorText(rval));
+        pmsg_ext_error("%s\n", usbErrorText(rval));
         return -1;
     }
     return 0;
@@ -257,7 +257,7 @@ static int avrdoper_send(const union filedescriptor *fdp, const unsigned char *b
         rval = usbSetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, (char *)buffer,
 			    reportDataSizes[lenIndex] + 2);
         if(rval != 0){
-            pmsg_error("avrdoper_send(): %s\n", usbErrorText(rval));
+            pmsg_error("%s\n", usbErrorText(rval));
             return -1;
         }
         buflen -= thisLen;
@@ -282,7 +282,7 @@ static int avrdoperFillBuffer(const union filedescriptor *fdp) {
         usbErr = usbGetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, lenIndex + 1,
 			      (char *)buffer, &len);
         if(usbErr != 0){
-            pmsg_error("avrdoperFillBuffer(): %s\n", usbErrorText(usbErr));
+            pmsg_error("%s\n", usbErrorText(usbErr));
             return -1;
         }
         msg_trace("Received %d bytes data chunk of total %d\n", len - 2, buffer[1]);
@@ -291,7 +291,7 @@ static int avrdoperFillBuffer(const union filedescriptor *fdp) {
         if(len > buffer[1])             /* cut away padding */
             len = buffer[1];
         if(avrdoperRxLength + len > sizeof(avrdoperRxBuffer)){
-            pmsg_error("avrdoperFillBuffer(): buffer overflow\n");
+            pmsg_error("buffer overflow\n");
             return -1;
         }
         memcpy(avrdoperRxBuffer + avrdoperRxLength, buffer + 2, len);

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -73,8 +73,7 @@ static int usbOpenDevice(union filedescriptor *fdp, int vendor, const char *vend
     dev = hid_open(vendor, product, NULL);
     if (dev == NULL)
     {
-      msg_info("%s: usbOpenDevice(): No device found\n",
-		    progname);
+      pmsg_info("usbOpenDevice(): No device found\n");
       return USB_ERROR_NOTFOUND;
     }
     fdp->usb.handle = dev;
@@ -113,7 +112,7 @@ static int usbSetReport(const union filedescriptor *fdp, int reportType, char *b
 
   if(bytesSent != len){
       if(bytesSent < 0)
-          msg_info("Error sending message: %s\n", hid_error(udev));
+          msg_info("Error sending message: %ls\n", hid_error(udev));
       return USB_ERROR_IO;
   }
   return USB_ERROR_NONE;
@@ -138,7 +137,7 @@ static int usbGetReport(const union filedescriptor *fdp, int reportType, int rep
       break;
   }
   if(bytesReceived < 0){
-      msg_info("Error sending message: %s\n", hid_error(udev));
+      msg_info("Error sending message: %ls\n", hid_error(udev));
       return USB_ERROR_IO;
   }
   *len = bytesReceived;
@@ -228,7 +227,7 @@ static int avrdoper_open(const char *port, union pinfo pinfo, union filedescript
 
     rval = usbOpenDevice(fdp, USB_VENDOR_ID, vname, USB_PRODUCT_ID, devname, 1);
     if(rval != 0){
-        msg_info("%s: avrdoper_open(): %s\n", progname, usbErrorText(rval));
+        pmsg_info("avrdoper_open(): %s\n", usbErrorText(rval));
         return -1;
     }
     return 0;
@@ -270,7 +269,7 @@ static int avrdoper_send(const union filedescriptor *fdp, const unsigned char *b
         rval = usbSetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, (char *)buffer,
 			    reportDataSizes[lenIndex] + 2);
         if(rval != 0){
-            msg_info("%s: avrdoper_send(): %s\n", progname, usbErrorText(rval));
+            pmsg_info("avrdoper_send(): %s\n", usbErrorText(rval));
             return -1;
         }
         buflen -= thisLen;
@@ -295,7 +294,7 @@ static int avrdoperFillBuffer(const union filedescriptor *fdp) {
         usbErr = usbGetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, lenIndex + 1,
 			      (char *)buffer, &len);
         if(usbErr != 0){
-            msg_info("%s: avrdoperFillBuffer(): %s\n", progname, usbErrorText(usbErr));
+            pmsg_info("avrdoperFillBuffer(): %s\n", usbErrorText(usbErr));
             return -1;
         }
         msg_trace("Received %d bytes data chunk of total %d\n", len - 2, buffer[1]);
@@ -304,8 +303,7 @@ static int avrdoperFillBuffer(const union filedescriptor *fdp) {
         if(len > buffer[1])             /* cut away padding */
             len = buffer[1];
         if(avrdoperRxLength + len > sizeof(avrdoperRxBuffer)){
-            msg_info("%s: avrdoperFillBuffer(): internal error: buffer overflow\n",
-                            progname);
+            pmsg_info("avrdoperFillBuffer(): internal error: buffer overflow\n");
             return -1;
         }
         memcpy(avrdoperRxBuffer + avrdoperRxLength, buffer + 2, len);
@@ -352,7 +350,7 @@ static int avrdoper_drain(const union filedescriptor *fdp, int display)
 
 static int avrdoper_set_dtr_rts(const union filedescriptor *fdp, int is_on)
 {
-	msg_info("%s: AVR-Doper doesn't support DTR/RTS setting\n", progname);
+	pmsg_info("AVR-Doper doesn't support DTR/RTS setting\n");
     return -1;
 }
 

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -262,7 +262,7 @@ static int ser_setparams(const union filedescriptor *fd, long baud, unsigned lon
   // handle nonstandard speed values the MacOS way
   if (nonstandard) {
     if (ioctl(fd->ifd, IOSSIOSPEED, &speed) < 0) {
-      ret = -errno;
+      int ret = -errno;
       pmsg_ext_error("ioctrl(IOSSIOSPEED) failed\n");
       return ret;
     }

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -159,7 +159,7 @@ static int ser_setparams(const union filedescriptor *fd, long baud, unsigned lon
   rc = tcgetattr(fd->ifd, &termios);
   if (rc < 0) {
     int ret = -errno;
-    pmsg_ext_error("ser_setparams(): tcgetattr() failed\n");
+    pmsg_ext_error("tcgetattr() failed\n");
     return ret;
   }
 
@@ -254,7 +254,7 @@ static int ser_setparams(const union filedescriptor *fd, long baud, unsigned lon
   rc = tcsetattr(fd->ifd, TCSANOW, &termios);
   if (rc < 0) {
     int ret = -errno;
-    pmsg_ext_error("ser_setparams(): tcsetattr() failed\n");
+    pmsg_ext_error("tcsetattr() failed\n");
     return ret;
   }
 
@@ -263,7 +263,7 @@ static int ser_setparams(const union filedescriptor *fd, long baud, unsigned lon
   if (nonstandard) {
     if (ioctl(fd->ifd, IOSSIOSPEED, &speed) < 0) {
       ret = -errno;
-      pmsg_ext_error("ser_setparams(): ioctrl(IOSSIOSPEED) failed\n");
+      pmsg_ext_error("ioctrl(IOSSIOSPEED) failed\n");
       return ret;
     }
   }
@@ -287,7 +287,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
   struct addrinfo *result, *rp;
 
   if ((hstr = hp = strdup(port)) == NULL) {
-    pmsg_error("net_open(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
 
@@ -297,7 +297,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
    * service name from the host or IP address.
    */
   if (((pstr = strrchr(hstr, ':')) == NULL) || (pstr == hstr)) {
-    pmsg_error("net_open(): mangled host:port string %s\n", hstr);
+    pmsg_error("mangled host:port string %s\n", hstr);
     goto error;
   }
 
@@ -320,7 +320,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
   s = getaddrinfo(hstr, pstr, &hints, &result);
 
   if (s != 0) {
-    pmsg_ext_error("net_open(): cannot resolve host=\"%s\", port=\"%s\": %s\n",
+    pmsg_ext_error("cannot resolve host=\"%s\", port=\"%s\": %s\n",
       hstr, pstr, gai_strerror(s));
     goto error;
   }
@@ -337,7 +337,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
     close(fd);
   }
   if (rp == NULL) {
-    pmsg_ext_error("net_open(): cannot connect: %s\n", strerror(errno));
+    pmsg_ext_error("cannot connect: %s\n", strerror(errno));
   }
   else {
     fdp->ifd = fd;
@@ -396,7 +396,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
    */
   fd = open(port, O_RDWR | O_NOCTTY | O_NONBLOCK);
   if (fd < 0) {
-    pmsg_ext_error("ser_open(): cannot open port %s: %s\n", port, strerror(errno));
+    pmsg_ext_error("cannot open port %s: %s\n", port, strerror(errno));
     return -1;
   }
 
@@ -407,7 +407,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
    */
   rc = ser_setparams(fdp, pinfo.serialinfo.baud, pinfo.serialinfo.cflags);
   if (rc) {
-    pmsg_ext_error("ser_open(): cannot set attributes for port %s: %s\n", port, strerror(-rc));
+    pmsg_ext_error("cannot set attributes for port %s: %s\n", port, strerror(-rc));
     close(fd);
     return -1;
   }
@@ -421,7 +421,7 @@ static void ser_close(union filedescriptor *fd) {
   if (saved_original_termios) {
     int rc = tcsetattr(fd->ifd, TCSANOW | TCSADRAIN, &original_termios);
     if (rc) {
-      pmsg_ext_error("ser_close(): cannot reset attributes for device: %s\n", strerror(errno));
+      pmsg_ext_error("cannot reset attributes for device: %s\n", strerror(errno));
     }
     saved_original_termios = 0;
   }
@@ -462,7 +462,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
   while (len) {
     rc = write(fd->ifd, p, (len > 1024) ? 1024 : len);
     if (rc < 0) {
-      pmsg_ext_error("ser_send(): unable to write: %s\n", strerror(errno));
+      pmsg_ext_error("unable to write: %s\n", strerror(errno));
       return -1;
     }
     p += rc;
@@ -497,18 +497,18 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
     }
     else if (nfds == -1) {
       if (errno == EINTR || errno == EAGAIN) {
-	pmsg_warning("ser_recv(): programmer is not responding, reselecting\n");
+	pmsg_warning("programmer is not responding, reselecting\n");
         goto reselect;
       }
       else {
-        pmsg_ext_error("ser_recv(): select(): %s\n", strerror(errno));
+        pmsg_ext_error("select(): %s\n", strerror(errno));
         return -1;
       }
     }
 
     rc = read(fd->ifd, p, (buflen - len > 1024) ? 1024 : buflen - len);
     if (rc < 0) {
-      pmsg_ext_error("ser_recv(): unable to read: %s\n", strerror(errno));
+      pmsg_ext_error("unable to read: %s\n", strerror(errno));
       return -1;
     }
     p += rc;
@@ -573,14 +573,14 @@ static int ser_drain(const union filedescriptor *fd, int display) {
         goto reselect;
       }
       else {
-        pmsg_ext_error("ser_drain(): select(): %s\n", strerror(errno));
+        pmsg_ext_error("select(): %s\n", strerror(errno));
         return -1;
       }
     }
 
     rc = read(fd->ifd, &buf, 1);
     if (rc < 0) {
-      pmsg_ext_error("ser_drain(): unable to read: %s\n", strerror(errno));
+      pmsg_ext_error("unable to read: %s\n", strerror(errno));
       return -1;
     }
     if (display) {

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -77,8 +77,7 @@ static DWORD serial_baud_lookup(long baud)
    * If a non-standard BAUD rate is used, issue
    * a warning (if we are verbose) and return the raw rate
    */
-  msg_notice("%s: serial_baud_lookup(): Using non-standard baud rate: %ld",
-              progname, baud);
+  pmsg_notice("serial_baud_lookup(): Using non-standard baud rate: %ld", baud);
 
   return baud;
 }
@@ -160,17 +159,17 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 	struct hostent *hp;
 
 	if (WSAStartup(MAKEWORD(2, 0), &wsaData) != 0) {
-		msg_info("%s: net_open(): WSAStartup() failed\n", progname);
+		pmsg_info("net_open(): WSAStartup() failed\n");
 		return -1;
 	}
 
 	if ((hstr = strdup(port)) == NULL) {
-		msg_info("%s: net_open(): Out of memory!\n", progname);
+		pmsg_info("net_open(): out of memory\n");
 		return -1;
 	}
 
 	if (((pstr = strchr(hstr, ':')) == NULL) || (pstr == hstr)) {
-		msg_info("%s: net_open(): Mangled host:port string \"%s\"\n", progname, hstr);
+		pmsg_info("net_open(): Mangled host:port string %s\n", hstr);
 		free(hstr);
 		return -1;
 	}
@@ -183,13 +182,13 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 	pnum = strtoul(pstr, &end, 10);
 
 	if ((*pstr == '\0') || (*end != '\0') || (pnum == 0) || (pnum > 65535)) {
-		msg_info("%s: net_open(): Bad port number \"%s\"\n", progname, pstr);
+		pmsg_info("net_open(): Bad port number %s\n", pstr);
 		free(hstr);
 		return -1;
 	}
 
 	if ((hp = gethostbyname(hstr)) == NULL) {
-		msg_info("%s: net_open(): unknown host \"%s\"\n", progname, hstr);
+		pmsg_info("net_open(): unknown host %s\n", hstr);
 		free(hstr);
 		return -1;
 	}
@@ -207,7 +206,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		msg_info("%s: net_open(): Cannot open socket: %s\n", progname, (char *)lpMsgBuf);
+		pmsg_info("net_open(): Cannot open socket: %s\n", (char *)lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -228,7 +227,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		msg_info("%s: net_open(): Connect failed: %s\n", progname, (char *)lpMsgBuf);
+		pmsg_info("net_open(): Connect failed: %s\n", (char *)lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -259,8 +258,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	    newname = malloc(strlen("\\\\.\\") + strlen(port) + 1);
 
 	    if (newname == 0) {
-		msg_info("%s: ser_open(): out of memory\n",
-                                progname);
+		pmsg_info("ser_open(): out of memory\n");
 		exit(1);
 	    }
 	    strcpy(newname, "\\\\.\\");
@@ -283,8 +281,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		msg_info("%s: ser_open(): can't open device \"%s\": %s\n",
-				progname, port, (char*)lpMsgBuf);
+		pmsg_info("ser_open(): can't open port %s: %s\n", port, (char*)lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
 	}
@@ -292,8 +289,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (!SetupComm(hComPort, W32SERBUFSIZE, W32SERBUFSIZE))
 	{
 		CloseHandle(hComPort);
-		msg_info("%s: ser_open(): can't set buffers for \"%s\"\n",
-				progname, port);
+		pmsg_info("ser_open(): can't set buffers for %s\n", port);
 		return -1;
 	}
 
@@ -301,16 +297,14 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (ser_setparams(fdp, pinfo.serialinfo.baud, pinfo.serialinfo.cflags) != 0)
 	{
 		CloseHandle(hComPort);
-		msg_info("%s: ser_open(): can't set com-state for \"%s\"\n",
-				progname, port);
+		pmsg_info("ser_open(): can't set com-state for %s\n", port);
 		return -1;
 	}
 
 	if (!serial_w32SetTimeOut(hComPort,0))
 	{
 		CloseHandle(hComPort);
-		msg_info("%s: ser_open(): can't set initial timeout for \"%s\"\n",
-				progname, port);
+		pmsg_info("ser_open(): can't set initial timeout for %s\n", port);
 		return -1;
 	}
 
@@ -358,7 +352,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char * buf, s
 	size_t len = buflen;
 
 	if (fd->ifd < 0) {
-		msg_notice("%s: net_send(): connection not open\n", progname);
+		pmsg_notice("net_send(): connection not open\n");
 		exit(1);
 	}
 
@@ -367,7 +361,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char * buf, s
 	}
 
 	if (verbose > 3) {
-		msg_trace("%s: Send: ", progname);
+		pmsg_trace("send: ");
 
 		while (buflen) {
 			unsigned char c = *buf;
@@ -398,7 +392,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char * buf, s
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			msg_info("%s: net_send(): send error: %s\n", progname, (char *)lpMsgBuf);
+			pmsg_info("net_send(): send error: %s\n", (char *)lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -423,8 +417,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 	HANDLE hComPort=(HANDLE)fd->pfd;
 
 	if (hComPort == INVALID_HANDLE_VALUE) {
-		msg_info("%s: ser_send(): port not open\n",
-              progname); 
+		pmsg_info("ser_send(): port not open\n");
 		return -1;
 	}
 
@@ -433,7 +426,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 
 	if (verbose > 3)
 	{
-		msg_trace("%s: Send: ", progname);
+		pmsg_trace("send: ");
 
 		while (len) {
 			c = *b;
@@ -453,14 +446,12 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 	serial_w32SetTimeOut(hComPort,500);
 
 	if (!WriteFile (hComPort, buf, buflen, &written, NULL)) {
-		msg_info("%s: ser_send(): write error: %s\n",
-              progname, "sorry no info avail"); // TODO
+		pmsg_info("ser_send(): write error: %s\n", "sorry no info avail"); // TODO
 		return -1;
 	}
 
 	if (written != buflen) {
-		msg_info("%s: ser_send(): size/send mismatch\n",
-              progname); 
+		pmsg_info("ser_send(): size/send mismatch\n");
 		return -1;
 	}
 
@@ -478,7 +469,7 @@ static int net_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 	size_t len = 0;
 
 	if (fd->ifd < 0) {
-		msg_info("%s: net_recv(): connection not open\n", progname);
+		pmsg_info("net_recv(): connection not open\n");
 		exit(1);
 	}
 
@@ -494,12 +485,12 @@ reselect:
 		nfds = select(fd->ifd + 1, &rfds, NULL, NULL, &to2);
 		if (nfds == 0) {
 			if (verbose > 1) {
-				msg_notice("%s: ser_recv(): programmer is not responding\n", progname);
+				pmsg_notice("ser_recv(): programmer is not responding\n");
 			}
 			return -1;
 		} else if (nfds == -1) {
 			if (WSAGetLastError() == WSAEINTR || WSAGetLastError() == WSAEINPROGRESS) {
-				msg_notice("%s: ser_recv(): programmer is not responding, reselecting\n", progname);
+				pmsg_notice("ser_recv(): programmer is not responding, reselecting\n");
 				goto reselect;
 			} else {
 				FormatMessage(
@@ -512,7 +503,7 @@ reselect:
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				msg_info("%s: ser_recv(): select(): %s\n", progname, (char *)lpMsgBuf);
+				pmsg_info("ser_recv(): select(): %s\n", (char *)lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -530,7 +521,7 @@ reselect:
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			msg_info("%s: ser_recv(): read error: %s\n", progname, (char *)lpMsgBuf);
+			pmsg_info("ser_recv(): read error: %s\n", (char *)lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -541,7 +532,7 @@ reselect:
 	p = buf;
 
 	if (verbose > 3) {
-		msg_trace("%s: Recv: ", progname);
+		pmsg_trace("Recv: ");
 
 		while (len) {
 			unsigned char c = *p;
@@ -573,8 +564,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 	HANDLE hComPort=(HANDLE)fd->pfd;
 	
 	if (hComPort == INVALID_HANDLE_VALUE) {
-		msg_info("%s: ser_read(): port not open\n",
-              progname); 
+		pmsg_info("ser_read(): port not open\n");
 		return -1;
 	}
 	
@@ -592,16 +582,14 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL 	);
-		msg_info("%s: ser_recv(): read error: %s\n",
-			      progname, (char*)lpMsgBuf);
+		pmsg_info("ser_recv(): read error: %s\n", (char*)lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
 	}
 
 	/* time out detected */
 	if (read == 0) {
-		msg_notice2("%s: ser_recv(): programmer is not responding\n",
-                                progname);
+		pmsg_notice2("ser_recv(): programmer is not responding\n");
 		return -1;
 	}
 
@@ -609,7 +597,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 
 	if (verbose > 3)
 	{
-		msg_trace("%s: Recv: ", progname);
+		pmsg_trace("recv: ");
 
 		while (read) {
 			c = *p;
@@ -638,7 +626,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 	int rc;
 
 	if (fd->ifd < 0) {
-		msg_info("%s: ser_drain(): connection not open\n", progname);
+		pmsg_info("ser_drain(): connection not open\n");
 		exit(1);
 	}
 
@@ -663,7 +651,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 		}
 		else if (nfds == -1) {
 			if (WSAGetLastError() == WSAEINTR || WSAGetLastError() == WSAEINPROGRESS) {
-				msg_notice("%s: ser_drain(): programmer is not responding, reselecting\n", progname);
+				pmsg_notice("ser_drain(): programmer is not responding, reselecting\n");
 				goto reselect;
 			} else {
 				FormatMessage(
@@ -676,7 +664,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				msg_info("%s: ser_drain(): select(): %s\n", progname, (char *)lpMsgBuf);
+				pmsg_info("ser_drain(): select(): %s\n", (char *)lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -694,7 +682,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			msg_info("%s: ser_drain(): read error: %s\n", progname, (char *)lpMsgBuf);
+			pmsg_info("ser_drain(): read error: %s\n", (char *)lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -720,8 +708,7 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 	HANDLE hComPort=(HANDLE)fd->pfd;
 
   	if (hComPort == INVALID_HANDLE_VALUE) {
-		msg_info("%s: ser_drain(): port not open\n",
-              progname); 
+		pmsg_info("ser_drain(): port not open\n");
 		return -1;
 	}
 
@@ -745,8 +732,7 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR) &lpMsgBuf,
 				0,
 				NULL 	);
-			msg_info("%s: ser_drain(): read error: %s\n",
-					  progname, (char*)lpMsgBuf);
+			pmsg_info("ser_drain(): read error: %s\n", (char*)lpMsgBuf);
 			LocalFree( lpMsgBuf );
 			return -1;
 		}

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -159,17 +159,17 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 	struct hostent *hp;
 
 	if (WSAStartup(MAKEWORD(2, 0), &wsaData) != 0) {
-		pmsg_error("net_open(): WSAStartup() failed\n");
+		pmsg_error("WSAStartup() failed\n");
 		return -1;
 	}
 
 	if ((hstr = strdup(port)) == NULL) {
-		pmsg_error("net_open(): out of memory\n");
+		pmsg_error("out of memory\n");
 		return -1;
 	}
 
 	if (((pstr = strchr(hstr, ':')) == NULL) || (pstr == hstr)) {
-		pmsg_error("net_open(): mangled host:port string %s\n", hstr);
+		pmsg_error("mangled host:port string %s\n", hstr);
 		free(hstr);
 		return -1;
 	}
@@ -182,13 +182,13 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 	pnum = strtoul(pstr, &end, 10);
 
 	if ((*pstr == '\0') || (*end != '\0') || (pnum == 0) || (pnum > 65535)) {
-		pmsg_error("net_open(): bad port number %s\n", pstr);
+		pmsg_error("bad port number %s\n", pstr);
 		free(hstr);
 		return -1;
 	}
 
 	if ((hp = gethostbyname(hstr)) == NULL) {
-		pmsg_error("net_open(): unknown host %s\n", hstr);
+		pmsg_error("unknown host %s\n", hstr);
 		free(hstr);
 		return -1;
 	}
@@ -206,7 +206,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		pmsg_error("net_open(): cannot open socket: %s\n", (char *) lpMsgBuf);
+		pmsg_error("cannot open socket: %s\n", (char *) lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -227,7 +227,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		pmsg_error("net_open(): connect failed: %s\n", (char *) lpMsgBuf);
+		pmsg_error("connect failed: %s\n", (char *) lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -258,7 +258,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	    newname = malloc(strlen("\\\\.\\") + strlen(port) + 1);
 
 	    if (newname == 0) {
-		pmsg_error("ser_open(): out of memory\n");
+		pmsg_error("out of memory\n");
 		exit(1);
 	    }
 	    strcpy(newname, "\\\\.\\");
@@ -281,7 +281,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		pmsg_error("ser_open(): cannot open port %s: %s\n", port, (char*) lpMsgBuf);
+		pmsg_error("cannot open port %s: %s\n", port, (char*) lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
 	}
@@ -289,7 +289,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (!SetupComm(hComPort, W32SERBUFSIZE, W32SERBUFSIZE))
 	{
 		CloseHandle(hComPort);
-		pmsg_error("ser_open(): cannot set buffers for %s\n", port);
+		pmsg_error("cannot set buffers for %s\n", port);
 		return -1;
 	}
 
@@ -297,14 +297,14 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (ser_setparams(fdp, pinfo.serialinfo.baud, pinfo.serialinfo.cflags) != 0)
 	{
 		CloseHandle(hComPort);
-		pmsg_error("ser_open(): cannot set com-state for %s\n", port);
+		pmsg_error("cannot set com-state for %s\n", port);
 		return -1;
 	}
 
 	if (!serial_w32SetTimeOut(hComPort,0))
 	{
 		CloseHandle(hComPort);
-		pmsg_error("ser_open(): cannot set initial timeout for %s\n", port);
+		pmsg_error("cannot set initial timeout for %s\n", port);
 		return -1;
 	}
 
@@ -392,7 +392,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char * buf, s
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			pmsg_error("net_send(): unable to send: %s\n", (char *) lpMsgBuf);
+			pmsg_error("unable to send: %s\n", (char *) lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -417,7 +417,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 	HANDLE hComPort=(HANDLE)fd->pfd;
 
 	if (hComPort == INVALID_HANDLE_VALUE) {
-		pmsg_error("ser_send(): port not open\n");
+		pmsg_error("port not open\n");
 		return -1;
 	}
 
@@ -446,12 +446,12 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 	serial_w32SetTimeOut(hComPort,500);
 
 	if (!WriteFile (hComPort, buf, buflen, &written, NULL)) {
-		pmsg_error("ser_send(): unable to write: %s\n", "sorry no info avail"); // TODO
+		pmsg_error("unable to write: %s\n", "sorry no info avail"); // TODO
 		return -1;
 	}
 
 	if (written != buflen) {
-		pmsg_error("ser_send(): size/send mismatch\n");
+		pmsg_error("size/send mismatch\n");
 		return -1;
 	}
 
@@ -469,7 +469,7 @@ static int net_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 	size_t len = 0;
 
 	if (fd->ifd < 0) {
-		pmsg_error("net_recv(): connection not open\n");
+		pmsg_error("connection not open\n");
 		exit(1);
 	}
 
@@ -503,7 +503,7 @@ reselect:
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				pmsg_error("ser_recv(): select(): %s\n", (char *) lpMsgBuf);
+				pmsg_error("select(): %s\n", (char *) lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -521,7 +521,7 @@ reselect:
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			pmsg_error("ser_recv(): unable to read: %s\n", (char *) lpMsgBuf);
+			pmsg_error("unable to read: %s\n", (char *) lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -564,7 +564,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 	HANDLE hComPort=(HANDLE)fd->pfd;
 	
 	if (hComPort == INVALID_HANDLE_VALUE) {
-		pmsg_error("ser_read(): port not open\n");
+		pmsg_error("port not open\n");
 		return -1;
 	}
 	
@@ -582,7 +582,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL 	);
-		pmsg_error("ser_recv(): unable to read: %s\n", (char*) lpMsgBuf);
+		pmsg_error("unable to read: %s\n", (char*) lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
 	}
@@ -626,7 +626,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 	int rc;
 
 	if (fd->ifd < 0) {
-		pmsg_error("ser_drain(): connection not open\n");
+		pmsg_error("connection not open\n");
 		exit(1);
 	}
 
@@ -664,7 +664,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				pmsg_error("ser_drain(): select(): %s\n", (char *) lpMsgBuf);
+				pmsg_error("select(): %s\n", (char *) lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -682,7 +682,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			pmsg_error("ser_drain(): unable to read: %s\n", (char *) lpMsgBuf);
+			pmsg_error("unable to read: %s\n", (char *) lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -708,7 +708,7 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 	HANDLE hComPort=(HANDLE)fd->pfd;
 
   	if (hComPort == INVALID_HANDLE_VALUE) {
-		pmsg_error("ser_drain(): port not open\n");
+		pmsg_error("port not open\n");
 		return -1;
 	}
 
@@ -732,7 +732,7 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR) &lpMsgBuf,
 				0,
 				NULL 	);
-			pmsg_error("ser_drain(): unable to read: %s\n", (char*) lpMsgBuf);
+			pmsg_error("unable to read: %s\n", (char*) lpMsgBuf);
 			LocalFree( lpMsgBuf );
 			return -1;
 		}

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -77,7 +77,7 @@ static DWORD serial_baud_lookup(long baud)
    * If a non-standard BAUD rate is used, issue
    * a warning (if we are verbose) and return the raw rate
    */
-  avrdude_message(MSG_NOTICE, "%s: serial_baud_lookup(): Using non-standard baud rate: %ld",
+  msg_notice("%s: serial_baud_lookup(): Using non-standard baud rate: %ld",
               progname, baud);
 
   return baud;
@@ -160,17 +160,17 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 	struct hostent *hp;
 
 	if (WSAStartup(MAKEWORD(2, 0), &wsaData) != 0) {
-		avrdude_message(MSG_INFO, "%s: net_open(): WSAStartup() failed\n", progname);
+		msg_info("%s: net_open(): WSAStartup() failed\n", progname);
 		return -1;
 	}
 
 	if ((hstr = strdup(port)) == NULL) {
-		avrdude_message(MSG_INFO, "%s: net_open(): Out of memory!\n", progname);
+		msg_info("%s: net_open(): Out of memory!\n", progname);
 		return -1;
 	}
 
 	if (((pstr = strchr(hstr, ':')) == NULL) || (pstr == hstr)) {
-		avrdude_message(MSG_INFO, "%s: net_open(): Mangled host:port string \"%s\"\n", progname, hstr);
+		msg_info("%s: net_open(): Mangled host:port string \"%s\"\n", progname, hstr);
 		free(hstr);
 		return -1;
 	}
@@ -183,13 +183,13 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 	pnum = strtoul(pstr, &end, 10);
 
 	if ((*pstr == '\0') || (*end != '\0') || (pnum == 0) || (pnum > 65535)) {
-		avrdude_message(MSG_INFO, "%s: net_open(): Bad port number \"%s\"\n", progname, pstr);
+		msg_info("%s: net_open(): Bad port number \"%s\"\n", progname, pstr);
 		free(hstr);
 		return -1;
 	}
 
 	if ((hp = gethostbyname(hstr)) == NULL) {
-		avrdude_message(MSG_INFO, "%s: net_open(): unknown host \"%s\"\n", progname, hstr);
+		msg_info("%s: net_open(): unknown host \"%s\"\n", progname, hstr);
 		free(hstr);
 		return -1;
 	}
@@ -207,7 +207,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		avrdude_message(MSG_INFO, "%s: net_open(): Cannot open socket: %s\n", progname, (char *)lpMsgBuf);
+		msg_info("%s: net_open(): Cannot open socket: %s\n", progname, (char *)lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -228,7 +228,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		avrdude_message(MSG_INFO, "%s: net_open(): Connect failed: %s\n", progname, (char *)lpMsgBuf);
+		msg_info("%s: net_open(): Connect failed: %s\n", progname, (char *)lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -259,7 +259,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	    newname = malloc(strlen("\\\\.\\") + strlen(port) + 1);
 
 	    if (newname == 0) {
-		avrdude_message(MSG_INFO, "%s: ser_open(): out of memory\n",
+		msg_info("%s: ser_open(): out of memory\n",
                                 progname);
 		exit(1);
 	    }
@@ -283,7 +283,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		avrdude_message(MSG_INFO, "%s: ser_open(): can't open device \"%s\": %s\n",
+		msg_info("%s: ser_open(): can't open device \"%s\": %s\n",
 				progname, port, (char*)lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
@@ -292,7 +292,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (!SetupComm(hComPort, W32SERBUFSIZE, W32SERBUFSIZE))
 	{
 		CloseHandle(hComPort);
-		avrdude_message(MSG_INFO, "%s: ser_open(): can't set buffers for \"%s\"\n",
+		msg_info("%s: ser_open(): can't set buffers for \"%s\"\n",
 				progname, port);
 		return -1;
 	}
@@ -301,7 +301,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (ser_setparams(fdp, pinfo.serialinfo.baud, pinfo.serialinfo.cflags) != 0)
 	{
 		CloseHandle(hComPort);
-		avrdude_message(MSG_INFO, "%s: ser_open(): can't set com-state for \"%s\"\n",
+		msg_info("%s: ser_open(): can't set com-state for \"%s\"\n",
 				progname, port);
 		return -1;
 	}
@@ -309,7 +309,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (!serial_w32SetTimeOut(hComPort,0))
 	{
 		CloseHandle(hComPort);
-		avrdude_message(MSG_INFO, "%s: ser_open(): can't set initial timeout for \"%s\"\n",
+		msg_info("%s: ser_open(): can't set initial timeout for \"%s\"\n",
 				progname, port);
 		return -1;
 	}
@@ -358,7 +358,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char * buf, s
 	size_t len = buflen;
 
 	if (fd->ifd < 0) {
-		avrdude_message(MSG_NOTICE, "%s: net_send(): connection not open\n", progname);
+		msg_notice("%s: net_send(): connection not open\n", progname);
 		exit(1);
 	}
 
@@ -367,22 +367,22 @@ static int net_send(const union filedescriptor *fd, const unsigned char * buf, s
 	}
 
 	if (verbose > 3) {
-		avrdude_message(MSG_TRACE, "%s: Send: ", progname);
+		msg_trace("%s: Send: ", progname);
 
 		while (buflen) {
 			unsigned char c = *buf;
 			if (isprint(c)) {
-				avrdude_message(MSG_TRACE, "%c ", c);
+				msg_trace("%c ", c);
 			} else {
-				avrdude_message(MSG_TRACE, ". ");
+				msg_trace(". ");
 			}
-			avrdude_message(MSG_TRACE, "[%02x] ", c);
+			msg_trace("[%02x] ", c);
 
 			buf++;
 			buflen--;
 		}
 
-		avrdude_message(MSG_TRACE, "\n");
+		msg_trace("\n");
 	}
 
 	while (len) {
@@ -398,7 +398,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char * buf, s
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			avrdude_message(MSG_INFO, "%s: net_send(): send error: %s\n", progname, (char *)lpMsgBuf);
+			msg_info("%s: net_send(): send error: %s\n", progname, (char *)lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -423,7 +423,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 	HANDLE hComPort=(HANDLE)fd->pfd;
 
 	if (hComPort == INVALID_HANDLE_VALUE) {
-		avrdude_message(MSG_INFO, "%s: ser_send(): port not open\n",
+		msg_info("%s: ser_send(): port not open\n",
               progname); 
 		return -1;
 	}
@@ -433,33 +433,33 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 
 	if (verbose > 3)
 	{
-		avrdude_message(MSG_TRACE, "%s: Send: ", progname);
+		msg_trace("%s: Send: ", progname);
 
 		while (len) {
 			c = *b;
 			if (isprint(c)) {
-				avrdude_message(MSG_TRACE, "%c ", c);
+				msg_trace("%c ", c);
 			}
 			else {
-				avrdude_message(MSG_TRACE, ". ");
+				msg_trace(". ");
 			}
-			avrdude_message(MSG_TRACE, "[%02x] ", c);
+			msg_trace("[%02x] ", c);
 			b++;
 			len--;
 		}
-      avrdude_message(MSG_INFO, "\n");
+      msg_info("\n");
 	}
 	
 	serial_w32SetTimeOut(hComPort,500);
 
 	if (!WriteFile (hComPort, buf, buflen, &written, NULL)) {
-		avrdude_message(MSG_INFO, "%s: ser_send(): write error: %s\n",
+		msg_info("%s: ser_send(): write error: %s\n",
               progname, "sorry no info avail"); // TODO
 		return -1;
 	}
 
 	if (written != buflen) {
-		avrdude_message(MSG_INFO, "%s: ser_send(): size/send mismatch\n",
+		msg_info("%s: ser_send(): size/send mismatch\n",
               progname); 
 		return -1;
 	}
@@ -478,7 +478,7 @@ static int net_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 	size_t len = 0;
 
 	if (fd->ifd < 0) {
-		avrdude_message(MSG_INFO, "%s: net_recv(): connection not open\n", progname);
+		msg_info("%s: net_recv(): connection not open\n", progname);
 		exit(1);
 	}
 
@@ -494,12 +494,12 @@ reselect:
 		nfds = select(fd->ifd + 1, &rfds, NULL, NULL, &to2);
 		if (nfds == 0) {
 			if (verbose > 1) {
-				avrdude_message(MSG_NOTICE, "%s: ser_recv(): programmer is not responding\n", progname);
+				msg_notice("%s: ser_recv(): programmer is not responding\n", progname);
 			}
 			return -1;
 		} else if (nfds == -1) {
 			if (WSAGetLastError() == WSAEINTR || WSAGetLastError() == WSAEINPROGRESS) {
-				avrdude_message(MSG_NOTICE, "%s: ser_recv(): programmer is not responding, reselecting\n", progname);
+				msg_notice("%s: ser_recv(): programmer is not responding, reselecting\n", progname);
 				goto reselect;
 			} else {
 				FormatMessage(
@@ -512,7 +512,7 @@ reselect:
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				avrdude_message(MSG_INFO, "%s: ser_recv(): select(): %s\n", progname, (char *)lpMsgBuf);
+				msg_info("%s: ser_recv(): select(): %s\n", progname, (char *)lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -530,7 +530,7 @@ reselect:
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			avrdude_message(MSG_INFO, "%s: ser_recv(): read error: %s\n", progname, (char *)lpMsgBuf);
+			msg_info("%s: ser_recv(): read error: %s\n", progname, (char *)lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -541,21 +541,21 @@ reselect:
 	p = buf;
 
 	if (verbose > 3) {
-		avrdude_message(MSG_TRACE, "%s: Recv: ", progname);
+		msg_trace("%s: Recv: ", progname);
 
 		while (len) {
 			unsigned char c = *p;
 			if (isprint(c)) {
-				avrdude_message(MSG_TRACE, "%c ", c);
+				msg_trace("%c ", c);
 			} else {
-				avrdude_message(MSG_TRACE, ". ");
+				msg_trace(". ");
 			}
-			avrdude_message(MSG_TRACE, "[%02x] ", c);
+			msg_trace("[%02x] ", c);
 
 			p++;
 			len--;
 		}
-		avrdude_message(MSG_TRACE, "\n");
+		msg_trace("\n");
 	}
 
 	return 0;
@@ -573,7 +573,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 	HANDLE hComPort=(HANDLE)fd->pfd;
 	
 	if (hComPort == INVALID_HANDLE_VALUE) {
-		avrdude_message(MSG_INFO, "%s: ser_read(): port not open\n",
+		msg_info("%s: ser_read(): port not open\n",
               progname); 
 		return -1;
 	}
@@ -592,7 +592,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL 	);
-		avrdude_message(MSG_INFO, "%s: ser_recv(): read error: %s\n",
+		msg_info("%s: ser_recv(): read error: %s\n",
 			      progname, (char*)lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
@@ -600,7 +600,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 
 	/* time out detected */
 	if (read == 0) {
-		avrdude_message(MSG_NOTICE2, "%s: ser_recv(): programmer is not responding\n",
+		msg_notice2("%s: ser_recv(): programmer is not responding\n",
                                 progname);
 		return -1;
 	}
@@ -609,22 +609,22 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 
 	if (verbose > 3)
 	{
-		avrdude_message(MSG_TRACE, "%s: Recv: ", progname);
+		msg_trace("%s: Recv: ", progname);
 
 		while (read) {
 			c = *p;
 			if (isprint(c)) {
-				avrdude_message(MSG_TRACE, "%c ", c);
+				msg_trace("%c ", c);
 			}
 			else {
-				avrdude_message(MSG_TRACE, ". ");
+				msg_trace(". ");
 			}
-			avrdude_message(MSG_TRACE, "[%02x] ", c);
+			msg_trace("[%02x] ", c);
 
 			p++;
 			read--;
 		}
-		avrdude_message(MSG_INFO, "\n");
+		msg_info("\n");
 	}
   return 0;
 }
@@ -638,12 +638,12 @@ static int net_drain(const union filedescriptor *fd, int display) {
 	int rc;
 
 	if (fd->ifd < 0) {
-		avrdude_message(MSG_INFO, "%s: ser_drain(): connection not open\n", progname);
+		msg_info("%s: ser_drain(): connection not open\n", progname);
 		exit(1);
 	}
 
 	if (display) {
-		avrdude_message(MSG_INFO, "drain>");
+		msg_info("drain>");
 	}
 
 	timeout.tv_sec  = 0;
@@ -657,13 +657,13 @@ static int net_drain(const union filedescriptor *fd, int display) {
 		nfds = select(fd->ifd + 1, &rfds, NULL, NULL, &timeout);
 		if (nfds == 0) {
 			if (display) {
-				avrdude_message(MSG_INFO, "<drain\n");
+				msg_info("<drain\n");
 			}
 			break;
 		}
 		else if (nfds == -1) {
 			if (WSAGetLastError() == WSAEINTR || WSAGetLastError() == WSAEINPROGRESS) {
-				avrdude_message(MSG_NOTICE, "%s: ser_drain(): programmer is not responding, reselecting\n", progname);
+				msg_notice("%s: ser_drain(): programmer is not responding, reselecting\n", progname);
 				goto reselect;
 			} else {
 				FormatMessage(
@@ -676,7 +676,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				avrdude_message(MSG_INFO, "%s: ser_drain(): select(): %s\n", progname, (char *)lpMsgBuf);
+				msg_info("%s: ser_drain(): select(): %s\n", progname, (char *)lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -694,13 +694,13 @@ static int net_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			avrdude_message(MSG_INFO, "%s: ser_drain(): read error: %s\n", progname, (char *)lpMsgBuf);
+			msg_info("%s: ser_drain(): read error: %s\n", progname, (char *)lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
 
 		if (display) {
-			avrdude_message(MSG_INFO, "%02x ", buf);
+			msg_info("%02x ", buf);
 		}
 	}
 
@@ -720,7 +720,7 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 	HANDLE hComPort=(HANDLE)fd->pfd;
 
   	if (hComPort == INVALID_HANDLE_VALUE) {
-		avrdude_message(MSG_INFO, "%s: ser_drain(): port not open\n",
+		msg_info("%s: ser_drain(): port not open\n",
               progname); 
 		return -1;
 	}
@@ -728,7 +728,7 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 	serial_w32SetTimeOut(hComPort,250);
   
 	if (display) {
-		avrdude_message(MSG_INFO, "drain>");
+		msg_info("drain>");
 	}
 
 	while (1) {
@@ -745,17 +745,17 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR) &lpMsgBuf,
 				0,
 				NULL 	);
-			avrdude_message(MSG_INFO, "%s: ser_drain(): read error: %s\n",
+			msg_info("%s: ser_drain(): read error: %s\n",
 					  progname, (char*)lpMsgBuf);
 			LocalFree( lpMsgBuf );
 			return -1;
 		}
 
 		if (read) { // data avail
-			if (display) avrdude_message(MSG_INFO, "%02x ", buf[0]);
+			if (display) msg_info("%02x ", buf[0]);
 		}
 		else { // no more data
-			if (display) avrdude_message(MSG_INFO, "<drain\n");
+			if (display) msg_info("<drain\n");
 			break;
 		}
 	} // while

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -206,7 +206,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		pmsg_error("net_open(): cannot open socket: %s\n", (char *)lpMsgBuf);
+		pmsg_error("net_open(): cannot open socket: %s\n", (char *) lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -227,7 +227,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 			(LPTSTR)&lpMsgBuf,
 			0,
 			NULL);
-		pmsg_error("net_open(): connect failed: %s\n", (char *)lpMsgBuf);
+		pmsg_error("net_open(): connect failed: %s\n", (char *) lpMsgBuf);
 		LocalFree(lpMsgBuf);
 		return -1;
 	}
@@ -281,7 +281,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		pmsg_error("ser_open(): cannot open port %s: %s\n", port, (char*)lpMsgBuf);
+		pmsg_error("ser_open(): cannot open port %s: %s\n", port, (char*) lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
 	}
@@ -503,7 +503,7 @@ reselect:
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				pmsg_error("ser_recv(): select(): %s\n", (char *)lpMsgBuf);
+				pmsg_error("ser_recv(): select(): %s\n", (char *) lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -582,7 +582,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL 	);
-		pmsg_error("ser_recv(): unable to read: %s\n", (char*)lpMsgBuf);
+		pmsg_error("ser_recv(): unable to read: %s\n", (char*) lpMsgBuf);
 		LocalFree( lpMsgBuf );
 		return -1;
 	}
@@ -664,7 +664,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 					(LPTSTR)&lpMsgBuf,
 					0,
 					NULL);
-				pmsg_error("ser_drain(): select(): %s\n", (char *)lpMsgBuf);
+				pmsg_error("ser_drain(): select(): %s\n", (char *) lpMsgBuf);
 				LocalFree(lpMsgBuf);
 				exit(1);
 			}
@@ -682,7 +682,7 @@ static int net_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR)&lpMsgBuf,
 				0,
 				NULL);
-			pmsg_error("ser_drain(): unable to read: %s\n", (char *)lpMsgBuf);
+			pmsg_error("ser_drain(): unable to read: %s\n", (char *) lpMsgBuf);
 			LocalFree(lpMsgBuf);
 			exit(1);
 		}
@@ -732,7 +732,7 @@ static int ser_drain(const union filedescriptor *fd, int display) {
 				(LPTSTR) &lpMsgBuf,
 				0,
 				NULL 	);
-			pmsg_error("ser_drain(): unable to read: %s\n", (char*)lpMsgBuf);
+			pmsg_error("ser_drain(): unable to read: %s\n", (char*) lpMsgBuf);
 			LocalFree( lpMsgBuf );
 			return -1;
 		}

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -229,7 +229,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 
   r = tcgetattr(pgm->fd.ifd, &mode);
   if (r < 0) {
-    avrdude_message(MSG_INFO, "%s: ", port);
+    msg_info("%s: ", port);
     perror("tcgetattr");
     return(-1);
   }
@@ -243,7 +243,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 
   r = tcsetattr(pgm->fd.ifd, TCSANOW, &mode);
   if (r < 0) {
-      avrdude_message(MSG_INFO, "%s: ", port);
+      msg_info("%s: ", port);
       perror("tcsetattr");
       return(-1);
   }
@@ -252,14 +252,14 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   flags = fcntl(pgm->fd.ifd, F_GETFL, 0);
   if (flags == -1)
     {
-      avrdude_message(MSG_INFO, "%s: Can not get flags: %s\n",
+      msg_info("%s: Can not get flags: %s\n",
 	      progname, strerror(errno));
       return(-1);
     }
   flags &= ~O_NONBLOCK;
   if (fcntl(pgm->fd.ifd, F_SETFL, flags) == -1)
     {
-      avrdude_message(MSG_INFO, "%s: Can not clear nonblock flag: %s\n",
+      msg_info("%s: Can not clear nonblock flag: %s\n",
 	      progname, strerror(errno));
       return(-1);
     }

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -91,33 +91,33 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
   switch ( pin )
   {
     case 3:  /* txd */
-        r = ioctl(pgm->fd.ifd, value ? TIOCSBRK : TIOCCBRK, 0);
-        if (r < 0) {
-          pmsg_ext_error("ioctl(\"TIOCxBRK\"): %s\n", strerror(errno));
-          return -1;
-        }
-        break;
+      r = ioctl(pgm->fd.ifd, value ? TIOCSBRK : TIOCCBRK, 0);
+      if (r < 0) {
+        pmsg_ext_error("ioctl(\"TIOCxBRK\"): %s\n", strerror(errno));
+        return -1;
+      }
+      break;
 
     case 4:  /* dtr */
     case 7:  /* rts */
-        r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
-        if (r < 0) {
-          pmsg_ext_error("ioctl(\"TIOCMGET\"): %s\n", strerror(errno));
-          return -1;
-        }
-        if (value)
-          ctl |= serregbits[pin];
-        else
-          ctl &= ~(serregbits[pin]);
-        r = ioctl(pgm->fd.ifd, TIOCMSET, &ctl);
-        if (r < 0) {
-          pmsg_ext_error("ioctl(\"TIOCMSET\"): %s\n", strerror(errno));
-          return -1;
-        }
-        break;
+      r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
+      if (r < 0) {
+        pmsg_ext_error("ioctl(\"TIOCMGET\"): %s\n", strerror(errno));
+        return -1;
+      }
+      if (value)
+        ctl |= serregbits[pin];
+      else
+        ctl &= ~(serregbits[pin]);
+      r = ioctl(pgm->fd.ifd, TIOCMSET, &ctl);
+      if (r < 0) {
+        pmsg_ext_error("ioctl(\"TIOCMSET\"): %s\n", strerror(errno));
+        return -1;
+      }
+      break;
 
     default: /* impossible */
-        return -1;
+      return -1;
   }
 
   if (pgm->ispdelay > 1)
@@ -145,34 +145,34 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
   switch ( pin )
   {
     case 2:  /* rxd, currently not implemented, FIXME */
-        return(-1);
+      return(-1);
 
     case 1:  /* cd  */
     case 6:  /* dsr */
     case 8:  /* cts */
     case 9:  /* ri  */
-        r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
-        if (r < 0) {
-          pmsg_ext_error("ioctl(\"TIOCMGET\"): %s\n", strerror(errno));
-          return -1;
-        }
-        if ( !invert )
-        {
+      r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
+      if (r < 0) {
+        pmsg_ext_error("ioctl(\"TIOCMGET\"): %s\n", strerror(errno));
+        return -1;
+      }
+      if ( !invert )
+      {
 #ifdef DEBUG
-          msg_info("%s is %d\n", serpins[pin], ctl & serregbits[pin]? 1: 0);
+        msg_info("%s is %d\n", serpins[pin], ctl & serregbits[pin]? 1: 0);
 #endif
-          return ctl & serregbits[pin]? 1: 0;
-        }
-        else
-        {
+        return ctl & serregbits[pin]? 1: 0;
+      }
+      else
+      {
 #ifdef DEBUG
-          msg_info("%s is %d (~)\n", serpins[pin], ctl & serregbits[pin]? 0: 1);
+        msg_info("%s is %d (~)\n", serpins[pin], ctl & serregbits[pin]? 0: 1);
 #endif
-          return ctl & serregbits[pin]? 0: 1;
-        }
+        return ctl & serregbits[pin]? 0: 1;
+      }
 
     default: /* impossible */
-        return(-1);
+      return(-1);
   }
 }
 

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -252,15 +252,13 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   flags = fcntl(pgm->fd.ifd, F_GETFL, 0);
   if (flags == -1)
     {
-      msg_info("%s: Can not get flags: %s\n",
-	      progname, strerror(errno));
+      pmsg_info("cannot get flags: %s\n", strerror(errno));
       return(-1);
     }
   flags &= ~O_NONBLOCK;
   if (fcntl(pgm->fd.ifd, F_SETFL, flags) == -1)
     {
-      msg_info("%s: Can not clear nonblock flag: %s\n",
-	      progname, strerror(errno));
+      pmsg_info("cannot clear nonblock flag: %s\n", strerror(errno));
       return(-1);
     }
 

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -85,39 +85,39 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
     return -1;
 
 #ifdef DEBUG
-  printf("%s to %d\n",serpins[pin],value);
+  msg_info("%s to %d\n", serpins[pin], value);
 #endif
 
   switch ( pin )
   {
     case 3:  /* txd */
-	     r = ioctl(pgm->fd.ifd, value ? TIOCSBRK : TIOCCBRK, 0);
-	     if (r < 0) {
-	       perror("ioctl(\"TIOCxBRK\")");
-	       return -1;
-	     }
-             break;
+        r = ioctl(pgm->fd.ifd, value ? TIOCSBRK : TIOCCBRK, 0);
+        if (r < 0) {
+          pmsg_ext_error("ioctl(\"TIOCxBRK\"): %s\n", strerror(errno));
+          return -1;
+        }
+        break;
 
     case 4:  /* dtr */
     case 7:  /* rts */
-             r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
- 	     if (r < 0) {
-	       perror("ioctl(\"TIOCMGET\")");
-	       return -1;
- 	     }
-             if ( value )
-               ctl |= serregbits[pin];
-             else
-               ctl &= ~(serregbits[pin]);
-	     r = ioctl(pgm->fd.ifd, TIOCMSET, &ctl);
- 	     if (r < 0) {
-	       perror("ioctl(\"TIOCMSET\")");
-	       return -1;
- 	     }
-             break;
+        r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
+        if (r < 0) {
+          pmsg_ext_error("ioctl(\"TIOCMGET\"): %s\n", strerror(errno));
+          return -1;
+        }
+        if (value)
+          ctl |= serregbits[pin];
+        else
+          ctl &= ~(serregbits[pin]);
+        r = ioctl(pgm->fd.ifd, TIOCMSET, &ctl);
+        if (r < 0) {
+          pmsg_ext_error("ioctl(\"TIOCMSET\"): %s\n", strerror(errno));
+          return -1;
+        }
+        break;
 
     default: /* impossible */
-             return -1;
+        return -1;
   }
 
   if (pgm->ispdelay > 1)
@@ -145,34 +145,34 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
   switch ( pin )
   {
     case 2:  /* rxd, currently not implemented, FIXME */
-             return(-1);
+        return(-1);
 
     case 1:  /* cd  */
     case 6:  /* dsr */
     case 8:  /* cts */
     case 9:  /* ri  */
-             r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
- 	     if (r < 0) {
-	       perror("ioctl(\"TIOCMGET\")");
-	       return -1;
- 	     }
-             if ( !invert )
-             {
+        r = ioctl(pgm->fd.ifd, TIOCMGET, &ctl);
+        if (r < 0) {
+          pmsg_ext_error("ioctl(\"TIOCMGET\"): %s\n", strerror(errno));
+          return -1;
+        }
+        if ( !invert )
+        {
 #ifdef DEBUG
-               printf("%s is %d\n",serpins[pin],(ctl & serregbits[pin]) ? 1 : 0 );
+          msg_info("%s is %d\n", serpins[pin], ctl & serregbits[pin]? 1: 0);
 #endif
-               return ( (ctl & serregbits[pin]) ? 1 : 0 );
-             }
-             else
-             {
+          return ctl & serregbits[pin]? 1: 0;
+        }
+        else
+        {
 #ifdef DEBUG
-               printf("%s is %d (~)\n",serpins[pin],(ctl & serregbits[pin]) ? 0 : 1 );
+          msg_info("%s is %d (~)\n", serpins[pin], ctl & serregbits[pin]? 0: 1);
 #endif
-               return (( ctl & serregbits[pin]) ? 0 : 1 );
-             }
+          return ctl & serregbits[pin]? 0: 1;
+        }
 
     default: /* impossible */
-             return(-1);
+        return(-1);
   }
 }
 
@@ -223,14 +223,13 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   pgm->fd.ifd = open(port, O_RDWR | O_NOCTTY | O_NONBLOCK);
 
   if (pgm->fd.ifd < 0) {
-    perror(port);
+    pmsg_ext_error("%s: %s\n", port, strerror(errno));
     return(-1);
   }
 
   r = tcgetattr(pgm->fd.ifd, &mode);
   if (r < 0) {
-    msg_info("%s: ", port);
-    perror("tcgetattr");
+    pmsg_ext_error("%s, tcgetattr(): %s\n", port, strerror(errno));
     return(-1);
   }
   oldmode = mode;
@@ -243,8 +242,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 
   r = tcsetattr(pgm->fd.ifd, TCSANOW, &mode);
   if (r < 0) {
-      msg_info("%s: ", port);
-      perror("tcsetattr");
+      pmsg_ext_error("%s, tcsetattr(): %s", port, strerror(errno));
       return(-1);
   }
 
@@ -252,13 +250,13 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   flags = fcntl(pgm->fd.ifd, F_GETFL, 0);
   if (flags == -1)
     {
-      pmsg_info("cannot get flags: %s\n", strerror(errno));
+      pmsg_ext_error("cannot get flags: %s\n", strerror(errno));
       return(-1);
     }
   flags &= ~O_NONBLOCK;
   if (fcntl(pgm->fd.ifd, F_SETFL, flags) == -1)
     {
-      pmsg_info("cannot clear nonblock flag: %s\n", strerror(errno));
+      pmsg_ext_error("cannot clear nonblock flag: %s\n", strerror(errno));
       return(-1);
     }
 

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -113,7 +113,7 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
                         (LPTSTR) &lpMsgBuf,
                         0,
                         NULL);
-                pmsg_error("serbb_setpin(): SetCommState() failed: %s\n", (char *) lpMsgBuf);
+                pmsg_error("SetCommState() failed: %s\n", (char *) lpMsgBuf);
                 CloseHandle(hComPort);
                 LocalFree(lpMsgBuf);
                 return -1;
@@ -157,7 +157,7 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
                                 (LPTSTR) &lpMsgBuf,
                                 0,
                                 NULL);
-                        pmsg_error("serbb_setpin(): GetCommModemStatus() failed: %s\n", (char *) lpMsgBuf);
+                        pmsg_error("GetCommModemStatus() failed: %s\n", (char *) lpMsgBuf);
                         CloseHandle(hComPort);
                         LocalFree(lpMsgBuf);
                         return -1;
@@ -261,7 +261,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		pmsg_error("ser_open(): cannot open port %s: %s\n", port, (char*) lpMsgBuf);
+		pmsg_error("cannot open port %s: %s\n", port, (char*) lpMsgBuf);
 		LocalFree(lpMsgBuf);
                 return -1;
 	}
@@ -269,7 +269,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetupComm(hComPort, W32SERBUFSIZE, W32SERBUFSIZE))
 	{
 		CloseHandle(hComPort);
-		pmsg_error("ser_open(): cannot set buffers for %s\n", port);
+		pmsg_error("cannot set buffers for %s\n", port);
                 return -1;
 	}
 
@@ -287,7 +287,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetCommState(hComPort, &dcb))
 	{
 		CloseHandle(hComPort);
-		pmsg_error("ser_open(): cannot set com-state for %s\n", port);
+		pmsg_error("cannot set com-state for %s\n", port);
                 return -1;
 	}
         pmsg_debug("ser_open(): opened comm port %s, handle 0x%zx\n", port, (INT_PTR) hComPort);

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -97,11 +97,11 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
                 break;
 
         default:
-                avrdude_message(MSG_NOTICE, "%s: serbb_setpin(): unknown pin %d\n",
+                msg_notice("%s: serbb_setpin(): unknown pin %d\n",
                                         progname, pin + 1);
                 return -1;
         }
-        avrdude_message(MSG_TRACE2, "%s: serbb_setpin(): EscapeCommFunction(%s)\n",
+        msg_trace2("%s: serbb_setpin(): EscapeCommFunction(%s)\n",
                                 progname, name);
         if (!EscapeCommFunction(hComPort, dwFunc))
         {
@@ -115,7 +115,7 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
                         (LPTSTR) &lpMsgBuf,
                         0,
                         NULL);
-                avrdude_message(MSG_INFO, "%s: serbb_setpin(): SetCommState() failed: %s\n",
+                msg_info("%s: serbb_setpin(): SetCommState() failed: %s\n",
                                 progname, (char *)lpMsgBuf);
                 CloseHandle(hComPort);
                 LocalFree(lpMsgBuf);
@@ -160,13 +160,13 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
                                 (LPTSTR) &lpMsgBuf,
                                 0,
                                 NULL);
-                        avrdude_message(MSG_INFO, "%s: serbb_setpin(): GetCommModemStatus() failed: %s\n",
+                        msg_info("%s: serbb_setpin(): GetCommModemStatus() failed: %s\n",
                                         progname, (char *)lpMsgBuf);
                         CloseHandle(hComPort);
                         LocalFree(lpMsgBuf);
                         return -1;
                 }
-                avrdude_message(MSG_TRACE2, "%s: serbb_getpin(): GetCommState() => 0x%lx\n",
+                msg_trace2("%s: serbb_getpin(): GetCommState() => 0x%lx\n",
                                         progname, modemstate);
                 switch (pin)
                 {
@@ -202,11 +202,11 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
                 name = "RTS";
                 break;
         default:
-                avrdude_message(MSG_NOTICE, "%s: serbb_getpin(): unknown pin %d\n",
+                msg_notice("%s: serbb_getpin(): unknown pin %d\n",
                                         progname, pin + 1);
                 return -1;
         }
-        avrdude_message(MSG_TRACE2, "%s: serbb_getpin(): return cached state for %s\n",
+        msg_trace2("%s: serbb_getpin(): return cached state for %s\n",
                                 progname, name);
         if (invert)
                 rv = !rv;
@@ -268,7 +268,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		avrdude_message(MSG_INFO, "%s: ser_open(): can't open device \"%s\": %s\n",
+		msg_info("%s: ser_open(): can't open device \"%s\": %s\n",
                         progname, port, (char*)lpMsgBuf);
 		LocalFree(lpMsgBuf);
                 return -1;
@@ -277,7 +277,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetupComm(hComPort, W32SERBUFSIZE, W32SERBUFSIZE))
 	{
 		CloseHandle(hComPort);
-		avrdude_message(MSG_INFO, "%s: ser_open(): can't set buffers for \"%s\"\n",
+		msg_info("%s: ser_open(): can't set buffers for \"%s\"\n",
                         progname, port);
                 return -1;
 	}
@@ -296,11 +296,11 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetCommState(hComPort, &dcb))
 	{
 		CloseHandle(hComPort);
-		avrdude_message(MSG_INFO, "%s: ser_open(): can't set com-state for \"%s\"\n",
+		msg_info("%s: ser_open(): can't set com-state for \"%s\"\n",
                         progname, port);
                 return -1;
 	}
-        avrdude_message(MSG_DEBUG, "%s: ser_open(): opened comm port \"%s\", handle 0x%zx\n",
+        msg_debug("%s: ser_open(): opened comm port \"%s\", handle 0x%zx\n",
                         progname, port, (INT_PTR)hComPort);
 
         pgm->fd.pfd = (void *)hComPort;
@@ -317,7 +317,7 @@ static void serbb_close(PROGRAMMER *pgm) {
 		pgm->setpin(pgm, PIN_AVR_RESET, 1);
 		CloseHandle (hComPort);
 	}
-        avrdude_message(MSG_DEBUG, "%s: ser_close(): closed comm port handle 0x%zx\n",
+        msg_debug("%s: ser_close(): closed comm port handle 0x%zx\n",
                                 progname, (INT_PTR)hComPort);
 
 	hComPort = INVALID_HANDLE_VALUE;

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -97,12 +97,10 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
                 break;
 
         default:
-                msg_notice("%s: serbb_setpin(): unknown pin %d\n",
-                                        progname, pin + 1);
+                pmsg_notice("serbb_setpin(): unknown pin %d\n", pin + 1);
                 return -1;
         }
-        msg_trace2("%s: serbb_setpin(): EscapeCommFunction(%s)\n",
-                                progname, name);
+        pmsg_trace2("serbb_setpin(): EscapeCommFunction(%s)\n", name);
         if (!EscapeCommFunction(hComPort, dwFunc))
         {
                 FormatMessage(
@@ -115,8 +113,7 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
                         (LPTSTR) &lpMsgBuf,
                         0,
                         NULL);
-                msg_info("%s: serbb_setpin(): SetCommState() failed: %s\n",
-                                progname, (char *)lpMsgBuf);
+                pmsg_info("serbb_setpin(): SetCommState() failed: %s\n", (char *)lpMsgBuf);
                 CloseHandle(hComPort);
                 LocalFree(lpMsgBuf);
                 return -1;
@@ -160,14 +157,12 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
                                 (LPTSTR) &lpMsgBuf,
                                 0,
                                 NULL);
-                        msg_info("%s: serbb_setpin(): GetCommModemStatus() failed: %s\n",
-                                        progname, (char *)lpMsgBuf);
+                        pmsg_info("serbb_setpin(): GetCommModemStatus() failed: %s\n", (char *)lpMsgBuf);
                         CloseHandle(hComPort);
                         LocalFree(lpMsgBuf);
                         return -1;
                 }
-                msg_trace2("%s: serbb_getpin(): GetCommState() => 0x%lx\n",
-                                        progname, modemstate);
+                pmsg_trace2("serbb_getpin(): GetCommState() => 0x%lx\n", modemstate);
                 switch (pin)
                 {
                 case 1:
@@ -202,12 +197,10 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
                 name = "RTS";
                 break;
         default:
-                msg_notice("%s: serbb_getpin(): unknown pin %d\n",
-                                        progname, pin + 1);
+                pmsg_notice("serbb_getpin(): unknown pin %d\n", pin + 1);
                 return -1;
         }
-        msg_trace2("%s: serbb_getpin(): return cached state for %s\n",
-                                progname, name);
+        pmsg_trace2("serbb_getpin(): return cached state for %s\n", name);
         if (invert)
                 rv = !rv;
 
@@ -268,8 +261,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		msg_info("%s: ser_open(): can't open device \"%s\": %s\n",
-                        progname, port, (char*)lpMsgBuf);
+		pmsg_info("ser_open(): can't open port %s: %s\n", port, (char*) lpMsgBuf);
 		LocalFree(lpMsgBuf);
                 return -1;
 	}
@@ -277,8 +269,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetupComm(hComPort, W32SERBUFSIZE, W32SERBUFSIZE))
 	{
 		CloseHandle(hComPort);
-		msg_info("%s: ser_open(): can't set buffers for \"%s\"\n",
-                        progname, port);
+		pmsg_info("ser_open(): can't set buffers for %s\n", port);
                 return -1;
 	}
 
@@ -296,12 +287,10 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetCommState(hComPort, &dcb))
 	{
 		CloseHandle(hComPort);
-		msg_info("%s: ser_open(): can't set com-state for \"%s\"\n",
-                        progname, port);
+		pmsg_info("ser_open(): can't set com-state for %s\n", port);
                 return -1;
 	}
-        msg_debug("%s: ser_open(): opened comm port \"%s\", handle 0x%zx\n",
-                        progname, port, (INT_PTR)hComPort);
+        pmsg_debug("ser_open(): opened comm port %s, handle 0x%zx\n", port, (INT_PTR) hComPort);
 
         pgm->fd.pfd = (void *)hComPort;
 
@@ -317,8 +306,7 @@ static void serbb_close(PROGRAMMER *pgm) {
 		pgm->setpin(pgm, PIN_AVR_RESET, 1);
 		CloseHandle (hComPort);
 	}
-        msg_debug("%s: ser_close(): closed comm port handle 0x%zx\n",
-                                progname, (INT_PTR)hComPort);
+        pmsg_debug("ser_close(): closed comm port handle 0x%zx\n", (INT_PTR)hComPort);
 
 	hComPort = INVALID_HANDLE_VALUE;
 }

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -306,7 +306,7 @@ static void serbb_close(PROGRAMMER *pgm) {
 		pgm->setpin(pgm, PIN_AVR_RESET, 1);
 		CloseHandle (hComPort);
 	}
-        pmsg_debug("ser_close(): closed comm port handle 0x%zx\n", (INT_PTR)hComPort);
+        pmsg_debug("ser_close(): closed comm port handle 0x%zx\n", (INT_PTR) hComPort);
 
 	hComPort = INVALID_HANDLE_VALUE;
 }

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -113,7 +113,7 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
                         (LPTSTR) &lpMsgBuf,
                         0,
                         NULL);
-                pmsg_info("serbb_setpin(): SetCommState() failed: %s\n", (char *)lpMsgBuf);
+                pmsg_error("serbb_setpin(): SetCommState() failed: %s\n", (char *) lpMsgBuf);
                 CloseHandle(hComPort);
                 LocalFree(lpMsgBuf);
                 return -1;
@@ -157,7 +157,7 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
                                 (LPTSTR) &lpMsgBuf,
                                 0,
                                 NULL);
-                        pmsg_info("serbb_setpin(): GetCommModemStatus() failed: %s\n", (char *)lpMsgBuf);
+                        pmsg_error("serbb_setpin(): GetCommModemStatus() failed: %s\n", (char *) lpMsgBuf);
                         CloseHandle(hComPort);
                         LocalFree(lpMsgBuf);
                         return -1;
@@ -261,7 +261,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 			(LPTSTR) &lpMsgBuf,
 			0,
 			NULL);
-		pmsg_info("ser_open(): can't open port %s: %s\n", port, (char*) lpMsgBuf);
+		pmsg_error("ser_open(): cannot open port %s: %s\n", port, (char*) lpMsgBuf);
 		LocalFree(lpMsgBuf);
                 return -1;
 	}
@@ -269,7 +269,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetupComm(hComPort, W32SERBUFSIZE, W32SERBUFSIZE))
 	{
 		CloseHandle(hComPort);
-		pmsg_info("ser_open(): can't set buffers for %s\n", port);
+		pmsg_error("ser_open(): cannot set buffers for %s\n", port);
                 return -1;
 	}
 
@@ -287,7 +287,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 	if (!SetCommState(hComPort, &dcb))
 	{
 		CloseHandle(hComPort);
-		pmsg_info("ser_open(): can't set com-state for %s\n", port);
+		pmsg_error("ser_open(): cannot set com-state for %s\n", port);
                 return -1;
 	}
         pmsg_debug("ser_open(): opened comm port %s, handle 0x%zx\n", port, (INT_PTR) hComPort);

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -49,7 +49,7 @@ static int serialupdi_leave_progmode(const PROGRAMMER *pgm);
 static void serialupdi_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(updi_state))) == 0) {
-    pmsg_error("serialupdi_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(updi_state));
@@ -937,7 +937,7 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
       continue;
     }
 
-    pmsg_error("serialupdi_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -49,9 +49,7 @@ static int serialupdi_leave_progmode(const PROGRAMMER *pgm);
 static void serialupdi_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(updi_state))) == 0) {
-    msg_info(
-	    "%s: serialupdi_setup(): Out of memory allocating private data\n",
-	    progname);
+    pmsg_info("serialupdi_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(updi_state));
@@ -91,10 +89,10 @@ static int serialupdi_reset(const PROGRAMMER *pgm, reset_mode mode) {
 */
   switch (mode) {
     case APPLY_RESET:
-      msg_debug("%s: Sending reset request\n", progname);
+      pmsg_debug("sending reset request\n");
       return updi_write_cs(pgm, UPDI_ASI_RESET_REQ, UPDI_RESET_REQ_VALUE);
     case RELEASE_RESET:
-      msg_debug("%s: Sending release reset request\n", progname);
+      pmsg_debug("sending release reset request\n");
       return updi_write_cs(pgm, UPDI_ASI_RESET_REQ, 0x00);
   }
   return -1;
@@ -102,12 +100,12 @@ static int serialupdi_reset(const PROGRAMMER *pgm, reset_mode mode) {
 
 static int serialupdi_reset_connection(const PROGRAMMER *pgm) {
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    msg_info("%s: Apply reset operation failed\n", progname);
+    pmsg_info("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    msg_info("%s: Release reset operation failed\n", progname);
+    pmsg_info("release reset operation failed\n");
     return -1;
   }
 
@@ -118,7 +116,7 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
   char * str_ptr;
 
   sib_info->sib_string[SIB_INFO_STRING_LENGTH]=0;
-  msg_debug("%s: Received SIB: [%s]\n", progname, sib_info->sib_string);
+  pmsg_debug("received SIB: [%s]\n", sib_info->sib_string);
   memset(sib_info->family_string, 0, SIB_INFO_FAMILY_LENGTH+1);
   memset(sib_info->nvm_string, 0, SIB_INFO_NVM_LENGTH+1);
   memset(sib_info->debug_string, 0, SIB_INFO_DEBUG_LENGTH+1);
@@ -134,41 +132,41 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
 
   str_ptr = strstr(sib_info->nvm_string, ":");
   if (!str_ptr) {
-    msg_info("%s: Incorrect format of NVM string\n", progname);
+    pmsg_info("incorrect format of NVM string\n");
     return -1;
   }
   sib_info->nvm_version = *(str_ptr+1);
 
   str_ptr = strstr(sib_info->debug_string, ":");
   if (!str_ptr) {
-    msg_info("%s: Incorrect format of DEBUG string\n", progname);
+    pmsg_info("incorrect format of DEBUG string\n");
     return -1;
   }
   sib_info->debug_version = *(str_ptr+1);
 
-  msg_debug("%s: Device family ID: %s\n", progname, sib_info->family_string);
-  msg_debug("%s: NVM interface: %s\n", progname, sib_info->nvm_string);
-  msg_debug("%s: Debug interface: %s\n", progname, sib_info->debug_string);
-  msg_debug("%s: PDI oscillator: %s\n", progname, sib_info->pdi_string);
-  msg_debug("%s: Extra information: %s\n", progname, sib_info->extra_string);
+  pmsg_debug("Device family ID: %s\n", sib_info->family_string);
+  pmsg_debug("NVM interface: %s\n", sib_info->nvm_string);
+  pmsg_debug("Debug interface: %s\n", sib_info->debug_string);
+  pmsg_debug("PDI oscillator: %s\n", sib_info->pdi_string);
+  pmsg_debug("Extra information: %s\n", sib_info->extra_string);
   switch (sib_info->nvm_version) {
     case '0':
-      msg_info("%s: NVM type 0: 16-bit, page oriented write\n", progname);
+      pmsg_info("NVM type 0: 16-bit, page oriented write\n");
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V0);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_16BIT);
       break;
     case '2':
-      msg_info("%s: NVM type 2: 24-bit, word oriented write\n", progname);
+      pmsg_info("NVM type 2: 24-bit, word oriented write\n");
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V2);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_24BIT);
       break;
     case '3':
-      msg_info("%s: NVM type 3: 16-bit, page oriented\n", progname);
+      pmsg_info("NVM type 3: 16-bit, page oriented\n");
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V3);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_16BIT);
       break;
     default:
-      msg_info("%s: Unsupported NVM type: %c, please update software\n", progname, sib_info->nvm_version);
+      pmsg_info("unsupported NVM type: %c, please update software\n", sib_info->nvm_version);
       return -1;
   }
   return 0;
@@ -176,13 +174,13 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
 
 static void serialupdi_close(PROGRAMMER * pgm)
 {
-  msg_info("%s: Leaving NVM programming mode\n", progname);
+  pmsg_info("leaving NVM programming mode\n");
 
   if (serialupdi_leave_progmode(pgm) < 0) {
-    msg_info("%s: Unable to leave NVM programming mode\n", progname);
+    pmsg_info("unable to leave NVM programming mode\n");
   }
   if (updi_get_rts_mode(pgm) != RTS_MODE_DEFAULT) {
-    msg_info("%s: Releasing DTR/RTS handshake lines\n", progname);
+    pmsg_info("releasing DTR/RTS handshake lines\n");
   }
 
   updi_link_close(pgm);
@@ -223,7 +221,7 @@ static int serialupdi_wait_for_unlock(const PROGRAMMER *pgm, unsigned int ms) {
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < (ms * 1000));
 
-  msg_info("%s: Timeout waiting for device to unlock\n", progname);
+  pmsg_info("timeout waiting for device to unlock\n");
   return -1;
 }
 
@@ -278,7 +276,7 @@ static int serialupdi_wait_for_urow(const PROGRAMMER *pgm, unsigned int ms, urow
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < (ms * 1000));
 
-  msg_info("%s: Timeout waiting for device to complete UROW WRITE\n", progname);
+  pmsg_info("timeout waiting for device to complete UROW WRITE\n");
   return -1;
 }
 
@@ -298,7 +296,7 @@ static int serialupdi_in_prog_mode(const PROGRAMMER *pgm, uint8_t *in_prog_mode)
   rc = updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value);
   
   if (rc < 0) {
-    msg_info("%s: Read CS operation failed\n", progname);
+    pmsg_info("read CS operation failed\n");
     return rc;
   }
 
@@ -354,57 +352,57 @@ def enter_progmode(self):
   uint8_t key_status;
 
   if (serialupdi_in_prog_mode(pgm, &in_prog_mode) < 0) {
-    msg_info("%s: Checking UPDI NVM prog mode failed\n", progname);
+    pmsg_info("checking UPDI NVM prog mode failed\n");
     return -1;
   }
   if (in_prog_mode) {
-    msg_debug("%s: Already in prog mode\n", progname);
+    pmsg_debug("already in prog mode\n");
     return 0;
   }
 
   memcpy(buffer, UPDI_KEY_NVM, sizeof(buffer));
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    msg_info("%s: Writing NVM KEY failed\n", progname);
+    pmsg_info("writing NVM KEY failed\n");
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    msg_info("%s: Checking KEY status failed\n", progname);
+    pmsg_info("checking KEY status failed\n");
     return -1;
   }
-  msg_debug("%s: Key status: 0x%02X\n", progname, key_status);
+  pmsg_debug("key status: 0x%02X\n", key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_NVMPROG))) {
-    msg_info("%s: Key was not accepted\n", progname);
+    pmsg_info("key was not accepted\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    msg_info("%s: Apply reset operation failed\n", progname);
+    pmsg_info("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    msg_info("%s: Release reset operation failed\n", progname);
+    pmsg_info("release reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_wait_for_unlock(pgm, 100) < 0) {
-    msg_info("%s: Failed to enter NVM programming mode: device is locked\n", progname);
+    pmsg_info("failed to enter NVM programming mode: device is locked\n");
     return -1;
   }
 
   if (serialupdi_in_prog_mode(pgm, &in_prog_mode) < 0) {
-    msg_info("%s: Checking UPDI NVM prog mode failed\n", progname);
+    pmsg_info("checking UPDI NVM prog mode failed\n");
     return -1;
   }
 
   if (!in_prog_mode) {
-    msg_info("%s: Failed to enter NVM programming mode\n", progname);
+    pmsg_info("failed to enter NVM programming mode\n");
     return -1;
   }
 
-  msg_debug("%s: Entered NVM programming mode\n", progname);
+  pmsg_debug("entered NVM programming mode\n");
 
   return 0;
 }
@@ -422,12 +420,12 @@ static int serialupdi_leave_progmode(const PROGRAMMER *pgm) {
                                 (1 << constants.UPDI_CTRLB_UPDIDIS_BIT) | (1 << constants.UPDI_CTRLB_CCDETDIS_BIT))
 */
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    msg_info("%s: Apply reset operation failed\n", progname);
+    pmsg_info("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    msg_info("%s: Release reset operation failed\n", progname);
+    pmsg_info("release reset operation failed\n");
     return -1;
   }
 
@@ -491,74 +489,74 @@ static int serialupdi_write_userrow(const PROGRAMMER *pgm, const AVRPART *p, con
 
   memcpy(buffer, UPDI_KEY_UROW, sizeof(buffer));
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    msg_info("%s: Writing USERROW KEY failed\n", progname);
+    pmsg_info("writing USERROW KEY failed\n");
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    msg_info("%s: Checking KEY status failed\n", progname);
+    pmsg_info("checking KEY status failed\n");
     return -1;
   }
-  msg_debug("%s: Key status: 0x%02X\n", progname, key_status);
+  pmsg_debug("key status: 0x%02X\n", key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_UROWWRITE))) {
-    msg_info("%s: Key was not accepted\n", progname);
+    pmsg_info("key was not accepted\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    msg_info("%s: Apply reset operation failed\n", progname);
+    pmsg_info("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    msg_info("%s: Release reset operation failed\n", progname);
+    pmsg_info("release reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_wait_for_urow(pgm, 500, WAIT_FOR_UROW_HIGH) < 0) {
-    msg_info("%s: Failed to enter USERROW programming mode\n", progname);
+    pmsg_info("failed to enter USERROW programming mode\n");
     return -1;
   }
 
   if (updi_write_data(pgm, m->offset+addr, m->buf + addr, n_bytes) < 0) {
-    msg_info("%s: Writing USER ROW failed\n", progname);
+    pmsg_info("writing USER ROW failed\n");
     return -1;
   }
 
   if (updi_write_cs(pgm, UPDI_ASI_SYS_CTRLA, (1 << UPDI_ASI_SYS_CTRLA_UROW_FINAL) |
                                              (1 << UPDI_CTRLB_CCDETDIS_BIT)) < 0) {
-    msg_info("%s: Failed trying to commit user row write\n", progname);
+    pmsg_info("failed trying to commit user row write\n");
     return -1;
   }
 
   if (serialupdi_wait_for_urow(pgm, 500, WAIT_FOR_UROW_LOW) < 0) {
-    msg_debug("%s: Failed to exit USERROW programming mode\n", progname);
+    pmsg_debug("failed to exit USERROW programming mode\n");
 
     if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-      msg_info("%s: Apply reset operation failed\n", progname);
+      pmsg_info("Apply reset operation failed\n");
       return -1;
     }
 
     if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-      msg_info("%s: Release reset operation failed\n", progname);
+      pmsg_info("release reset operation failed\n");
       return -1;
     }
   }
 
   if (updi_write_cs(pgm, UPDI_ASI_KEY_STATUS, (1 << UPDI_ASI_KEY_STATUS_UROWWRITE) |
                                               (1 << UPDI_CTRLB_CCDETDIS_BIT)) < 0) {
-    msg_info("%s: Failed trying to complete user row write\n", progname);
+    pmsg_info("failed trying to complete user row write\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    msg_info("%s: Apply reset operation failed\n", progname);
+    pmsg_info("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    msg_info("%s: Release reset operation failed\n", progname);
+    pmsg_info("release reset operation failed\n");
     return -1;
   }
 
@@ -574,13 +572,13 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t reset_link_required=0;
   
   if (updi_link_init(pgm) < 0) {
-    msg_info("%s: UPDI link initialization failed\n", progname);
+    pmsg_info("UPDI link initialization failed\n");
     return -1;
   }
-  msg_info("%s: UPDI link initialization OK\n", progname);
+  pmsg_info("UPDI link initialization OK\n");
 
   if (updi_get_rts_mode(pgm) != RTS_MODE_DEFAULT) {
-    msg_info("%s: Forcing serial DTR/RTS handshake lines %s\n", progname, updi_get_rts_mode(pgm) == RTS_MODE_LOW ? "LOW" : "HIGH");
+    pmsg_info("forcing serial DTR/RTS handshake lines %s\n", updi_get_rts_mode(pgm) == RTS_MODE_LOW ? "LOW" : "HIGH");
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
@@ -591,33 +589,33 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
 
     if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-      msg_info("%s: Read CS operation during initialization failed\n", progname);
+      pmsg_info("read CS operation during initialization failed\n");
       return -1;
     }
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_LOCKSTATUS)) {
-    msg_info("%s: Device is locked\n", progname);
+    pmsg_info("device is locked\n");
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_UROWPROG)) {
-    msg_info("%s: Device in USER ROW programming state, leaving programming mode\n", progname);
+    pmsg_info("device in USER ROW programming state, leaving programming mode\n");
     reset_link_required = 1;
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_NVMPROG)) {
-    msg_info("%s: Device in NVM programming state, leaving programming mode\n", progname);
+    pmsg_info("device in NVM programming state, leaving programming mode\n");
     reset_link_required = 1;
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_INSLEEP)) {
-    msg_info("%s: Device is in SLEEP mode\n", progname);
+    pmsg_info("device is in SLEEP mode\n");
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_RSTSYS)) {
-    msg_info("%s: Device in reset status, trying to release it\n", progname);
+    pmsg_info("device in reset status, trying to release it\n");
     if (serialupdi_reset(pgm, RELEASE_RESET)<0) {
       return -1;
     }
   }
   if (reset_link_required) {
     if (serialupdi_reset_connection(pgm) < 0) {
-      msg_info("%s: UPDI link reset failed\n", progname);
+      pmsg_info("UPDI link reset failed\n");
       return -1;
     }
   }
@@ -627,25 +625,25 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (updi_read_sib(pgm, sib_info->sib_string, 32) < 0) {
     /* this should never happen, let's try to reset connection and try again */
     if (serialupdi_reset_connection(pgm) < 0) {
-      msg_info("%s: SerialUPDI reset connection failed\n", progname);
+      pmsg_info("SerialUPDI reset connection failed\n");
       return -1;
     }
     if (updi_read_sib(pgm, sib_info->sib_string, 32) < 0) {
-      msg_info("%s: Read SIB operation failed\n", progname);
+      pmsg_info("read SIB operation failed\n");
       return -1;
     }
   }
   if (serialupdi_decode_sib(pgm, sib_info) < 0) {
-    msg_info("%s: Decode SIB_INFO failed\n", progname);
+    pmsg_info("decode SIB_INFO failed\n");
     return -1;
   }
 
   if (updi_link_init(pgm) < 0) {
-    msg_info("%s: UPDI link initialization failed\n", progname);
+    pmsg_info("UPDI link initialization failed\n");
     return -1;
   }
 
-  msg_info("%s: Entering NVM programming mode\n", progname);
+  pmsg_info("entering NVM programming mode\n");
     /* try, but ignore failure */
   serialupdi_enter_progmode(pgm);
 
@@ -671,14 +669,12 @@ static void serialupdi_display(const PROGRAMMER *pgm, const char *p) {
 static int serialupdi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                           unsigned char * res)
 {
-  msg_info("%s: error: cmd %s[%s] not implemented yet\n",
-    	    progname, cmd, res);
+  pmsg_info("cmd %s[%s] not implemented yet\n", cmd, res);
   return -1;
 }
 
 static int serialupdi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-  msg_info("%s: error: program enable not implemented yet\n",
-    	    progname);
+  pmsg_info("program enable not implemented yet\n");
   return -1;
 }
 
@@ -724,7 +720,7 @@ static int serialupdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
       rc = updi_read_data(pgm, m->offset + read_offset, m->buf + read_offset, 
                           remaining_bytes > m->readsize ? m->readsize : remaining_bytes);
       if (rc < 0) {
-        msg_info("%s: Paged load operation failed\n", progname);
+        pmsg_info("paged load operation failed\n");
         return rc;
       } else {
         read_bytes+=rc;
@@ -759,15 +755,15 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
         rc = serialupdi_write_userrow(pgm, p, m, page_size, write_offset, 
                                       remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
       } else if (strcmp(m->desc, "fuses")==0) {
-        msg_debug("%s: Page write operation requested for fuses, falling back to byte-level write\n", progname);
+        pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         return -1;
       } else {
-        msg_info("%s: Invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", progname, m->desc, page_size, addr, n_bytes, n_bytes);
+        pmsg_info("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
         rc = -1;
       }
 
       if (rc < 0) {
-        msg_info("%s: Paged write operation failed\n", progname);
+        pmsg_info("paged write operation failed\n");
         return rc;
       } else {
         write_bytes+=rc;
@@ -784,10 +780,10 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     } else if (strcmp(m->desc, "userrow")==0) {
       rc = serialupdi_write_userrow(pgm, p, m, page_size, addr, n_bytes);
     } else if (strcmp(m->desc, "fuses")==0) {
-        msg_debug("%s: Page write operation requested for fuses, falling back to byte-level write\n", progname);
+        pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         rc = -1;
     } else {
-      msg_info("%s: Invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", progname, m->desc, page_size, addr, n_bytes, n_bytes);
+      pmsg_info("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
       rc = -1;
     }
     return rc;
@@ -824,38 +820,38 @@ static int serialupdi_unlock(const PROGRAMMER *pgm, const AVRPART *p) {
   memcpy(buffer, UPDI_KEY_CHIPERASE, sizeof(buffer));
 
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    msg_info("%s: Writing NVM KEY failed\n", progname);
+    pmsg_info("writing NVM KEY failed\n");
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    msg_info("%s: Checking KEY status failed\n", progname);
+    pmsg_info("checking KEY status failed\n");
     return -1;
   }
-  msg_debug("%s: Key status: 0x%02X\n", progname, key_status);
+  pmsg_debug("key status: 0x%02X\n", key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_CHIPERASE))) {
-    msg_info("%s: Key not accepted\n", progname);
+    pmsg_info("key not accepted\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    msg_info("%s: Apply reset operation failed\n", progname);
+    pmsg_info("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    msg_info("%s: Release reset operation failed\n", progname);
+    pmsg_info("release reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_wait_for_unlock(pgm, 500) < 0) {
-    msg_info("%s: Waiting for unlock failed\n", progname);
+    pmsg_info("waiting for unlock failed\n");
     return -1;
   }
 
   if (updi_link_init(pgm) < 0) {
-    msg_info("%s: UPDI link reinitialization failed\n", progname);
+    pmsg_info("UPDI link reinitialization failed\n");
     return -1;
   }
 
@@ -866,14 +862,14 @@ static int serialupdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t value;
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-    msg_info("%s: Read CS operation during chip erase failed\n", progname);
+    pmsg_info("read CS operation during chip erase failed\n");
     return -1;
   }
   
   if (value & (1 << UPDI_ASI_SYS_STATUS_LOCKSTATUS)) {
-    msg_info("%s: Device is locked\n", progname);
+    pmsg_info("device is locked\n");
     if (ovsigck) {
-      msg_info("%s: Attempting device erase\n", progname);
+      pmsg_info("attempting device erase\n");
       return serialupdi_unlock(pgm, p);
     }
   } else {
@@ -885,8 +881,7 @@ static int serialupdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int serialupdi_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int baseaddr)
 {
-  msg_info("%s: error: page erase not implemented yet\n",
-    	    progname);
+  pmsg_info("page erase not implemented yet\n");
   return -1;
 }
 
@@ -895,7 +890,7 @@ static int serialupdi_read_signature(const PROGRAMMER *pgm, const AVRPART *p, co
   uint8_t value;
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-    msg_info("%s: Read CS operation during signature read failed\n", progname);
+    pmsg_info("read CS operation during signature read failed\n");
     return -1;
   }
 
@@ -936,14 +931,13 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
       } else if (strcasecmp(rts_mode, "high") == 0) {
         updi_set_rts_mode(pgm, RTS_MODE_HIGH);
       } else {
-        msg_info("%s: RTS/DTR mode must be LOW or HIGH\n", progname);
+        pmsg_info("RTS/DTR mode must be LOW or HIGH\n");
         return -1;
       }
       continue;
     }
 
-    msg_info("%s: serialupdi_parseextparms(): invalid extended parameter '%s'\n",
-                    progname, extended_param);
+    pmsg_info("serialupdi_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -49,7 +49,7 @@ static int serialupdi_leave_progmode(const PROGRAMMER *pgm);
 static void serialupdi_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(updi_state))) == 0) {
-    avrdude_message(MSG_INFO,
+    msg_info(
 	    "%s: serialupdi_setup(): Out of memory allocating private data\n",
 	    progname);
     exit(1);
@@ -91,10 +91,10 @@ static int serialupdi_reset(const PROGRAMMER *pgm, reset_mode mode) {
 */
   switch (mode) {
     case APPLY_RESET:
-      avrdude_message(MSG_DEBUG, "%s: Sending reset request\n", progname);
+      msg_debug("%s: Sending reset request\n", progname);
       return updi_write_cs(pgm, UPDI_ASI_RESET_REQ, UPDI_RESET_REQ_VALUE);
     case RELEASE_RESET:
-      avrdude_message(MSG_DEBUG, "%s: Sending release reset request\n", progname);
+      msg_debug("%s: Sending release reset request\n", progname);
       return updi_write_cs(pgm, UPDI_ASI_RESET_REQ, 0x00);
   }
   return -1;
@@ -102,12 +102,12 @@ static int serialupdi_reset(const PROGRAMMER *pgm, reset_mode mode) {
 
 static int serialupdi_reset_connection(const PROGRAMMER *pgm) {
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
+    msg_info("%s: Apply reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Release reset operation failed\n", progname);
+    msg_info("%s: Release reset operation failed\n", progname);
     return -1;
   }
 
@@ -118,7 +118,7 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
   char * str_ptr;
 
   sib_info->sib_string[SIB_INFO_STRING_LENGTH]=0;
-  avrdude_message(MSG_DEBUG, "%s: Received SIB: [%s]\n", progname, sib_info->sib_string);
+  msg_debug("%s: Received SIB: [%s]\n", progname, sib_info->sib_string);
   memset(sib_info->family_string, 0, SIB_INFO_FAMILY_LENGTH+1);
   memset(sib_info->nvm_string, 0, SIB_INFO_NVM_LENGTH+1);
   memset(sib_info->debug_string, 0, SIB_INFO_DEBUG_LENGTH+1);
@@ -134,41 +134,41 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
 
   str_ptr = strstr(sib_info->nvm_string, ":");
   if (!str_ptr) {
-    avrdude_message(MSG_INFO, "%s: Incorrect format of NVM string\n", progname);
+    msg_info("%s: Incorrect format of NVM string\n", progname);
     return -1;
   }
   sib_info->nvm_version = *(str_ptr+1);
 
   str_ptr = strstr(sib_info->debug_string, ":");
   if (!str_ptr) {
-    avrdude_message(MSG_INFO, "%s: Incorrect format of DEBUG string\n", progname);
+    msg_info("%s: Incorrect format of DEBUG string\n", progname);
     return -1;
   }
   sib_info->debug_version = *(str_ptr+1);
 
-  avrdude_message(MSG_DEBUG, "%s: Device family ID: %s\n", progname, sib_info->family_string);
-  avrdude_message(MSG_DEBUG, "%s: NVM interface: %s\n", progname, sib_info->nvm_string);
-  avrdude_message(MSG_DEBUG, "%s: Debug interface: %s\n", progname, sib_info->debug_string);
-  avrdude_message(MSG_DEBUG, "%s: PDI oscillator: %s\n", progname, sib_info->pdi_string);
-  avrdude_message(MSG_DEBUG, "%s: Extra information: %s\n", progname, sib_info->extra_string);
+  msg_debug("%s: Device family ID: %s\n", progname, sib_info->family_string);
+  msg_debug("%s: NVM interface: %s\n", progname, sib_info->nvm_string);
+  msg_debug("%s: Debug interface: %s\n", progname, sib_info->debug_string);
+  msg_debug("%s: PDI oscillator: %s\n", progname, sib_info->pdi_string);
+  msg_debug("%s: Extra information: %s\n", progname, sib_info->extra_string);
   switch (sib_info->nvm_version) {
     case '0':
-      avrdude_message(MSG_INFO, "%s: NVM type 0: 16-bit, page oriented write\n", progname);
+      msg_info("%s: NVM type 0: 16-bit, page oriented write\n", progname);
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V0);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_16BIT);
       break;
     case '2':
-      avrdude_message(MSG_INFO, "%s: NVM type 2: 24-bit, word oriented write\n", progname);
+      msg_info("%s: NVM type 2: 24-bit, word oriented write\n", progname);
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V2);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_24BIT);
       break;
     case '3':
-      avrdude_message(MSG_INFO, "%s: NVM type 3: 16-bit, page oriented\n", progname);
+      msg_info("%s: NVM type 3: 16-bit, page oriented\n", progname);
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V3);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_16BIT);
       break;
     default:
-      avrdude_message(MSG_INFO, "%s: Unsupported NVM type: %c, please update software\n", progname, sib_info->nvm_version);
+      msg_info("%s: Unsupported NVM type: %c, please update software\n", progname, sib_info->nvm_version);
       return -1;
   }
   return 0;
@@ -176,13 +176,13 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
 
 static void serialupdi_close(PROGRAMMER * pgm)
 {
-  avrdude_message(MSG_INFO, "%s: Leaving NVM programming mode\n", progname);
+  msg_info("%s: Leaving NVM programming mode\n", progname);
 
   if (serialupdi_leave_progmode(pgm) < 0) {
-    avrdude_message(MSG_INFO, "%s: Unable to leave NVM programming mode\n", progname);
+    msg_info("%s: Unable to leave NVM programming mode\n", progname);
   }
   if (updi_get_rts_mode(pgm) != RTS_MODE_DEFAULT) {
-    avrdude_message(MSG_INFO, "%s: Releasing DTR/RTS handshake lines\n", progname);
+    msg_info("%s: Releasing DTR/RTS handshake lines\n", progname);
   }
 
   updi_link_close(pgm);
@@ -223,7 +223,7 @@ static int serialupdi_wait_for_unlock(const PROGRAMMER *pgm, unsigned int ms) {
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < (ms * 1000));
 
-  avrdude_message(MSG_INFO, "%s: Timeout waiting for device to unlock\n", progname);
+  msg_info("%s: Timeout waiting for device to unlock\n", progname);
   return -1;
 }
 
@@ -278,7 +278,7 @@ static int serialupdi_wait_for_urow(const PROGRAMMER *pgm, unsigned int ms, urow
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < (ms * 1000));
 
-  avrdude_message(MSG_INFO, "%s: Timeout waiting for device to complete UROW WRITE\n", progname);
+  msg_info("%s: Timeout waiting for device to complete UROW WRITE\n", progname);
   return -1;
 }
 
@@ -298,7 +298,7 @@ static int serialupdi_in_prog_mode(const PROGRAMMER *pgm, uint8_t *in_prog_mode)
   rc = updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value);
   
   if (rc < 0) {
-    avrdude_message(MSG_INFO, "%s: Read CS operation failed\n", progname);
+    msg_info("%s: Read CS operation failed\n", progname);
     return rc;
   }
 
@@ -354,57 +354,57 @@ def enter_progmode(self):
   uint8_t key_status;
 
   if (serialupdi_in_prog_mode(pgm, &in_prog_mode) < 0) {
-    avrdude_message(MSG_INFO, "%s: Checking UPDI NVM prog mode failed\n", progname);
+    msg_info("%s: Checking UPDI NVM prog mode failed\n", progname);
     return -1;
   }
   if (in_prog_mode) {
-    avrdude_message(MSG_DEBUG, "%s: Already in prog mode\n", progname);
+    msg_debug("%s: Already in prog mode\n", progname);
     return 0;
   }
 
   memcpy(buffer, UPDI_KEY_NVM, sizeof(buffer));
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    avrdude_message(MSG_INFO, "%s: Writing NVM KEY failed\n", progname);
+    msg_info("%s: Writing NVM KEY failed\n", progname);
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    avrdude_message(MSG_INFO, "%s: Checking KEY status failed\n", progname);
+    msg_info("%s: Checking KEY status failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Key status: 0x%02X\n", progname, key_status);
+  msg_debug("%s: Key status: 0x%02X\n", progname, key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_NVMPROG))) {
-    avrdude_message(MSG_INFO, "%s: Key was not accepted\n", progname);
+    msg_info("%s: Key was not accepted\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
+    msg_info("%s: Apply reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Release reset operation failed\n", progname);
+    msg_info("%s: Release reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_wait_for_unlock(pgm, 100) < 0) {
-    avrdude_message(MSG_INFO, "%s: Failed to enter NVM programming mode: device is locked\n", progname);
+    msg_info("%s: Failed to enter NVM programming mode: device is locked\n", progname);
     return -1;
   }
 
   if (serialupdi_in_prog_mode(pgm, &in_prog_mode) < 0) {
-    avrdude_message(MSG_INFO, "%s: Checking UPDI NVM prog mode failed\n", progname);
+    msg_info("%s: Checking UPDI NVM prog mode failed\n", progname);
     return -1;
   }
 
   if (!in_prog_mode) {
-    avrdude_message(MSG_INFO, "%s: Failed to enter NVM programming mode\n", progname);
+    msg_info("%s: Failed to enter NVM programming mode\n", progname);
     return -1;
   }
 
-  avrdude_message(MSG_DEBUG, "%s: Entered NVM programming mode\n", progname);
+  msg_debug("%s: Entered NVM programming mode\n", progname);
 
   return 0;
 }
@@ -422,12 +422,12 @@ static int serialupdi_leave_progmode(const PROGRAMMER *pgm) {
                                 (1 << constants.UPDI_CTRLB_UPDIDIS_BIT) | (1 << constants.UPDI_CTRLB_CCDETDIS_BIT))
 */
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
+    msg_info("%s: Apply reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Release reset operation failed\n", progname);
+    msg_info("%s: Release reset operation failed\n", progname);
     return -1;
   }
 
@@ -491,74 +491,74 @@ static int serialupdi_write_userrow(const PROGRAMMER *pgm, const AVRPART *p, con
 
   memcpy(buffer, UPDI_KEY_UROW, sizeof(buffer));
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    avrdude_message(MSG_INFO, "%s: Writing USERROW KEY failed\n", progname);
+    msg_info("%s: Writing USERROW KEY failed\n", progname);
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    avrdude_message(MSG_INFO, "%s: Checking KEY status failed\n", progname);
+    msg_info("%s: Checking KEY status failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Key status: 0x%02X\n", progname, key_status);
+  msg_debug("%s: Key status: 0x%02X\n", progname, key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_UROWWRITE))) {
-    avrdude_message(MSG_INFO, "%s: Key was not accepted\n", progname);
+    msg_info("%s: Key was not accepted\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
+    msg_info("%s: Apply reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Release reset operation failed\n", progname);
+    msg_info("%s: Release reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_wait_for_urow(pgm, 500, WAIT_FOR_UROW_HIGH) < 0) {
-    avrdude_message(MSG_INFO, "%s: Failed to enter USERROW programming mode\n", progname);
+    msg_info("%s: Failed to enter USERROW programming mode\n", progname);
     return -1;
   }
 
   if (updi_write_data(pgm, m->offset+addr, m->buf + addr, n_bytes) < 0) {
-    avrdude_message(MSG_INFO, "%s: Writing USER ROW failed\n", progname);
+    msg_info("%s: Writing USER ROW failed\n", progname);
     return -1;
   }
 
   if (updi_write_cs(pgm, UPDI_ASI_SYS_CTRLA, (1 << UPDI_ASI_SYS_CTRLA_UROW_FINAL) |
                                              (1 << UPDI_CTRLB_CCDETDIS_BIT)) < 0) {
-    avrdude_message(MSG_INFO, "%s: Failed trying to commit user row write\n", progname);
+    msg_info("%s: Failed trying to commit user row write\n", progname);
     return -1;
   }
 
   if (serialupdi_wait_for_urow(pgm, 500, WAIT_FOR_UROW_LOW) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: Failed to exit USERROW programming mode\n", progname);
+    msg_debug("%s: Failed to exit USERROW programming mode\n", progname);
 
     if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-      avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
+      msg_info("%s: Apply reset operation failed\n", progname);
       return -1;
     }
 
     if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-      avrdude_message(MSG_INFO, "%s: Release reset operation failed\n", progname);
+      msg_info("%s: Release reset operation failed\n", progname);
       return -1;
     }
   }
 
   if (updi_write_cs(pgm, UPDI_ASI_KEY_STATUS, (1 << UPDI_ASI_KEY_STATUS_UROWWRITE) |
                                               (1 << UPDI_CTRLB_CCDETDIS_BIT)) < 0) {
-    avrdude_message(MSG_INFO, "%s: Failed trying to complete user row write\n", progname);
+    msg_info("%s: Failed trying to complete user row write\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
+    msg_info("%s: Apply reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Release reset operation failed\n", progname);
+    msg_info("%s: Release reset operation failed\n", progname);
     return -1;
   }
 
@@ -574,13 +574,13 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t reset_link_required=0;
   
   if (updi_link_init(pgm) < 0) {
-    avrdude_message(MSG_INFO, "%s: UPDI link initialization failed\n", progname);
+    msg_info("%s: UPDI link initialization failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_INFO, "%s: UPDI link initialization OK\n", progname);
+  msg_info("%s: UPDI link initialization OK\n", progname);
 
   if (updi_get_rts_mode(pgm) != RTS_MODE_DEFAULT) {
-    avrdude_message(MSG_INFO, "%s: Forcing serial DTR/RTS handshake lines %s\n", progname, updi_get_rts_mode(pgm) == RTS_MODE_LOW ? "LOW" : "HIGH");
+    msg_info("%s: Forcing serial DTR/RTS handshake lines %s\n", progname, updi_get_rts_mode(pgm) == RTS_MODE_LOW ? "LOW" : "HIGH");
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
@@ -591,33 +591,33 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
 
     if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-      avrdude_message(MSG_INFO, "%s: Read CS operation during initialization failed\n", progname);
+      msg_info("%s: Read CS operation during initialization failed\n", progname);
       return -1;
     }
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_LOCKSTATUS)) {
-    avrdude_message(MSG_INFO, "%s: Device is locked\n", progname);
+    msg_info("%s: Device is locked\n", progname);
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_UROWPROG)) {
-    avrdude_message(MSG_INFO, "%s: Device in USER ROW programming state, leaving programming mode\n", progname);
+    msg_info("%s: Device in USER ROW programming state, leaving programming mode\n", progname);
     reset_link_required = 1;
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_NVMPROG)) {
-    avrdude_message(MSG_INFO, "%s: Device in NVM programming state, leaving programming mode\n", progname);
+    msg_info("%s: Device in NVM programming state, leaving programming mode\n", progname);
     reset_link_required = 1;
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_INSLEEP)) {
-    avrdude_message(MSG_INFO, "%s: Device is in SLEEP mode\n", progname);
+    msg_info("%s: Device is in SLEEP mode\n", progname);
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_RSTSYS)) {
-    avrdude_message(MSG_INFO, "%s: Device in reset status, trying to release it\n", progname);
+    msg_info("%s: Device in reset status, trying to release it\n", progname);
     if (serialupdi_reset(pgm, RELEASE_RESET)<0) {
       return -1;
     }
   }
   if (reset_link_required) {
     if (serialupdi_reset_connection(pgm) < 0) {
-      avrdude_message(MSG_INFO, "%s: UPDI link reset failed\n", progname);
+      msg_info("%s: UPDI link reset failed\n", progname);
       return -1;
     }
   }
@@ -627,25 +627,25 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (updi_read_sib(pgm, sib_info->sib_string, 32) < 0) {
     /* this should never happen, let's try to reset connection and try again */
     if (serialupdi_reset_connection(pgm) < 0) {
-      avrdude_message(MSG_INFO, "%s: SerialUPDI reset connection failed\n", progname);  
+      msg_info("%s: SerialUPDI reset connection failed\n", progname);
       return -1;
     }
     if (updi_read_sib(pgm, sib_info->sib_string, 32) < 0) {
-      avrdude_message(MSG_INFO, "%s: Read SIB operation failed\n", progname);  
+      msg_info("%s: Read SIB operation failed\n", progname);
       return -1;
     }
   }
   if (serialupdi_decode_sib(pgm, sib_info) < 0) {
-    avrdude_message(MSG_INFO, "%s: Decode SIB_INFO failed\n", progname);
+    msg_info("%s: Decode SIB_INFO failed\n", progname);
     return -1;
   }
 
   if (updi_link_init(pgm) < 0) {
-    avrdude_message(MSG_INFO, "%s: UPDI link initialization failed\n", progname);
+    msg_info("%s: UPDI link initialization failed\n", progname);
     return -1;
   }
 
-  avrdude_message(MSG_INFO, "%s: Entering NVM programming mode\n", progname);
+  msg_info("%s: Entering NVM programming mode\n", progname);
     /* try, but ignore failure */
   serialupdi_enter_progmode(pgm);
 
@@ -671,13 +671,13 @@ static void serialupdi_display(const PROGRAMMER *pgm, const char *p) {
 static int serialupdi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                           unsigned char * res)
 {
-  avrdude_message(MSG_INFO, "%s: error: cmd %s[%s] not implemented yet\n",
+  msg_info("%s: error: cmd %s[%s] not implemented yet\n",
     	    progname, cmd, res);
   return -1;
 }
 
 static int serialupdi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-  avrdude_message(MSG_INFO, "%s: error: program enable not implemented yet\n",
+  msg_info("%s: error: program enable not implemented yet\n",
     	    progname);
   return -1;
 }
@@ -724,7 +724,7 @@ static int serialupdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
       rc = updi_read_data(pgm, m->offset + read_offset, m->buf + read_offset, 
                           remaining_bytes > m->readsize ? m->readsize : remaining_bytes);
       if (rc < 0) {
-        avrdude_message(MSG_INFO, "%s: Paged load operation failed\n", progname);
+        msg_info("%s: Paged load operation failed\n", progname);
         return rc;
       } else {
         read_bytes+=rc;
@@ -759,15 +759,15 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
         rc = serialupdi_write_userrow(pgm, p, m, page_size, write_offset, 
                                       remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
       } else if (strcmp(m->desc, "fuses")==0) {
-        avrdude_message(MSG_DEBUG, "%s: Page write operation requested for fuses, falling back to byte-level write\n", progname);
+        msg_debug("%s: Page write operation requested for fuses, falling back to byte-level write\n", progname);
         return -1;
       } else {
-        avrdude_message(MSG_INFO, "%s: Invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", progname, m->desc, page_size, addr, n_bytes, n_bytes);
+        msg_info("%s: Invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", progname, m->desc, page_size, addr, n_bytes, n_bytes);
         rc = -1;
       }
 
       if (rc < 0) {
-        avrdude_message(MSG_INFO, "%s: Paged write operation failed\n", progname);
+        msg_info("%s: Paged write operation failed\n", progname);
         return rc;
       } else {
         write_bytes+=rc;
@@ -784,10 +784,10 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     } else if (strcmp(m->desc, "userrow")==0) {
       rc = serialupdi_write_userrow(pgm, p, m, page_size, addr, n_bytes);
     } else if (strcmp(m->desc, "fuses")==0) {
-        avrdude_message(MSG_DEBUG, "%s: Page write operation requested for fuses, falling back to byte-level write\n", progname);
+        msg_debug("%s: Page write operation requested for fuses, falling back to byte-level write\n", progname);
         rc = -1;
     } else {
-      avrdude_message(MSG_INFO, "%s: Invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", progname, m->desc, page_size, addr, n_bytes, n_bytes);
+      msg_info("%s: Invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", progname, m->desc, page_size, addr, n_bytes, n_bytes);
       rc = -1;
     }
     return rc;
@@ -824,38 +824,38 @@ static int serialupdi_unlock(const PROGRAMMER *pgm, const AVRPART *p) {
   memcpy(buffer, UPDI_KEY_CHIPERASE, sizeof(buffer));
 
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    avrdude_message(MSG_INFO, "%s: Writing NVM KEY failed\n", progname);
+    msg_info("%s: Writing NVM KEY failed\n", progname);
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    avrdude_message(MSG_INFO, "%s: Checking KEY status failed\n", progname);
+    msg_info("%s: Checking KEY status failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Key status: 0x%02X\n", progname, key_status);
+  msg_debug("%s: Key status: 0x%02X\n", progname, key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_CHIPERASE))) {
-    avrdude_message(MSG_INFO, "%s: Key not accepted\n", progname);
+    msg_info("%s: Key not accepted\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Apply reset operation failed\n", progname);
+    msg_info("%s: Apply reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    avrdude_message(MSG_INFO, "%s: Release reset operation failed\n", progname);
+    msg_info("%s: Release reset operation failed\n", progname);
     return -1;
   }
 
   if (serialupdi_wait_for_unlock(pgm, 500) < 0) {
-    avrdude_message(MSG_INFO, "%s: Waiting for unlock failed\n", progname);
+    msg_info("%s: Waiting for unlock failed\n", progname);
     return -1;
   }
 
   if (updi_link_init(pgm) < 0) {
-    avrdude_message(MSG_INFO, "%s: UPDI link reinitialization failed\n", progname);
+    msg_info("%s: UPDI link reinitialization failed\n", progname);
     return -1;
   }
 
@@ -866,14 +866,14 @@ static int serialupdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t value;
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-    avrdude_message(MSG_INFO, "%s: Read CS operation during chip erase failed\n", progname);
+    msg_info("%s: Read CS operation during chip erase failed\n", progname);
     return -1;
   }
   
   if (value & (1 << UPDI_ASI_SYS_STATUS_LOCKSTATUS)) {
-    avrdude_message(MSG_INFO, "%s: Device is locked\n", progname);
+    msg_info("%s: Device is locked\n", progname);
     if (ovsigck) {
-      avrdude_message(MSG_INFO, "%s: Attempting device erase\n", progname);
+      msg_info("%s: Attempting device erase\n", progname);
       return serialupdi_unlock(pgm, p);
     }
   } else {
@@ -885,7 +885,7 @@ static int serialupdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int serialupdi_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int baseaddr)
 {
-  avrdude_message(MSG_INFO, "%s: error: page erase not implemented yet\n",
+  msg_info("%s: error: page erase not implemented yet\n",
     	    progname);
   return -1;
 }
@@ -895,7 +895,7 @@ static int serialupdi_read_signature(const PROGRAMMER *pgm, const AVRPART *p, co
   uint8_t value;
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-    avrdude_message(MSG_INFO, "%s: Read CS operation during signature read failed\n", progname);
+    msg_info("%s: Read CS operation during signature read failed\n", progname);
     return -1;
   }
 
@@ -936,13 +936,13 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
       } else if (strcasecmp(rts_mode, "high") == 0) {
         updi_set_rts_mode(pgm, RTS_MODE_HIGH);
       } else {
-        avrdude_message(MSG_INFO, "%s: RTS/DTR mode must be LOW or HIGH\n", progname);
+        msg_info("%s: RTS/DTR mode must be LOW or HIGH\n", progname);
         return -1;
       }
       continue;
     }
 
-    avrdude_message(MSG_INFO, "%s: serialupdi_parseextparms(): invalid extended parameter '%s'\n",
+    msg_info("%s: serialupdi_parseextparms(): invalid extended parameter '%s'\n",
                     progname, extended_param);
     rv = -1;
   }

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -49,7 +49,7 @@ static int serialupdi_leave_progmode(const PROGRAMMER *pgm);
 static void serialupdi_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(updi_state))) == 0) {
-    pmsg_info("serialupdi_setup(): Out of memory allocating private data\n");
+    pmsg_error("serialupdi_setup(): out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(updi_state));
@@ -100,12 +100,12 @@ static int serialupdi_reset(const PROGRAMMER *pgm, reset_mode mode) {
 
 static int serialupdi_reset_connection(const PROGRAMMER *pgm) {
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    pmsg_info("apply reset operation failed\n");
+    pmsg_error("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    pmsg_info("release reset operation failed\n");
+    pmsg_error("release reset operation failed\n");
     return -1;
   }
 
@@ -132,14 +132,14 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
 
   str_ptr = strstr(sib_info->nvm_string, ":");
   if (!str_ptr) {
-    pmsg_info("incorrect format of NVM string\n");
+    pmsg_error("incorrect format of NVM string\n");
     return -1;
   }
   sib_info->nvm_version = *(str_ptr+1);
 
   str_ptr = strstr(sib_info->debug_string, ":");
   if (!str_ptr) {
-    pmsg_info("incorrect format of DEBUG string\n");
+    pmsg_error("incorrect format of DEBUG string\n");
     return -1;
   }
   sib_info->debug_version = *(str_ptr+1);
@@ -151,22 +151,22 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
   pmsg_debug("Extra information: %s\n", sib_info->extra_string);
   switch (sib_info->nvm_version) {
     case '0':
-      pmsg_info("NVM type 0: 16-bit, page oriented write\n");
+      pmsg_notice("NVM type 0: 16-bit, page oriented write\n");
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V0);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_16BIT);
       break;
     case '2':
-      pmsg_info("NVM type 2: 24-bit, word oriented write\n");
+      pmsg_notice("NVM type 2: 24-bit, word oriented write\n");
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V2);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_24BIT);
       break;
     case '3':
-      pmsg_info("NVM type 3: 16-bit, page oriented\n");
+      pmsg_notice("NVM type 3: 16-bit, page oriented\n");
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V3);
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_16BIT);
       break;
     default:
-      pmsg_info("unsupported NVM type: %c, please update software\n", sib_info->nvm_version);
+      pmsg_warning("unsupported NVM type: %c, please update software\n", sib_info->nvm_version);
       return -1;
   }
   return 0;
@@ -174,13 +174,13 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
 
 static void serialupdi_close(PROGRAMMER * pgm)
 {
-  pmsg_info("leaving NVM programming mode\n");
+  pmsg_notice("leaving NVM programming mode\n");
 
   if (serialupdi_leave_progmode(pgm) < 0) {
-    pmsg_info("unable to leave NVM programming mode\n");
+    pmsg_error("unable to leave NVM programming mode\n");
   }
   if (updi_get_rts_mode(pgm) != RTS_MODE_DEFAULT) {
-    pmsg_info("releasing DTR/RTS handshake lines\n");
+    pmsg_warning("releasing DTR/RTS handshake lines\n");
   }
 
   updi_link_close(pgm);
@@ -221,7 +221,7 @@ static int serialupdi_wait_for_unlock(const PROGRAMMER *pgm, unsigned int ms) {
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < (ms * 1000));
 
-  pmsg_info("timeout waiting for device to unlock\n");
+  pmsg_error("timeout waiting for device to unlock\n");
   return -1;
 }
 
@@ -276,7 +276,7 @@ static int serialupdi_wait_for_urow(const PROGRAMMER *pgm, unsigned int ms, urow
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < (ms * 1000));
 
-  pmsg_info("timeout waiting for device to complete UROW WRITE\n");
+  pmsg_error("timeout waiting for device to complete UROW WRITE\n");
   return -1;
 }
 
@@ -296,7 +296,7 @@ static int serialupdi_in_prog_mode(const PROGRAMMER *pgm, uint8_t *in_prog_mode)
   rc = updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value);
   
   if (rc < 0) {
-    pmsg_info("read CS operation failed\n");
+    pmsg_error("read CS operation failed\n");
     return rc;
   }
 
@@ -352,7 +352,7 @@ def enter_progmode(self):
   uint8_t key_status;
 
   if (serialupdi_in_prog_mode(pgm, &in_prog_mode) < 0) {
-    pmsg_info("checking UPDI NVM prog mode failed\n");
+    pmsg_error("checking UPDI NVM prog mode failed\n");
     return -1;
   }
   if (in_prog_mode) {
@@ -362,43 +362,43 @@ def enter_progmode(self):
 
   memcpy(buffer, UPDI_KEY_NVM, sizeof(buffer));
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    pmsg_info("writing NVM KEY failed\n");
+    pmsg_error("writing NVM KEY failed\n");
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    pmsg_info("checking KEY status failed\n");
+    pmsg_error("checking KEY status failed\n");
     return -1;
   }
   pmsg_debug("key status: 0x%02X\n", key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_NVMPROG))) {
-    pmsg_info("key was not accepted\n");
+    pmsg_error("key was not accepted\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    pmsg_info("apply reset operation failed\n");
+    pmsg_error("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    pmsg_info("release reset operation failed\n");
+    pmsg_error("release reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_wait_for_unlock(pgm, 100) < 0) {
-    pmsg_info("failed to enter NVM programming mode: device is locked\n");
+    pmsg_error("unable to enter NVM programming mode: device is locked\n");
     return -1;
   }
 
   if (serialupdi_in_prog_mode(pgm, &in_prog_mode) < 0) {
-    pmsg_info("checking UPDI NVM prog mode failed\n");
+    pmsg_error("checking UPDI NVM prog mode failed\n");
     return -1;
   }
 
   if (!in_prog_mode) {
-    pmsg_info("failed to enter NVM programming mode\n");
+    pmsg_error("unable to enter NVM programming mode\n");
     return -1;
   }
 
@@ -420,12 +420,12 @@ static int serialupdi_leave_progmode(const PROGRAMMER *pgm) {
                                 (1 << constants.UPDI_CTRLB_UPDIDIS_BIT) | (1 << constants.UPDI_CTRLB_CCDETDIS_BIT))
 */
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    pmsg_info("apply reset operation failed\n");
+    pmsg_error("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    pmsg_info("release reset operation failed\n");
+    pmsg_error("release reset operation failed\n");
     return -1;
   }
 
@@ -489,74 +489,74 @@ static int serialupdi_write_userrow(const PROGRAMMER *pgm, const AVRPART *p, con
 
   memcpy(buffer, UPDI_KEY_UROW, sizeof(buffer));
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    pmsg_info("writing USERROW KEY failed\n");
+    pmsg_error("writing USERROW KEY failed\n");
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    pmsg_info("checking KEY status failed\n");
+    pmsg_error("checking KEY status failed\n");
     return -1;
   }
   pmsg_debug("key status: 0x%02X\n", key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_UROWWRITE))) {
-    pmsg_info("key was not accepted\n");
+    pmsg_error("key was not accepted\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    pmsg_info("apply reset operation failed\n");
+    pmsg_error("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    pmsg_info("release reset operation failed\n");
+    pmsg_error("release reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_wait_for_urow(pgm, 500, WAIT_FOR_UROW_HIGH) < 0) {
-    pmsg_info("failed to enter USERROW programming mode\n");
+    pmsg_error("unable to enter USERROW programming mode\n");
     return -1;
   }
 
   if (updi_write_data(pgm, m->offset+addr, m->buf + addr, n_bytes) < 0) {
-    pmsg_info("writing USER ROW failed\n");
+    pmsg_error("writing USER ROW failed\n");
     return -1;
   }
 
   if (updi_write_cs(pgm, UPDI_ASI_SYS_CTRLA, (1 << UPDI_ASI_SYS_CTRLA_UROW_FINAL) |
                                              (1 << UPDI_CTRLB_CCDETDIS_BIT)) < 0) {
-    pmsg_info("failed trying to commit user row write\n");
+    pmsg_error("unable to commit user row write\n");
     return -1;
   }
 
   if (serialupdi_wait_for_urow(pgm, 500, WAIT_FOR_UROW_LOW) < 0) {
-    pmsg_debug("failed to exit USERROW programming mode\n");
+    pmsg_debug("unable to exit USERROW programming mode\n");
 
     if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-      pmsg_info("Apply reset operation failed\n");
+      pmsg_error("apply reset operation failed\n");
       return -1;
     }
 
     if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-      pmsg_info("release reset operation failed\n");
+      pmsg_error("release reset operation failed\n");
       return -1;
     }
   }
 
   if (updi_write_cs(pgm, UPDI_ASI_KEY_STATUS, (1 << UPDI_ASI_KEY_STATUS_UROWWRITE) |
                                               (1 << UPDI_CTRLB_CCDETDIS_BIT)) < 0) {
-    pmsg_info("failed trying to complete user row write\n");
+    pmsg_error("unable to complete user row write\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    pmsg_info("apply reset operation failed\n");
+    pmsg_error("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    pmsg_info("release reset operation failed\n");
+    pmsg_error("release reset operation failed\n");
     return -1;
   }
 
@@ -572,13 +572,13 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t reset_link_required=0;
   
   if (updi_link_init(pgm) < 0) {
-    pmsg_info("UPDI link initialization failed\n");
+    pmsg_error("UPDI link initialization failed\n");
     return -1;
   }
-  pmsg_info("UPDI link initialization OK\n");
+  pmsg_notice2("UPDI link initialization OK\n");
 
   if (updi_get_rts_mode(pgm) != RTS_MODE_DEFAULT) {
-    pmsg_info("forcing serial DTR/RTS handshake lines %s\n", updi_get_rts_mode(pgm) == RTS_MODE_LOW ? "LOW" : "HIGH");
+    pmsg_warning("forcing serial DTR/RTS handshake lines %s\n", updi_get_rts_mode(pgm) == RTS_MODE_LOW ? "LOW" : "HIGH");
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
@@ -589,33 +589,33 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
 
     if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-      pmsg_info("read CS operation during initialization failed\n");
+      pmsg_error("read CS operation during initialization failed\n");
       return -1;
     }
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_LOCKSTATUS)) {
-    pmsg_info("device is locked\n");
+    pmsg_notice("device is locked\n");
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_UROWPROG)) {
-    pmsg_info("device in USER ROW programming state, leaving programming mode\n");
+    pmsg_notice("device in USER ROW programming state, leaving programming mode\n");
     reset_link_required = 1;
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_NVMPROG)) {
-    pmsg_info("device in NVM programming state, leaving programming mode\n");
+    pmsg_notice("device in NVM programming state, leaving programming mode\n");
     reset_link_required = 1;
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_INSLEEP)) {
-    pmsg_info("device is in SLEEP mode\n");
+    pmsg_notice("device is in SLEEP mode\n");
   }
   if (value & (1 << UPDI_ASI_SYS_STATUS_RSTSYS)) {
-    pmsg_info("device in reset status, trying to release it\n");
-    if (serialupdi_reset(pgm, RELEASE_RESET)<0) {
+    pmsg_notice("device in reset status, trying to release it\n");
+    if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
       return -1;
     }
   }
   if (reset_link_required) {
     if (serialupdi_reset_connection(pgm) < 0) {
-      pmsg_info("UPDI link reset failed\n");
+      pmsg_error("UPDI link reset failed\n");
       return -1;
     }
   }
@@ -625,25 +625,25 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (updi_read_sib(pgm, sib_info->sib_string, 32) < 0) {
     /* this should never happen, let's try to reset connection and try again */
     if (serialupdi_reset_connection(pgm) < 0) {
-      pmsg_info("SerialUPDI reset connection failed\n");
+      pmsg_error("SerialUPDI reset connection failed\n");
       return -1;
     }
     if (updi_read_sib(pgm, sib_info->sib_string, 32) < 0) {
-      pmsg_info("read SIB operation failed\n");
+      pmsg_error("read SIB operation failed\n");
       return -1;
     }
   }
   if (serialupdi_decode_sib(pgm, sib_info) < 0) {
-    pmsg_info("decode SIB_INFO failed\n");
+    pmsg_error("decode SIB_INFO failed\n");
     return -1;
   }
 
   if (updi_link_init(pgm) < 0) {
-    pmsg_info("UPDI link initialization failed\n");
+    pmsg_error("UPDI link initialization failed\n");
     return -1;
   }
 
-  pmsg_info("entering NVM programming mode\n");
+  pmsg_notice("entering NVM programming mode\n");
     /* try, but ignore failure */
   serialupdi_enter_progmode(pgm);
 
@@ -669,12 +669,12 @@ static void serialupdi_display(const PROGRAMMER *pgm, const char *p) {
 static int serialupdi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                           unsigned char * res)
 {
-  pmsg_info("cmd %s[%s] not implemented yet\n", cmd, res);
+  pmsg_error("cmd %s[%s] not implemented yet\n", cmd, res);
   return -1;
 }
 
 static int serialupdi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-  pmsg_info("program enable not implemented yet\n");
+  pmsg_error("program enable not implemented yet\n");
   return -1;
 }
 
@@ -720,7 +720,7 @@ static int serialupdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
       rc = updi_read_data(pgm, m->offset + read_offset, m->buf + read_offset, 
                           remaining_bytes > m->readsize ? m->readsize : remaining_bytes);
       if (rc < 0) {
-        pmsg_info("paged load operation failed\n");
+        pmsg_error("paged load operation failed\n");
         return rc;
       } else {
         read_bytes+=rc;
@@ -758,12 +758,12 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         return -1;
       } else {
-        pmsg_info("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
+        pmsg_error("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
         rc = -1;
       }
 
       if (rc < 0) {
-        pmsg_info("paged write operation failed\n");
+        pmsg_error("paged write operation failed\n");
         return rc;
       } else {
         write_bytes+=rc;
@@ -783,7 +783,7 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         rc = -1;
     } else {
-      pmsg_info("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
+      pmsg_error("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
       rc = -1;
     }
     return rc;
@@ -820,38 +820,38 @@ static int serialupdi_unlock(const PROGRAMMER *pgm, const AVRPART *p) {
   memcpy(buffer, UPDI_KEY_CHIPERASE, sizeof(buffer));
 
   if (updi_write_key(pgm, buffer, UPDI_KEY_64, sizeof(buffer)) < 0) {
-    pmsg_info("writing NVM KEY failed\n");
+    pmsg_error("writing NVM KEY failed\n");
     return -1;
   }
 
   if (updi_read_cs(pgm, UPDI_ASI_KEY_STATUS, &key_status) < 0) {
-    pmsg_info("checking KEY status failed\n");
+    pmsg_error("checking KEY status failed\n");
     return -1;
   }
   pmsg_debug("key status: 0x%02X\n", key_status);
 
   if (!(key_status & (1 << UPDI_ASI_KEY_STATUS_CHIPERASE))) {
-    pmsg_info("key not accepted\n");
+    pmsg_error("key not accepted\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, APPLY_RESET) < 0) {
-    pmsg_info("apply reset operation failed\n");
+    pmsg_error("apply reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_reset(pgm, RELEASE_RESET) < 0) {
-    pmsg_info("release reset operation failed\n");
+    pmsg_error("release reset operation failed\n");
     return -1;
   }
 
   if (serialupdi_wait_for_unlock(pgm, 500) < 0) {
-    pmsg_info("waiting for unlock failed\n");
+    pmsg_error("waiting for unlock failed\n");
     return -1;
   }
 
   if (updi_link_init(pgm) < 0) {
-    pmsg_info("UPDI link reinitialization failed\n");
+    pmsg_error("UPDI link reinitialization failed\n");
     return -1;
   }
 
@@ -862,14 +862,14 @@ static int serialupdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   uint8_t value;
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-    pmsg_info("read CS operation during chip erase failed\n");
+    pmsg_error("read CS operation during chip erase failed\n");
     return -1;
   }
   
   if (value & (1 << UPDI_ASI_SYS_STATUS_LOCKSTATUS)) {
-    pmsg_info("device is locked\n");
+    pmsg_warning("device is locked\n");
     if (ovsigck) {
-      pmsg_info("attempting device erase\n");
+      pmsg_warning("attempting device erase\n");
       return serialupdi_unlock(pgm, p);
     }
   } else {
@@ -881,7 +881,7 @@ static int serialupdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int serialupdi_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                  unsigned int baseaddr)
 {
-  pmsg_info("page erase not implemented yet\n");
+  pmsg_error("page erase not implemented yet\n");
   return -1;
 }
 
@@ -890,7 +890,7 @@ static int serialupdi_read_signature(const PROGRAMMER *pgm, const AVRPART *p, co
   uint8_t value;
 
   if (updi_read_cs(pgm, UPDI_ASI_SYS_STATUS, &value)<0) {
-    pmsg_info("read CS operation during signature read failed\n");
+    pmsg_error("read CS operation during signature read failed\n");
     return -1;
   }
 
@@ -931,13 +931,13 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
       } else if (strcasecmp(rts_mode, "high") == 0) {
         updi_set_rts_mode(pgm, RTS_MODE_HIGH);
       } else {
-        pmsg_info("RTS/DTR mode must be LOW or HIGH\n");
+        pmsg_error("RTS/DTR mode must be LOW or HIGH\n");
         return -1;
       }
       continue;
     }
 
-    pmsg_info("serialupdi_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("serialupdi_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -60,8 +60,7 @@ static int stk500_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, buf, len);
   if (rv < 0) {
-    msg_info("%s: stk500_recv(): programmer is not responding\n",
-                    progname);
+    pmsg_info("stk500_recv(): programmer is not responding\n");
     return -1;
   }
   return 0;
@@ -110,8 +109,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
     if(stk500_recv(pgm, resp, 1) >= 0 && resp[0] == Resp_STK_INSYNC)
       break;
 
-    msg_info("%s: stk500_getsync() attempt %d of %d: not in sync: resp=0x%02x\n",
-                    progname, attempt + 1, max_sync_attempts, resp[0]);
+    pmsg_info("stk500_getsync() attempt %d of %d: not in sync: resp=0x%02x\n", attempt + 1, max_sync_attempts, resp[0]);
   }
   if (attempt == max_sync_attempts) {
     stk500_drain(pgm, 0);
@@ -121,9 +119,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
   if (stk500_recv(pgm, resp, 1) < 0)
     return -1;
   if (resp[0] != Resp_STK_OK) {
-    msg_info("%s: stk500_getsync(): can't communicate with device: "
-                    "resp=0x%02x\n",
-                    progname, resp[0]);
+    pmsg_info("stk500_getsync(): can't communicate with device: resp=0x%02x\n", resp[0]);
     return -1;
   }
 
@@ -152,7 +148,7 @@ static int stk500_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("%s: stk500_cmd(): programmer is out of sync\n", progname);
+    pmsg_info("stk500_cmd(): programmer is out of sync\n");
     return -1;
   }
 
@@ -165,7 +161,7 @@ static int stk500_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_OK) {
-    msg_info("%s: stk500_cmd(): protocol error\n", progname);
+    pmsg_info("stk500_cmd(): protocol error\n");
     return -1;
   }
 
@@ -182,15 +178,13 @@ static int stk500_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char res[4];
 
   if (pgm->cmd == NULL) {
-    msg_info("%s: Error: %s programmer uses stk500_chip_erase() but does not\n"
-                    "provide a cmd() method.\n",
-                    progname, pgm->type);
+    pmsg_info("%s programmer uses stk500_chip_erase() but does not\n"
+      "%sprovide a cmd() method\n", pgm->type, progbuf);
     return -1;
   }
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    msg_info("%s: chip erase instruction not defined for part \"%s\"\n",
-            progname, p->desc);
+    pmsg_info("chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -226,8 +220,7 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      msg_info("%s: stk500_program_enable(): can't get into sync\n",
-              progname);
+      pmsg_info("stk500_program_enable(): can't get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -235,9 +228,8 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("%s: stk500_program_enable(): protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+    pmsg_info("stk500_program_enable(): protocol error, "
+      "expect=0x%02x, resp=0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -247,21 +239,18 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    msg_info("%s: stk500_program_enable(): no device\n",
-            progname);
+    pmsg_info("stk500_program_enable(): no device\n");
     return -1;
   }
 
   if(buf[0] == Resp_STK_FAILED)
   {
-      msg_info("%s: stk500_program_enable(): failed to enter programming mode\n",
-                      progname);
-	  return -1;
+      pmsg_info("stk500_program_enable(): failed to enter programming mode\n");
+      return -1;
   }
 
 
-  msg_info("%s: stk500_program_enable(): unknown response=0x%02x\n",
-          progname, buf[0]);
+  pmsg_info("stk500_program_enable(): unknown response=0x%02x\n", buf[0]);
 
   return -1;
 }
@@ -291,8 +280,7 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      msg_info("%s: stk500_set_extended_parms(): can't get into sync\n",
-              progname);
+      pmsg_info("stk500_set_extended_parms(): can't get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -300,9 +288,8 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("%s: stk500_set_extended_parms(): protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+    pmsg_info("stk500_set_extended_parms(): protocol error, "
+      "expect=0x%02x, resp=0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -312,22 +299,19 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    msg_info("%s: stk500_set_extended_parms(): no device\n",
-            progname);
+    pmsg_info("stk500_set_extended_parms(): no device\n");
     return -1;
   }
 
   if(buf[0] == Resp_STK_FAILED)
   {
-      msg_info("%s: stk500_set_extended_parms(): failed to set extended "
-                      "device programming parameters\n",
-                      progname);
-	  return -1;
+      pmsg_info("stk500_set_extended_parms(): failed to set extended "
+        "device programming parameters\n");
+      return -1;
   }
 
 
-  msg_info("%s: stk500_set_extended_parms(): unknown response=0x%02x\n",
-          progname, buf[0]);
+  pmsg_info("stk500_set_extended_parms(): unknown response=0x%02x\n", buf[0]);
 
   return -1;
 }
@@ -360,8 +344,7 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      msg_info("%s: mib510_isp(): can't get into sync\n",
-              progname);
+      pmsg_info("mib510_isp(): can't get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -369,9 +352,8 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("%s: mib510_isp(): protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+    pmsg_info("mib510_isp(): protocol error, "
+      "expect=0x%02x, resp=0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -381,21 +363,18 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    msg_info("%s: mib510_isp(): no device\n",
-            progname);
+    pmsg_info("mib510_isp(): no device\n");
     return -1;
   }
 
   if (buf[0] == Resp_STK_FAILED)
   {
-      msg_info("%s: mib510_isp(): command %d failed\n",
-                      progname, cmd);
+      pmsg_info("mib510_isp(): command %d failed\n", cmd);
       return -1;
   }
 
 
-  msg_info("%s: mib510_isp(): unknown response=0x%02x\n",
-          progname, buf[0]);
+  pmsg_info("mib510_isp(): unknown response=0x%02x\n", buf[0]);
 
   return -1;
 }
@@ -454,8 +433,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
 #if 0
-  msg_info("%s: stk500_initialize(): n_extparms = %d\n",
-          progname, n_extparms);
+  pmsg_info("stk500_initialize(): n_extparms = %d\n", n_extparms);
 #endif
     
   buf[5] = 1; /* polling supported - XXX need this in config file */
@@ -528,8 +506,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    msg_info("%s: stk500_initialize(): programmer not in sync, resp=0x%02x\n",
-                    progname, buf[0]);
+    pmsg_info("stk500_initialize(): programmer not in sync, resp=0x%02x\n", buf[0]);
     if (tries > 33)
       return -1;
     if (stk500_getsync(pgm) < 0)
@@ -537,26 +514,23 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("%s: stk500_initialize(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+    pmsg_info("stk500_initialize(): (a) protocol error, "
+      "expect=0x%02x, resp=0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_OK) {
-    msg_info("%s: stk500_initialize(): (b) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_OK, buf[0]);
+    pmsg_info("stk500_initialize(): (b) protocol error, "
+      "expect=0x%02x, resp=0x%02x\n", Resp_STK_OK, buf[0]);
     return -1;
   }
 
   if (n_extparms) {
     if ((p->pagel == 0) || (p->bs2 == 0)) {
-      msg_notice2("%s: PAGEL and BS2 signals not defined in the configuration "
-                          "file for part %s, using dummy values\n",
-                          progname, p->desc);
+      pmsg_notice2("PAGEL and BS2 signals not defined in the configuration "
+        "file for part %s, using dummy values\n", p->desc);
       buf[2] = 0xD7;            /* they look somehow possible, */
       buf[3] = 0xA0;            /* don't they? ;) */
     }
@@ -584,7 +558,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     rc = stk500_set_extended_parms(pgm, n_extparms+1, buf);
     if (rc) {
-      msg_info("%s: stk500_initialize(): failed\n", progname);
+      pmsg_info("stk500_initialize(): failed\n");
       return -1;
     }
   }
@@ -604,13 +578,11 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 
      if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
        PDATA(pgm)->retry_attempts = attempts;
-       msg_info("%s: Setting number of retry attempts to %d\n",
-                     progname, attempts);
+       pmsg_info("Setting number of retry attempts to %d\n", attempts);
        continue;
      }
 
-     msg_info("%s: stk500_parseextparms(): invalid extended parameter '%s'\n",
-                     progname, extended_param);
+     pmsg_info("stk500_parseextparms(): invalid extended parameter '%s'\n", extended_param);
      rv = -1;
    }
 
@@ -633,8 +605,7 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     return;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      msg_info("%s: stk500_disable(): can't get into sync\n",
-              progname);
+      pmsg_info("stk500_disable(): can't get into sync\n");
       return;
     }
     if (stk500_getsync(pgm) < 0)
@@ -642,9 +613,8 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("%s: stk500_disable(): protocol error, expect=0x%02x, "
-                    "resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+    pmsg_info("stk500_disable(): protocol error, expect=0x%02x, "
+      "resp=0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return;
   }
 
@@ -654,13 +624,11 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     return;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    msg_info("%s: stk500_disable(): no device\n",
-            progname);
+    pmsg_info("stk500_disable(): no device\n");
     return;
   }
 
-  msg_info("%s: stk500_disable(): unknown response=0x%02x\n",
-          progname, buf[0]);
+  pmsg_info("stk500_disable(): unknown response=0x%02x\n", buf[0]);
 
   return;
 }
@@ -742,8 +710,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      msg_info("%s: stk500_loadaddr(): can't get into sync\n",
-              progname);
+      pmsg_info("stk500_loadaddr(): can't get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -751,9 +718,8 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info("%s: stk500_loadaddr(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+    pmsg_info("stk500_loadaddr(): (a) protocol error, "
+      "expect=0x%02x, resp=0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -762,9 +728,8 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
   if (buf[0] == Resp_STK_OK)
     return 0;
 
-  msg_info("%s: stk500_loadaddr(): (b) protocol error, "
-                  "expect=0x%02x, resp=0x%02x\n",
-                  progname, Resp_STK_OK, buf[0]);
+  pmsg_info("stk500_loadaddr(): (b) protocol error, "
+    "expect=0x%02x, resp=0x%02x\n", Resp_STK_OK, buf[0]);
 
   return -1;
 }
@@ -839,7 +804,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if (buf[0] == Resp_STK_NOSYNC) {
       if (tries > 33) {
         msg_info("\n%s: stk500_paged_write(): can't get into sync\n",
-                progname);
+          progname);
         return -3;
       }
       if (stk500_getsync(pgm) < 0)
@@ -848,8 +813,8 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     }
     else if (buf[0] != Resp_STK_INSYNC) {
       msg_info("\n%s: stk500_paged_write(): (a) protocol error, "
-                      "expect=0x%02x, resp=0x%02x\n",
-                      progname, Resp_STK_INSYNC, buf[0]);
+        "expect=0x%02x, resp=0x%02x\n",
+        progname, Resp_STK_INSYNC, buf[0]);
       return -4;
     }
 
@@ -857,8 +822,8 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       return -1;
     if (buf[0] != Resp_STK_OK) {
       msg_info("\n%s: stk500_paged_write(): (b) protocol error, "
-                      "expect=0x%02x, resp=0x%02x\n",
-                      progname, Resp_STK_OK, buf[0]);
+        "expect=0x%02x, resp=0x%02x\n",
+        progname, Resp_STK_OK, buf[0]);
       return -5;
     }
   }
@@ -920,8 +885,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
       return -1;
     if (buf[0] == Resp_STK_NOSYNC) {
       if (tries > 33) {
-        msg_info("\n%s: stk500_paged_load(): can't get into sync\n",
-                progname);
+        msg_info("\n%s: stk500_paged_load(): can't get into sync\n", progname);
         return -3;
       }
       if (stk500_getsync(pgm) < 0)
@@ -930,8 +894,8 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     }
     else if (buf[0] != Resp_STK_INSYNC) {
       msg_info("\n%s: stk500_paged_load(): (a) protocol error, "
-                      "expect=0x%02x, resp=0x%02x\n",
-                      progname, Resp_STK_INSYNC, buf[0]);
+        "expect=0x%02x, resp=0x%02x\n",
+        progname, Resp_STK_INSYNC, buf[0]);
       return -4;
     }
 
@@ -944,16 +908,16 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if(strcmp(ldata(lfirst(pgm->id)), "mib510") == 0) {
       if (buf[0] != Resp_STK_INSYNC) {
       msg_info("\n%s: stk500_paged_load(): (a) protocol error, "
-                      "expect=0x%02x, resp=0x%02x\n",
-                      progname, Resp_STK_INSYNC, buf[0]);
+        "expect=0x%02x, resp=0x%02x\n",
+        progname, Resp_STK_INSYNC, buf[0]);
       return -5;
     }
   }
     else {
       if (buf[0] != Resp_STK_OK) {
         msg_info("\n%s: stk500_paged_load(): (b) protocol error, "
-                        "expect=0x%02x, resp=0x%02x\n",
-                        progname, Resp_STK_OK, buf[0]);
+          "expect=0x%02x, resp=0x%02x\n",
+          progname, Resp_STK_OK, buf[0]);
         return -5;
       }
     }
@@ -969,14 +933,12 @@ static int stk500_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500_getparm(pgm, Parm_STK_VADJUST, &uaref) != 0) {
-    msg_info("%s: stk500_set_vtarget(): cannot obtain V[aref]\n",
-                    progname);
+    pmsg_info("stk500_set_vtarget(): cannot obtain V[aref]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    msg_info("%s: stk500_set_vtarget(): reducing V[aref] from %.1f to %.1f\n",
-                    progname, uaref / 10.0, v);
+    pmsg_info("stk500_set_vtarget(): reducing V[aref] from %.1f to %.1f\n", uaref / 10.0, v);
     if (stk500_setparm(pgm, Parm_STK_VADJUST, utarg)
 	!= 0)
       return -1;
@@ -993,15 +955,13 @@ static int stk500_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused *
   uaref = (unsigned)((v + 0.049) * 10);
 
   if (stk500_getparm(pgm, Parm_STK_VTARGET, &utarg) != 0) {
-    msg_info("%s: stk500_set_varef(): cannot obtain V[target]\n",
-                    progname);
+    pmsg_info("stk500_set_varef(): cannot obtain V[target]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    msg_info("%s: stk500_set_varef(): V[aref] must not be greater than "
-                    "V[target] = %.1f\n",
-                    progname, utarg / 10.0);
+    pmsg_info("stk500_set_varef(): V[aref] must not be greater than "
+      "V[target] = %.1f\n", utarg/10.0);
     return -1;
   }
   return stk500_setparm(pgm, Parm_STK_VADJUST, uaref);
@@ -1028,8 +988,7 @@ static int stk500_set_fosc(const PROGRAMMER *pgm, double v) {
         unit = "kHz";
       } else
         unit = "Hz";
-      msg_info("%s: stk500_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
-                      progname, v, unit, STK500_XTAL / 2e6);
+      pmsg_info("stk500_set_fosc(): f = %.3f %s too high, using %.3f MHz\n", v, unit, STK500_XTAL/2e6);
       fosc = STK500_XTAL / 2;
     } else
       fosc = (unsigned)v;
@@ -1043,8 +1002,7 @@ static int stk500_set_fosc(const PROGRAMMER *pgm, double v) {
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
-      msg_info("%s: stk500_set_fosc(): f = %u Hz too low, %u Hz min\n",
-          progname, fosc, STK500_XTAL / (256 * 1024 * 2));
+      pmsg_info("stk500_set_fosc(): f = %u Hz too low, %u Hz min\n", fosc, STK500_XTAL / (256 * 1024 * 2));
       return -1;
     }
   }
@@ -1074,12 +1032,12 @@ static int stk500_set_sck_period(const PROGRAMMER *pgm, double v) {
   
   if (v < min) {
       dur = 1;
-      msg_info("%s: stk500_set_sck_period(): p = %.1f us too small, using %.1f us\n",
-                      progname, v / 1e-6, dur * min / 1e-6);
+      pmsg_info("stk500_set_sck_period(): p = %.1f us too small, using %.1f us\n",
+        v/1e-6, dur*min/1e-6);
   } else if (v > max) {
       dur = 255;
-      msg_info("%s: stk500_set_sck_period(): p = %.1f us too large, using %.1f us\n",
-                      progname, v / 1e-6, dur * min / 1e-6);
+      pmsg_info("stk500_set_sck_period(): p = %.1f us too large, using %.1f us\n",
+        v/1e-6, dur*min/1e-6);
   }
   
   return stk500_setparm(pgm, Parm_STK_SCK_DURATION, dur);
@@ -1103,8 +1061,7 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      msg_info("\n%s: stk500_getparm(): can't get into sync\n",
-              progname);
+      msg_info("\n%s: stk500_getparm(): can't get into sync\n", progname);
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -1113,8 +1070,7 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
   }
   else if (buf[0] != Resp_STK_INSYNC) {
     msg_info("\n%s: stk500_getparm(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+     "expect=0x%02x, resp=0x%02x\n", progname, Resp_STK_INSYNC, buf[0]);
     return -2;
   }
 
@@ -1125,14 +1081,12 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_FAILED) {
-    msg_info("\n%s: stk500_getparm(): parameter 0x%02x failed\n",
-                    progname, v);
+    msg_info("\n%s: stk500_getparm(): parameter 0x%02x failed\n", progname, v);
     return -3;
   }
   else if (buf[0] != Resp_STK_OK) {
     msg_info("\n%s: stk500_getparm(): (b) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_OK, buf[0]);
+      "expect=0x%02x, resp=0x%02x\n", progname, Resp_STK_OK, buf[0]);
     return -3;
   }
 
@@ -1159,8 +1113,7 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      msg_info("\n%s: stk500_setparm(): can't get into sync\n",
-              progname);
+      msg_info("\n%s: stk500_setparm(): can't get into sync\n", progname);
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -1169,8 +1122,7 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
   }
   else if (buf[0] != Resp_STK_INSYNC) {
     msg_info("\n%s: stk500_setparm(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+      "expect=0x%02x, resp=0x%02x\n", progname, Resp_STK_INSYNC, buf[0]);
     return -2;
   }
 
@@ -1183,14 +1135,12 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_FAILED) {
-    msg_info("\n%s: stk500_setparm(): parameter 0x%02x failed\n",
-                    progname, parm);
+    msg_info("\n%s: stk500_setparm(): parameter 0x%02x failed\n", progname, parm);
     return -3;
   }
   else {
     msg_info("\n%s: stk500_setparm(): (b) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_OK, buf[0]);
+      "expect=0x%02x, resp=0x%02x\n", progname, Resp_STK_OK, buf[0]);
     return -3;
   }
 }
@@ -1280,8 +1230,7 @@ static void stk500_print_parms(const PROGRAMMER *pgm) {
 static void stk500_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: stk500_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("stk500_setup(): Out of memory allocating private data\n");
     return;
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -178,8 +178,8 @@ static int stk500_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char res[4];
 
   if (pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses stk500_chip_erase() but does not\n"
-      "%sprovide a cmd() method\n", pgm->type, progbuf);
+    pmsg_error("%s programmer uses stk500_chip_erase() but does not\n", pgm->type);
+    imsg_error("provide a cmd() method\n");
     return -1;
   }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -60,7 +60,7 @@ static int stk500_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, buf, len);
   if (rv < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500_recv(): programmer is not responding\n",
+    msg_info("%s: stk500_recv(): programmer is not responding\n",
                     progname);
     return -1;
   }
@@ -110,7 +110,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
     if(stk500_recv(pgm, resp, 1) >= 0 && resp[0] == Resp_STK_INSYNC)
       break;
 
-    avrdude_message(MSG_INFO, "%s: stk500_getsync() attempt %d of %d: not in sync: resp=0x%02x\n",
+    msg_info("%s: stk500_getsync() attempt %d of %d: not in sync: resp=0x%02x\n",
                     progname, attempt + 1, max_sync_attempts, resp[0]);
   }
   if (attempt == max_sync_attempts) {
@@ -121,7 +121,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
   if (stk500_recv(pgm, resp, 1) < 0)
     return -1;
   if (resp[0] != Resp_STK_OK) {
-    avrdude_message(MSG_INFO, "%s: stk500_getsync(): can't communicate with device: "
+    msg_info("%s: stk500_getsync(): can't communicate with device: "
                     "resp=0x%02x\n",
                     progname, resp[0]);
     return -1;
@@ -152,7 +152,7 @@ static int stk500_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_cmd(): programmer is out of sync\n", progname);
+    msg_info("%s: stk500_cmd(): programmer is out of sync\n", progname);
     return -1;
   }
 
@@ -165,7 +165,7 @@ static int stk500_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_OK) {
-    avrdude_message(MSG_INFO, "%s: stk500_cmd(): protocol error\n", progname);
+    msg_info("%s: stk500_cmd(): protocol error\n", progname);
     return -1;
   }
 
@@ -182,14 +182,14 @@ static int stk500_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char res[4];
 
   if (pgm->cmd == NULL) {
-    avrdude_message(MSG_INFO, "%s: Error: %s programmer uses stk500_chip_erase() but does not\n"
+    msg_info("%s: Error: %s programmer uses stk500_chip_erase() but does not\n"
                     "provide a cmd() method.\n",
                     progname, pgm->type);
     return -1;
   }
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    avrdude_message(MSG_INFO, "%s: chip erase instruction not defined for part \"%s\"\n",
+    msg_info("%s: chip erase instruction not defined for part \"%s\"\n",
             progname, p->desc);
     return -1;
   }
@@ -226,7 +226,7 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      avrdude_message(MSG_INFO, "%s: stk500_program_enable(): can't get into sync\n",
+      msg_info("%s: stk500_program_enable(): can't get into sync\n",
               progname);
       return -1;
     }
@@ -235,7 +235,7 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_program_enable(): protocol error, "
+    msg_info("%s: stk500_program_enable(): protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -1;
@@ -247,20 +247,20 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    avrdude_message(MSG_INFO, "%s: stk500_program_enable(): no device\n",
+    msg_info("%s: stk500_program_enable(): no device\n",
             progname);
     return -1;
   }
 
   if(buf[0] == Resp_STK_FAILED)
   {
-      avrdude_message(MSG_INFO, "%s: stk500_program_enable(): failed to enter programming mode\n",
+      msg_info("%s: stk500_program_enable(): failed to enter programming mode\n",
                       progname);
 	  return -1;
   }
 
 
-  avrdude_message(MSG_INFO, "%s: stk500_program_enable(): unknown response=0x%02x\n",
+  msg_info("%s: stk500_program_enable(): unknown response=0x%02x\n",
           progname, buf[0]);
 
   return -1;
@@ -291,7 +291,7 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      avrdude_message(MSG_INFO, "%s: stk500_set_extended_parms(): can't get into sync\n",
+      msg_info("%s: stk500_set_extended_parms(): can't get into sync\n",
               progname);
       return -1;
     }
@@ -300,7 +300,7 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_set_extended_parms(): protocol error, "
+    msg_info("%s: stk500_set_extended_parms(): protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -1;
@@ -312,21 +312,21 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    avrdude_message(MSG_INFO, "%s: stk500_set_extended_parms(): no device\n",
+    msg_info("%s: stk500_set_extended_parms(): no device\n",
             progname);
     return -1;
   }
 
   if(buf[0] == Resp_STK_FAILED)
   {
-      avrdude_message(MSG_INFO, "%s: stk500_set_extended_parms(): failed to set extended "
+      msg_info("%s: stk500_set_extended_parms(): failed to set extended "
                       "device programming parameters\n",
                       progname);
 	  return -1;
   }
 
 
-  avrdude_message(MSG_INFO, "%s: stk500_set_extended_parms(): unknown response=0x%02x\n",
+  msg_info("%s: stk500_set_extended_parms(): unknown response=0x%02x\n",
           progname, buf[0]);
 
   return -1;
@@ -360,7 +360,7 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      avrdude_message(MSG_INFO, "%s: mib510_isp(): can't get into sync\n",
+      msg_info("%s: mib510_isp(): can't get into sync\n",
               progname);
       return -1;
     }
@@ -369,7 +369,7 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: mib510_isp(): protocol error, "
+    msg_info("%s: mib510_isp(): protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -1;
@@ -381,20 +381,20 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    avrdude_message(MSG_INFO, "%s: mib510_isp(): no device\n",
+    msg_info("%s: mib510_isp(): no device\n",
             progname);
     return -1;
   }
 
   if (buf[0] == Resp_STK_FAILED)
   {
-      avrdude_message(MSG_INFO, "%s: mib510_isp(): command %d failed\n",
+      msg_info("%s: mib510_isp(): command %d failed\n",
                       progname, cmd);
       return -1;
   }
 
 
-  avrdude_message(MSG_INFO, "%s: mib510_isp(): unknown response=0x%02x\n",
+  msg_info("%s: mib510_isp(): unknown response=0x%02x\n",
           progname, buf[0]);
 
   return -1;
@@ -454,7 +454,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
 #if 0
-  avrdude_message(MSG_INFO, "%s: stk500_initialize(): n_extparms = %d\n",
+  msg_info("%s: stk500_initialize(): n_extparms = %d\n",
           progname, n_extparms);
 #endif
     
@@ -528,7 +528,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_initialize(): programmer not in sync, resp=0x%02x\n",
+    msg_info("%s: stk500_initialize(): programmer not in sync, resp=0x%02x\n",
                     progname, buf[0]);
     if (tries > 33)
       return -1;
@@ -537,7 +537,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_initialize(): (a) protocol error, "
+    msg_info("%s: stk500_initialize(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -1;
@@ -546,7 +546,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_OK) {
-    avrdude_message(MSG_INFO, "%s: stk500_initialize(): (b) protocol error, "
+    msg_info("%s: stk500_initialize(): (b) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_OK, buf[0]);
     return -1;
@@ -554,7 +554,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   if (n_extparms) {
     if ((p->pagel == 0) || (p->bs2 == 0)) {
-      avrdude_message(MSG_NOTICE2, "%s: PAGEL and BS2 signals not defined in the configuration "
+      msg_notice2("%s: PAGEL and BS2 signals not defined in the configuration "
                           "file for part %s, using dummy values\n",
                           progname, p->desc);
       buf[2] = 0xD7;            /* they look somehow possible, */
@@ -584,7 +584,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     rc = stk500_set_extended_parms(pgm, n_extparms+1, buf);
     if (rc) {
-      avrdude_message(MSG_INFO, "%s: stk500_initialize(): failed\n", progname);
+      msg_info("%s: stk500_initialize(): failed\n", progname);
       return -1;
     }
   }
@@ -604,12 +604,12 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 
      if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
        PDATA(pgm)->retry_attempts = attempts;
-       avrdude_message(MSG_INFO, "%s: Setting number of retry attempts to %d\n",
+       msg_info("%s: Setting number of retry attempts to %d\n",
                      progname, attempts);
        continue;
      }
 
-     avrdude_message(MSG_INFO, "%s: stk500_parseextparms(): invalid extended parameter '%s'\n",
+     msg_info("%s: stk500_parseextparms(): invalid extended parameter '%s'\n",
                      progname, extended_param);
      rv = -1;
    }
@@ -633,7 +633,7 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     return;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      avrdude_message(MSG_INFO, "%s: stk500_disable(): can't get into sync\n",
+      msg_info("%s: stk500_disable(): can't get into sync\n",
               progname);
       return;
     }
@@ -642,7 +642,7 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_disable(): protocol error, expect=0x%02x, "
+    msg_info("%s: stk500_disable(): protocol error, expect=0x%02x, "
                     "resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return;
@@ -654,12 +654,12 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     return;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    avrdude_message(MSG_INFO, "%s: stk500_disable(): no device\n",
+    msg_info("%s: stk500_disable(): no device\n",
             progname);
     return;
   }
 
-  avrdude_message(MSG_INFO, "%s: stk500_disable(): unknown response=0x%02x\n",
+  msg_info("%s: stk500_disable(): unknown response=0x%02x\n",
           progname, buf[0]);
 
   return;
@@ -742,7 +742,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      avrdude_message(MSG_INFO, "%s: stk500_loadaddr(): can't get into sync\n",
+      msg_info("%s: stk500_loadaddr(): can't get into sync\n",
               progname);
       return -1;
     }
@@ -751,7 +751,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_loadaddr(): (a) protocol error, "
+    msg_info("%s: stk500_loadaddr(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -1;
@@ -762,7 +762,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
   if (buf[0] == Resp_STK_OK)
     return 0;
 
-  avrdude_message(MSG_INFO, "%s: stk500_loadaddr(): (b) protocol error, "
+  msg_info("%s: stk500_loadaddr(): (b) protocol error, "
                   "expect=0x%02x, resp=0x%02x\n",
                   progname, Resp_STK_OK, buf[0]);
 
@@ -800,7 +800,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   n = addr + n_bytes;
 #if 0
-  avrdude_message(MSG_INFO, "n_bytes   = %d\n"
+  msg_info("n_bytes   = %d\n"
                   "n         = %u\n"
                   "a_div     = %d\n"
                   "page_size = %d\n",
@@ -838,7 +838,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       return -1;
     if (buf[0] == Resp_STK_NOSYNC) {
       if (tries > 33) {
-        avrdude_message(MSG_INFO, "\n%s: stk500_paged_write(): can't get into sync\n",
+        msg_info("\n%s: stk500_paged_write(): can't get into sync\n",
                 progname);
         return -3;
       }
@@ -847,7 +847,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       goto retry;
     }
     else if (buf[0] != Resp_STK_INSYNC) {
-      avrdude_message(MSG_INFO, "\n%s: stk500_paged_write(): (a) protocol error, "
+      msg_info("\n%s: stk500_paged_write(): (a) protocol error, "
                       "expect=0x%02x, resp=0x%02x\n",
                       progname, Resp_STK_INSYNC, buf[0]);
       return -4;
@@ -856,7 +856,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if (stk500_recv(pgm, buf, 1) < 0)
       return -1;
     if (buf[0] != Resp_STK_OK) {
-      avrdude_message(MSG_INFO, "\n%s: stk500_paged_write(): (b) protocol error, "
+      msg_info("\n%s: stk500_paged_write(): (b) protocol error, "
                       "expect=0x%02x, resp=0x%02x\n",
                       progname, Resp_STK_OK, buf[0]);
       return -5;
@@ -920,7 +920,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
       return -1;
     if (buf[0] == Resp_STK_NOSYNC) {
       if (tries > 33) {
-        avrdude_message(MSG_INFO, "\n%s: stk500_paged_load(): can't get into sync\n",
+        msg_info("\n%s: stk500_paged_load(): can't get into sync\n",
                 progname);
         return -3;
       }
@@ -929,7 +929,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
       goto retry;
     }
     else if (buf[0] != Resp_STK_INSYNC) {
-      avrdude_message(MSG_INFO, "\n%s: stk500_paged_load(): (a) protocol error, "
+      msg_info("\n%s: stk500_paged_load(): (a) protocol error, "
                       "expect=0x%02x, resp=0x%02x\n",
                       progname, Resp_STK_INSYNC, buf[0]);
       return -4;
@@ -943,7 +943,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
     if(strcmp(ldata(lfirst(pgm->id)), "mib510") == 0) {
       if (buf[0] != Resp_STK_INSYNC) {
-      avrdude_message(MSG_INFO, "\n%s: stk500_paged_load(): (a) protocol error, "
+      msg_info("\n%s: stk500_paged_load(): (a) protocol error, "
                       "expect=0x%02x, resp=0x%02x\n",
                       progname, Resp_STK_INSYNC, buf[0]);
       return -5;
@@ -951,7 +951,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   }
     else {
       if (buf[0] != Resp_STK_OK) {
-        avrdude_message(MSG_INFO, "\n%s: stk500_paged_load(): (b) protocol error, "
+        msg_info("\n%s: stk500_paged_load(): (b) protocol error, "
                         "expect=0x%02x, resp=0x%02x\n",
                         progname, Resp_STK_OK, buf[0]);
         return -5;
@@ -969,13 +969,13 @@ static int stk500_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500_getparm(pgm, Parm_STK_VADJUST, &uaref) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500_set_vtarget(): cannot obtain V[aref]\n",
+    msg_info("%s: stk500_set_vtarget(): cannot obtain V[aref]\n",
                     progname);
     return -1;
   }
 
   if (uaref > utarg) {
-    avrdude_message(MSG_INFO, "%s: stk500_set_vtarget(): reducing V[aref] from %.1f to %.1f\n",
+    msg_info("%s: stk500_set_vtarget(): reducing V[aref] from %.1f to %.1f\n",
                     progname, uaref / 10.0, v);
     if (stk500_setparm(pgm, Parm_STK_VADJUST, utarg)
 	!= 0)
@@ -993,13 +993,13 @@ static int stk500_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused *
   uaref = (unsigned)((v + 0.049) * 10);
 
   if (stk500_getparm(pgm, Parm_STK_VTARGET, &utarg) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500_set_varef(): cannot obtain V[target]\n",
+    msg_info("%s: stk500_set_varef(): cannot obtain V[target]\n",
                     progname);
     return -1;
   }
 
   if (uaref > utarg) {
-    avrdude_message(MSG_INFO, "%s: stk500_set_varef(): V[aref] must not be greater than "
+    msg_info("%s: stk500_set_varef(): V[aref] must not be greater than "
                     "V[target] = %.1f\n",
                     progname, utarg / 10.0);
     return -1;
@@ -1028,7 +1028,7 @@ static int stk500_set_fosc(const PROGRAMMER *pgm, double v) {
         unit = "kHz";
       } else
         unit = "Hz";
-      avrdude_message(MSG_INFO, "%s: stk500_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
+      msg_info("%s: stk500_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
                       progname, v, unit, STK500_XTAL / 2e6);
       fosc = STK500_XTAL / 2;
     } else
@@ -1043,7 +1043,7 @@ static int stk500_set_fosc(const PROGRAMMER *pgm, double v) {
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
-      avrdude_message(MSG_INFO, "%s: stk500_set_fosc(): f = %u Hz too low, %u Hz min\n",
+      msg_info("%s: stk500_set_fosc(): f = %u Hz too low, %u Hz min\n",
           progname, fosc, STK500_XTAL / (256 * 1024 * 2));
       return -1;
     }
@@ -1074,11 +1074,11 @@ static int stk500_set_sck_period(const PROGRAMMER *pgm, double v) {
   
   if (v < min) {
       dur = 1;
-      avrdude_message(MSG_INFO, "%s: stk500_set_sck_period(): p = %.1f us too small, using %.1f us\n",
+      msg_info("%s: stk500_set_sck_period(): p = %.1f us too small, using %.1f us\n",
                       progname, v / 1e-6, dur * min / 1e-6);
   } else if (v > max) {
       dur = 255;
-      avrdude_message(MSG_INFO, "%s: stk500_set_sck_period(): p = %.1f us too large, using %.1f us\n",
+      msg_info("%s: stk500_set_sck_period(): p = %.1f us too large, using %.1f us\n",
                       progname, v / 1e-6, dur * min / 1e-6);
   }
   
@@ -1103,7 +1103,7 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      avrdude_message(MSG_INFO, "\n%s: stk500_getparm(): can't get into sync\n",
+      msg_info("\n%s: stk500_getparm(): can't get into sync\n",
               progname);
       return -1;
     }
@@ -1112,7 +1112,7 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "\n%s: stk500_getparm(): (a) protocol error, "
+    msg_info("\n%s: stk500_getparm(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -2;
@@ -1125,12 +1125,12 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_FAILED) {
-    avrdude_message(MSG_INFO, "\n%s: stk500_getparm(): parameter 0x%02x failed\n",
+    msg_info("\n%s: stk500_getparm(): parameter 0x%02x failed\n",
                     progname, v);
     return -3;
   }
   else if (buf[0] != Resp_STK_OK) {
-    avrdude_message(MSG_INFO, "\n%s: stk500_getparm(): (b) protocol error, "
+    msg_info("\n%s: stk500_getparm(): (b) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_OK, buf[0]);
     return -3;
@@ -1159,7 +1159,7 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      avrdude_message(MSG_INFO, "\n%s: stk500_setparm(): can't get into sync\n",
+      msg_info("\n%s: stk500_setparm(): can't get into sync\n",
               progname);
       return -1;
     }
@@ -1168,7 +1168,7 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "\n%s: stk500_setparm(): (a) protocol error, "
+    msg_info("\n%s: stk500_setparm(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -2;
@@ -1183,12 +1183,12 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_FAILED) {
-    avrdude_message(MSG_INFO, "\n%s: stk500_setparm(): parameter 0x%02x failed\n",
+    msg_info("\n%s: stk500_setparm(): parameter 0x%02x failed\n",
                     progname, parm);
     return -3;
   }
   else {
-    avrdude_message(MSG_INFO, "\n%s: stk500_setparm(): (b) protocol error, "
+    msg_info("\n%s: stk500_setparm(): (b) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_OK, buf[0]);
     return -3;
@@ -1204,8 +1204,8 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
   stk500_getparm(pgm, Parm_STK_SW_MINOR, &min);
   stk500_getparm(pgm, Param_STK500_TOPCARD_DETECT, &topcard);
 
-  avrdude_message(MSG_INFO, "%sHardware Version: %d\n", p, hdw);
-  avrdude_message(MSG_INFO, "%sFirmware Version: %d.%d\n", p, maj, min);
+  msg_info("%sHardware Version: %d\n", p, hdw);
+  msg_info("%sFirmware Version: %d.%d\n", p, maj, min);
   if (topcard < 3) {
     const char *n = "Unknown";
 
@@ -1218,7 +1218,7 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
 	n = "STK501";
 	break;
     }
-    avrdude_message(MSG_INFO, "%sTopcard         : %s\n", p, n);
+    msg_info("%sTopcard         : %s\n", p, n);
   }
   if(strcmp(pgm->type, "Arduino") != 0)
     stk500_print_parms1(pgm, p);
@@ -1236,11 +1236,11 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p) {
   stk500_getparm(pgm, Parm_STK_OSC_CMATCH, &osc_cmatch);
   stk500_getparm(pgm, Parm_STK_SCK_DURATION, &sck_duration);
 
-  avrdude_message(MSG_INFO, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
-  avrdude_message(MSG_INFO, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
-  avrdude_message(MSG_INFO, "%sOscillator      : ", p);
+  msg_info("%sVtarget         : %.1f V\n", p, vtarget / 10.0);
+  msg_info("%sVaref           : %.1f V\n", p, vadjust / 10.0);
+  msg_info("%sOscillator      : ", p);
   if (osc_pscale == 0)
-    avrdude_message(MSG_INFO, "Off\n");
+    msg_info("Off\n");
   else {
     int prescale = 1;
     double f = STK500_XTAL / 2;
@@ -1264,9 +1264,9 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p) {
       unit = "kHz";
     } else
       unit = "Hz";
-    avrdude_message(MSG_INFO, "%.3f %s\n", f, unit);
+    msg_info("%.3f %s\n", f, unit);
   }
-  avrdude_message(MSG_INFO, "%sSCK period      : %.1f us\n", p,
+  msg_info("%sSCK period      : %.1f us\n", p,
 	  sck_duration * 8.0e6 / STK500_XTAL + 0.05);
 
   return;
@@ -1280,7 +1280,7 @@ static void stk500_print_parms(const PROGRAMMER *pgm) {
 static void stk500_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: stk500_setup(): Out of memory allocating private data\n",
+    msg_info("%s: stk500_setup(): Out of memory allocating private data\n",
                     progname);
     return;
   }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -60,7 +60,7 @@ static int stk500_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
 
   rv = serial_recv(&pgm->fd, buf, len);
   if (rv < 0) {
-    pmsg_error("stk500_recv(): programmer is not responding\n");
+    pmsg_error("programmer is not responding\n");
     return -1;
   }
   return 0;
@@ -109,7 +109,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
     if(stk500_recv(pgm, resp, 1) >= 0 && resp[0] == Resp_STK_INSYNC)
       break;
 
-    pmsg_warning("stk500_getsync() attempt %d of %d: not in sync: resp=0x%02x\n", attempt + 1, max_sync_attempts, resp[0]);
+    pmsg_warning("attempt %d of %d: not in sync: resp=0x%02x\n", attempt + 1, max_sync_attempts, resp[0]);
   }
   if (attempt == max_sync_attempts) {
     stk500_drain(pgm, 0);
@@ -119,7 +119,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
   if (stk500_recv(pgm, resp, 1) < 0)
     return -1;
   if (resp[0] != Resp_STK_OK) {
-    pmsg_error("stk500_getsync(): cannot communicate with device: resp=0x%02x\n", resp[0]);
+    pmsg_error("cannot communicate with device: resp=0x%02x\n", resp[0]);
     return -1;
   }
 
@@ -148,7 +148,7 @@ static int stk500_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_INSYNC) {
-    pmsg_error("stk500_cmd(): programmer is out of sync\n");
+    pmsg_error("programmer is out of sync\n");
     return -1;
   }
 
@@ -161,7 +161,7 @@ static int stk500_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_OK) {
-    pmsg_error("stk500_cmd(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
     return -1;
   }
 
@@ -220,7 +220,7 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      pmsg_error("stk500_program_enable(): cannot get into sync\n");
+      pmsg_error("cannot get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -228,7 +228,7 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    pmsg_error("stk500_program_enable(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -238,18 +238,18 @@ static int stk500_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    pmsg_error("stk500_program_enable(): no device\n");
+    pmsg_error("no device\n");
     return -1;
   }
 
   if(buf[0] == Resp_STK_FAILED)
   {
-      pmsg_error("stk500_program_enable(): unable to enter programming mode\n");
+      pmsg_error("unable to enter programming mode\n");
       return -1;
   }
 
 
-  pmsg_error("stk500_program_enable(): unknown response=0x%02x\n", buf[0]);
+  pmsg_error("unknown response=0x%02x\n", buf[0]);
 
   return -1;
 }
@@ -279,7 +279,7 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      pmsg_error("stk500_set_extended_parms(): cannot get into sync\n");
+      pmsg_error("cannot get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -287,7 +287,7 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    pmsg_error("stk500_set_extended_parms(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -297,19 +297,19 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    pmsg_error("stk500_set_extended_parms(): no device\n");
+    pmsg_error("no device\n");
     return -1;
   }
 
   if(buf[0] == Resp_STK_FAILED)
   {
-      pmsg_error("stk500_set_extended_parms(): unable to set extended "
+      pmsg_error("unable to set extended "
         "device programming parameters\n");
       return -1;
   }
 
 
-  pmsg_error("stk500_set_extended_parms(): unknown response=0x%02x\n", buf[0]);
+  pmsg_error("unknown response=0x%02x\n", buf[0]);
 
   return -1;
 }
@@ -342,7 +342,7 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      pmsg_error("mib510_isp(): cannot get into sync\n");
+      pmsg_error("cannot get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -350,7 +350,7 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    pmsg_error("mib510_isp(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -360,18 +360,18 @@ static int mib510_isp(const PROGRAMMER *pgm, unsigned char cmd) {
     return 0;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    pmsg_error("mib510_isp(): no device\n");
+    pmsg_error("no device\n");
     return -1;
   }
 
   if (buf[0] == Resp_STK_FAILED)
   {
-      pmsg_error("mib510_isp(): command %d failed\n", cmd);
+      pmsg_error("command %d failed\n", cmd);
       return -1;
   }
 
 
-  pmsg_error("mib510_isp(): unknown response=0x%02x\n", buf[0]);
+  pmsg_error("unknown response=0x%02x\n", buf[0]);
 
   return -1;
 }
@@ -503,7 +503,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    pmsg_warning("stk500_initialize(): programmer not in sync, resp=0x%02x\n", buf[0]);
+    pmsg_warning("programmer not in sync, resp=0x%02x\n", buf[0]);
     if (tries > 33)
       return -1;
     if (stk500_getsync(pgm) < 0)
@@ -511,14 +511,14 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    pmsg_error("stk500_initialize(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] != Resp_STK_OK) {
-    pmsg_error("stk500_initialize(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
     return -1;
   }
 
@@ -553,7 +553,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     rc = stk500_set_extended_parms(pgm, n_extparms+1, buf);
     if (rc) {
-      pmsg_error("stk500_initialize(): failed\n");
+      pmsg_error("failed to initialise programmer\n");
       return -1;
     }
   }
@@ -577,7 +577,7 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
        continue;
      }
 
-     pmsg_error("stk500_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+     pmsg_error("invalid extended parameter '%s'\n", extended_param);
      rv = -1;
    }
 
@@ -600,7 +600,7 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     return;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      pmsg_error("stk500_disable(): cannot get into sync\n");
+      pmsg_error("cannot get into sync\n");
       return;
     }
     if (stk500_getsync(pgm) < 0)
@@ -608,7 +608,7 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    pmsg_error("stk500_disable(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return;
   }
 
@@ -618,11 +618,11 @@ static void stk500_disable(const PROGRAMMER *pgm) {
     return;
   }
   else if (buf[0] == Resp_STK_NODEVICE) {
-    pmsg_error("stk500_disable(): no device\n");
+    pmsg_error("no device\n");
     return;
   }
 
-  pmsg_error("stk500_disable(): unknown response=0x%02x\n", buf[0]);
+  pmsg_error("unknown response=0x%02x\n", buf[0]);
 
   return;
 }
@@ -704,7 +704,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
-      pmsg_error("stk500_loadaddr(): cannot get into sync\n");
+      pmsg_error("cannot get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -712,7 +712,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
     goto retry;
   }
   else if (buf[0] != Resp_STK_INSYNC) {
-    pmsg_error("stk500_loadaddr(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -1;
   }
 
@@ -721,7 +721,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, const unsig
   if (buf[0] == Resp_STK_OK)
     return 0;
 
-  pmsg_error("stk500_loadaddr(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+  pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
 
   return -1;
 }
@@ -797,7 +797,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if (buf[0] == Resp_STK_NOSYNC) {
       if (tries > 33) {
         msg_error("\n");
-        pmsg_error("stk500_paged_write(): cannot get into sync\n");
+        pmsg_error("cannot get into sync\n");
         return -3;
       }
       if (stk500_getsync(pgm) < 0)
@@ -806,7 +806,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     }
     else if (buf[0] != Resp_STK_INSYNC) {
       msg_error("\n");
-      pmsg_error("stk500_paged_write(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+      pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
       return -4;
     }
 
@@ -814,7 +814,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       return -1;
     if (buf[0] != Resp_STK_OK) {
       msg_error("\n");
-      pmsg_error("stk500_paged_write(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+      pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
       return -5;
     }
   }
@@ -877,7 +877,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if (buf[0] == Resp_STK_NOSYNC) {
       if (tries > 33) {
         msg_error("\n");
-        pmsg_error("stk500_paged_load(): cannot get into sync\n");
+        pmsg_error("cannot get into sync\n");
         return -3;
       }
       if (stk500_getsync(pgm) < 0)
@@ -886,7 +886,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     }
     else if (buf[0] != Resp_STK_INSYNC) {
       msg_error("\n");
-      pmsg_error("stk500_paged_load(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+      pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
       return -4;
     }
 
@@ -899,14 +899,14 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if(strcmp(ldata(lfirst(pgm->id)), "mib510") == 0) {
       if (buf[0] != Resp_STK_INSYNC) {
         msg_error("\n");
-        pmsg_error("stk500_paged_load(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+        pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
         return -5;
       }
     }
     else {
       if (buf[0] != Resp_STK_OK) {
         msg_error("\n");
-        pmsg_error("stk500_paged_load(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+        pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
         return -5;
       }
     }
@@ -922,12 +922,12 @@ static int stk500_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500_getparm(pgm, Parm_STK_VADJUST, &uaref) != 0) {
-    pmsg_error("stk500_set_vtarget(): cannot obtain V[aref]\n");
+    pmsg_error("cannot obtain V[aref]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    pmsg_error("stk500_set_vtarget(): reducing V[aref] from %.1f to %.1f\n", uaref / 10.0, v);
+    pmsg_error("reducing V[aref] from %.1f to %.1f\n", uaref / 10.0, v);
     if (stk500_setparm(pgm, Parm_STK_VADJUST, utarg)
 	!= 0)
       return -1;
@@ -944,12 +944,12 @@ static int stk500_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused *
   uaref = (unsigned)((v + 0.049) * 10);
 
   if (stk500_getparm(pgm, Parm_STK_VTARGET, &utarg) != 0) {
-    pmsg_error("stk500_set_varef(): cannot obtain V[target]\n");
+    pmsg_error("cannot obtain V[target]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    pmsg_error("stk500_set_varef(): V[aref] must not be greater than "
+    pmsg_error("V[aref] must not be greater than "
       "V[target] = %.1f\n", utarg/10.0);
     return -1;
   }
@@ -977,7 +977,7 @@ static int stk500_set_fosc(const PROGRAMMER *pgm, double v) {
         unit = "kHz";
       } else
         unit = "Hz";
-      pmsg_warning("stk500_set_fosc(): f = %.3f %s too high, using %.3f MHz\n", v, unit, STK500_XTAL/2e6);
+      pmsg_warning("f = %.3f %s too high, using %.3f MHz\n", v, unit, STK500_XTAL/2e6);
       fosc = STK500_XTAL / 2;
     } else
       fosc = (unsigned) v;
@@ -991,7 +991,7 @@ static int stk500_set_fosc(const PROGRAMMER *pgm, double v) {
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
-      pmsg_warning("stk500_set_fosc(): f = %u Hz too low, %u Hz min\n", fosc, STK500_XTAL / (256 * 1024 * 2));
+      pmsg_warning("f = %u Hz too low, %u Hz min\n", fosc, STK500_XTAL / (256 * 1024 * 2));
       return -1;
     }
   }
@@ -1021,11 +1021,11 @@ static int stk500_set_sck_period(const PROGRAMMER *pgm, double v) {
   
   if (v < min) {
       dur = 1;
-      pmsg_warning("stk500_set_sck_period(): p = %.1f us too small, using %.1f us\n",
+      pmsg_warning("p = %.1f us too small, using %.1f us\n",
         v/1e-6, dur*min/1e-6);
   } else if (v > max) {
       dur = 255;
-      pmsg_warning("stk500_set_sck_period(): p = %.1f us too large, using %.1f us\n",
+      pmsg_warning("p = %.1f us too large, using %.1f us\n",
         v/1e-6, dur*min/1e-6);
   }
   
@@ -1051,7 +1051,7 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
       msg_error("\n");
-      pmsg_error("stk500_getparm(): cannot get into sync\n");
+      pmsg_error("cannot get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -1060,7 +1060,7 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
   }
   else if (buf[0] != Resp_STK_INSYNC) {
     msg_error("\n");
-    pmsg_error("stk500_getparm(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -2;
   }
 
@@ -1072,12 +1072,12 @@ static int stk500_getparm(const PROGRAMMER *pgm, unsigned parm, unsigned *value)
     return -1;
   if (buf[0] == Resp_STK_FAILED) {
     msg_error("\n");
-    pmsg_error("stk500_getparm(): parameter 0x%02x failed\n", v);
+    pmsg_error("parameter 0x%02x failed\n", v);
     return -3;
   }
   else if (buf[0] != Resp_STK_OK) {
     msg_error("\n");
-    pmsg_error("stk500_getparm(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
     return -3;
   }
 
@@ -1105,7 +1105,7 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
   if (buf[0] == Resp_STK_NOSYNC) {
     if (tries > 33) {
       msg_error("\n");
-      pmsg_error("stk500_setparm(): cannot get into sync\n");
+      pmsg_error("cannot get into sync\n");
       return -1;
     }
     if (stk500_getsync(pgm) < 0)
@@ -1114,7 +1114,7 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
   }
   else if (buf[0] != Resp_STK_INSYNC) {
     msg_error("\n");
-    pmsg_error("stk500_setparm(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -2;
   }
 
@@ -1128,12 +1128,12 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
     return -1;
   if (buf[0] == Resp_STK_FAILED) {
     msg_error("\n");
-    pmsg_error("stk500_setparm(): parameter 0x%02x failed\n", parm);
+    pmsg_error("parameter 0x%02x failed\n", parm);
     return -3;
   }
   else {
     msg_error("\n");
-    pmsg_error("stk500_setparm(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
     return -3;
   }
 }
@@ -1223,7 +1223,7 @@ static void stk500_print_parms(const PROGRAMMER *pgm) {
 static void stk500_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("stk500_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     return;
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -301,13 +301,10 @@ static int stk500_set_extended_parms(const PROGRAMMER *pgm, int n,
     return -1;
   }
 
-  if(buf[0] == Resp_STK_FAILED)
-  {
-      pmsg_error("unable to set extended "
-        "device programming parameters\n");
-      return -1;
+  if(buf[0] == Resp_STK_FAILED) {
+    pmsg_error("unable to set extended device programming parameters\n");
+    return -1;
   }
-
 
   pmsg_error("unknown response=0x%02x\n", buf[0]);
 
@@ -801,7 +798,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
         return -3;
       }
       if (stk500_getsync(pgm) < 0)
-	return -1;
+        return -1;
       goto retry;
     }
     else if (buf[0] != Resp_STK_INSYNC) {
@@ -881,7 +878,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
         return -3;
       }
       if (stk500_getsync(pgm) < 0)
-	return -1;
+        return -1;
       goto retry;
     }
     else if (buf[0] != Resp_STK_INSYNC) {
@@ -928,8 +925,7 @@ static int stk500_set_vtarget(const PROGRAMMER *pgm, double v) {
 
   if (uaref > utarg) {
     pmsg_error("reducing V[aref] from %.1f to %.1f\n", uaref / 10.0, v);
-    if (stk500_setparm(pgm, Parm_STK_VADJUST, utarg)
-	!= 0)
+    if (stk500_setparm(pgm, Parm_STK_VADJUST, utarg) != 0)
       return -1;
   }
   return stk500_setparm(pgm, Parm_STK_VTARGET, utarg);
@@ -1123,7 +1119,7 @@ static int stk500_setparm(const PROGRAMMER *pgm, unsigned parm, unsigned value) 
   if (buf[0] == Resp_STK_OK)
     return 0;
 
-  parm = buf[0];	/* if not STK_OK, we've been echoed parm here */
+  parm = buf[0];                /* if not STK_OK, we've been echoed parm here */
   if (stk500_recv(pgm, buf, 1) < 0)
     return -1;
   if (buf[0] == Resp_STK_FAILED) {
@@ -1154,12 +1150,12 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
 
     switch (topcard) {
       case 1:
-	n = "STK502";
-	break;
+        n = "STK502";
+        break;
 
       case 2:
-	n = "STK501";
-	break;
+        n = "STK501";
+        break;
     }
     msg_info("%sTopcard         : %s\n", p, n);
   }
@@ -1209,8 +1205,7 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p) {
       unit = "Hz";
     msg_info("%.3f %s\n", f, unit);
   }
-  msg_info("%sSCK period      : %.1f us\n", p,
-	  sck_duration * 8.0e6 / STK500_XTAL + 0.05);
+  msg_info("%sSCK period      : %.1f us\n", p, sck_duration * 8.0e6 / STK500_XTAL + 0.05);
 
   return;
 }

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -42,8 +42,7 @@ static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
   stk500_initpgm(pgm);
   if (pgm->open(pgm, port) >= 0)
     {
-      msg_info("%s: successfully opened stk500v1 device -- please use -c stk500v1\n",
-                      progname);
+      pmsg_info("successfully opened stk500v1 device -- please use -c stk500v1\n");
       return 0;
     }
 
@@ -52,13 +51,11 @@ static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
   stk500v2_initpgm(pgm);
   if (pgm->open(pgm, port) >= 0)
     {
-      msg_info("%s: successfully opened stk500v2 device -- please use -c stk500v2\n",
-                      progname);
+      pmsg_info("successfully opened stk500v2 device -- please use -c stk500v2\n");
       return 0;
     }
 
-  msg_info("%s: cannot open either stk500v1 or stk500v2 programmer\n",
-                  progname);
+  pmsg_info("cannot open either stk500v1 or stk500v2 programmer\n");
   return -1;
 }
 

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -55,7 +55,7 @@ static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
       return 0;
     }
 
-  pmsg_info("cannot open either stk500v1 or stk500v2 programmer\n");
+  pmsg_error("cannot open either stk500v1 or stk500v2 programmer\n");
   return -1;
 }
 

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -42,7 +42,7 @@ static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
   stk500_initpgm(pgm);
   if (pgm->open(pgm, port) >= 0)
     {
-      avrdude_message(MSG_INFO, "%s: successfully opened stk500v1 device -- please use -c stk500v1\n",
+      msg_info("%s: successfully opened stk500v1 device -- please use -c stk500v1\n",
                       progname);
       return 0;
     }
@@ -52,12 +52,12 @@ static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
   stk500v2_initpgm(pgm);
   if (pgm->open(pgm, port) >= 0)
     {
-      avrdude_message(MSG_INFO, "%s: successfully opened stk500v2 device -- please use -c stk500v2\n",
+      msg_info("%s: successfully opened stk500v2 device -- please use -c stk500v2\n",
                       progname);
       return 0;
     }
 
-  avrdude_message(MSG_INFO, "%s: cannot open either stk500v1 or stk500v2 programmer\n",
+  msg_info("%s: cannot open either stk500v1 or stk500v2 programmer\n",
                   progname);
   return -1;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -284,7 +284,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p);
 void stk500v2_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("stk500v2_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -297,7 +297,7 @@ static void stk500v2_jtagmkII_setup(PROGRAMMER * pgm)
   void *mycookie, *theircookie;
 
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("stk500v2_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -319,7 +319,7 @@ static void stk500v2_jtag3_setup(PROGRAMMER * pgm)
   void *mycookie, *theircookie;
 
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("stk500v2_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -379,7 +379,7 @@ b2_to_u16(unsigned char *b)
 
 static int stk500v2_send_mk2(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   if (serial_send(&pgm->fd, data, len) != 0) {
-    pmsg_error("stk500_send_mk2(): unable to send command to serial port\n");
+    pmsg_error("unable to send command to serial port\n");
     return -1;
   }
 
@@ -495,7 +495,7 @@ static int stk500v2_send(const PROGRAMMER *pgm, unsigned char *data, size_t len)
   DEBUG(", %d)\n", (int) len+6);
 
   if (serial_send(&pgm->fd, buf, len+6) != 0) {
-    pmsg_error("stk500_send(): unable to send command to serial port\n");
+    pmsg_error("unable to send command to serial port\n");
     return -1;
   }
 
@@ -514,7 +514,7 @@ static int stk500v2_recv_mk2(const PROGRAMMER *pgm, unsigned char *msg,
 
   rv = serial_recv(&pgm->fd, msg, maxsize);
   if (rv < 0) {
-    pmsg_error("stk500v2_recv_mk2(): unable to receive from USB\n");
+    pmsg_error("unable to receive from USB\n");
     return -1;
   }
 
@@ -532,24 +532,24 @@ static int stk500v2_jtagmkII_recv(const PROGRAMMER *pgm, unsigned char *msg,
   rv = jtagmkII_recv(pgmcp, &jtagmsg);
   pgm_free(pgmcp);
   if (rv <= 0) {
-    pmsg_error("stk500v2_jtagmkII_recv(): unable to receive\n");
+    pmsg_error("unable to receive\n");
     return -1;
   }
   if ((size_t) rv - 1 > maxsize) {
-    pmsg_warning("stk500v2_jtagmkII_recv(): got %u bytes, have only room for %u bytes\n", (unsigned) rv - 1, (unsigned) maxsize);
+    pmsg_warning("got %u bytes, have only room for %u bytes\n", (unsigned) rv - 1, (unsigned) maxsize);
     rv = maxsize;
   }
   switch (jtagmsg[0]) {
   case RSP_SPI_DATA:
     break;
   case RSP_FAILED:
-    pmsg_error("stk500v2_jtagmkII_recv(): failed\n");
+    pmsg_error("receive failed\n");
     return -1;
   case RSP_ILLEGAL_MCU_STATE:
-    pmsg_error("stk500v2_jtagmkII_recv(): illegal MCU state\n");
+    pmsg_error("illegal MCU state\n");
     return -1;
   default:
-    pmsg_error("stk500v2_jtagmkII_recv(): unknown status %d\n", jtagmsg[0]);
+    pmsg_error("unknown status %d\n", jtagmsg[0]);
     return -1;
   }
   memcpy(msg, jtagmsg + 1, rv - 1);
@@ -569,7 +569,7 @@ static int stk500v2_jtag3_recv(const PROGRAMMER *pgm, unsigned char *msg,
   pgm_free(pgmcp);
 
   if (rv <= 0) {
-    pmsg_error("stk500v2_jtag3_recv(): unable to receive\n");
+    pmsg_error("unable to receive\n");
     return -1;
   }
   /* Getting more data than expected is a normal case for the EDBG
@@ -581,7 +581,7 @@ static int stk500v2_jtag3_recv(const PROGRAMMER *pgm, unsigned char *msg,
     rv = maxsize;
   }
   if (jtagmsg[0] != SCOPE_AVR_ISP) {
-    pmsg_error("stk500v2_jtag3_recv(): message is not AVR ISP: 0x%02x\n", jtagmsg[0]);
+    pmsg_error("message is not AVR ISP: 0x%02x\n", jtagmsg[0]);
     free(jtagmsg);
     return -1;
   }
@@ -665,12 +665,12 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
         if (curlen < maxsize) {
           msg[curlen] = c;
         } else {
-          pmsg_error("stk500v2_recv(): buffer too small, received %d byte into %u byte buffer\n",
+          pmsg_error("buffer too small, received %d byte into %u byte buffer\n",
             curlen, (unsigned int) maxsize);
           return -2;
         }
         if ((curlen == 0) && (msg[0] == ANSWER_CKSUM_ERROR)) {
-          pmsg_error("stk500v2_recv(): previous packet sent with wrong checksum\n");
+          pmsg_error("previous packet sent with wrong checksum\n");
           return -3;
         }
         curlen++;
@@ -681,12 +681,12 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
           state = sDONE;
         } else {
           state = sSTART;
-          pmsg_error("stk500v2_recv(): wrong checksum\n");
+          pmsg_error("wrong checksum\n");
           return -4;
         }
         break;
       default:
-        pmsg_error("stk500v2_recv(): unknown state\n");
+        pmsg_error("unknown state\n");
         return -5;
      } /* switch */
 
@@ -694,7 +694,7 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
      tnow = tv.tv_sec;
      if (tnow-tstart > timeoutval) {			// wuff - signed/unsigned/overflow
       timedout:
-       pmsg_error("stk500v2_ReceiveMessage(): timeout\n");
+       pmsg_error("timeout\n");
        return -1;
      }
 
@@ -755,7 +755,7 @@ retry:
       return 0;
     } else {
       if (tries > RETRIES) {
-        pmsg_error("stk500v2_getsync(): cannot communicate with device: resp=0x%02x\n", resp[0]);
+        pmsg_error("cannot communicate with device: resp=0x%02x\n", resp[0]);
         return -6;
       } else
         goto retry;
@@ -764,7 +764,7 @@ retry:
   // or if we got a timeout
   } else if (status == -1) {
     if (tries > RETRIES) {
-      pmsg_error("stk500v2_getsync(): timeout communicating with programmer\n");
+      pmsg_error("timeout communicating with programmer\n");
       return -1;
     } else
       goto retry;
@@ -772,7 +772,7 @@ retry:
   // or any other error
   } else {
     if (tries > RETRIES) {
-      pmsg_error("stk500v2_getsync(): unable to communicate with programmer (%d)\n", status);
+      pmsg_error("unable to communicate with programmer (%d)\n", status);
     } else
       goto retry;
   }
@@ -802,7 +802,7 @@ retry:
   if (status > 0) {
     DEBUG(" = %d\n",status);
     if (status < 2) {
-      pmsg_error("stk500v2_command(): short reply\n");
+      pmsg_error("short reply\n");
       return -1;
     }
     if (buf[0] == CMD_XPROG_SETMODE || buf[0] == CMD_XPROG) {
@@ -826,7 +826,7 @@ retry:
             case XPRG_ERR_TIMEOUT:  msg = "Timeout"; break;
             default:                msg = "Unknown"; break;
             }
-            pmsg_error("stk500v2_command(): %s: %s\n",
+            pmsg_error("%s: %s\n",
               buf[0]==CMD_XPROG_SETMODE? "CMD_XPROG_SETMODE": "CMD_XPROG", msg);
             return -1;
         }
@@ -856,15 +856,15 @@ retry:
                 msg = msgbuf;
                 break;
             }
-            pmsg_warning("stk500v2_command(): %s\n", msg);
+            pmsg_warning("%s\n", msg);
         } else if (buf[1] == STATUS_CMD_OK) {
             return status;
         } else if (buf[1] == STATUS_CMD_FAILED) {
-            pmsg_error("stk500v2_command(): command failed\n");
+            pmsg_error("command failed\n");
         } else if (buf[1] == STATUS_CMD_UNKNOWN) {
-            pmsg_error("stk500v2_command(): unknown command\n");
+            pmsg_error("unknown command\n");
         } else {
-            pmsg_error("stk500v2_command(): unknown status 0x%02x\n", buf[1]);
+            pmsg_error("unknown status 0x%02x\n", buf[1]);
         }
         return -1;
     }
@@ -874,7 +874,7 @@ retry:
   status = stk500v2_getsync(pgm);
   if (status != 0) {
     if (tries > RETRIES) {
-      pmsg_error("stk500v2_command(): failed miserably to execute command 0x%02x\n", buf[0]);
+      pmsg_error("failed to execute command 0x%02x\n", buf[0]);
       return -1;
     } else
       goto retry;
@@ -903,10 +903,10 @@ static int stk500v2_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 
   result = stk500v2_command(pgm, buf, 8, sizeof(buf));
   if (result < 0) {
-    pmsg_error("stk500v2_cmd(): send command failed\n");
+    pmsg_error("send command failed\n");
     return -1;
   } else if (result < 6) {
-    pmsg_error("stk500v2_cmd(): short reply, len = %d\n", result);
+    pmsg_error("short reply, len = %d\n", result);
     return -1;
   }
 
@@ -922,7 +922,7 @@ static int stk500v2_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 static int stk500v2_jtag3_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 			      unsigned char *res)
 {
-  pmsg_error("stk500v2_jtag3_cmd(): not available in JTAGICE3\n");
+  pmsg_error("not available in JTAGICE3\n");
 
   return -1;
 }
@@ -936,7 +936,7 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[16];
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    pmsg_error("stk500v2_chip_erase(): chip erase instruction not defined for part %s\n", p->desc);
+    pmsg_error("chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -1052,7 +1052,7 @@ static int stk500v2_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   PDATA(pgm)->lastpart = p;
 
   if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-    pmsg_error("stk500v2_program_enable(): program enable instruction not defined for part %s\n", p->desc);
+    pmsg_error("program enable instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -1082,11 +1082,10 @@ retry:
     case PGMTYPE_STK600:
     case PGMTYPE_AVRISP_MKII:
         if (stk500v2_getparm(pgm, PARAM_STATUS_TGT_CONN, &buf[0]) != 0) {
-            pmsg_error("stk500v2_program_enable(): cannot get connection status\n");
+            pmsg_error("cannot get connection status\n");
         } else {
             stk500v2_translate_conn_status(buf[0], msg);
-            pmsg_error("stk500v2_program_enable():"
-              " bad AVRISPmkII connection status: %s\n", msg);
+            pmsg_error("bad AVRISPmkII connection status: %s\n", msg);
         }
         break;
 
@@ -1206,7 +1205,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       AVRMEM *bootmem = avr_locate_mem(p, "boot");
       AVRMEM *flashmem = avr_locate_mem(p, "flash");
       if (bootmem == NULL || flashmem == NULL) {
-        pmsg_error("stk500v2_initialize(): cannot locate flash or boot memories\n");
+        pmsg_error("cannot locate flash or boot memories\n");
       } else {
         PDATA(pgm)->boot_start = bootmem->offset - flashmem->offset;
       }
@@ -1240,11 +1239,11 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    pmsg_error("stk500v2_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    pmsg_error("stk500v2_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -1273,7 +1272,7 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   // FIXME: condition below looks fishy, suspect the code wants !(p->prog_modes & (PM_debugWIRE | PM_JTAG | PM_JTAGmkI /* | PM_XMEGAJTAG | PM_AVR32JTAG */))
   if (p->prog_modes & (PM_PDI | PM_TPI)) {
-    pmsg_error("jtag3_initialize(): part %s has no ISP interface\n", p->desc);
+    pmsg_error("part %s has no ISP interface\n", p->desc);
     return -1;
   }
 
@@ -1334,11 +1333,11 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    pmsg_error("stk500hv_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    pmsg_error("stk500hv_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -1358,8 +1357,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   AVRMEM * m;
 
   if (p->ctl_stack_type != (mode == PPMODE? CTL_STACK_PP: CTL_STACK_HVSP)) {
-    pmsg_error("stk500hv_initialize(): "
-      "%s programming control stack not defined for part %s\n",
+    pmsg_error("%s programming control stack not defined for part %s\n",
       mode == PPMODE? "parallel": "high-voltage serial", p->desc);
     return -1;
   }
@@ -1370,7 +1368,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   result = stk500v2_command(pgm, buf, CTL_STACK_SIZE + 1, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500hv_initalize(): unable to set control stack\n");
+    pmsg_error("unable to set control stack\n");
     return -1;
   }
 
@@ -1398,11 +1396,11 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    pmsg_error("stk500hv_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    pmsg_error("stk500hv_initialize(): out of memory\n");
+    pmsg_error("out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -1441,7 +1439,7 @@ static void stk500v2_jtag3_disable(const PROGRAMMER *pgm) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500v2_disable(): unable to leave programming mode\n");
+    pmsg_error("unable to leave programming mode\n");
   }
 
   return;
@@ -1458,7 +1456,7 @@ static void stk500v2_disable(const PROGRAMMER *pgm) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500v2_disable(): unable to leave programming mode\n");
+    pmsg_error("unable to leave programming mode\n");
   }
 
   return;
@@ -1486,7 +1484,7 @@ static void stk500hv_disable(const PROGRAMMER *pgm, enum hvmode mode) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500hv_disable(): unable to leave programming mode\n");
+    pmsg_error("unable to leave programming mode\n");
   }
 
   return;
@@ -1670,7 +1668,7 @@ static int stk500v2_loadaddr(const PROGRAMMER *pgm, unsigned int addr) {
   result = stk500v2_command(pgm, buf, 5, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500v2_loadaddr(): unable to set load address\n");
+    pmsg_error("unable to set load address\n");
     return -1;
   }
 
@@ -1768,8 +1766,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   result = stk500v2_command(pgm, buf, cmdlen, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500hv_read_byte(): "
-                    "timeout/error communicating with programmer\n");
+    pmsg_error("timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -1871,13 +1868,13 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   }
 
   if ((op = mem->op[AVR_OP_READ]) == NULL) {
-    pmsg_error("stk500isp_read_byte(): invalid operation AVR_OP_READ on %s memory\n", mem->desc);
+    pmsg_error("invalid operation AVR_OP_READ on %s memory\n", mem->desc);
     return -1;
   }
   memset(buf+2, 0, 4);
   avr_set_bits(op, buf + 2);
   if ((pollidx = avr_get_output_index(op)) == -1) {
-    pmsg_warning("stk500isp_read_byte(): cannot determine pollidx to read %s memory\n", mem->desc);
+    pmsg_warning("cannot determine pollidx to read %s memory\n", mem->desc);
     pollidx = 3;
   }
   buf[1] = pollidx + 1;
@@ -1888,7 +1885,7 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   result = stk500v2_command(pgm, buf, 6, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500isp_read_byte(): timeout/error communicating with programmer\n");
+    pmsg_error("timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -1957,7 +1954,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     pulsewidth = p->programlockpulsewidth;
     timeout = p->programlockpolltimeout;
   } else {
-    pmsg_error("stk500hv_write_byte(): unsupported memory type %s\n", mem->desc);
+    pmsg_error("unsupported memory type %s\n", mem->desc);
     return -1;
   }
 
@@ -2020,7 +2017,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   result = stk500v2_command(pgm, buf, cmdlen, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500hv_write_byte(): timeout/error communicating with programmer\n");
+    pmsg_error("timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -2117,12 +2114,12 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   } else if (strcmp(mem->desc, "lock") == 0) {
     buf[0] = CMD_PROGRAM_LOCK_ISP;
   } else {
-    pmsg_error("stk500isp_write_byte(): unsupported memory type: %s\n", mem->desc);
+    pmsg_error("unsupported memory type: %s\n", mem->desc);
     return -1;
   }
 
   if ((op = mem->op[AVR_OP_WRITE]) == NULL) {
-    pmsg_error("stk500isp_write_byte(): no AVR_OP_WRITE for %s memory\n", mem->desc);
+    pmsg_error("no AVR_OP_WRITE for %s memory\n", mem->desc);
     return -1;
   }
 
@@ -2135,7 +2132,7 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   result = stk500v2_command(pgm, buf, 5, sizeof(buf));
 
   if (result < 0) {
-    pmsg_error("stk500isp_write_byte(): timeout/error communicating with programmer\n");
+    pmsg_error("timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -2204,7 +2201,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[3] = m->mode | 0x80;		// yes, write the page to flash
 
     if (m->op[AVR_OP_LOADPAGE_LO] == NULL) {
-      pmsg_error("stk500v2_paged_write: loadpage instruction not defined for part %s\n", p->desc);
+      pmsg_error("loadpage instruction not defined for part %s\n", p->desc);
       return -1;
     }
     memset(cmds, 0, sizeof cmds);
@@ -2212,7 +2209,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[5] = cmds[0];
 
     if (m->op[AVR_OP_WRITEPAGE] == NULL) {
-      pmsg_error("stk500v2_paged_write: write page instruction not defined for part %s\n", p->desc);
+      pmsg_error("write page instruction not defined for part %s\n", p->desc);
       return -1;
     }
 
@@ -2226,7 +2223,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[3] = m->mode | 0x80;		// yes, write the words to flash
 
     if (wop == NULL) {
-      pmsg_error("stk500v2_paged_write: write instruction not defined for part %s\n", p->desc);
+      pmsg_error("write instruction not defined for part %s\n", p->desc);
       return -1;
     }
     memset(cmds, 0, sizeof cmds);
@@ -2237,7 +2234,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
   // the read command is common to both methods
   if (rop == NULL) {
-    pmsg_error("stk500v2_paged_write: read instruction not defined for part %s\n", p->desc);
+    pmsg_error("read instruction not defined for part %s\n", p->desc);
     return -1;
   }
   memset(cmds, 0, sizeof cmds);
@@ -2272,7 +2269,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
     result = stk500v2_command(pgm,buf,block_size+10, sizeof(buf));
     if (result < 0) {
-      pmsg_error("stk500v2_paged_write: write command failed\n");
+      pmsg_error("write command failed\n");
       return -1;
     }
   }
@@ -2366,7 +2363,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
     result = stk500v2_command(pgm, buf, page_size + 5, sizeof(buf));
     if (result < 0) {
-      pmsg_error("stk500hv_paged_write: write command failed\n");
+      pmsg_error("write command failed\n");
       return -1;
     }
   }
@@ -2438,7 +2435,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   // the read command is common to both methods
   if (rop == NULL) {
-    pmsg_error("stk500v2_paged_load: read instruction not defined for part %s\n", p->desc);
+    pmsg_error("read instruction not defined for part %s\n", p->desc);
     return -1;
   }
   memset(cmds, 0, sizeof cmds);
@@ -2467,7 +2464,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
     result = stk500v2_command(pgm,buf,4,sizeof(buf));
     if (result < 0) {
-      pmsg_error("stk500v2_paged_load: read command failed\n");
+      pmsg_error("read command failed\n");
       return -1;
     }
 #if 0
@@ -2547,7 +2544,7 @@ static int stk500hv_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
     result = stk500v2_command(pgm, buf, 3, sizeof(buf));
     if (result < 0) {
-      pmsg_error("stk500hv_paged_load: read command failed\n");
+      pmsg_error("read command failed\n");
       return -1;
     }
 #if 0
@@ -2588,7 +2585,7 @@ static int stk500hvsp_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 static int stk500v2_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int addr)
 {
-  pmsg_error("stk500v2_page_erase(): this function must never be called\n");
+  pmsg_error("this function must never be called\n");
   return -1;
 }
 
@@ -2598,12 +2595,12 @@ static int stk500v2_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VADJUST, &uaref) != 0) {
-    pmsg_error("stk500v2_set_vtarget(): cannot obtain V[aref]\n");
+    pmsg_error("cannot obtain V[aref]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    pmsg_warning("stk500v2_set_vtarget(): reducing V[aref] from %.1f to %.1f\n", uaref/10.0, v);
+    pmsg_warning("reducing V[aref] from %.1f to %.1f\n", uaref/10.0, v);
     if (stk500v2_setparm(pgm, PARAM_VADJUST, utarg) != 0)
       return -1;
   }
@@ -2619,12 +2616,12 @@ static int stk500v2_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused
   uaref = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
-    pmsg_error("stk500v2_set_varef(): cannot obtain V[target]\n");
+    pmsg_error("cannot obtain V[target]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    pmsg_error("stk500v2_set_varef(): V[aref] must not be greater than "
+    pmsg_error("V[aref] must not be greater than "
                     "V[target] = %.1f\n", utarg/10.0);
     return -1;
   }
@@ -2653,7 +2650,7 @@ static int stk500v2_set_fosc(const PROGRAMMER *pgm, double v) {
         unit = "kHz";
       } else
         unit = "Hz";
-      pmsg_warning("stk500v2_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
+      pmsg_warning("f = %.3f %s too high, using %.3f MHz\n",
         v, unit, STK500V2_XTAL / 2e6);
       fosc = STK500V2_XTAL / 2;
     } else
@@ -2668,7 +2665,7 @@ static int stk500v2_set_fosc(const PROGRAMMER *pgm, double v) {
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
-      pmsg_warning("stk500v2_set_fosc(): f = %u Hz too low, %u Hz min\n",
+      pmsg_warning("f = %u Hz too low, %u Hz min\n",
         fosc, STK500V2_XTAL / (256 * 1024 * 2));
       return -1;
     }
@@ -2714,7 +2711,7 @@ static int stk500v2_set_sck_period_mk2(const PROGRAMMER *pgm, double v) {
   }
 
   if (i >= sizeof(avrispmkIIfreqs) / sizeof(avrispmkIIfreqs[0])) {
-    pmsg_error("stk500v2_set_sck_period_mk2(): invalid SCK period: %g\n", v);
+    pmsg_error("invalid SCK period: %g\n", v);
     return -1;
   }
 
@@ -2741,7 +2738,7 @@ static unsigned int stk500v2_mode_for_pagesize(unsigned int pagesize)
     case 64:   return 6u << 1;
     case 128:  return 7u << 1;
     }
-  pmsg_error("stk500v2_mode_for_pagesize(): invalid pagesize: %u\n", pagesize);
+  pmsg_error("invalid pagesize: %u\n", pagesize);
   return 0;
 }
 
@@ -2806,24 +2803,24 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm2(pgm, PARAM2_AREF0, &uaref) != 0) {
-    pmsg_error("stk500v2_set_vtarget(): cannot obtain V[aref][0]\n");
+    pmsg_error("cannot obtain V[aref][0]\n");
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    pmsg_warning("stk500v2_set_vtarget(): reducing V[aref][0] from %.2f to %.1f\n", uaref/100.0, v);
+    pmsg_warning("reducing V[aref][0] from %.2f to %.1f\n", uaref/100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF0, uaref) != 0)
       return -1;
   }
 
   if (stk500v2_getparm2(pgm, PARAM2_AREF1, &uaref) != 0) {
-    pmsg_error("stk500v2_set_vtarget(): cannot obtain V[aref][1]\n");
+    pmsg_error("cannot obtain V[aref][1]\n");
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    pmsg_warning("stk500v2_set_vtarget(): reducing V[aref][1] from %.2f to %.1f\n", uaref/100.0, v);
+    pmsg_warning("reducing V[aref][1] from %.2f to %.1f\n", uaref/100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF1, uaref)
 	!= 0)
@@ -2851,13 +2848,12 @@ static int stk600_set_varef(const PROGRAMMER *pgm, unsigned int chan, double v) 
   uaref = (unsigned)((v + 0.0049) * 100);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
-    pmsg_error("stk500v2_set_varef(): cannot obtain V[target]\n");
+    pmsg_error("cannot obtain V[target]\n");
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    pmsg_error("stk500v2_set_varef(): V[aref] must not be greater than "
-      "V[target] = %.1f\n", utarg/10.0);
+    pmsg_error("V[aref] must not be greater than V[target] = %.1f\n", utarg/10.0);
     return -1;
   }
 
@@ -2870,7 +2866,7 @@ static int stk600_set_varef(const PROGRAMMER *pgm, unsigned int chan, double v) 
     return stk500v2_setparm2(pgm, PARAM2_AREF1, uaref);
 
   default:
-    pmsg_error("stk500v2_set_varef(): invalid channel %d\n", chan);
+    pmsg_error("invalid channel %d\n", chan);
     return -1;
   }
 }
@@ -2925,7 +2921,7 @@ static int stk500v2_getparm(const PROGRAMMER *pgm, unsigned char parm, unsigned 
   buf[1] = parm;
 
   if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-    pmsg_error("stk500v2_getparm(): unable to get parameter 0x%02x\n", parm);
+    pmsg_error("unable to get parameter 0x%02x\n", parm);
     return -1;
   }
 
@@ -2976,7 +2972,7 @@ static int stk500v2_getparm2(const PROGRAMMER *pgm, unsigned char parm, unsigned
   buf[1] = parm;
 
   if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-    pmsg_error("stk500v2_getparm2(): unable to get parameter 0x%02x\n", parm);
+    pmsg_error("unable to get parameter 0x%02x\n", parm);
     return -1;
   }
 
@@ -3221,7 +3217,7 @@ static int stk500v2_perform_osccal(const PROGRAMMER *pgm) {
 
   rv = stk500v2_command(pgm, buf, 1, sizeof(buf));
   if (rv < 0) {
-    pmsg_error("stk500v2_perform_osccal(): failed\n");
+    pmsg_error("unable to perform oscillator calibaration\n");
     return -1;
   }
 
@@ -3546,7 +3542,7 @@ static int stk600_xprog_command(const PROGRAMMER *pgm, unsigned char *b,
         s = cmdsize;
 
     if ((newb = malloc(s + 1)) == 0) {
-        pmsg_error("stk600_xprog_cmd(): out of memory\n");
+        pmsg_error("out of memory\n");
         return -1;
     }
 
@@ -3577,12 +3573,12 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
 
     if (!use_tpi) {
         if (p->nvm_base == 0) {
-            pmsg_error("stk600_xprog_program_enable(): no nvm_base parameter for PDI device\n");
+            pmsg_error("no nvm_base parameter for PDI device\n");
             return -1;
         }
         if ((mem = avr_locate_mem(p, "eeprom")) != NULL) {
             if (mem->page_size <= 1) {
-                pmsg_error("stk600_xprog_program_enable(): no EEPROM page_size parameter for PDI device\n");
+                pmsg_error("no EEPROM page_size parameter for PDI device\n");
                 return -1;
             }
             eepagesize = mem->page_size;
@@ -3592,13 +3588,13 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
     buf[0] = CMD_XPROG_SETMODE;
     buf[1] = use_tpi? XPRG_MODE_TPI: XPRG_MODE_PDI;
     if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-        pmsg_error("stk600_xprog_program_enable(): CMD_XPROG_SETMODE(XPRG_MODE_%s) failed\n", use_tpi? "TPI": "PDI");
+        pmsg_error("CMD_XPROG_SETMODE(XPRG_MODE_%s) failed\n", use_tpi? "TPI": "PDI");
         return -1;
     }
 
     buf[0] = XPRG_CMD_ENTER_PROGMODE;
     if (stk600_xprog_command(pgm, buf, 1, 2) < 0) {
-        pmsg_error("stk600_xprog_program_enable(): XPRG_CMD_ENTER_PROGMODE failed\n");
+        pmsg_error("XPRG_CMD_ENTER_PROGMODE failed\n");
         return -1;
     }
 
@@ -3614,7 +3610,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[1] = XPRG_PARAM_TPI_3;
         buf[2] = 51;
         if (stk600_xprog_command(pgm, buf, 3, 2) < 0) {
-            pmsg_error("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_3) failed\n");
+            pmsg_error("XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_3) failed\n");
             return -1;
         }
 
@@ -3622,7 +3618,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[1] = XPRG_PARAM_TPI_4;
         buf[2] = 50;
         if (stk600_xprog_command(pgm, buf, 3, 2) < 0) {
-            pmsg_error("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_4) failed\n");
+            pmsg_error("XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_4) failed\n");
             return -1;
         }
     } else {
@@ -3641,7 +3637,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[4] = nvm_base >> 8;
         buf[5] = nvm_base;
         if (stk600_xprog_command(pgm, buf, 6, 2) < 0) {
-            pmsg_error("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_NVMBASE) failed\n");
+            pmsg_error("XPRG_CMD_SET_PARAM(XPRG_PARAM_NVMBASE) failed\n");
             return -1;
         }
 
@@ -3651,7 +3647,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
             buf[2] = eepagesize >> 8;
             buf[3] = eepagesize;
             if (stk600_xprog_command(pgm, buf, 4, 2) < 0) {
-                pmsg_error("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_EEPPAGESIZE) failed\n");
+                pmsg_error("XPRG_CMD_SET_PARAM(XPRG_PARAM_EEPPAGESIZE) failed\n");
                 return -1;
             }
         }
@@ -3673,7 +3669,7 @@ static void stk600_xprog_disable(const PROGRAMMER *pgm) {
 
     buf[0] = XPRG_CMD_LEAVE_PROGMODE;
     if (stk600_xprog_command(pgm, buf, 1, 2) < 0) {
-        pmsg_error("stk600_xprog_program_disable(): XPRG_CMD_LEAVE_PROGMODE failed\n");
+        pmsg_error("XPRG_CMD_LEAVE_PROGMODE failed\n");
     }
 }
 
@@ -3710,7 +3706,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(mem->desc, "userrow") == 0) {
         memcode = XPRG_MEM_TYPE_USERSIG;
     } else {
-        pmsg_error("stk600_xprog_write_byte(): unknown memory %s\n", mem->desc);
+        pmsg_error("unknown memory %s\n", mem->desc);
         return -1;
     }
     addr += mem->offset;
@@ -3723,7 +3719,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
         b[4] = mem->offset >> 8;
         b[5] = mem->offset + 1;
         if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    pmsg_error("stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CONFIG) failed\n");
+	    pmsg_error("XPRG_CMD_ERASE(XPRG_ERASE_CONFIG) failed\n");
 	    return -1;
 	}
     }
@@ -3749,7 +3745,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
     b[8] = write_size;
     b[9] = data;
     if (stk600_xprog_command(pgm, b, 9 + write_size, 2) < 0) {
-        pmsg_error("stk600_xprog_write_byte(): XPRG_CMD_WRITE_MEM failed\n");
+        pmsg_error("XPRG_CMD_WRITE_MEM failed\n");
         return -1;
     }
     return 0;
@@ -3783,7 +3779,7 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
                strcmp(mem->desc, "userrow") == 0) {
         b[1] = XPRG_MEM_TYPE_USERSIG;
     } else {
-        pmsg_error("stk600_xprog_read_byte(): unknown memory %s\n", mem->desc);
+        pmsg_error("unknown memory %s\n", mem->desc);
         return -1;
     }
     addr += mem->offset;
@@ -3796,7 +3792,7 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
     b[6] = 0;
     b[7] = 1;
     if (stk600_xprog_command(pgm, b, 8, 3) < 0) {
-        pmsg_error("stk600_xprog_read_byte(): XPRG_CMD_READ_MEM failed\n");
+        pmsg_error("XPRG_CMD_READ_MEM failed\n");
         return -1;
     }
     *value = b[2];
@@ -3857,14 +3853,14 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(mem->desc, "userrow") == 0) {
         memtype = XPRG_MEM_TYPE_USERSIG;
     } else {
-        pmsg_error("stk600_xprog_paged_load(): unknown paged memory %s\n", mem->desc);
+        pmsg_error("unknown paged memory %s\n", mem->desc);
         return -1;
     }
     offset = addr;
     addr += mem->offset;
 
     if ((b = malloc(page_size + 2)) == NULL) {
-	pmsg_error("stk600_xprog_paged_load(): out of memory\n");
+	pmsg_error("out of memory\n");
         return -1;
     }
 
@@ -3886,7 +3882,7 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
 	b[6] = page_size >> 8;
 	b[7] = page_size;
 	if (stk600_xprog_command(pgm, b, 8, page_size + 2) < 0) {
-	    pmsg_error("stk600_xprog_paged_load(): XPRG_CMD_READ_MEM failed\n");
+	    pmsg_error("XPRG_CMD_READ_MEM failed\n");
 	    free(b);
 	    return -1;
 	}
@@ -3920,7 +3916,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
      * transfer.
      */
     if (page_size > 512) {
-	pmsg_error("stk600_xprog_paged_write(): cannot handle page size > 512\n");
+	pmsg_error("cannot handle page size > 512\n");
 	return -1;
     }
 
@@ -3968,14 +3964,14 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
         memtype = XPRG_MEM_TYPE_USERSIG;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
     } else {
-        pmsg_error("stk600_xprog_paged_write(): unknown paged memory %s\n", mem->desc);
+        pmsg_error("unknown paged memory %s\n", mem->desc);
         return -1;
     }
     offset = addr;
     addr += mem->offset;
 
     if ((b = malloc(page_size + 9)) == NULL) {
-	pmsg_error("stk600_xprog_paged_write(): out of memory\n");
+	pmsg_error("out of memory\n");
         return -1;
     }
 
@@ -4000,7 +3996,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 	     * erase page / write page bits in the final chunk helps.
 	     */
 	    if (page_size % 256 != 0) {
-		pmsg_error("stk600_xprog_paged_write(): page size not multiple of 256\n");
+		pmsg_error("page size not multiple of 256\n");
 		free(b);
 		return -1;
 	    }
@@ -4023,7 +4019,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 		b[8] = 0;
 		memcpy(b + 9, mem->buf + offset, writesize);
 		if (stk600_xprog_command(pgm, b, 256 + 9, 2) < 0) {
-		    pmsg_error("stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n");
+		    pmsg_error("XPRG_CMD_WRITE_MEM failed\n");
 		    free(b);
 		    return -1;
 		}
@@ -4056,7 +4052,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 	    b[8] = page_size;
 	    memcpy(b + 9, mem->buf + offset, writesize);
 	    if (stk600_xprog_command(pgm, b, page_size + 9, 2) < 0) {
-		pmsg_error("stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n");
+		pmsg_error("XPRG_CMD_WRITE_MEM failed\n");
 		free(b);
 		return -1;
 	    }
@@ -4080,7 +4076,7 @@ static int stk600_xprog_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->prog_modes & PM_TPI) {
         if ((mem = avr_locate_mem(p, "flash")) == NULL) {
-            pmsg_error("stk600_xprog_chip_erase(): no FLASH definition found for TPI device\n");
+            pmsg_error("no FLASH definition found for TPI device\n");
             return -1;
         }
         addr = mem->offset + 1;
@@ -4093,7 +4089,7 @@ static int stk600_xprog_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     b[4] = addr >> 8;
     b[5] = addr;
     if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    pmsg_error("stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CHIP) failed\n");
+	    pmsg_error("XPRG_CMD_ERASE(XPRG_ERASE_CHIP) failed\n");
 	    return -1;
 	}
     return 0;
@@ -4118,7 +4114,7 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(m->desc, "userrow") == 0) {
       b[1] = XPRG_ERASE_USERSIG;
     } else {
-      pmsg_error("stk600_xprog_page_erase(): unknown paged memory %s\n", m->desc);
+      pmsg_error("unknown paged memory %s\n", m->desc);
       return -1;
     }
     addr += m->offset;
@@ -4128,7 +4124,7 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
     b[4] = addr >> 8;
     b[5] = addr;
     if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    pmsg_error("stk600_xprog_page_erase(): XPRG_CMD_ERASE(%d) failed\n", b[1]);
+	    pmsg_error("XPRG_CMD_ERASE(%d) failed\n", b[1]);
 	    return -1;
 	}
     return 0;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -78,9 +78,9 @@
 // Retry count
 #define RETRIES 5
 
-#define DEBUG(...) avrdude_message(MSG_TRACE2, __VA_ARGS__)
+#define DEBUG(...) msg_trace2(__VA_ARGS__)
 
-#define DEBUGRECV(...) avrdude_message(MSG_TRACE2, __VA_ARGS__)
+#define DEBUGRECV(...) msg_trace2(__VA_ARGS__)
 
 enum hvmode
 {
@@ -284,7 +284,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p);
 void stk500v2_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_setup(): Out of memory allocating private data\n",
+    msg_info("%s: stk500v2_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -298,7 +298,7 @@ static void stk500v2_jtagmkII_setup(PROGRAMMER * pgm)
   void *mycookie, *theircookie;
 
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_setup(): Out of memory allocating private data\n",
+    msg_info("%s: stk500v2_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -321,7 +321,7 @@ static void stk500v2_jtag3_setup(PROGRAMMER * pgm)
   void *mycookie, *theircookie;
 
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_setup(): Out of memory allocating private data\n",
+    msg_info("%s: stk500v2_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -382,7 +382,7 @@ b2_to_u16(unsigned char *b)
 
 static int stk500v2_send_mk2(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   if (serial_send(&pgm->fd, data, len) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500_send_mk2(): failed to send command to serial port\n",progname);
+    msg_info("%s: stk500_send_mk2(): failed to send command to serial port\n",progname);
     return -1;
   }
 
@@ -411,7 +411,7 @@ static int stk500v2_jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, si
 
   sz = get_jtagisp_return_size(data[0]);
   if (sz == 0) {
-    avrdude_message(MSG_INFO, "%s: unsupported encapsulated ISP command: %#x\n",
+    msg_info("%s: unsupported encapsulated ISP command: %#x\n",
 	    progname, data[0]);
     return -1;
   }
@@ -431,7 +431,7 @@ static int stk500v2_jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, si
   }
 
   if ((cmdbuf = malloc(len + 3)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory for command packet\n",
+    msg_info("%s: out of memory for command packet\n",
             progname);
     exit(1);
   }
@@ -456,7 +456,7 @@ static int stk500v2_jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_
   int rv;
 
   if ((cmdbuf = malloc(len + 1)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: out of memory for command packet\n",
+    msg_info("%s: out of memory for command packet\n",
             progname);
     exit(1);
   }
@@ -501,7 +501,7 @@ static int stk500v2_send(const PROGRAMMER *pgm, unsigned char *data, size_t len)
   DEBUG(", %d)\n", (int) len+6);
 
   if (serial_send(&pgm->fd, buf, len+6) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500_send(): failed to send command to serial port\n",progname);
+    msg_info("%s: stk500_send(): failed to send command to serial port\n",progname);
     return -1;
   }
 
@@ -520,7 +520,7 @@ static int stk500v2_recv_mk2(const PROGRAMMER *pgm, unsigned char *msg,
 
   rv = serial_recv(&pgm->fd, msg, maxsize);
   if (rv < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_recv_mk2: error in USB receive\n", progname);
+    msg_info("%s: stk500v2_recv_mk2: error in USB receive\n", progname);
     return -1;
   }
 
@@ -538,12 +538,12 @@ static int stk500v2_jtagmkII_recv(const PROGRAMMER *pgm, unsigned char *msg,
   rv = jtagmkII_recv(pgmcp, &jtagmsg);
   pgm_free(pgmcp);
   if (rv <= 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_jtagmkII_recv(): error in jtagmkII_recv()\n",
+    msg_info("%s: stk500v2_jtagmkII_recv(): error in jtagmkII_recv()\n",
             progname);
     return -1;
   }
   if ((size_t) rv - 1 > maxsize) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_jtagmkII_recv(): got %u bytes, have only room for %u bytes\n",
+    msg_info("%s: stk500v2_jtagmkII_recv(): got %u bytes, have only room for %u bytes\n",
                     progname, (unsigned) rv - 1, (unsigned) maxsize);
     rv = maxsize;
   }
@@ -551,15 +551,15 @@ static int stk500v2_jtagmkII_recv(const PROGRAMMER *pgm, unsigned char *msg,
   case RSP_SPI_DATA:
     break;
   case RSP_FAILED:
-    avrdude_message(MSG_INFO, "%s: stk500v2_jtagmkII_recv(): failed\n",
+    msg_info("%s: stk500v2_jtagmkII_recv(): failed\n",
 	    progname);
     return -1;
   case RSP_ILLEGAL_MCU_STATE:
-    avrdude_message(MSG_INFO, "%s: stk500v2_jtagmkII_recv(): illegal MCU state\n",
+    msg_info("%s: stk500v2_jtagmkII_recv(): illegal MCU state\n",
 	    progname);
     return -1;
   default:
-    avrdude_message(MSG_INFO, "%s: stk500v2_jtagmkII_recv(): unknown status %d\n",
+    msg_info("%s: stk500v2_jtagmkII_recv(): unknown status %d\n",
 	    progname, jtagmsg[0]);
     return -1;
   }
@@ -580,7 +580,7 @@ static int stk500v2_jtag3_recv(const PROGRAMMER *pgm, unsigned char *msg,
   pgm_free(pgmcp);
 
   if (rv <= 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_jtag3_recv(): error in jtagmkII_recv()\n",
+    msg_info("%s: stk500v2_jtag3_recv(): error in jtagmkII_recv()\n",
             progname);
     return -1;
   }
@@ -589,12 +589,12 @@ static int stk500v2_jtag3_recv(const PROGRAMMER *pgm, unsigned char *msg,
      octets from the ICE.  Thus, only complain at high verbose
      levels. */
   if ((size_t) rv - 1 > maxsize) {
-    avrdude_message(MSG_DEBUG, "%s: stk500v2_jtag3_recv(): got %u bytes, have only room for %u bytes\n",
+    msg_debug("%s: stk500v2_jtag3_recv(): got %u bytes, have only room for %u bytes\n",
                       progname, (unsigned) rv - 1, (unsigned) maxsize);
     rv = maxsize;
   }
   if (jtagmsg[0] != SCOPE_AVR_ISP) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_jtag3_recv(): message is not AVR ISP: 0x%02x\n",
+    msg_info("%s: stk500v2_jtag3_recv(): message is not AVR ISP: 0x%02x\n",
                     progname, jtagmsg[0]);
     free(jtagmsg);
     return -1;
@@ -679,12 +679,12 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
         if (curlen < maxsize) {
           msg[curlen] = c;
         } else {
-          avrdude_message(MSG_INFO, "%s: stk500v2_recv(): buffer too small, received %d byte into %u byte buffer\n",
+          msg_info("%s: stk500v2_recv(): buffer too small, received %d byte into %u byte buffer\n",
                   progname,curlen,(unsigned int)maxsize);
           return -2;
         }
         if ((curlen == 0) && (msg[0] == ANSWER_CKSUM_ERROR)) {
-          avrdude_message(MSG_INFO, "%s: stk500v2_recv(): previous packet sent with wrong checksum\n",
+          msg_info("%s: stk500v2_recv(): previous packet sent with wrong checksum\n",
                   progname);
           return -3;
         }
@@ -696,13 +696,13 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
           state = sDONE;
         } else {
           state = sSTART;
-          avrdude_message(MSG_INFO, "%s: stk500v2_recv(): checksum error\n",
+          msg_info("%s: stk500v2_recv(): checksum error\n",
                   progname);
           return -4;
         }
         break;
       default:
-        avrdude_message(MSG_INFO, "%s: stk500v2_recv(): unknown state\n",
+        msg_info("%s: stk500v2_recv(): unknown state\n",
                 progname);
         return -5;
      } /* switch */
@@ -711,7 +711,7 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
      tnow = tv.tv_sec;
      if (tnow-tstart > timeoutval) {			// wuff - signed/unsigned/overflow
       timedout:
-       avrdude_message(MSG_INFO, "%s: stk500v2_ReceiveMessage(): timeout\n",
+       msg_info("%s: stk500v2_ReceiveMessage(): timeout\n",
                progname);
        return -1;
      }
@@ -765,17 +765,17 @@ retry:
 	PDATA(pgm)->pgmtype = PGMTYPE_STK600;
       } else {
 	resp[siglen + 3] = 0;
-        avrdude_message(MSG_NOTICE, "%s: stk500v2_getsync(): got response from unknown "
+        msg_notice("%s: stk500v2_getsync(): got response from unknown "
                           "programmer %s, assuming STK500\n",
                           progname, resp + 3);
 	PDATA(pgm)->pgmtype = PGMTYPE_STK500;
       }
-      avrdude_message(MSG_DEBUG, "%s: stk500v2_getsync(): found %s programmer\n",
+      msg_debug("%s: stk500v2_getsync(): found %s programmer\n",
                         progname, pgmname[PDATA(pgm)->pgmtype]);
       return 0;
     } else {
       if (tries > RETRIES) {
-        avrdude_message(MSG_INFO, "%s: stk500v2_getsync(): can't communicate with device: resp=0x%02x\n",
+        msg_info("%s: stk500v2_getsync(): can't communicate with device: resp=0x%02x\n",
                         progname, resp[0]);
         return -6;
       } else
@@ -785,7 +785,7 @@ retry:
   // or if we got a timeout
   } else if (status == -1) {
     if (tries > RETRIES) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_getsync(): timeout communicating with programmer\n",
+      msg_info("%s: stk500v2_getsync(): timeout communicating with programmer\n",
               progname);
       return -1;
     } else
@@ -794,7 +794,7 @@ retry:
   // or any other error
   } else {
     if (tries > RETRIES) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_getsync(): error communicating with programmer: (%d)\n",
+      msg_info("%s: stk500v2_getsync(): error communicating with programmer: (%d)\n",
               progname,status);
     } else
       goto retry;
@@ -825,7 +825,7 @@ retry:
   if (status > 0) {
     DEBUG(" = %d\n",status);
     if (status < 2) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_command(): short reply\n", progname);
+      msg_info("%s: stk500v2_command(): short reply\n", progname);
       return -1;
     }
     if (buf[0] == CMD_XPROG_SETMODE || buf[0] == CMD_XPROG) {
@@ -849,7 +849,7 @@ retry:
             case XPRG_ERR_TIMEOUT:  msg = "Timeout"; break;
             default:                msg = "Unknown"; break;
             }
-            avrdude_message(MSG_INFO, "%s: stk500v2_command(): error in %s: %s\n",
+            msg_info("%s: stk500v2_command(): error in %s: %s\n",
                     progname,
                     (buf[0] == CMD_XPROG_SETMODE? "CMD_XPROG_SETMODE": "CMD_XPROG"),
                     msg);
@@ -882,19 +882,19 @@ retry:
                 break;
             }
             if (quell_progress < 2) {
-                avrdude_message(MSG_INFO, "%s: stk500v2_command(): warning: %s\n",
+                msg_info("%s: stk500v2_command(): warning: %s\n",
                         progname, msg);
             }
         } else if (buf[1] == STATUS_CMD_OK) {
             return status;
         } else if (buf[1] == STATUS_CMD_FAILED) {
-            avrdude_message(MSG_INFO, "%s: stk500v2_command(): command failed\n",
+            msg_info("%s: stk500v2_command(): command failed\n",
                             progname);
         } else if (buf[1] == STATUS_CMD_UNKNOWN) {
-            avrdude_message(MSG_INFO, "%s: stk500v2_command(): unknown command\n",
+            msg_info("%s: stk500v2_command(): unknown command\n",
                             progname);
         } else {
-            avrdude_message(MSG_INFO, "%s: stk500v2_command(): unknown status 0x%02x\n",
+            msg_info("%s: stk500v2_command(): unknown status 0x%02x\n",
                     progname, buf[1]);
         }
         return -1;
@@ -905,7 +905,7 @@ retry:
   status = stk500v2_getsync(pgm);
   if (status != 0) {
     if (tries > RETRIES) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_command(): failed miserably to execute command 0x%02x\n",
+      msg_info("%s: stk500v2_command(): failed miserably to execute command 0x%02x\n",
               progname,buf[0]);
       return -1;
     } else
@@ -935,11 +935,11 @@ static int stk500v2_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 
   result = stk500v2_command(pgm, buf, 8, sizeof(buf));
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_cmd(): failed to send command\n",
+    msg_info("%s: stk500v2_cmd(): failed to send command\n",
             progname);
     return -1;
   } else if (result < 6) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_cmd(): short reply, len = %d\n",
+    msg_info("%s: stk500v2_cmd(): short reply, len = %d\n",
             progname, result);
     return -1;
   }
@@ -956,7 +956,7 @@ static int stk500v2_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 static int stk500v2_jtag3_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 			      unsigned char *res)
 {
-  avrdude_message(MSG_INFO, "%s: stk500v2_jtag3_cmd(): Not available in JTAGICE3\n",
+  msg_info("%s: stk500v2_jtag3_cmd(): Not available in JTAGICE3\n",
                   progname);
 
   return -1;
@@ -971,7 +971,7 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[16];
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_chip_erase: chip erase instruction not defined for part \"%s\"\n",
+    msg_info("%s: stk500v2_chip_erase: chip erase instruction not defined for part \"%s\"\n",
             progname, p->desc);
     return -1;
   }
@@ -1088,7 +1088,7 @@ static int stk500v2_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   PDATA(pgm)->lastpart = p;
 
   if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_program_enable(): program enable instruction not defined for part \"%s\"\n",
+    msg_info("%s: stk500v2_program_enable(): program enable instruction not defined for part \"%s\"\n",
 	    progname, p->desc);
     return -1;
   }
@@ -1119,11 +1119,11 @@ retry:
     case PGMTYPE_STK600:
     case PGMTYPE_AVRISP_MKII:
         if (stk500v2_getparm(pgm, PARAM_STATUS_TGT_CONN, &buf[0]) != 0) {
-            avrdude_message(MSG_INFO, "%s: stk500v2_program_enable(): cannot get connection status\n",
+            msg_info("%s: stk500v2_program_enable(): cannot get connection status\n",
                             progname);
         } else {
             stk500v2_translate_conn_status(buf[0], msg);
-            avrdude_message(MSG_INFO, "%s: stk500v2_program_enable():"
+            msg_info("%s: stk500v2_program_enable():"
                     " bad AVRISPmkII connection status: %s\n",
                     progname, msg);
         }
@@ -1134,7 +1134,7 @@ retry:
             unsigned char cmd[4], *resp;
 
             /* Try debugWIRE, and MONCON_DISABLE */
-            avrdude_message(MSG_NOTICE2, "%s: No response in ISP mode, trying debugWIRE\n",
+            msg_notice2("%s: No response in ISP mode, trying debugWIRE\n",
                                 progname);
 
             PROGRAMMER *pgmcp = pgm_dup(pgm);
@@ -1164,11 +1164,11 @@ retry:
             }
             pgm_free(pgmcp);
             if (tries++ > 3) {
-                avrdude_message(MSG_INFO, "%s: Failed to return from debugWIRE to ISP.\n",
+                msg_info("%s: Failed to return from debugWIRE to ISP.\n",
                                 progname);
                 break;
             }
-            avrdude_message(MSG_INFO, "%s: Target prepared for ISP, signed off.\n"
+            msg_info("%s: Target prepared for ISP, signed off.\n"
                             "%s: Now retrying without power-cycling the target.\n",
                             progname, progname);
             goto retry;
@@ -1248,7 +1248,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       AVRMEM *bootmem = avr_locate_mem(p, "boot");
       AVRMEM *flashmem = avr_locate_mem(p, "flash");
       if (bootmem == NULL || flashmem == NULL) {
-        avrdude_message(MSG_INFO, "%s: stk500v2_initialize(): Cannot locate \"flash\" and \"boot\" memories in description\n",
+        msg_info("%s: stk500v2_initialize(): Cannot locate \"flash\" and \"boot\" memories in description\n",
                         progname);
       } else {
         PDATA(pgm)->boot_start = bootmem->offset - flashmem->offset;
@@ -1283,12 +1283,12 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_initialize(): Out of memory\n",
+    msg_info("%s: stk500v2_initialize(): Out of memory\n",
 	    progname);
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_initialize(): Out of memory\n",
+    msg_info("%s: stk500v2_initialize(): Out of memory\n",
 	    progname);
     free(PDATA(pgm)->flash_pagecache);
     return -1;
@@ -1318,7 +1318,7 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   // FIXME: condition below looks fishy, suspect the code wants !(p->prog_modes & (PM_debugWIRE | PM_JTAG | PM_JTAGmkI /* | PM_XMEGAJTAG | PM_AVR32JTAG */))
   if (p->prog_modes & (PM_PDI | PM_TPI)) {
-    avrdude_message(MSG_INFO, "%s: jtag3_initialize(): part %s has no ISP interface\n",
+    msg_info("%s: jtag3_initialize(): part %s has no ISP interface\n",
 	    progname, p->desc);
     return -1;
   }
@@ -1380,12 +1380,12 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_initialize(): Out of memory\n",
+    msg_info("%s: stk500hv_initialize(): Out of memory\n",
 	    progname);
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_initialize(): Out of memory\n",
+    msg_info("%s: stk500hv_initialize(): Out of memory\n",
 	    progname);
     free(PDATA(pgm)->flash_pagecache);
     return -1;
@@ -1406,7 +1406,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   AVRMEM * m;
 
   if (p->ctl_stack_type != (mode == PPMODE? CTL_STACK_PP: CTL_STACK_HVSP)) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_initialize(): "
+    msg_info("%s: stk500hv_initialize(): "
                     "%s programming control stack not defined for part \"%s\"\n",
                     progname,
                     (mode == PPMODE? "parallel": "high-voltage serial"),
@@ -1420,7 +1420,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   result = stk500v2_command(pgm, buf, CTL_STACK_SIZE + 1, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_initalize(): "
+    msg_info("%s: stk500hv_initalize(): "
                     "failed to set control stack\n",
                     progname);
     return -1;
@@ -1450,12 +1450,12 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_initialize(): Out of memory\n",
+    msg_info("%s: stk500hv_initialize(): Out of memory\n",
 	    progname);
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_initialize(): Out of memory\n",
+    msg_info("%s: stk500hv_initialize(): Out of memory\n",
 	    progname);
     free(PDATA(pgm)->flash_pagecache);
     return -1;
@@ -1495,7 +1495,7 @@ static void stk500v2_jtag3_disable(const PROGRAMMER *pgm) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_disable(): failed to leave programming mode\n",
+    msg_info("%s: stk500v2_disable(): failed to leave programming mode\n",
                     progname);
   }
 
@@ -1513,7 +1513,7 @@ static void stk500v2_disable(const PROGRAMMER *pgm) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_disable(): failed to leave programming mode\n",
+    msg_info("%s: stk500v2_disable(): failed to leave programming mode\n",
                     progname);
   }
 
@@ -1542,7 +1542,7 @@ static void stk500hv_disable(const PROGRAMMER *pgm, enum hvmode mode) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_disable(): "
+    msg_info("%s: stk500hv_disable(): "
                     "failed to leave programming mode\n",
                     progname);
   }
@@ -1596,7 +1596,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     serdev = &avrdoper_serdev;
     PDATA(pgm)->pgmtype = PGMTYPE_STK500;
 #else
-    avrdude_message(MSG_INFO, "avrdoper requires avrdude with libhidapi support.\n");
+    msg_info("avrdoper requires avrdude with libhidapi support.\n");
     return -1;
 #endif
   }
@@ -1620,7 +1620,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1677,7 +1677,7 @@ static int stk600_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_STK600;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -1728,7 +1728,7 @@ static int stk500v2_loadaddr(const PROGRAMMER *pgm, unsigned int addr) {
   result = stk500v2_command(pgm, buf, 5, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_loadaddr(): failed to set load address\n",
+    msg_info("%s: stk500v2_loadaddr(): failed to set load address\n",
                     progname);
     return -1;
   }
@@ -1750,7 +1750,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned int pagesize = 0, use_ext_addr = 0, addrshift = 0;
   unsigned char *cache_ptr = NULL;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500hv_read_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: stk500hv_read_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0) {
@@ -1823,13 +1823,13 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     buf[1] = addr;
   }
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500hv_read_byte(): Sending read memory command: ",
+  msg_notice2("%s: stk500hv_read_byte(): Sending read memory command: ",
 	    progname);
 
   result = stk500v2_command(pgm, buf, cmdlen, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_read_byte(): "
+    msg_info("%s: stk500hv_read_byte(): "
                     "timeout/error communicating with programmer\n",
                     progname);
     return -1;
@@ -1880,7 +1880,7 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   unsigned char *cache_ptr = NULL;
   OPCODE *op;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500isp_read_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: stk500isp_read_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0 ||
@@ -1934,27 +1934,27 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   }
 
   if ((op = mem->op[AVR_OP_READ]) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500isp_read_byte(): invalid operation AVR_OP_READ on %s memory\n",
+    msg_info("%s: stk500isp_read_byte(): invalid operation AVR_OP_READ on %s memory\n",
                     progname, mem->desc);
     return -1;
   }
   memset(buf+2, 0, 4);
   avr_set_bits(op, buf + 2);
   if ((pollidx = avr_get_output_index(op)) == -1) {
-    avrdude_message(MSG_INFO, "%s: stk500isp_read_byte(): cannot determine pollidx to read %s memory\n",
+    msg_info("%s: stk500isp_read_byte(): cannot determine pollidx to read %s memory\n",
                     progname, mem->desc);
     pollidx = 3;
   }
   buf[1] = pollidx + 1;
   avr_set_addr(op, buf + 2, addr);
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500isp_read_byte(): Sending read memory command: ",
+  msg_notice2("%s: stk500isp_read_byte(): Sending read memory command: ",
 	    progname);
 
   result = stk500v2_command(pgm, buf, 6, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500isp_read_byte(): "
+    msg_info("%s: stk500isp_read_byte(): "
                     "timeout/error communicating with programmer\n",
                     progname);
     return -1;
@@ -1978,7 +1978,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   unsigned int pagesize = 0, use_ext_addr = 0, addrshift = 0;
   unsigned char *cache_ptr = NULL;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500hv_write_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: stk500hv_write_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0) {
@@ -2026,7 +2026,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     pulsewidth = p->programlockpulsewidth;
     timeout = p->programlockpolltimeout;
   } else {
-    avrdude_message(MSG_INFO, "%s: stk500hv_write_byte(): "
+    msg_info("%s: stk500hv_write_byte(): "
                     "unsupported memory type: %s\n",
                     progname, mem->desc);
     return -1;
@@ -2086,13 +2086,13 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     }
   }
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500hv_write_byte(): Sending write memory command: ",
+  msg_notice2("%s: stk500hv_write_byte(): Sending write memory command: ",
 	    progname);
 
   result = stk500v2_command(pgm, buf, cmdlen, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500hv_write_byte(): "
+    msg_info("%s: stk500hv_write_byte(): "
                     "timeout/error communicating with programmer\n",
                     progname);
     return -1;
@@ -2138,7 +2138,7 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   unsigned char *cache_ptr = NULL;
   OPCODE *op;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500isp_write_byte(.., %s, 0x%lx, ...)\n",
+  msg_notice2("%s: stk500isp_write_byte(.., %s, 0x%lx, ...)\n",
 	    progname, mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0 ||
@@ -2192,14 +2192,14 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   } else if (strcmp(mem->desc, "lock") == 0) {
     buf[0] = CMD_PROGRAM_LOCK_ISP;
   } else {
-    avrdude_message(MSG_INFO, "%s: stk500isp_write_byte(): "
+    msg_info("%s: stk500isp_write_byte(): "
                     "unsupported memory type: %s\n",
                     progname, mem->desc);
     return -1;
   }
 
   if ((op = mem->op[AVR_OP_WRITE]) == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500isp_write_byte(): "
+    msg_info("%s: stk500isp_write_byte(): "
                     "no AVR_OP_WRITE for %s memory\n",
                     progname, mem->desc);
     return -1;
@@ -2209,13 +2209,13 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   avr_set_addr(op, buf + 1, addr);
   avr_set_input(op, buf + 1, data);
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500isp_write_byte(): Sending write memory command: ",
+  msg_notice2("%s: stk500isp_write_byte(): Sending write memory command: ",
 	    progname);
 
   result = stk500v2_command(pgm, buf, 5, sizeof(buf));
 
   if (result < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500isp_write_byte(): "
+    msg_info("%s: stk500isp_write_byte(): "
                     "timeout/error communicating with programmer\n",
                     progname);
     return -1;
@@ -2286,7 +2286,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[3] = m->mode | 0x80;		// yes, write the page to flash
 
     if (m->op[AVR_OP_LOADPAGE_LO] == NULL) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_paged_write: loadpage instruction not defined for part \"%s\"\n",
+      msg_info("%s: stk500v2_paged_write: loadpage instruction not defined for part \"%s\"\n",
               progname, p->desc);
       return -1;
     }
@@ -2295,7 +2295,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[5] = cmds[0];
 
     if (m->op[AVR_OP_WRITEPAGE] == NULL) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_paged_write: write page instruction not defined for part \"%s\"\n",
+      msg_info("%s: stk500v2_paged_write: write page instruction not defined for part \"%s\"\n",
               progname, p->desc);
       return -1;
     }
@@ -2310,7 +2310,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[3] = m->mode | 0x80;		// yes, write the words to flash
 
     if (wop == NULL) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_paged_write: write instruction not defined for part \"%s\"\n",
+      msg_info("%s: stk500v2_paged_write: write instruction not defined for part \"%s\"\n",
               progname, p->desc);
       return -1;
     }
@@ -2322,7 +2322,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
   // the read command is common to both methods
   if (rop == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_paged_write: read instruction not defined for part \"%s\"\n",
+    msg_info("%s: stk500v2_paged_write: read instruction not defined for part \"%s\"\n",
             progname, p->desc);
     return -1;
   }
@@ -2358,7 +2358,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
     result = stk500v2_command(pgm,buf,block_size+10, sizeof(buf));
     if (result < 0) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_paged_write: write command failed\n",
+      msg_info("%s: stk500v2_paged_write: write command failed\n",
                       progname);
       return -1;
     }
@@ -2453,7 +2453,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
     result = stk500v2_command(pgm, buf, page_size + 5, sizeof(buf));
     if (result < 0) {
-      avrdude_message(MSG_INFO, "%s: stk500hv_paged_write: write command failed\n",
+      msg_info("%s: stk500hv_paged_write: write command failed\n",
                       progname);
       return -1;
     }
@@ -2526,7 +2526,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   // the read command is common to both methods
   if (rop == NULL) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_paged_load: read instruction not defined for part \"%s\"\n",
+    msg_info("%s: stk500v2_paged_load: read instruction not defined for part \"%s\"\n",
             progname, p->desc);
     return -1;
   }
@@ -2556,14 +2556,14 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
     result = stk500v2_command(pgm,buf,4,sizeof(buf));
     if (result < 0) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_paged_load: read command failed\n",
+      msg_info("%s: stk500v2_paged_load: read command failed\n",
                       progname);
       return -1;
     }
 #if 0
     for (i=0;i<page_size;i++) {
-      avrdude_message(MSG_INFO, "%02X",buf[2+i]);
-      if (i%16 == 15) avrdude_message(MSG_INFO, "\n");
+      msg_info("%02X",buf[2+i]);
+      if (i%16 == 15) msg_info("\n");
     }
 #endif
 
@@ -2636,14 +2636,14 @@ static int stk500hv_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
     result = stk500v2_command(pgm, buf, 3, sizeof(buf));
     if (result < 0) {
-      avrdude_message(MSG_INFO, "%s: stk500hv_paged_load: read command failed\n",
+      msg_info("%s: stk500hv_paged_load: read command failed\n",
                       progname);
       return -1;
     }
 #if 0
     for (i = 0; i < page_size; i++) {
-      avrdude_message(MSG_INFO, "%02X", buf[2 + i]);
-      if (i % 16 == 15) avrdude_message(MSG_INFO, "\n");
+      msg_info("%02X", buf[2 + i]);
+      if (i % 16 == 15) msg_info("\n");
     }
 #endif
 
@@ -2677,7 +2677,7 @@ static int stk500hvsp_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 static int stk500v2_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int addr)
 {
-  avrdude_message(MSG_INFO, "%s: stk500v2_page_erase(): this function must never be called\n",
+  msg_info("%s: stk500v2_page_erase(): this function must never be called\n",
                   progname);
   return -1;
 }
@@ -2688,13 +2688,13 @@ static int stk500v2_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VADJUST, &uaref) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_vtarget(): cannot obtain V[aref]\n",
+    msg_info("%s: stk500v2_set_vtarget(): cannot obtain V[aref]\n",
                     progname);
     return -1;
   }
 
   if (uaref > utarg) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_vtarget(): reducing V[aref] from %.1f to %.1f\n",
+    msg_info("%s: stk500v2_set_vtarget(): reducing V[aref] from %.1f to %.1f\n",
                     progname, uaref / 10.0, v);
     if (stk500v2_setparm(pgm, PARAM_VADJUST, utarg)
 	!= 0)
@@ -2712,13 +2712,13 @@ static int stk500v2_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused
   uaref = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_varef(): cannot obtain V[target]\n",
+    msg_info("%s: stk500v2_set_varef(): cannot obtain V[target]\n",
                     progname);
     return -1;
   }
 
   if (uaref > utarg) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_varef(): V[aref] must not be greater than "
+    msg_info("%s: stk500v2_set_varef(): V[aref] must not be greater than "
                     "V[target] = %.1f\n",
                     progname, utarg / 10.0);
     return -1;
@@ -2748,7 +2748,7 @@ static int stk500v2_set_fosc(const PROGRAMMER *pgm, double v) {
         unit = "kHz";
       } else
         unit = "Hz";
-      avrdude_message(MSG_INFO, "%s: stk500v2_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
+      msg_info("%s: stk500v2_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
                       progname, v, unit, STK500V2_XTAL / 2e6);
       fosc = STK500V2_XTAL / 2;
     } else
@@ -2763,7 +2763,7 @@ static int stk500v2_set_fosc(const PROGRAMMER *pgm, double v) {
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
-      avrdude_message(MSG_INFO, "%s: stk500v2_set_fosc(): f = %u Hz too low, %u Hz min\n",
+      msg_info("%s: stk500v2_set_fosc(): f = %u Hz too low, %u Hz min\n",
           progname, fosc, STK500V2_XTAL / (256 * 1024 * 2));
       return -1;
     }
@@ -2809,12 +2809,12 @@ static int stk500v2_set_sck_period_mk2(const PROGRAMMER *pgm, double v) {
   }
 
   if (i >= sizeof(avrispmkIIfreqs) / sizeof(avrispmkIIfreqs[0])) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_sck_period_mk2(): "
+    msg_info("%s: stk500v2_set_sck_period_mk2(): "
                     "invalid SCK period: %g\n", progname, v);
     return -1;
   }
 
-  avrdude_message(MSG_NOTICE2, "Using p = %.2f us for SCK (param = %d)\n",
+  msg_notice2("Using p = %.2f us for SCK (param = %d)\n",
 	    1000000 / avrispmkIIfreqs[i], i);
 
   return stk500v2_setparm(pgm, PARAM_SCK_DURATION, i);
@@ -2837,7 +2837,7 @@ static unsigned int stk500v2_mode_for_pagesize(unsigned int pagesize)
     case 64:   return 6u << 1;
     case 128:  return 7u << 1;
     }
-  avrdude_message(MSG_INFO, "%s: stk500v2_mode_for_pagesize(): invalid pagesize: %u\n",
+  msg_info("%s: stk500v2_mode_for_pagesize(): invalid pagesize: %u\n",
                   progname, pagesize);
   return 0;
 }
@@ -2903,13 +2903,13 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm2(pgm, PARAM2_AREF0, &uaref) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_vtarget(): cannot obtain V[aref][0]\n",
+    msg_info("%s: stk500v2_set_vtarget(): cannot obtain V[aref][0]\n",
                     progname);
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_vtarget(): reducing V[aref][0] from %.2f to %.1f\n",
+    msg_info("%s: stk500v2_set_vtarget(): reducing V[aref][0] from %.2f to %.1f\n",
                     progname, uaref / 100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF0, uaref)
@@ -2918,13 +2918,13 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
   }
 
   if (stk500v2_getparm2(pgm, PARAM2_AREF1, &uaref) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_vtarget(): cannot obtain V[aref][1]\n",
+    msg_info("%s: stk500v2_set_vtarget(): cannot obtain V[aref][1]\n",
                     progname);
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_vtarget(): reducing V[aref][1] from %.2f to %.1f\n",
+    msg_info("%s: stk500v2_set_vtarget(): reducing V[aref][1] from %.2f to %.1f\n",
                     progname, uaref / 100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF1, uaref)
@@ -2953,13 +2953,13 @@ static int stk600_set_varef(const PROGRAMMER *pgm, unsigned int chan, double v) 
   uaref = (unsigned)((v + 0.0049) * 100);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_varef(): cannot obtain V[target]\n",
+    msg_info("%s: stk500v2_set_varef(): cannot obtain V[target]\n",
                     progname);
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_varef(): V[aref] must not be greater than "
+    msg_info("%s: stk500v2_set_varef(): V[aref] must not be greater than "
                     "V[target] = %.1f\n",
                     progname, utarg / 10.0);
     return -1;
@@ -2974,7 +2974,7 @@ static int stk600_set_varef(const PROGRAMMER *pgm, unsigned int chan, double v) 
     return stk500v2_setparm2(pgm, PARAM2_AREF1, uaref);
 
   default:
-    avrdude_message(MSG_INFO, "%s: stk500v2_set_varef(): invalid channel %d\n",
+    msg_info("%s: stk500v2_set_varef(): invalid channel %d\n",
                     progname, chan);
     return -1;
   }
@@ -3030,7 +3030,7 @@ static int stk500v2_getparm(const PROGRAMMER *pgm, unsigned char parm, unsigned 
   buf[1] = parm;
 
   if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_getparm(): failed to get parameter 0x%02x\n",
+    msg_info("%s: stk500v2_getparm(): failed to get parameter 0x%02x\n",
             progname, parm);
     return -1;
   }
@@ -3048,7 +3048,7 @@ static int stk500v2_setparm_real(const PROGRAMMER *pgm, unsigned char parm, unsi
   buf[2] = value;
 
   if (stk500v2_command(pgm, buf, 3, sizeof(buf)) < 0) {
-    avrdude_message(MSG_INFO, "\n%s: stk500v2_setparm(): failed to set parameter 0x%02x\n",
+    msg_info("\n%s: stk500v2_setparm(): failed to set parameter 0x%02x\n",
             progname, parm);
     return -1;
   }
@@ -3062,13 +3062,13 @@ static int stk500v2_setparm(const PROGRAMMER *pgm, unsigned char parm, unsigned 
 
   res = stk500v2_getparm(pgm, parm, &current_value);
   if (res < 0) {
-    avrdude_message(MSG_INFO, "%s: Unable to get parameter 0x%02x\n", progname, parm);
+    msg_info("%s: Unable to get parameter 0x%02x\n", progname, parm);
     return -1;
   }
 
   // don't issue a write if the correct value is already set.
   if (value == current_value) {
-    avrdude_message(MSG_NOTICE2, "%s: Skipping parameter write; parameter value already set.\n", progname);
+    msg_notice2("%s: Skipping parameter write; parameter value already set.\n", progname);
     return 0;
   }
 
@@ -3082,7 +3082,7 @@ static int stk500v2_getparm2(const PROGRAMMER *pgm, unsigned char parm, unsigned
   buf[1] = parm;
 
   if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_getparm2(): failed to get parameter 0x%02x\n",
+    msg_info("%s: stk500v2_getparm2(): failed to get parameter 0x%02x\n",
             progname, parm);
     return -1;
   }
@@ -3101,7 +3101,7 @@ static int stk500v2_setparm2(const PROGRAMMER *pgm, unsigned char parm, unsigned
   buf[3] = value;
 
   if (stk500v2_command(pgm, buf, 4, sizeof(buf)) < 0) {
-    avrdude_message(MSG_INFO, "\n%s: stk500v2_setparm2(): failed to set parameter 0x%02x\n",
+    msg_info("\n%s: stk500v2_setparm2(): failed to set parameter 0x%02x\n",
             progname, parm);
     return -1;
   }
@@ -3142,19 +3142,19 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
   }
   if (PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE_MKII &&
       PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE3) {
-    avrdude_message(MSG_INFO, "%sProgrammer Model: %s\n", p, pgmname);
+    msg_info("%sProgrammer Model: %s\n", p, pgmname);
     stk500v2_getparm(pgm, PARAM_HW_VER, &hdw);
     stk500v2_getparm(pgm, PARAM_SW_MAJOR, &maj);
     stk500v2_getparm(pgm, PARAM_SW_MINOR, &min);
-    avrdude_message(MSG_INFO, "%sHardware Version: %d\n", p, hdw);
-    avrdude_message(MSG_INFO, "%sFirmware Version Master : %d.%02d\n", p, maj, min);
+    msg_info("%sHardware Version: %d\n", p, hdw);
+    msg_info("%sFirmware Version Master : %d.%02d\n", p, maj, min);
     if (PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
       stk500v2_getparm(pgm, PARAM_SW_MAJOR_SLAVE1, &maj_s1);
       stk500v2_getparm(pgm, PARAM_SW_MINOR_SLAVE1, &min_s1);
       stk500v2_getparm(pgm, PARAM_SW_MAJOR_SLAVE2, &maj_s2);
       stk500v2_getparm(pgm, PARAM_SW_MINOR_SLAVE2, &min_s2);
-      avrdude_message(MSG_INFO, "%sFirmware Version Slave 1: %d.%02d\n", p, maj_s1, min_s1);
-      avrdude_message(MSG_INFO, "%sFirmware Version Slave 2: %d.%02d\n", p, maj_s2, min_s2);
+      msg_info("%sFirmware Version Slave 1: %d.%02d\n", p, maj_s1, min_s1);
+      msg_info("%sFirmware Version Slave 2: %d.%02d\n", p, maj_s2, min_s2);
     }
   }
 
@@ -3169,22 +3169,22 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
       case 0xDD: topcard_name = "STK520"; break;
       default: topcard_name = "Unknown"; break;
     }
-    avrdude_message(MSG_INFO, "%sTopcard         : %s\n", p, topcard_name);
+    msg_info("%sTopcard         : %s\n", p, topcard_name);
   } else if (PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
     stk500v2_getparm(pgm, PARAM_ROUTINGCARD_ID, &topcard);
-    avrdude_message(MSG_INFO, "%sRouting card    : %s\n", p,
+    msg_info("%sRouting card    : %s\n", p,
 	    stk600_get_cardname(routing_cards,
 				sizeof routing_cards / sizeof routing_cards[0],
 				topcard));
     stk500v2_getparm(pgm, PARAM_SOCKETCARD_ID, &topcard);
-    avrdude_message(MSG_INFO, "%sSocket card     : %s\n", p,
+    msg_info("%sSocket card     : %s\n", p,
 	    stk600_get_cardname(socket_cards,
 				sizeof socket_cards / sizeof socket_cards[0],
 				topcard));
     stk500v2_getparm2(pgm, PARAM2_RC_ID_TABLE_REV, &rev);
-    avrdude_message(MSG_INFO, "%sRC_ID table rev : %d\n", p, rev);
+    msg_info("%sRC_ID table rev : %d\n", p, rev);
     stk500v2_getparm2(pgm, PARAM2_EC_ID_TABLE_REV, &rev);
-    avrdude_message(MSG_INFO, "%sEC_ID table rev : %d\n", p, rev);
+    msg_info("%sEC_ID table rev : %d\n", p, rev);
   }
   stk500v2_print_parms1(pgm, p);
 
@@ -3221,7 +3221,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
     pgmcp->cookie = PDATA(pgm)->chained_pdata;
     jtagmkII_getparm(pgmcp, PAR_OCD_VTARGET, vtarget_jtag);
     pgm_free(pgmcp);
-    avrdude_message(MSG_INFO, "%sVtarget         : %.1f V\n", p,
+    msg_info("%sVtarget         : %.1f V\n", p,
 	    b2_to_u16(vtarget_jtag) / 1000.0);
   } else if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE3) {
     PROGRAMMER *pgmcp = pgm_dup(pgm);
@@ -3234,7 +3234,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
     pgm_free(pgmcp);
   } else {
     stk500v2_getparm(pgm, PARAM_VTARGET, &vtarget);
-    avrdude_message(MSG_INFO, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
+    msg_info("%sVtarget         : %.1f V\n", p, vtarget / 10.0);
   }
 
   switch (PDATA(pgm)->pgmtype) {
@@ -3243,12 +3243,12 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
     stk500v2_getparm(pgm, PARAM_VADJUST, &vadjust);
     stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
     stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
-    avrdude_message(MSG_INFO, "%sSCK period      : %.1f us\n", p,
+    msg_info("%sSCK period      : %.1f us\n", p,
 	    stk500v2_sck_to_us(pgm, sck_duration));
-    avrdude_message(MSG_INFO, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
-    avrdude_message(MSG_INFO, "%sOscillator      : ", p);
+    msg_info("%sVaref           : %.1f V\n", p, vadjust / 10.0);
+    msg_info("%sOscillator      : ", p);
     if (osc_pscale == 0)
-      avrdude_message(MSG_INFO, "Off\n");
+      msg_info("Off\n");
     else {
       prescale = 1;
       f = STK500V2_XTAL / 2;
@@ -3264,14 +3264,14 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
       f /= prescale;
       f /= (osc_cmatch + 1);
       f = f_to_kHz_MHz(f, &unit);
-      avrdude_message(MSG_INFO, "%.3f %s\n", f, unit);
+      msg_info("%.3f %s\n", f, unit);
     }
     break;
 
   case PGMTYPE_AVRISP_MKII:
   case PGMTYPE_JTAGICE_MKII:
     stk500v2_getparm(pgm, PARAM_SCK_DURATION, &sck_duration);
-    avrdude_message(MSG_INFO, "%sSCK period      : %.2f us\n", p,
+    msg_info("%sSCK period      : %.2f us\n", p,
 	    (float) 1000000 / avrispmkIIfreqs[sck_duration]);
     break;
 
@@ -3283,7 +3283,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
       if (stk500v2_jtag3_send(pgm, cmd, 1) >= 0 &&
 	  stk500v2_jtag3_recv(pgm, cmd, 4) >= 2) {
 	unsigned int sck = cmd[1] | (cmd[2] << 8);
-	avrdude_message(MSG_INFO, "%sSCK period                   : %.2f us\n", p,
+	msg_info("%sSCK period                   : %.2f us\n", p,
 		(float)(1E6 / (1000.0 * sck)));
       }
     }
@@ -3291,23 +3291,23 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p) {
 
   case PGMTYPE_STK600:
     stk500v2_getparm2(pgm, PARAM2_AREF0, &varef);
-    avrdude_message(MSG_INFO, "%sVaref 0         : %.2f V\n", p, varef / 100.0);
+    msg_info("%sVaref 0         : %.2f V\n", p, varef / 100.0);
     stk500v2_getparm2(pgm, PARAM2_AREF1, &varef);
-    avrdude_message(MSG_INFO, "%sVaref 1         : %.2f V\n", p, varef / 100.0);
+    msg_info("%sVaref 1         : %.2f V\n", p, varef / 100.0);
     stk500v2_getparm2(pgm, PARAM2_SCK_DURATION, &sck_stk600);
-    avrdude_message(MSG_INFO, "%sSCK period      : %.2f us\n", p,
+    msg_info("%sSCK period      : %.2f us\n", p,
 	    (float) (sck_stk600 + 1) / 8.0);
     stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf);
     oct = (clock_conf & 0xf000) >> 12u;
     dac = (clock_conf & 0x0ffc) >> 2u;
     f = pow(2, (double)oct) * 2078.0 / (2 - (double)dac / 1024.0);
     f = f_to_kHz_MHz(f, &unit);
-    avrdude_message(MSG_INFO, "%sOscillator      : %.3f %s\n",
+    msg_info("%sOscillator      : %.3f %s\n",
             p, f, unit);
     break;
 
   default:
-    avrdude_message(MSG_INFO, "%sSCK period      : %.1f us\n", p,
+    msg_info("%sSCK period      : %.1f us\n", p,
 	  sck_duration * 8.0e6 / STK500V2_XTAL + 0.05);
     break;
   }
@@ -3328,7 +3328,7 @@ static int stk500v2_perform_osccal(const PROGRAMMER *pgm) {
 
   rv = stk500v2_command(pgm, buf, 1, sizeof(buf));
   if (rv < 0) {
-    avrdude_message(MSG_INFO, "%s: stk500v2_perform_osccal(): failed\n",
+    msg_info("%s: stk500v2_perform_osccal(): failed\n",
             progname);
     return -1;
   }
@@ -3351,7 +3351,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   void *mycookie;
   int rv;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500v2_jtagmkII_open()\n", progname);
+  msg_notice2("%s: stk500v2_jtagmkII_open()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -3379,7 +3379,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -3398,7 +3398,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   pgm->cookie = PDATA(pgm)->chained_pdata;
   if ((rv = jtagmkII_getsync(pgm, EMULATOR_MODE_SPI)) != 0) {
     if (rv != JTAGII_GETSYNC_FAIL_GRACEFUL)
-        avrdude_message(MSG_INFO, "%s: failed to sync with the JTAG ICE mkII in ISP mode\n",
+        msg_info("%s: failed to sync with the JTAG ICE mkII in ISP mode\n",
                         progname);
     pgm->cookie = mycookie;
     return -1;
@@ -3423,7 +3423,7 @@ static void stk500v2_jtagmkII_close(PROGRAMMER * pgm)
 {
   void *mycookie;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500v2_jtagmkII_close()\n", progname);
+  msg_notice2("%s: stk500v2_jtagmkII_close()\n", progname);
 
   mycookie = pgm->cookie;
   pgm->cookie = PDATA(pgm)->chained_pdata;
@@ -3439,7 +3439,7 @@ static void stk500v2_jtag3_close(PROGRAMMER * pgm)
 {
   void *mycookie;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500v2_jtag3_close()\n", progname);
+  msg_notice2("%s: stk500v2_jtag3_close()\n", progname);
 
   mycookie = pgm->cookie;
   pgm->cookie = PDATA(pgm)->chained_pdata;
@@ -3462,7 +3462,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   void *mycookie;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500v2_dragon_isp_open()\n", progname);
+  msg_notice2("%s: stk500v2_dragon_isp_open()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -3490,7 +3490,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -3508,7 +3508,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
   mycookie = pgm->cookie;
   pgm->cookie = PDATA(pgm)->chained_pdata;
   if (jtagmkII_getsync(pgm, EMULATOR_MODE_SPI) != 0) {
-    avrdude_message(MSG_INFO, "%s: failed to sync with the AVR Dragon in ISP mode\n",
+    msg_info("%s: failed to sync with the AVR Dragon in ISP mode\n",
             progname);
     pgm->cookie = mycookie;
     return -1;
@@ -3539,7 +3539,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
 static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500v2_dragon_hv_open()\n", progname);
+  msg_notice2("%s: stk500v2_dragon_hv_open()\n", progname);
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -3567,7 +3567,7 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    avrdude_message(MSG_INFO, "avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support.\n");
     return -1;
 #endif
   }
@@ -3585,7 +3585,7 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
   PROGRAMMER *pgmcp = pgm_dup(pgm);
   pgmcp->cookie = PDATA(pgm)->chained_pdata;
   if (jtagmkII_getsync(pgmcp, EMULATOR_MODE_HV) != 0) {
-    avrdude_message(MSG_INFO, "%s: failed to sync with the AVR Dragon in HV mode\n",
+    msg_info("%s: failed to sync with the AVR Dragon in HV mode\n",
             progname);
     pgm_free(pgmcp);
     return -1;
@@ -3615,7 +3615,7 @@ static int stk500v2_jtag3_open(PROGRAMMER *pgm, const char *port) {
   void *mycookie;
   int rv;
 
-  avrdude_message(MSG_NOTICE2, "%s: stk500v2_jtag3_open()\n", progname);
+  msg_notice2("%s: stk500v2_jtag3_open()\n", progname);
 
   if (jtag3_open_common(pgm, port) < 0)
     return -1;
@@ -3624,7 +3624,7 @@ static int stk500v2_jtag3_open(PROGRAMMER *pgm, const char *port) {
   pgm->cookie = PDATA(pgm)->chained_pdata;
   if ((rv = jtag3_getsync(pgm, 42)) != 0) {
     if (rv != JTAGII_GETSYNC_FAIL_GRACEFUL)
-        avrdude_message(MSG_INFO, "%s: failed to sync with the JTAGICE3 in ISP mode\n",
+        msg_info("%s: failed to sync with the JTAGICE3 in ISP mode\n",
                         progname);
     pgm->cookie = mycookie;
     return -1;
@@ -3658,7 +3658,7 @@ static int stk600_xprog_command(const PROGRAMMER *pgm, unsigned char *b,
         s = cmdsize;
 
     if ((newb = malloc(s + 1)) == 0) {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_cmd(): out of memory\n",
+        msg_info("%s: stk600_xprog_cmd(): out of memory\n",
                 progname);
         return -1;
     }
@@ -3690,13 +3690,13 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
 
     if (!use_tpi) {
         if (p->nvm_base == 0) {
-            avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): no nvm_base parameter for PDI device\n",
+            msg_info("%s: stk600_xprog_program_enable(): no nvm_base parameter for PDI device\n",
                             progname);
             return -1;
         }
         if ((mem = avr_locate_mem(p, "eeprom")) != NULL) {
             if (mem->page_size <= 1) {
-                avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): no EEPROM page_size parameter for PDI device\n",
+                msg_info("%s: stk600_xprog_program_enable(): no EEPROM page_size parameter for PDI device\n",
                                 progname);
                 return -1;
             }
@@ -3707,14 +3707,14 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
     buf[0] = CMD_XPROG_SETMODE;
     buf[1] = use_tpi? XPRG_MODE_TPI: XPRG_MODE_PDI;
     if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): CMD_XPROG_SETMODE(XPRG_MODE_%s) failed\n",
+        msg_info("%s: stk600_xprog_program_enable(): CMD_XPROG_SETMODE(XPRG_MODE_%s) failed\n",
                         progname, use_tpi? "TPI": "PDI");
         return -1;
     }
 
     buf[0] = XPRG_CMD_ENTER_PROGMODE;
     if (stk600_xprog_command(pgm, buf, 1, 2) < 0) {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): XPRG_CMD_ENTER_PROGMODE failed\n",
+        msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_ENTER_PROGMODE failed\n",
                         progname);
         return -1;
     }
@@ -3731,7 +3731,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[1] = XPRG_PARAM_TPI_3;
         buf[2] = 51;
         if (stk600_xprog_command(pgm, buf, 3, 2) < 0) {
-            avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_3) failed\n",
+            msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_3) failed\n",
                             progname);
             return -1;
         }
@@ -3740,7 +3740,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[1] = XPRG_PARAM_TPI_4;
         buf[2] = 50;
         if (stk600_xprog_command(pgm, buf, 3, 2) < 0) {
-            avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_4) failed\n",
+            msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_4) failed\n",
                             progname);
             return -1;
         }
@@ -3760,7 +3760,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[4] = nvm_base >> 8;
         buf[5] = nvm_base;
         if (stk600_xprog_command(pgm, buf, 6, 2) < 0) {
-            avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_NVMBASE) failed\n",
+            msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_NVMBASE) failed\n",
                             progname);
             return -1;
         }
@@ -3771,7 +3771,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
             buf[2] = eepagesize >> 8;
             buf[3] = eepagesize;
             if (stk600_xprog_command(pgm, buf, 4, 2) < 0) {
-                avrdude_message(MSG_INFO, "%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_EEPPAGESIZE) failed\n",
+                msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_EEPPAGESIZE) failed\n",
                                 progname);
                 return -1;
             }
@@ -3794,7 +3794,7 @@ static void stk600_xprog_disable(const PROGRAMMER *pgm) {
 
     buf[0] = XPRG_CMD_LEAVE_PROGMODE;
     if (stk600_xprog_command(pgm, buf, 1, 2) < 0) {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_program_disable(): XPRG_CMD_LEAVE_PROGMODE failed\n",
+        msg_info("%s: stk600_xprog_program_disable(): XPRG_CMD_LEAVE_PROGMODE failed\n",
                         progname);
     }
 }
@@ -3832,7 +3832,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(mem->desc, "userrow") == 0) {
         memcode = XPRG_MEM_TYPE_USERSIG;
     } else {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_write_byte(): unknown memory \"%s\"\n",
+        msg_info("%s: stk600_xprog_write_byte(): unknown memory \"%s\"\n",
                         progname, mem->desc);
         return -1;
     }
@@ -3846,7 +3846,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
         b[4] = mem->offset >> 8;
         b[5] = mem->offset + 1;
         if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    avrdude_message(MSG_INFO, "%s: stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CONFIG) failed\n",
+	    msg_info("%s: stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CONFIG) failed\n",
                             progname);
 	    return -1;
 	}
@@ -3873,7 +3873,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
     b[8] = write_size;
     b[9] = data;
     if (stk600_xprog_command(pgm, b, 9 + write_size, 2) < 0) {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_write_byte(): XPRG_CMD_WRITE_MEM failed\n",
+        msg_info("%s: stk600_xprog_write_byte(): XPRG_CMD_WRITE_MEM failed\n",
                         progname);
         return -1;
     }
@@ -3908,7 +3908,7 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
                strcmp(mem->desc, "userrow") == 0) {
         b[1] = XPRG_MEM_TYPE_USERSIG;
     } else {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_read_byte(): unknown memory \"%s\"\n",
+        msg_info("%s: stk600_xprog_read_byte(): unknown memory \"%s\"\n",
                         progname, mem->desc);
         return -1;
     }
@@ -3922,7 +3922,7 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
     b[6] = 0;
     b[7] = 1;
     if (stk600_xprog_command(pgm, b, 8, 3) < 0) {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_read_byte(): XPRG_CMD_READ_MEM failed\n",
+        msg_info("%s: stk600_xprog_read_byte(): XPRG_CMD_READ_MEM failed\n",
                         progname);
         return -1;
     }
@@ -3984,7 +3984,7 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(mem->desc, "userrow") == 0) {
         memtype = XPRG_MEM_TYPE_USERSIG;
     } else {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_load(): unknown paged memory \"%s\"\n",
+        msg_info("%s: stk600_xprog_paged_load(): unknown paged memory \"%s\"\n",
                         progname, mem->desc);
         return -1;
     }
@@ -3992,7 +3992,7 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
     addr += mem->offset;
 
     if ((b = malloc(page_size + 2)) == NULL) {
-	avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_load(): out of memory\n",
+	msg_info("%s: stk600_xprog_paged_load(): out of memory\n",
                         progname);
         return -1;
     }
@@ -4015,7 +4015,7 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
 	b[6] = page_size >> 8;
 	b[7] = page_size;
 	if (stk600_xprog_command(pgm, b, 8, page_size + 2) < 0) {
-	    avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_load(): XPRG_CMD_READ_MEM failed\n",
+	    msg_info("%s: stk600_xprog_paged_load(): XPRG_CMD_READ_MEM failed\n",
                             progname);
 	    free(b);
 	    return -1;
@@ -4050,7 +4050,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
      * transfer.
      */
     if (page_size > 512) {
-	avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_write(): cannot handle page size > 512\n",
+	msg_info("%s: stk600_xprog_paged_write(): cannot handle page size > 512\n",
                         progname);
 	return -1;
     }
@@ -4099,7 +4099,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
         memtype = XPRG_MEM_TYPE_USERSIG;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
     } else {
-        avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_write(): unknown paged memory \"%s\"\n",
+        msg_info("%s: stk600_xprog_paged_write(): unknown paged memory \"%s\"\n",
                         progname, mem->desc);
         return -1;
     }
@@ -4107,7 +4107,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     addr += mem->offset;
 
     if ((b = malloc(page_size + 9)) == NULL) {
-	avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_write(): out of memory\n",
+	msg_info("%s: stk600_xprog_paged_write(): out of memory\n",
                         progname);
         return -1;
     }
@@ -4133,7 +4133,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 	     * erase page / write page bits in the final chunk helps.
 	     */
 	    if (page_size % 256 != 0) {
-		avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_write(): page size not multiple of 256\n",
+		msg_info("%s: stk600_xprog_paged_write(): page size not multiple of 256\n",
                                 progname);
 		free(b);
 		return -1;
@@ -4157,7 +4157,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 		b[8] = 0;
 		memcpy(b + 9, mem->buf + offset, writesize);
 		if (stk600_xprog_command(pgm, b, 256 + 9, 2) < 0) {
-		    avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n",
+		    msg_info("%s: stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n",
                                     progname);
 		    free(b);
 		    return -1;
@@ -4191,7 +4191,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 	    b[8] = page_size;
 	    memcpy(b + 9, mem->buf + offset, writesize);
 	    if (stk600_xprog_command(pgm, b, page_size + 9, 2) < 0) {
-		avrdude_message(MSG_INFO, "%s: stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n",
+		msg_info("%s: stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n",
                                 progname);
 		free(b);
 		return -1;
@@ -4216,7 +4216,7 @@ static int stk600_xprog_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->prog_modes & PM_TPI) {
         if ((mem = avr_locate_mem(p, "flash")) == NULL) {
-            avrdude_message(MSG_INFO, "%s: stk600_xprog_chip_erase(): no FLASH definition found for TPI device\n",
+            msg_info("%s: stk600_xprog_chip_erase(): no FLASH definition found for TPI device\n",
                             progname);
             return -1;
         }
@@ -4230,7 +4230,7 @@ static int stk600_xprog_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     b[4] = addr >> 8;
     b[5] = addr;
     if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    avrdude_message(MSG_INFO, "%s: stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CHIP) failed\n",
+	    msg_info("%s: stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CHIP) failed\n",
                             progname);
 	    return -1;
 	}
@@ -4256,7 +4256,7 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(m->desc, "userrow") == 0) {
       b[1] = XPRG_ERASE_USERSIG;
     } else {
-      avrdude_message(MSG_INFO, "%s: stk600_xprog_page_erase(): unknown paged memory \"%s\"\n",
+      msg_info("%s: stk600_xprog_page_erase(): unknown paged memory \"%s\"\n",
                       progname, m->desc);
       return -1;
     }
@@ -4267,7 +4267,7 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
     b[4] = addr >> 8;
     b[5] = addr;
     if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    avrdude_message(MSG_INFO, "%s: stk600_xprog_page_erase(): XPRG_CMD_ERASE(%d) failed\n",
+	    msg_info("%s: stk600_xprog_page_erase(): XPRG_CMD_ERASE(%d) failed\n",
                             progname, b[1]);
 	    return -1;
 	}

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1127,7 +1127,7 @@ retry:
                 break;
             }
             pmsg_warning("target prepared for ISP, signed off\n");
-            pmsg_warning("now retrying without power-cycling the target\n");
+            imsg_warning("now retrying without power-cycling the target\n");
             goto retry;
         }
         break;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -284,8 +284,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p);
 void stk500v2_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: stk500v2_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("stk500v2_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -298,8 +297,7 @@ static void stk500v2_jtagmkII_setup(PROGRAMMER * pgm)
   void *mycookie, *theircookie;
 
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: stk500v2_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("stk500v2_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -321,8 +319,7 @@ static void stk500v2_jtag3_setup(PROGRAMMER * pgm)
   void *mycookie, *theircookie;
 
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: stk500v2_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("stk500v2_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -382,7 +379,7 @@ b2_to_u16(unsigned char *b)
 
 static int stk500v2_send_mk2(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
   if (serial_send(&pgm->fd, data, len) != 0) {
-    msg_info("%s: stk500_send_mk2(): failed to send command to serial port\n",progname);
+    pmsg_info("stk500_send_mk2(): failed to send command to serial port\n");
     return -1;
   }
 
@@ -411,8 +408,7 @@ static int stk500v2_jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, si
 
   sz = get_jtagisp_return_size(data[0]);
   if (sz == 0) {
-    msg_info("%s: unsupported encapsulated ISP command: %#x\n",
-	    progname, data[0]);
+    pmsg_info("unsupported encapsulated ISP command: %#x\n", data[0]);
     return -1;
   }
   if (sz == SZ_READ_FLASH_EE) {
@@ -431,8 +427,7 @@ static int stk500v2_jtagmkII_send(const PROGRAMMER *pgm, unsigned char *data, si
   }
 
   if ((cmdbuf = malloc(len + 3)) == NULL) {
-    msg_info("%s: out of memory for command packet\n",
-            progname);
+    pmsg_info("out of memory for command packet\n");
     exit(1);
   }
   PROGRAMMER *pgmcp = pgm_dup(pgm);
@@ -456,8 +451,7 @@ static int stk500v2_jtag3_send(const PROGRAMMER *pgm, unsigned char *data, size_
   int rv;
 
   if ((cmdbuf = malloc(len + 1)) == NULL) {
-    msg_info("%s: out of memory for command packet\n",
-            progname);
+    pmsg_info("out of memory for command packet\n");
     exit(1);
   }
 
@@ -501,7 +495,7 @@ static int stk500v2_send(const PROGRAMMER *pgm, unsigned char *data, size_t len)
   DEBUG(", %d)\n", (int) len+6);
 
   if (serial_send(&pgm->fd, buf, len+6) != 0) {
-    msg_info("%s: stk500_send(): failed to send command to serial port\n",progname);
+    pmsg_info("stk500_send(): failed to send command to serial port\n");
     return -1;
   }
 
@@ -520,7 +514,7 @@ static int stk500v2_recv_mk2(const PROGRAMMER *pgm, unsigned char *msg,
 
   rv = serial_recv(&pgm->fd, msg, maxsize);
   if (rv < 0) {
-    msg_info("%s: stk500v2_recv_mk2: error in USB receive\n", progname);
+    pmsg_info("stk500v2_recv_mk2: error in USB receive\n");
     return -1;
   }
 
@@ -538,29 +532,24 @@ static int stk500v2_jtagmkII_recv(const PROGRAMMER *pgm, unsigned char *msg,
   rv = jtagmkII_recv(pgmcp, &jtagmsg);
   pgm_free(pgmcp);
   if (rv <= 0) {
-    msg_info("%s: stk500v2_jtagmkII_recv(): error in jtagmkII_recv()\n",
-            progname);
+    pmsg_info("stk500v2_jtagmkII_recv(): error in jtagmkII_recv()\n");
     return -1;
   }
   if ((size_t) rv - 1 > maxsize) {
-    msg_info("%s: stk500v2_jtagmkII_recv(): got %u bytes, have only room for %u bytes\n",
-                    progname, (unsigned) rv - 1, (unsigned) maxsize);
+    pmsg_info("stk500v2_jtagmkII_recv(): got %u bytes, have only room for %u bytes\n", (unsigned) rv - 1, (unsigned) maxsize);
     rv = maxsize;
   }
   switch (jtagmsg[0]) {
   case RSP_SPI_DATA:
     break;
   case RSP_FAILED:
-    msg_info("%s: stk500v2_jtagmkII_recv(): failed\n",
-	    progname);
+    pmsg_info("stk500v2_jtagmkII_recv(): failed\n");
     return -1;
   case RSP_ILLEGAL_MCU_STATE:
-    msg_info("%s: stk500v2_jtagmkII_recv(): illegal MCU state\n",
-	    progname);
+    pmsg_info("stk500v2_jtagmkII_recv(): illegal MCU state\n");
     return -1;
   default:
-    msg_info("%s: stk500v2_jtagmkII_recv(): unknown status %d\n",
-	    progname, jtagmsg[0]);
+    pmsg_info("stk500v2_jtagmkII_recv(): unknown status %d\n", jtagmsg[0]);
     return -1;
   }
   memcpy(msg, jtagmsg + 1, rv - 1);
@@ -580,8 +569,7 @@ static int stk500v2_jtag3_recv(const PROGRAMMER *pgm, unsigned char *msg,
   pgm_free(pgmcp);
 
   if (rv <= 0) {
-    msg_info("%s: stk500v2_jtag3_recv(): error in jtagmkII_recv()\n",
-            progname);
+    pmsg_info("stk500v2_jtag3_recv(): error in jtagmkII_recv()\n");
     return -1;
   }
   /* Getting more data than expected is a normal case for the EDBG
@@ -589,13 +577,11 @@ static int stk500v2_jtag3_recv(const PROGRAMMER *pgm, unsigned char *msg,
      octets from the ICE.  Thus, only complain at high verbose
      levels. */
   if ((size_t) rv - 1 > maxsize) {
-    msg_debug("%s: stk500v2_jtag3_recv(): got %u bytes, have only room for %u bytes\n",
-                      progname, (unsigned) rv - 1, (unsigned) maxsize);
+    pmsg_debug("stk500v2_jtag3_recv(): got %u bytes, have only room for %u bytes\n", (unsigned) rv - 1, (unsigned) maxsize);
     rv = maxsize;
   }
   if (jtagmsg[0] != SCOPE_AVR_ISP) {
-    msg_info("%s: stk500v2_jtag3_recv(): message is not AVR ISP: 0x%02x\n",
-                    progname, jtagmsg[0]);
+    pmsg_info("stk500v2_jtag3_recv(): message is not AVR ISP: 0x%02x\n", jtagmsg[0]);
     free(jtagmsg);
     return -1;
   }
@@ -641,7 +627,7 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
 
     switch (state) {
       case sSTART:
-        DEBUGRECV("hoping for start token...");
+        DEBUGRECV("hoping for start token ...");
         if (c == MESSAGE_START) {
           DEBUGRECV("got it\n");
           checksum = MESSAGE_START;
@@ -650,7 +636,7 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
           DEBUGRECV("sorry\n");
         break;
       case sSEQNUM:
-        DEBUGRECV("hoping for sequence...\n");
+        DEBUGRECV("hoping for sequence ...\n");
         if (c == PDATA(pgm)->command_sequence) {
           DEBUGRECV("got it, incrementing\n");
           state = sSIZE1;
@@ -666,7 +652,7 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
         state = sSIZE2;
         break;
       case sSIZE2:
-        DEBUGRECV("hoping for size MSB...");
+        DEBUGRECV("hoping for size MSB ...");
         msglen += (unsigned)c;
         DEBUG(" msg is %u bytes\n",msglen);
         state = sTOKEN;
@@ -679,13 +665,12 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
         if (curlen < maxsize) {
           msg[curlen] = c;
         } else {
-          msg_info("%s: stk500v2_recv(): buffer too small, received %d byte into %u byte buffer\n",
-                  progname,curlen,(unsigned int)maxsize);
+          pmsg_info("stk500v2_recv(): buffer too small, received %d byte into %u byte buffer\n",
+            curlen, (unsigned int) maxsize);
           return -2;
         }
         if ((curlen == 0) && (msg[0] == ANSWER_CKSUM_ERROR)) {
-          msg_info("%s: stk500v2_recv(): previous packet sent with wrong checksum\n",
-                  progname);
+          pmsg_info("stk500v2_recv(): previous packet sent with wrong checksum\n");
           return -3;
         }
         curlen++;
@@ -696,14 +681,12 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
           state = sDONE;
         } else {
           state = sSTART;
-          msg_info("%s: stk500v2_recv(): checksum error\n",
-                  progname);
+          pmsg_info("stk500v2_recv(): checksum error\n");
           return -4;
         }
         break;
       default:
-        msg_info("%s: stk500v2_recv(): unknown state\n",
-                progname);
+        pmsg_info("stk500v2_recv(): unknown state\n");
         return -5;
      } /* switch */
 
@@ -711,8 +694,7 @@ static int stk500v2_recv(const PROGRAMMER *pgm, unsigned char *msg, size_t maxsi
      tnow = tv.tv_sec;
      if (tnow-tstart > timeoutval) {			// wuff - signed/unsigned/overflow
       timedout:
-       msg_info("%s: stk500v2_ReceiveMessage(): timeout\n",
-               progname);
+       pmsg_info("stk500v2_ReceiveMessage(): timeout\n");
        return -1;
      }
 
@@ -765,18 +747,15 @@ retry:
 	PDATA(pgm)->pgmtype = PGMTYPE_STK600;
       } else {
 	resp[siglen + 3] = 0;
-        msg_notice("%s: stk500v2_getsync(): got response from unknown "
-                          "programmer %s, assuming STK500\n",
-                          progname, resp + 3);
+        pmsg_notice("stk500v2_getsync(): got response from unknown "
+          "programmer %s, assuming STK500\n", resp + 3);
 	PDATA(pgm)->pgmtype = PGMTYPE_STK500;
       }
-      msg_debug("%s: stk500v2_getsync(): found %s programmer\n",
-                        progname, pgmname[PDATA(pgm)->pgmtype]);
+      pmsg_debug("stk500v2_getsync(): found %s programmer\n", pgmname[PDATA(pgm)->pgmtype]);
       return 0;
     } else {
       if (tries > RETRIES) {
-        msg_info("%s: stk500v2_getsync(): can't communicate with device: resp=0x%02x\n",
-                        progname, resp[0]);
+        pmsg_info("stk500v2_getsync(): can't communicate with device: resp=0x%02x\n", resp[0]);
         return -6;
       } else
         goto retry;
@@ -785,8 +764,7 @@ retry:
   // or if we got a timeout
   } else if (status == -1) {
     if (tries > RETRIES) {
-      msg_info("%s: stk500v2_getsync(): timeout communicating with programmer\n",
-              progname);
+      pmsg_info("stk500v2_getsync(): timeout communicating with programmer\n");
       return -1;
     } else
       goto retry;
@@ -794,8 +772,7 @@ retry:
   // or any other error
   } else {
     if (tries > RETRIES) {
-      msg_info("%s: stk500v2_getsync(): error communicating with programmer: (%d)\n",
-              progname,status);
+      pmsg_info("stk500v2_getsync(): error communicating with programmer (%d)\n", status);
     } else
       goto retry;
   }
@@ -825,7 +802,7 @@ retry:
   if (status > 0) {
     DEBUG(" = %d\n",status);
     if (status < 2) {
-      msg_info("%s: stk500v2_command(): short reply\n", progname);
+      pmsg_info("stk500v2_command(): short reply\n");
       return -1;
     }
     if (buf[0] == CMD_XPROG_SETMODE || buf[0] == CMD_XPROG) {
@@ -849,10 +826,8 @@ retry:
             case XPRG_ERR_TIMEOUT:  msg = "Timeout"; break;
             default:                msg = "Unknown"; break;
             }
-            msg_info("%s: stk500v2_command(): error in %s: %s\n",
-                    progname,
-                    (buf[0] == CMD_XPROG_SETMODE? "CMD_XPROG_SETMODE": "CMD_XPROG"),
-                    msg);
+            pmsg_info("stk500v2_command(): error in %s: %s\n",
+              buf[0]==CMD_XPROG_SETMODE? "CMD_XPROG_SETMODE": "CMD_XPROG", msg);
             return -1;
         }
         return 0;
@@ -882,20 +857,16 @@ retry:
                 break;
             }
             if (quell_progress < 2) {
-                msg_info("%s: stk500v2_command(): warning: %s\n",
-                        progname, msg);
+                pmsg_info("stk500v2_command(): warning: %s\n", msg);
             }
         } else if (buf[1] == STATUS_CMD_OK) {
             return status;
         } else if (buf[1] == STATUS_CMD_FAILED) {
-            msg_info("%s: stk500v2_command(): command failed\n",
-                            progname);
+            pmsg_info("stk500v2_command(): command failed\n");
         } else if (buf[1] == STATUS_CMD_UNKNOWN) {
-            msg_info("%s: stk500v2_command(): unknown command\n",
-                            progname);
+            pmsg_info("stk500v2_command(): unknown command\n");
         } else {
-            msg_info("%s: stk500v2_command(): unknown status 0x%02x\n",
-                    progname, buf[1]);
+            pmsg_info("stk500v2_command(): unknown status 0x%02x\n", buf[1]);
         }
         return -1;
     }
@@ -905,8 +876,7 @@ retry:
   status = stk500v2_getsync(pgm);
   if (status != 0) {
     if (tries > RETRIES) {
-      msg_info("%s: stk500v2_command(): failed miserably to execute command 0x%02x\n",
-              progname,buf[0]);
+      pmsg_info("stk500v2_command(): failed miserably to execute command 0x%02x\n", buf[0]);
       return -1;
     } else
       goto retry;
@@ -935,12 +905,10 @@ static int stk500v2_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 
   result = stk500v2_command(pgm, buf, 8, sizeof(buf));
   if (result < 0) {
-    msg_info("%s: stk500v2_cmd(): failed to send command\n",
-            progname);
+    pmsg_info("stk500v2_cmd(): failed to send command\n");
     return -1;
   } else if (result < 6) {
-    msg_info("%s: stk500v2_cmd(): short reply, len = %d\n",
-            progname, result);
+    pmsg_info("stk500v2_cmd(): short reply, len = %d\n", result);
     return -1;
   }
 
@@ -956,8 +924,7 @@ static int stk500v2_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 static int stk500v2_jtag3_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 			      unsigned char *res)
 {
-  msg_info("%s: stk500v2_jtag3_cmd(): Not available in JTAGICE3\n",
-                  progname);
+  pmsg_info("stk500v2_jtag3_cmd(): Not available in JTAGICE3\n");
 
   return -1;
 }
@@ -971,8 +938,7 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char buf[16];
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    msg_info("%s: stk500v2_chip_erase: chip erase instruction not defined for part \"%s\"\n",
-            progname, p->desc);
+    pmsg_info("stk500v2_chip_erase: chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -1088,8 +1054,7 @@ static int stk500v2_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   PDATA(pgm)->lastpart = p;
 
   if (p->op[AVR_OP_PGM_ENABLE] == NULL) {
-    msg_info("%s: stk500v2_program_enable(): program enable instruction not defined for part \"%s\"\n",
-	    progname, p->desc);
+    pmsg_info("stk500v2_program_enable(): program enable instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -1119,13 +1084,11 @@ retry:
     case PGMTYPE_STK600:
     case PGMTYPE_AVRISP_MKII:
         if (stk500v2_getparm(pgm, PARAM_STATUS_TGT_CONN, &buf[0]) != 0) {
-            msg_info("%s: stk500v2_program_enable(): cannot get connection status\n",
-                            progname);
+            pmsg_info("stk500v2_program_enable(): cannot get connection status\n");
         } else {
             stk500v2_translate_conn_status(buf[0], msg);
-            msg_info("%s: stk500v2_program_enable():"
-                    " bad AVRISPmkII connection status: %s\n",
-                    progname, msg);
+            pmsg_info("stk500v2_program_enable():"
+              " bad AVRISPmkII connection status: %s\n", msg);
         }
         break;
 
@@ -1134,8 +1097,7 @@ retry:
             unsigned char cmd[4], *resp;
 
             /* Try debugWIRE, and MONCON_DISABLE */
-            msg_notice2("%s: No response in ISP mode, trying debugWIRE\n",
-                                progname);
+            pmsg_notice2("no response in ISP mode, trying debugWIRE\n");
 
             PROGRAMMER *pgmcp = pgm_dup(pgm);
             pgmcp->cookie = PDATA(pgm)->chained_pdata;
@@ -1164,13 +1126,11 @@ retry:
             }
             pgm_free(pgmcp);
             if (tries++ > 3) {
-                msg_info("%s: Failed to return from debugWIRE to ISP.\n",
-                                progname);
+                pmsg_info("failed to return from debugWIRE to ISP\n");
                 break;
             }
-            msg_info("%s: Target prepared for ISP, signed off.\n"
-                            "%s: Now retrying without power-cycling the target.\n",
-                            progname, progname);
+            pmsg_info("target prepared for ISP, signed off\n");
+            pmsg_info("now retrying without power-cycling the target\n");
             goto retry;
         }
         break;
@@ -1248,8 +1208,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       AVRMEM *bootmem = avr_locate_mem(p, "boot");
       AVRMEM *flashmem = avr_locate_mem(p, "flash");
       if (bootmem == NULL || flashmem == NULL) {
-        msg_info("%s: stk500v2_initialize(): Cannot locate \"flash\" and \"boot\" memories in description\n",
-                        progname);
+        pmsg_info("stk500v2_initialize(): Cannot locate flash and boot memories in description\n");
       } else {
         PDATA(pgm)->boot_start = bootmem->offset - flashmem->offset;
       }
@@ -1283,13 +1242,11 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    msg_info("%s: stk500v2_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("stk500v2_initialize(): Out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    msg_info("%s: stk500v2_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("stk500v2_initialize(): Out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -1318,8 +1275,7 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   // FIXME: condition below looks fishy, suspect the code wants !(p->prog_modes & (PM_debugWIRE | PM_JTAG | PM_JTAGmkI /* | PM_XMEGAJTAG | PM_AVR32JTAG */))
   if (p->prog_modes & (PM_PDI | PM_TPI)) {
-    msg_info("%s: jtag3_initialize(): part %s has no ISP interface\n",
-	    progname, p->desc);
+    pmsg_info("jtag3_initialize(): part %s has no ISP interface\n", p->desc);
     return -1;
   }
 
@@ -1380,13 +1336,11 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    msg_info("%s: stk500hv_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("stk500hv_initialize(): Out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    msg_info("%s: stk500hv_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("stk500hv_initialize(): Out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -1406,11 +1360,9 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   AVRMEM * m;
 
   if (p->ctl_stack_type != (mode == PPMODE? CTL_STACK_PP: CTL_STACK_HVSP)) {
-    msg_info("%s: stk500hv_initialize(): "
-                    "%s programming control stack not defined for part \"%s\"\n",
-                    progname,
-                    (mode == PPMODE? "parallel": "high-voltage serial"),
-                    p->desc);
+    pmsg_info("stk500hv_initialize(): "
+      "%s programming control stack not defined for part %s\n",
+      mode == PPMODE? "parallel": "high-voltage serial", p->desc);
     return -1;
   }
 
@@ -1420,9 +1372,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   result = stk500v2_command(pgm, buf, CTL_STACK_SIZE + 1, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500hv_initalize(): "
-                    "failed to set control stack\n",
-                    progname);
+    pmsg_info("stk500hv_initalize(): failed to set control stack\n");
     return -1;
   }
 
@@ -1450,13 +1400,11 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   free(PDATA(pgm)->flash_pagecache);
   free(PDATA(pgm)->eeprom_pagecache);
   if ((PDATA(pgm)->flash_pagecache = malloc(PDATA(pgm)->flash_pagesize)) == NULL) {
-    msg_info("%s: stk500hv_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("stk500hv_initialize(): Out of memory\n");
     return -1;
   }
   if ((PDATA(pgm)->eeprom_pagecache = malloc(PDATA(pgm)->eeprom_pagesize)) == NULL) {
-    msg_info("%s: stk500hv_initialize(): Out of memory\n",
-	    progname);
+    pmsg_info("stk500hv_initialize(): Out of memory\n");
     free(PDATA(pgm)->flash_pagecache);
     return -1;
   }
@@ -1495,8 +1443,7 @@ static void stk500v2_jtag3_disable(const PROGRAMMER *pgm) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500v2_disable(): failed to leave programming mode\n",
-                    progname);
+    pmsg_info("stk500v2_disable(): failed to leave programming mode\n");
   }
 
   return;
@@ -1513,8 +1460,7 @@ static void stk500v2_disable(const PROGRAMMER *pgm) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500v2_disable(): failed to leave programming mode\n",
-                    progname);
+    pmsg_info("stk500v2_disable(): failed to leave programming mode\n");
   }
 
   return;
@@ -1542,9 +1488,7 @@ static void stk500hv_disable(const PROGRAMMER *pgm, enum hvmode mode) {
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500hv_disable(): "
-                    "failed to leave programming mode\n",
-                    progname);
+    pmsg_info("stk500hv_disable(): failed to leave programming mode\n");
   }
 
   return;
@@ -1596,7 +1540,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     serdev = &avrdoper_serdev;
     PDATA(pgm)->pgmtype = PGMTYPE_STK500;
 #else
-    msg_info("avrdoper requires avrdude with libhidapi support.\n");
+    msg_info("avrdoper requires avrdude with libhidapi support\n");
     return -1;
 #endif
   }
@@ -1620,7 +1564,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    msg_info("avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support\n");
     return -1;
 #endif
   }
@@ -1677,7 +1621,7 @@ static int stk600_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_STK600;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    msg_info("avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support\n");
     return -1;
 #endif
   }
@@ -1728,8 +1672,7 @@ static int stk500v2_loadaddr(const PROGRAMMER *pgm, unsigned int addr) {
   result = stk500v2_command(pgm, buf, 5, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500v2_loadaddr(): failed to set load address\n",
-                    progname);
+    pmsg_info("stk500v2_loadaddr(): failed to set load address\n");
     return -1;
   }
 
@@ -1750,8 +1693,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned int pagesize = 0, use_ext_addr = 0, addrshift = 0;
   unsigned char *cache_ptr = NULL;
 
-  msg_notice2("%s: stk500hv_read_byte(.., %s, 0x%lx, ...)\n",
-	    progname, mem->desc, addr);
+  pmsg_notice2("stk500hv_read_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0) {
     buf[0] = mode == PPMODE? CMD_READ_FLASH_PP: CMD_READ_FLASH_HVSP;
@@ -1823,15 +1765,13 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     buf[1] = addr;
   }
 
-  msg_notice2("%s: stk500hv_read_byte(): Sending read memory command: ",
-	    progname);
+  pmsg_notice2("stk500hv_read_byte(): Sending read memory command: ");
 
   result = stk500v2_command(pgm, buf, cmdlen, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500hv_read_byte(): "
-                    "timeout/error communicating with programmer\n",
-                    progname);
+    pmsg_info("stk500hv_read_byte(): "
+                    "timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -1880,8 +1820,7 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   unsigned char *cache_ptr = NULL;
   OPCODE *op;
 
-  msg_notice2("%s: stk500isp_read_byte(.., %s, 0x%lx, ...)\n",
-	    progname, mem->desc, addr);
+  pmsg_notice2("stk500isp_read_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0 ||
       strcmp(mem->desc, "eeprom") == 0) {
@@ -1934,29 +1873,24 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   }
 
   if ((op = mem->op[AVR_OP_READ]) == NULL) {
-    msg_info("%s: stk500isp_read_byte(): invalid operation AVR_OP_READ on %s memory\n",
-                    progname, mem->desc);
+    pmsg_info("stk500isp_read_byte(): invalid operation AVR_OP_READ on %s memory\n", mem->desc);
     return -1;
   }
   memset(buf+2, 0, 4);
   avr_set_bits(op, buf + 2);
   if ((pollidx = avr_get_output_index(op)) == -1) {
-    msg_info("%s: stk500isp_read_byte(): cannot determine pollidx to read %s memory\n",
-                    progname, mem->desc);
+    pmsg_info("stk500isp_read_byte(): cannot determine pollidx to read %s memory\n", mem->desc);
     pollidx = 3;
   }
   buf[1] = pollidx + 1;
   avr_set_addr(op, buf + 2, addr);
 
-  msg_notice2("%s: stk500isp_read_byte(): Sending read memory command: ",
-	    progname);
+  pmsg_notice2("stk500isp_read_byte(): Sending read memory command: ");
 
   result = stk500v2_command(pgm, buf, 6, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500isp_read_byte(): "
-                    "timeout/error communicating with programmer\n",
-                    progname);
+    pmsg_info("stk500isp_read_byte(): timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -1978,8 +1912,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   unsigned int pagesize = 0, use_ext_addr = 0, addrshift = 0;
   unsigned char *cache_ptr = NULL;
 
-  msg_notice2("%s: stk500hv_write_byte(.., %s, 0x%lx, ...)\n",
-	    progname, mem->desc, addr);
+  pmsg_notice2("stk500hv_write_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_FLASH_PP: CMD_PROGRAM_FLASH_HVSP;
@@ -2026,9 +1959,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     pulsewidth = p->programlockpulsewidth;
     timeout = p->programlockpolltimeout;
   } else {
-    msg_info("%s: stk500hv_write_byte(): "
-                    "unsupported memory type: %s\n",
-                    progname, mem->desc);
+    pmsg_info("stk500hv_write_byte(): unsupported memory type %s\n", mem->desc);
     return -1;
   }
 
@@ -2086,15 +2017,12 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     }
   }
 
-  msg_notice2("%s: stk500hv_write_byte(): Sending write memory command: ",
-	    progname);
+  pmsg_notice2("stk500hv_write_byte(): sending write memory command: ");
 
   result = stk500v2_command(pgm, buf, cmdlen, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500hv_write_byte(): "
-                    "timeout/error communicating with programmer\n",
-                    progname);
+    pmsg_info("stk500hv_write_byte(): timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -2138,8 +2066,7 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   unsigned char *cache_ptr = NULL;
   OPCODE *op;
 
-  msg_notice2("%s: stk500isp_write_byte(.., %s, 0x%lx, ...)\n",
-	    progname, mem->desc, addr);
+  pmsg_notice2("stk500isp_write_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
   if (strcmp(mem->desc, "flash") == 0 ||
       strcmp(mem->desc, "eeprom") == 0) {
@@ -2192,16 +2119,12 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   } else if (strcmp(mem->desc, "lock") == 0) {
     buf[0] = CMD_PROGRAM_LOCK_ISP;
   } else {
-    msg_info("%s: stk500isp_write_byte(): "
-                    "unsupported memory type: %s\n",
-                    progname, mem->desc);
+    pmsg_info("stk500isp_write_byte(): unsupported memory type: %s\n", mem->desc);
     return -1;
   }
 
   if ((op = mem->op[AVR_OP_WRITE]) == NULL) {
-    msg_info("%s: stk500isp_write_byte(): "
-                    "no AVR_OP_WRITE for %s memory\n",
-                    progname, mem->desc);
+    pmsg_info("stk500isp_write_byte(): no AVR_OP_WRITE for %s memory\n", mem->desc);
     return -1;
   }
 
@@ -2209,15 +2132,12 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   avr_set_addr(op, buf + 1, addr);
   avr_set_input(op, buf + 1, data);
 
-  msg_notice2("%s: stk500isp_write_byte(): Sending write memory command: ",
-	    progname);
+  pmsg_notice2("stk500isp_write_byte(): Sending write memory command: ");
 
   result = stk500v2_command(pgm, buf, 5, sizeof(buf));
 
   if (result < 0) {
-    msg_info("%s: stk500isp_write_byte(): "
-                    "timeout/error communicating with programmer\n",
-                    progname);
+    pmsg_info("stk500isp_write_byte(): timeout/error communicating with programmer\n");
     return -1;
   }
 
@@ -2286,8 +2206,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[3] = m->mode | 0x80;		// yes, write the page to flash
 
     if (m->op[AVR_OP_LOADPAGE_LO] == NULL) {
-      msg_info("%s: stk500v2_paged_write: loadpage instruction not defined for part \"%s\"\n",
-              progname, p->desc);
+      pmsg_info("stk500v2_paged_write: loadpage instruction not defined for part %s\n", p->desc);
       return -1;
     }
     memset(cmds, 0, sizeof cmds);
@@ -2295,8 +2214,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[5] = cmds[0];
 
     if (m->op[AVR_OP_WRITEPAGE] == NULL) {
-      msg_info("%s: stk500v2_paged_write: write page instruction not defined for part \"%s\"\n",
-              progname, p->desc);
+      pmsg_info("stk500v2_paged_write: write page instruction not defined for part %s\n", p->desc);
       return -1;
     }
 
@@ -2310,8 +2228,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     commandbuf[3] = m->mode | 0x80;		// yes, write the words to flash
 
     if (wop == NULL) {
-      msg_info("%s: stk500v2_paged_write: write instruction not defined for part \"%s\"\n",
-              progname, p->desc);
+      pmsg_info("stk500v2_paged_write: write instruction not defined for part %s\n", p->desc);
       return -1;
     }
     memset(cmds, 0, sizeof cmds);
@@ -2322,8 +2239,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
   // the read command is common to both methods
   if (rop == NULL) {
-    msg_info("%s: stk500v2_paged_write: read instruction not defined for part \"%s\"\n",
-            progname, p->desc);
+    pmsg_info("stk500v2_paged_write: read instruction not defined for part %s\n", p->desc);
     return -1;
   }
   memset(cmds, 0, sizeof cmds);
@@ -2358,8 +2274,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
     result = stk500v2_command(pgm,buf,block_size+10, sizeof(buf));
     if (result < 0) {
-      msg_info("%s: stk500v2_paged_write: write command failed\n",
-                      progname);
+      pmsg_info("stk500v2_paged_write: write command failed\n");
       return -1;
     }
   }
@@ -2380,7 +2295,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   unsigned char commandbuf[5], buf[266];
   int result;
 
-  DEBUG("STK500V2: stk500hv_paged_write(..,%s,%u,%u)\n",
+  DEBUG("STK500V2: stk500hv_paged_write(..,%s,%u,%u,%u)\n",
         m->desc, page_size, addr, n_bytes);
 
   addrshift = 0;
@@ -2453,8 +2368,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
     result = stk500v2_command(pgm, buf, page_size + 5, sizeof(buf));
     if (result < 0) {
-      msg_info("%s: stk500hv_paged_write: write command failed\n",
-                      progname);
+      pmsg_info("stk500hv_paged_write: write command failed\n");
       return -1;
     }
   }
@@ -2526,8 +2440,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   // the read command is common to both methods
   if (rop == NULL) {
-    msg_info("%s: stk500v2_paged_load: read instruction not defined for part \"%s\"\n",
-            progname, p->desc);
+    pmsg_info("stk500v2_paged_load: read instruction not defined for part %s\n", p->desc);
     return -1;
   }
   memset(cmds, 0, sizeof cmds);
@@ -2556,8 +2469,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
     result = stk500v2_command(pgm,buf,4,sizeof(buf));
     if (result < 0) {
-      msg_info("%s: stk500v2_paged_load: read command failed\n",
-                      progname);
+      pmsg_info("stk500v2_paged_load: read command failed\n");
       return -1;
     }
 #if 0
@@ -2636,8 +2548,7 @@ static int stk500hv_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
     result = stk500v2_command(pgm, buf, 3, sizeof(buf));
     if (result < 0) {
-      msg_info("%s: stk500hv_paged_load: read command failed\n",
-                      progname);
+      pmsg_info("stk500hv_paged_load: read command failed\n");
       return -1;
     }
 #if 0
@@ -2677,8 +2588,7 @@ static int stk500hvsp_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 static int stk500v2_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                unsigned int addr)
 {
-  msg_info("%s: stk500v2_page_erase(): this function must never be called\n",
-                  progname);
+  pmsg_info("stk500v2_page_erase(): this function must never be called\n");
   return -1;
 }
 
@@ -2688,14 +2598,12 @@ static int stk500v2_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VADJUST, &uaref) != 0) {
-    msg_info("%s: stk500v2_set_vtarget(): cannot obtain V[aref]\n",
-                    progname);
+    pmsg_info("stk500v2_set_vtarget(): cannot obtain V[aref]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    msg_info("%s: stk500v2_set_vtarget(): reducing V[aref] from %.1f to %.1f\n",
-                    progname, uaref / 10.0, v);
+    pmsg_info("stk500v2_set_vtarget(): reducing V[aref] from %.1f to %.1f\n", uaref/10.0, v);
     if (stk500v2_setparm(pgm, PARAM_VADJUST, utarg)
 	!= 0)
       return -1;
@@ -2712,15 +2620,13 @@ static int stk500v2_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused
   uaref = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
-    msg_info("%s: stk500v2_set_varef(): cannot obtain V[target]\n",
-                    progname);
+    pmsg_info("stk500v2_set_varef(): cannot obtain V[target]\n");
     return -1;
   }
 
   if (uaref > utarg) {
-    msg_info("%s: stk500v2_set_varef(): V[aref] must not be greater than "
-                    "V[target] = %.1f\n",
-                    progname, utarg / 10.0);
+    pmsg_info("stk500v2_set_varef(): V[aref] must not be greater than "
+                    "V[target] = %.1f\n", utarg/10.0);
     return -1;
   }
   return stk500v2_setparm(pgm, PARAM_VADJUST, uaref);
@@ -2748,8 +2654,8 @@ static int stk500v2_set_fosc(const PROGRAMMER *pgm, double v) {
         unit = "kHz";
       } else
         unit = "Hz";
-      msg_info("%s: stk500v2_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
-                      progname, v, unit, STK500V2_XTAL / 2e6);
+      pmsg_info("stk500v2_set_fosc(): f = %.3f %s too high, using %.3f MHz\n",
+        v, unit, STK500V2_XTAL / 2e6);
       fosc = STK500V2_XTAL / 2;
     } else
       fosc = (unsigned)v;
@@ -2763,8 +2669,8 @@ static int stk500v2_set_fosc(const PROGRAMMER *pgm, double v) {
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
-      msg_info("%s: stk500v2_set_fosc(): f = %u Hz too low, %u Hz min\n",
-          progname, fosc, STK500V2_XTAL / (256 * 1024 * 2));
+      pmsg_info("stk500v2_set_fosc(): f = %u Hz too low, %u Hz min\n",
+        fosc, STK500V2_XTAL / (256 * 1024 * 2));
       return -1;
     }
   }
@@ -2809,13 +2715,12 @@ static int stk500v2_set_sck_period_mk2(const PROGRAMMER *pgm, double v) {
   }
 
   if (i >= sizeof(avrispmkIIfreqs) / sizeof(avrispmkIIfreqs[0])) {
-    msg_info("%s: stk500v2_set_sck_period_mk2(): "
-                    "invalid SCK period: %g\n", progname, v);
+    pmsg_info("stk500v2_set_sck_period_mk2(): invalid SCK period: %g\n", v);
     return -1;
   }
 
   msg_notice2("Using p = %.2f us for SCK (param = %d)\n",
-	    1000000 / avrispmkIIfreqs[i], i);
+	    1000000 / avrispmkIIfreqs[i], (int) i);
 
   return stk500v2_setparm(pgm, PARAM_SCK_DURATION, i);
 }
@@ -2837,8 +2742,7 @@ static unsigned int stk500v2_mode_for_pagesize(unsigned int pagesize)
     case 64:   return 6u << 1;
     case 128:  return 7u << 1;
     }
-  msg_info("%s: stk500v2_mode_for_pagesize(): invalid pagesize: %u\n",
-                  progname, pagesize);
+  pmsg_info("stk500v2_mode_for_pagesize(): invalid pagesize: %u\n", pagesize);
   return 0;
 }
 
@@ -2903,14 +2807,12 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
   utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm2(pgm, PARAM2_AREF0, &uaref) != 0) {
-    msg_info("%s: stk500v2_set_vtarget(): cannot obtain V[aref][0]\n",
-                    progname);
+    pmsg_info("stk500v2_set_vtarget(): cannot obtain V[aref][0]\n");
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    msg_info("%s: stk500v2_set_vtarget(): reducing V[aref][0] from %.2f to %.1f\n",
-                    progname, uaref / 100.0, v);
+    pmsg_info("stk500v2_set_vtarget(): reducing V[aref][0] from %.2f to %.1f\n", uaref/100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF0, uaref)
 	!= 0)
@@ -2918,14 +2820,12 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
   }
 
   if (stk500v2_getparm2(pgm, PARAM2_AREF1, &uaref) != 0) {
-    msg_info("%s: stk500v2_set_vtarget(): cannot obtain V[aref][1]\n",
-                    progname);
+    pmsg_info("stk500v2_set_vtarget(): cannot obtain V[aref][1]\n");
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    msg_info("%s: stk500v2_set_vtarget(): reducing V[aref][1] from %.2f to %.1f\n",
-                    progname, uaref / 100.0, v);
+    pmsg_info("stk500v2_set_vtarget(): reducing V[aref][1] from %.2f to %.1f\n", uaref/100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF1, uaref)
 	!= 0)
@@ -2953,15 +2853,13 @@ static int stk600_set_varef(const PROGRAMMER *pgm, unsigned int chan, double v) 
   uaref = (unsigned)((v + 0.0049) * 100);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
-    msg_info("%s: stk500v2_set_varef(): cannot obtain V[target]\n",
-                    progname);
+    pmsg_info("stk500v2_set_varef(): cannot obtain V[target]\n");
     return -1;
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    msg_info("%s: stk500v2_set_varef(): V[aref] must not be greater than "
-                    "V[target] = %.1f\n",
-                    progname, utarg / 10.0);
+    pmsg_info("stk500v2_set_varef(): V[aref] must not be greater than "
+      "V[target] = %.1f\n", utarg/10.0);
     return -1;
   }
 
@@ -2974,8 +2872,7 @@ static int stk600_set_varef(const PROGRAMMER *pgm, unsigned int chan, double v) 
     return stk500v2_setparm2(pgm, PARAM2_AREF1, uaref);
 
   default:
-    msg_info("%s: stk500v2_set_varef(): invalid channel %d\n",
-                    progname, chan);
+    pmsg_info("stk500v2_set_varef(): invalid channel %d\n", chan);
     return -1;
   }
 }
@@ -3030,8 +2927,7 @@ static int stk500v2_getparm(const PROGRAMMER *pgm, unsigned char parm, unsigned 
   buf[1] = parm;
 
   if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-    msg_info("%s: stk500v2_getparm(): failed to get parameter 0x%02x\n",
-            progname, parm);
+    pmsg_info("stk500v2_getparm(): failed to get parameter 0x%02x\n", parm);
     return -1;
   }
 
@@ -3049,7 +2945,7 @@ static int stk500v2_setparm_real(const PROGRAMMER *pgm, unsigned char parm, unsi
 
   if (stk500v2_command(pgm, buf, 3, sizeof(buf)) < 0) {
     msg_info("\n%s: stk500v2_setparm(): failed to set parameter 0x%02x\n",
-            progname, parm);
+      progname, parm);
     return -1;
   }
 
@@ -3062,13 +2958,13 @@ static int stk500v2_setparm(const PROGRAMMER *pgm, unsigned char parm, unsigned 
 
   res = stk500v2_getparm(pgm, parm, &current_value);
   if (res < 0) {
-    msg_info("%s: Unable to get parameter 0x%02x\n", progname, parm);
+    pmsg_info("Unable to get parameter 0x%02x\n", parm);
     return -1;
   }
 
   // don't issue a write if the correct value is already set.
   if (value == current_value) {
-    msg_notice2("%s: Skipping parameter write; parameter value already set.\n", progname);
+    pmsg_notice2("skipping parameter write; parameter value already set\n");
     return 0;
   }
 
@@ -3082,8 +2978,7 @@ static int stk500v2_getparm2(const PROGRAMMER *pgm, unsigned char parm, unsigned
   buf[1] = parm;
 
   if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-    msg_info("%s: stk500v2_getparm2(): failed to get parameter 0x%02x\n",
-            progname, parm);
+    pmsg_info("stk500v2_getparm2(): failed to get parameter 0x%02x\n", parm);
     return -1;
   }
 
@@ -3102,7 +2997,7 @@ static int stk500v2_setparm2(const PROGRAMMER *pgm, unsigned char parm, unsigned
 
   if (stk500v2_command(pgm, buf, 4, sizeof(buf)) < 0) {
     msg_info("\n%s: stk500v2_setparm2(): failed to set parameter 0x%02x\n",
-            progname, parm);
+      progname, parm);
     return -1;
   }
 
@@ -3328,8 +3223,7 @@ static int stk500v2_perform_osccal(const PROGRAMMER *pgm) {
 
   rv = stk500v2_command(pgm, buf, 1, sizeof(buf));
   if (rv < 0) {
-    msg_info("%s: stk500v2_perform_osccal(): failed\n",
-            progname);
+    pmsg_info("stk500v2_perform_osccal(): failed\n");
     return -1;
   }
 
@@ -3351,7 +3245,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   void *mycookie;
   int rv;
 
-  msg_notice2("%s: stk500v2_jtagmkII_open()\n", progname);
+  pmsg_notice2("stk500v2_jtagmkII_open()\n");
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -3379,7 +3273,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    msg_info("avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support\n");
     return -1;
 #endif
   }
@@ -3398,8 +3292,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   pgm->cookie = PDATA(pgm)->chained_pdata;
   if ((rv = jtagmkII_getsync(pgm, EMULATOR_MODE_SPI)) != 0) {
     if (rv != JTAGII_GETSYNC_FAIL_GRACEFUL)
-        msg_info("%s: failed to sync with the JTAG ICE mkII in ISP mode\n",
-                        progname);
+        pmsg_info("failed to sync with the JTAG ICE mkII in ISP mode\n");
     pgm->cookie = mycookie;
     return -1;
   }
@@ -3423,7 +3316,7 @@ static void stk500v2_jtagmkII_close(PROGRAMMER * pgm)
 {
   void *mycookie;
 
-  msg_notice2("%s: stk500v2_jtagmkII_close()\n", progname);
+  pmsg_notice2("stk500v2_jtagmkII_close()\n");
 
   mycookie = pgm->cookie;
   pgm->cookie = PDATA(pgm)->chained_pdata;
@@ -3439,7 +3332,7 @@ static void stk500v2_jtag3_close(PROGRAMMER * pgm)
 {
   void *mycookie;
 
-  msg_notice2("%s: stk500v2_jtag3_close()\n", progname);
+  pmsg_notice2("stk500v2_jtag3_close()\n");
 
   mycookie = pgm->cookie;
   pgm->cookie = PDATA(pgm)->chained_pdata;
@@ -3462,7 +3355,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   void *mycookie;
 
-  msg_notice2("%s: stk500v2_dragon_isp_open()\n", progname);
+  pmsg_notice2("stk500v2_dragon_isp_open()\n");
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -3490,7 +3383,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    msg_info("avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support\n");
     return -1;
 #endif
   }
@@ -3508,8 +3401,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
   mycookie = pgm->cookie;
   pgm->cookie = PDATA(pgm)->chained_pdata;
   if (jtagmkII_getsync(pgm, EMULATOR_MODE_SPI) != 0) {
-    msg_info("%s: failed to sync with the AVR Dragon in ISP mode\n",
-            progname);
+    pmsg_info("failed to sync with the AVR Dragon in ISP mode\n");
     pgm->cookie = mycookie;
     return -1;
   }
@@ -3539,7 +3431,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
 static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
 
-  msg_notice2("%s: stk500v2_dragon_hv_open()\n", progname);
+  pmsg_notice2("stk500v2_dragon_hv_open()\n");
 
   /*
    * The JTAG ICE mkII always starts with a baud rate of 19200 Bd upon
@@ -3567,7 +3459,7 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_MKII;
     pgm->fd.usb.eep = 0;           /* no seperate EP for events */
 #else
-    msg_info("avrdude was compiled without usb support.\n");
+    msg_info("avrdude was compiled without usb support\n");
     return -1;
 #endif
   }
@@ -3585,8 +3477,7 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
   PROGRAMMER *pgmcp = pgm_dup(pgm);
   pgmcp->cookie = PDATA(pgm)->chained_pdata;
   if (jtagmkII_getsync(pgmcp, EMULATOR_MODE_HV) != 0) {
-    msg_info("%s: failed to sync with the AVR Dragon in HV mode\n",
-            progname);
+    pmsg_info("failed to sync with the AVR Dragon in HV mode\n");
     pgm_free(pgmcp);
     return -1;
   }
@@ -3615,7 +3506,7 @@ static int stk500v2_jtag3_open(PROGRAMMER *pgm, const char *port) {
   void *mycookie;
   int rv;
 
-  msg_notice2("%s: stk500v2_jtag3_open()\n", progname);
+  pmsg_notice2("stk500v2_jtag3_open()\n");
 
   if (jtag3_open_common(pgm, port) < 0)
     return -1;
@@ -3624,8 +3515,7 @@ static int stk500v2_jtag3_open(PROGRAMMER *pgm, const char *port) {
   pgm->cookie = PDATA(pgm)->chained_pdata;
   if ((rv = jtag3_getsync(pgm, 42)) != 0) {
     if (rv != JTAGII_GETSYNC_FAIL_GRACEFUL)
-        msg_info("%s: failed to sync with the JTAGICE3 in ISP mode\n",
-                        progname);
+        pmsg_info("failed to sync with the JTAGICE3 in ISP mode\n");
     pgm->cookie = mycookie;
     return -1;
   }
@@ -3658,8 +3548,7 @@ static int stk600_xprog_command(const PROGRAMMER *pgm, unsigned char *b,
         s = cmdsize;
 
     if ((newb = malloc(s + 1)) == 0) {
-        msg_info("%s: stk600_xprog_cmd(): out of memory\n",
-                progname);
+        pmsg_info("stk600_xprog_cmd(): out of memory\n");
         return -1;
     }
 
@@ -3690,14 +3579,12 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
 
     if (!use_tpi) {
         if (p->nvm_base == 0) {
-            msg_info("%s: stk600_xprog_program_enable(): no nvm_base parameter for PDI device\n",
-                            progname);
+            pmsg_info("stk600_xprog_program_enable(): no nvm_base parameter for PDI device\n");
             return -1;
         }
         if ((mem = avr_locate_mem(p, "eeprom")) != NULL) {
             if (mem->page_size <= 1) {
-                msg_info("%s: stk600_xprog_program_enable(): no EEPROM page_size parameter for PDI device\n",
-                                progname);
+                pmsg_info("stk600_xprog_program_enable(): no EEPROM page_size parameter for PDI device\n");
                 return -1;
             }
             eepagesize = mem->page_size;
@@ -3707,15 +3594,13 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
     buf[0] = CMD_XPROG_SETMODE;
     buf[1] = use_tpi? XPRG_MODE_TPI: XPRG_MODE_PDI;
     if (stk500v2_command(pgm, buf, 2, sizeof(buf)) < 0) {
-        msg_info("%s: stk600_xprog_program_enable(): CMD_XPROG_SETMODE(XPRG_MODE_%s) failed\n",
-                        progname, use_tpi? "TPI": "PDI");
+        pmsg_info("stk600_xprog_program_enable(): CMD_XPROG_SETMODE(XPRG_MODE_%s) failed\n", use_tpi? "TPI": "PDI");
         return -1;
     }
 
     buf[0] = XPRG_CMD_ENTER_PROGMODE;
     if (stk600_xprog_command(pgm, buf, 1, 2) < 0) {
-        msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_ENTER_PROGMODE failed\n",
-                        progname);
+        pmsg_info("stk600_xprog_program_enable(): XPRG_CMD_ENTER_PROGMODE failed\n");
         return -1;
     }
 
@@ -3731,8 +3616,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[1] = XPRG_PARAM_TPI_3;
         buf[2] = 51;
         if (stk600_xprog_command(pgm, buf, 3, 2) < 0) {
-            msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_3) failed\n",
-                            progname);
+            pmsg_info("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_3) failed\n");
             return -1;
         }
 
@@ -3740,8 +3624,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[1] = XPRG_PARAM_TPI_4;
         buf[2] = 50;
         if (stk600_xprog_command(pgm, buf, 3, 2) < 0) {
-            msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_4) failed\n",
-                            progname);
+            pmsg_info("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_TPI_4) failed\n");
             return -1;
         }
     } else {
@@ -3760,8 +3643,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
         buf[4] = nvm_base >> 8;
         buf[5] = nvm_base;
         if (stk600_xprog_command(pgm, buf, 6, 2) < 0) {
-            msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_NVMBASE) failed\n",
-                            progname);
+            pmsg_info("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_NVMBASE) failed\n");
             return -1;
         }
 
@@ -3771,8 +3653,7 @@ static int stk600_xprog_program_enable(const PROGRAMMER *pgm, const AVRPART *p) 
             buf[2] = eepagesize >> 8;
             buf[3] = eepagesize;
             if (stk600_xprog_command(pgm, buf, 4, 2) < 0) {
-                msg_info("%s: stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_EEPPAGESIZE) failed\n",
-                                progname);
+                pmsg_info("stk600_xprog_program_enable(): XPRG_CMD_SET_PARAM(XPRG_PARAM_EEPPAGESIZE) failed\n");
                 return -1;
             }
         }
@@ -3794,8 +3675,7 @@ static void stk600_xprog_disable(const PROGRAMMER *pgm) {
 
     buf[0] = XPRG_CMD_LEAVE_PROGMODE;
     if (stk600_xprog_command(pgm, buf, 1, 2) < 0) {
-        msg_info("%s: stk600_xprog_program_disable(): XPRG_CMD_LEAVE_PROGMODE failed\n",
-                        progname);
+        pmsg_info("stk600_xprog_program_disable(): XPRG_CMD_LEAVE_PROGMODE failed\n");
     }
 }
 
@@ -3832,8 +3712,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(mem->desc, "userrow") == 0) {
         memcode = XPRG_MEM_TYPE_USERSIG;
     } else {
-        msg_info("%s: stk600_xprog_write_byte(): unknown memory \"%s\"\n",
-                        progname, mem->desc);
+        pmsg_info("stk600_xprog_write_byte(): unknown memory %s\n", mem->desc);
         return -1;
     }
     addr += mem->offset;
@@ -3846,8 +3725,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
         b[4] = mem->offset >> 8;
         b[5] = mem->offset + 1;
         if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    msg_info("%s: stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CONFIG) failed\n",
-                            progname);
+	    pmsg_info("stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CONFIG) failed\n");
 	    return -1;
 	}
     }
@@ -3873,8 +3751,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
     b[8] = write_size;
     b[9] = data;
     if (stk600_xprog_command(pgm, b, 9 + write_size, 2) < 0) {
-        msg_info("%s: stk600_xprog_write_byte(): XPRG_CMD_WRITE_MEM failed\n",
-                        progname);
+        pmsg_info("stk600_xprog_write_byte(): XPRG_CMD_WRITE_MEM failed\n");
         return -1;
     }
     return 0;
@@ -3908,8 +3785,7 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
                strcmp(mem->desc, "userrow") == 0) {
         b[1] = XPRG_MEM_TYPE_USERSIG;
     } else {
-        msg_info("%s: stk600_xprog_read_byte(): unknown memory \"%s\"\n",
-                        progname, mem->desc);
+        pmsg_info("stk600_xprog_read_byte(): unknown memory %s\n", mem->desc);
         return -1;
     }
     addr += mem->offset;
@@ -3922,8 +3798,7 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
     b[6] = 0;
     b[7] = 1;
     if (stk600_xprog_command(pgm, b, 8, 3) < 0) {
-        msg_info("%s: stk600_xprog_read_byte(): XPRG_CMD_READ_MEM failed\n",
-                        progname);
+        pmsg_info("stk600_xprog_read_byte(): XPRG_CMD_READ_MEM failed\n");
         return -1;
     }
     *value = b[2];
@@ -3984,16 +3859,14 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(mem->desc, "userrow") == 0) {
         memtype = XPRG_MEM_TYPE_USERSIG;
     } else {
-        msg_info("%s: stk600_xprog_paged_load(): unknown paged memory \"%s\"\n",
-                        progname, mem->desc);
+        pmsg_info("stk600_xprog_paged_load(): unknown paged memory %s\n", mem->desc);
         return -1;
     }
     offset = addr;
     addr += mem->offset;
 
     if ((b = malloc(page_size + 2)) == NULL) {
-	msg_info("%s: stk600_xprog_paged_load(): out of memory\n",
-                        progname);
+	pmsg_info("stk600_xprog_paged_load(): out of memory\n");
         return -1;
     }
 
@@ -4015,8 +3888,7 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
 	b[6] = page_size >> 8;
 	b[7] = page_size;
 	if (stk600_xprog_command(pgm, b, 8, page_size + 2) < 0) {
-	    msg_info("%s: stk600_xprog_paged_load(): XPRG_CMD_READ_MEM failed\n",
-                            progname);
+	    pmsg_info("stk600_xprog_paged_load(): XPRG_CMD_READ_MEM failed\n");
 	    free(b);
 	    return -1;
 	}
@@ -4050,8 +3922,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
      * transfer.
      */
     if (page_size > 512) {
-	msg_info("%s: stk600_xprog_paged_write(): cannot handle page size > 512\n",
-                        progname);
+	pmsg_info("stk600_xprog_paged_write(): cannot handle page size > 512\n");
 	return -1;
     }
 
@@ -4099,16 +3970,14 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
         memtype = XPRG_MEM_TYPE_USERSIG;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
     } else {
-        msg_info("%s: stk600_xprog_paged_write(): unknown paged memory \"%s\"\n",
-                        progname, mem->desc);
+        pmsg_info("stk600_xprog_paged_write(): unknown paged memory %s\n", mem->desc);
         return -1;
     }
     offset = addr;
     addr += mem->offset;
 
     if ((b = malloc(page_size + 9)) == NULL) {
-	msg_info("%s: stk600_xprog_paged_write(): out of memory\n",
-                        progname);
+	pmsg_info("stk600_xprog_paged_write(): out of memory\n");
         return -1;
     }
 
@@ -4133,8 +4002,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 	     * erase page / write page bits in the final chunk helps.
 	     */
 	    if (page_size % 256 != 0) {
-		msg_info("%s: stk600_xprog_paged_write(): page size not multiple of 256\n",
-                                progname);
+		pmsg_info("stk600_xprog_paged_write(): page size not multiple of 256\n");
 		free(b);
 		return -1;
 	    }
@@ -4157,8 +4025,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 		b[8] = 0;
 		memcpy(b + 9, mem->buf + offset, writesize);
 		if (stk600_xprog_command(pgm, b, 256 + 9, 2) < 0) {
-		    msg_info("%s: stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n",
-                                    progname);
+		    pmsg_info("stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n");
 		    free(b);
 		    return -1;
 		}
@@ -4191,8 +4058,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 	    b[8] = page_size;
 	    memcpy(b + 9, mem->buf + offset, writesize);
 	    if (stk600_xprog_command(pgm, b, page_size + 9, 2) < 0) {
-		msg_info("%s: stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n",
-                                progname);
+		pmsg_info("stk600_xprog_paged_write(): XPRG_CMD_WRITE_MEM failed\n");
 		free(b);
 		return -1;
 	    }
@@ -4216,8 +4082,7 @@ static int stk600_xprog_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     if (p->prog_modes & PM_TPI) {
         if ((mem = avr_locate_mem(p, "flash")) == NULL) {
-            msg_info("%s: stk600_xprog_chip_erase(): no FLASH definition found for TPI device\n",
-                            progname);
+            pmsg_info("stk600_xprog_chip_erase(): no FLASH definition found for TPI device\n");
             return -1;
         }
         addr = mem->offset + 1;
@@ -4230,8 +4095,7 @@ static int stk600_xprog_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     b[4] = addr >> 8;
     b[5] = addr;
     if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    msg_info("%s: stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CHIP) failed\n",
-                            progname);
+	    pmsg_info("stk600_xprog_chip_erase(): XPRG_CMD_ERASE(XPRG_ERASE_CHIP) failed\n");
 	    return -1;
 	}
     return 0;
@@ -4256,8 +4120,7 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
                strcmp(m->desc, "userrow") == 0) {
       b[1] = XPRG_ERASE_USERSIG;
     } else {
-      msg_info("%s: stk600_xprog_page_erase(): unknown paged memory \"%s\"\n",
-                      progname, m->desc);
+      pmsg_info("stk600_xprog_page_erase(): unknown paged memory %s\n", m->desc);
       return -1;
     }
     addr += m->offset;
@@ -4267,8 +4130,7 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
     b[4] = addr >> 8;
     b[5] = addr;
     if (stk600_xprog_command(pgm, b, 6, 2) < 0) {
-	    msg_info("%s: stk600_xprog_page_erase(): XPRG_CMD_ERASE(%d) failed\n",
-                            progname, b[1]);
+	    pmsg_info("stk600_xprog_page_erase(): XPRG_CMD_ERASE(%d) failed\n", b[1]);
 	    return -1;
 	}
     return 0;

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -127,7 +127,7 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
             // On Linux, libhidapi does not seem to return the HID usage from the report descriptor.
             // We try to infer the board from the part information, until somebody fixes libhidapi.
             // To use this workaround, the -F option is required.
-            msg_info("%s: WARNING: Cannot detect board type (HID usage is 0)\n", progname);
+            pmsg_info("cannot detect board type (HID usage is 0)\n");
 
             AVRMEM* mem = avr_locate_mem(p, "flash");
             if (mem == NULL)
@@ -147,8 +147,7 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
         }
         else
         {
-            msg_info("%s: ERROR: Teensy board not supported (HID usage 0x%02X)\n",
-                progname, pdata->hid_usage);
+            pmsg_info("Teensy board not supported (HID usage 0x%02X)\n", pdata->hid_usage);
             return -1;
         }
     }
@@ -158,21 +157,21 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
 
 static void teensy_dump_device_info(pdata_t* pdata)
 {
-    msg_notice("%s: HID usage: 0x%02X\n", progname, pdata->hid_usage);
-    msg_notice("%s: Board: %s\n", progname, pdata->board);
-    msg_notice("%s: Available flash size: %u\n", progname, pdata->flash_size);
-    msg_notice("%s: Page size: %u\n", progname, pdata->page_size);
-    msg_notice("%s: Signature: 0x%02X%02X%02X\n", progname,
-        pdata->sig_bytes[0], pdata->sig_bytes[1], pdata->sig_bytes[2]);
+    pmsg_notice("HID usage: 0x%02X\n", pdata->hid_usage);
+    pmsg_notice("Board: %s\n", pdata->board);
+    pmsg_notice("Available flash size: %u\n", pdata->flash_size);
+    pmsg_notice("Page size: %u\n", pdata->page_size);
+    pmsg_notice("Signature: 0x%02X%02X%02X\n",
+      pdata->sig_bytes[0], pdata->sig_bytes[1], pdata->sig_bytes[2]);
 }
 
 static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* buffer, uint32_t size)
 {
-    msg_debug("%s: teensy_write_page(address=0x%06X, size=%d)\n", progname, address, size);
+    pmsg_debug("teensy_write_page(address=0x%06X, size=%d)\n", address, size);
 
     if (size > pdata->page_size)
     {
-        msg_info("%s: ERROR: Invalid page size: %u\n", progname, pdata->page_size);
+        pmsg_info("invalid page size: %u\n", pdata->page_size);
         return -1;
     }
 
@@ -180,7 +179,7 @@ static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* bu
     uint8_t* report = (uint8_t*)malloc(report_size);
     if (report == NULL)
     {
-        msg_info("%s: ERROR: Failed to allocate memory\n", progname);
+        pmsg_info("failed to allocate memory\n");
         return -1;
     }
 
@@ -207,8 +206,7 @@ static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* bu
     free(report);
     if (result < 0)
     {
-        msg_info("%s: WARNING: Failed to write page: %ls\n",
-            progname, hid_error(pdata->hid_handle));
+        pmsg_info("failed to write page: %ls\n", hid_error(pdata->hid_handle));
         return result;
     }
 
@@ -217,7 +215,7 @@ static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* bu
 
 static int teensy_erase_flash(pdata_t* pdata)
 {
-    msg_debug("%s: teensy_erase_flash()\n", progname);
+    pmsg_debug("teensy_erase_flash()\n");
 
     // Write a dummy page at address 0 to explicitly erase the flash.
     return teensy_write_page(pdata, 0, NULL, 0);
@@ -225,7 +223,7 @@ static int teensy_erase_flash(pdata_t* pdata)
 
 static int teensy_reboot(pdata_t* pdata)
 {
-    msg_debug("%s: teensy_reboot()\n", progname);
+    pmsg_debug("teensy_reboot()\n");
 
     // Write a dummy page at address -1 to reboot the Teensy.
     return teensy_write_page(pdata, 0xFFFFFFFF, NULL, 0);
@@ -235,11 +233,11 @@ static int teensy_reboot(pdata_t* pdata)
 
 static void teensy_setup(PROGRAMMER* pgm)
 {
-    msg_debug("%s: teensy_setup()\n", progname);
+    pmsg_debug("teensy_setup()\n");
 
     if ((pgm->cookie = malloc(sizeof(pdata_t))) == NULL)
     {
-        msg_info("%s: ERROR: Failed to allocate memory\n", progname);
+        pmsg_info("failed to allocate memory\n");
         exit(1);
     }
 
@@ -248,12 +246,12 @@ static void teensy_setup(PROGRAMMER* pgm)
 
 static void teensy_teardown(PROGRAMMER* pgm)
 {
-    msg_debug("%s: teensy_teardown()\n", progname);
+    pmsg_debug("teensy_teardown()\n");
     free(pgm->cookie);
 }
 
 static int teensy_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
-    msg_debug("%s: teensy_initialize()\n", progname);
+    pmsg_debug("teensy_initialize()\n");
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -267,15 +265,15 @@ static int teensy_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static void teensy_display(const PROGRAMMER *pgm, const char *prefix) {
-    msg_debug("%s: teensy_display()\n", progname);
+    pmsg_debug("teensy_display()\n");
 }
 
 static void teensy_powerup(const PROGRAMMER *pgm) {
-    msg_debug("%s: teensy_powerup()\n", progname);
+    pmsg_debug("teensy_powerup()\n");
 }
 
 static void teensy_powerdown(const PROGRAMMER *pgm) {
-    msg_debug("%s: teensy_powerdown()\n", progname);
+    pmsg_debug("teensy_powerdown()\n");
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -293,24 +291,24 @@ static void teensy_powerdown(const PROGRAMMER *pgm) {
 }
 
 static void teensy_enable(PROGRAMMER* pgm, const AVRPART *p) {
-    msg_debug("%s: teensy_enable()\n", progname);
+    pmsg_debug("teensy_enable()\n");
 }
 
 static void teensy_disable(const PROGRAMMER *pgm) {
-    msg_debug("%s: teensy_disable()\n", progname);
+    pmsg_debug("teensy_disable()\n");
 }
 
 static int teensy_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-    msg_debug("%s: teensy_program_enable()\n", progname);
+    pmsg_debug("teensy_program_enable()\n");
     return 0;
 }
 
 static int teensy_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
-    msg_debug("%s: teensy_read_sig_bytes()\n", progname);
+    pmsg_debug("teensy_read_sig_bytes()\n");
 
     if (mem->size < 3)
     {
-        msg_info("%s: memory size too small for read_sig_bytes\n", progname);
+        pmsg_info("memory size too small for read_sig_bytes\n");
         return -1;
     }
 
@@ -321,7 +319,7 @@ static int teensy_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
 }
 
 static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
-    msg_debug("%s: teensy_chip_erase()\n", progname);
+    pmsg_debug("teensy_chip_erase()\n");
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -332,7 +330,7 @@ static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int teensy_open(PROGRAMMER *pgm, const char *port) {
-    msg_debug("%s: teensy_open(\"%s\")\n", progname, port);
+    pmsg_debug("teensy_open(\"%s\")\n", port);
 
     pdata_t* pdata = PDATA(pgm);
     const char *bus_name = NULL;
@@ -360,7 +358,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
 
     if (port != NULL && dev_name == NULL)
     {
-        msg_info("%s: ERROR: Invalid -P value: '%s'\n", progname, port);
+        pmsg_info("invalid -P value: '%s'\n", port);
         msg_info("%sUse -P usb:bus:device\n", progbuf);
         return -1;
     }
@@ -375,8 +373,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
         pid = *(int*)(ldata(usbpid));
         if (lnext(usbpid))
         {
-            msg_info("%s: WARNING: using PID 0x%04x, ignoring remaining PIDs in list\n",
-                progname, pid);
+            pmsg_info("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
         }
     }
 
@@ -396,7 +393,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
                 pdata->hid_handle = hid_open_path(device->path);
                 if (pdata->hid_handle == NULL)
                 {
-                    msg_info("%s: ERROR: Found HID device, but hid_open_path() failed.\n", progname);
+                    pmsg_info("found HID device, but hid_open_path() failed\n");
                 }
                 else
                 {
@@ -416,16 +413,15 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
             {
                 if (pdata->wait_timout < 0)
                 {
-                    msg_info("%s: No device found, waiting for device to be plugged in...\n", progname);
+                    pmsg_info("no device found, waiting for device to be plugged in ...\n");
                 }
                 else
                 {
-                    msg_info("%s: No device found, waiting %d seconds for device to be plugged in...\n",
-                        progname,
+                    pmsg_info("no device found, waiting %d seconds for device to be plugged in ...\n",
                         pdata->wait_timout);
                 }
 
-                msg_info("%s: Press CTRL-C to terminate.\n", progname);
+                pmsg_info("press CTRL-C to terminate\n");
                 show_retry_message = false;
             }
 
@@ -441,8 +437,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
 
     if (!pdata->hid_handle)
     {
-        msg_info("%s: ERROR: Could not find device with Teensy bootloader (%04X:%04X)\n",
-            progname, vid, pid);
+        pmsg_info("could not find device with Teensy bootloader (%04X:%04X)\n", vid, pid);
         return -1;
     }
 
@@ -451,7 +446,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
 
 static void teensy_close(PROGRAMMER* pgm)
 {
-    msg_debug("%s: teensy_close()\n", progname);
+    pmsg_debug("teensy_close()\n");
 
     pdata_t* pdata = PDATA(pgm);
     if (pdata->hid_handle != NULL)
@@ -464,8 +459,7 @@ static void teensy_close(PROGRAMMER* pgm)
 static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char* value)
 {
-    msg_debug("%s: teensy_read_byte(desc=%s, addr=0x%0X)\n",
-        progname, mem->desc, addr);
+    pmsg_debug("teensy_read_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
 
     if (strcmp(mem->desc, "lfuse") == 0 ||
         strcmp(mem->desc, "hfuse") == 0 ||
@@ -477,7 +471,7 @@ static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
     }
     else
     {
-        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
+        pmsg_info("unsupported memory type: %s\n", mem->desc);
         return -1;
     }
 }
@@ -485,8 +479,7 @@ static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
 static int teensy_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char value)
 {
-    msg_debug("%s: teensy_write_byte(desc=%s, addr=0x%0X)\n",
-        progname, mem->desc, addr);
+    pmsg_debug("teensy_write_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
     return -1;
 }
 
@@ -494,8 +487,7 @@ static int teensy_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    msg_debug("%s: teensy_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
-        progname, page_size, addr, n_bytes);
+    pmsg_debug("teensy_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
     return -1;
 }
 
@@ -503,8 +495,7 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    msg_debug("%s: teensy_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
-        progname, page_size, addr, n_bytes);
+    pmsg_debug("teensy_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
 
     if (strcmp(mem->desc, "flash") == 0)
     {
@@ -512,13 +503,13 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
         if (n_bytes > page_size)
         {
-            msg_info("%s: Buffer size (%u) exceeds page size (%u)\n", progname, n_bytes, page_size);
+            pmsg_info("buffer size %u exceeds page size %u\n", n_bytes, page_size);
             return -1;
         }
 
         if (addr + n_bytes > pdata->flash_size)
         {
-            msg_info("%s: Program size (%u) exceeds flash size (%u)\n", progname, addr + n_bytes, pdata->flash_size);
+            pmsg_info("program size %u exceeds flash size %u\n", addr + n_bytes, pdata->flash_size);
             return -1;
         }
 
@@ -551,13 +542,13 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     }
     else
     {
-        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
+        pmsg_info("unsupported memory type: %s\n", mem->desc);
         return -1;
     }
 }
 
 static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
-    msg_debug("%s: teensy_parseextparams()\n", progname);
+    pmsg_debug("teensy_parseextparams()\n");
 
     pdata_t* pdata = PDATA(pgm);
     for (LNODEID node = lfirst(xparams); node != NULL; node = lnext(node))
@@ -576,7 +567,7 @@ static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
         }
         else
         {
-            msg_info("%s: Invalid extended parameter '%s'\n", progname, param);
+            pmsg_info("invalid extended parameter '%s'\n", param);
             return -1;
         }
     }
@@ -612,7 +603,7 @@ void teensy_initpgm(PROGRAMMER *pgm) {
 
  // Give a proper error if we were not compiled with libhidapi
 static int teensy_nousb_open(PROGRAMMER *pgm, const char *name) {
-    msg_info("%s: error: No HID support. Please compile again with libhidapi installed.\n", progname);
+    pmsg_info("no HID support; please compile again with libhidapi installed\n");
     return -1;
 }
 

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -127,12 +127,12 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
             // On Linux, libhidapi does not seem to return the HID usage from the report descriptor.
             // We try to infer the board from the part information, until somebody fixes libhidapi.
             // To use this workaround, the -F option is required.
-            avrdude_message(MSG_INFO, "%s: WARNING: Cannot detect board type (HID usage is 0)\n", progname);
+            msg_info("%s: WARNING: Cannot detect board type (HID usage is 0)\n", progname);
 
             AVRMEM* mem = avr_locate_mem(p, "flash");
             if (mem == NULL)
             {
-                avrdude_message(MSG_INFO, "No flash memory for part %s\n", p->desc);
+                msg_info("No flash memory for part %s\n", p->desc);
                 return -1;
             }
 
@@ -147,7 +147,7 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
         }
         else
         {
-            avrdude_message(MSG_INFO, "%s: ERROR: Teensy board not supported (HID usage 0x%02X)\n",
+            msg_info("%s: ERROR: Teensy board not supported (HID usage 0x%02X)\n",
                 progname, pdata->hid_usage);
             return -1;
         }
@@ -158,21 +158,21 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
 
 static void teensy_dump_device_info(pdata_t* pdata)
 {
-    avrdude_message(MSG_NOTICE, "%s: HID usage: 0x%02X\n", progname, pdata->hid_usage);
-    avrdude_message(MSG_NOTICE, "%s: Board: %s\n", progname, pdata->board);
-    avrdude_message(MSG_NOTICE, "%s: Available flash size: %u\n", progname, pdata->flash_size);
-    avrdude_message(MSG_NOTICE, "%s: Page size: %u\n", progname, pdata->page_size);
-    avrdude_message(MSG_NOTICE, "%s: Signature: 0x%02X%02X%02X\n", progname,
+    msg_notice("%s: HID usage: 0x%02X\n", progname, pdata->hid_usage);
+    msg_notice("%s: Board: %s\n", progname, pdata->board);
+    msg_notice("%s: Available flash size: %u\n", progname, pdata->flash_size);
+    msg_notice("%s: Page size: %u\n", progname, pdata->page_size);
+    msg_notice("%s: Signature: 0x%02X%02X%02X\n", progname,
         pdata->sig_bytes[0], pdata->sig_bytes[1], pdata->sig_bytes[2]);
 }
 
 static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* buffer, uint32_t size)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_write_page(address=0x%06X, size=%d)\n", progname, address, size);
+    msg_debug("%s: teensy_write_page(address=0x%06X, size=%d)\n", progname, address, size);
 
     if (size > pdata->page_size)
     {
-        avrdude_message(MSG_INFO, "%s: ERROR: Invalid page size: %u\n", progname, pdata->page_size);
+        msg_info("%s: ERROR: Invalid page size: %u\n", progname, pdata->page_size);
         return -1;
     }
 
@@ -180,7 +180,7 @@ static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* bu
     uint8_t* report = (uint8_t*)malloc(report_size);
     if (report == NULL)
     {
-        avrdude_message(MSG_INFO, "%s: ERROR: Failed to allocate memory\n", progname);
+        msg_info("%s: ERROR: Failed to allocate memory\n", progname);
         return -1;
     }
 
@@ -207,7 +207,7 @@ static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* bu
     free(report);
     if (result < 0)
     {
-        avrdude_message(MSG_INFO, "%s: WARNING: Failed to write page: %ls\n",
+        msg_info("%s: WARNING: Failed to write page: %ls\n",
             progname, hid_error(pdata->hid_handle));
         return result;
     }
@@ -217,7 +217,7 @@ static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* bu
 
 static int teensy_erase_flash(pdata_t* pdata)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_erase_flash()\n", progname);
+    msg_debug("%s: teensy_erase_flash()\n", progname);
 
     // Write a dummy page at address 0 to explicitly erase the flash.
     return teensy_write_page(pdata, 0, NULL, 0);
@@ -225,7 +225,7 @@ static int teensy_erase_flash(pdata_t* pdata)
 
 static int teensy_reboot(pdata_t* pdata)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_reboot()\n", progname);
+    msg_debug("%s: teensy_reboot()\n", progname);
 
     // Write a dummy page at address -1 to reboot the Teensy.
     return teensy_write_page(pdata, 0xFFFFFFFF, NULL, 0);
@@ -235,11 +235,11 @@ static int teensy_reboot(pdata_t* pdata)
 
 static void teensy_setup(PROGRAMMER* pgm)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_setup()\n", progname);
+    msg_debug("%s: teensy_setup()\n", progname);
 
     if ((pgm->cookie = malloc(sizeof(pdata_t))) == NULL)
     {
-        avrdude_message(MSG_INFO, "%s: ERROR: Failed to allocate memory\n", progname);
+        msg_info("%s: ERROR: Failed to allocate memory\n", progname);
         exit(1);
     }
 
@@ -248,12 +248,12 @@ static void teensy_setup(PROGRAMMER* pgm)
 
 static void teensy_teardown(PROGRAMMER* pgm)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_teardown()\n", progname);
+    msg_debug("%s: teensy_teardown()\n", progname);
     free(pgm->cookie);
 }
 
 static int teensy_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_initialize()\n", progname);
+    msg_debug("%s: teensy_initialize()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -267,15 +267,15 @@ static int teensy_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static void teensy_display(const PROGRAMMER *pgm, const char *prefix) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_display()\n", progname);
+    msg_debug("%s: teensy_display()\n", progname);
 }
 
 static void teensy_powerup(const PROGRAMMER *pgm) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_powerup()\n", progname);
+    msg_debug("%s: teensy_powerup()\n", progname);
 }
 
 static void teensy_powerdown(const PROGRAMMER *pgm) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_powerdown()\n", progname);
+    msg_debug("%s: teensy_powerdown()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -293,24 +293,24 @@ static void teensy_powerdown(const PROGRAMMER *pgm) {
 }
 
 static void teensy_enable(PROGRAMMER* pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_enable()\n", progname);
+    msg_debug("%s: teensy_enable()\n", progname);
 }
 
 static void teensy_disable(const PROGRAMMER *pgm) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_disable()\n", progname);
+    msg_debug("%s: teensy_disable()\n", progname);
 }
 
 static int teensy_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_program_enable()\n", progname);
+    msg_debug("%s: teensy_program_enable()\n", progname);
     return 0;
 }
 
 static int teensy_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_read_sig_bytes()\n", progname);
+    msg_debug("%s: teensy_read_sig_bytes()\n", progname);
 
     if (mem->size < 3)
     {
-        avrdude_message(MSG_INFO, "%s: memory size too small for read_sig_bytes\n", progname);
+        msg_info("%s: memory size too small for read_sig_bytes\n", progname);
         return -1;
     }
 
@@ -321,7 +321,7 @@ static int teensy_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
 }
 
 static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_chip_erase()\n", progname);
+    msg_debug("%s: teensy_chip_erase()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
 
@@ -332,7 +332,7 @@ static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int teensy_open(PROGRAMMER *pgm, const char *port) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_open(\"%s\")\n", progname, port);
+    msg_debug("%s: teensy_open(\"%s\")\n", progname, port);
 
     pdata_t* pdata = PDATA(pgm);
     const char *bus_name = NULL;
@@ -360,8 +360,8 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
 
     if (port != NULL && dev_name == NULL)
     {
-        avrdude_message(MSG_INFO, "%s: ERROR: Invalid -P value: '%s'\n", progname, port);
-        avrdude_message(MSG_INFO, "%sUse -P usb:bus:device\n", progbuf);
+        msg_info("%s: ERROR: Invalid -P value: '%s'\n", progname, port);
+        msg_info("%sUse -P usb:bus:device\n", progbuf);
         return -1;
     }
 
@@ -375,7 +375,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
         pid = *(int*)(ldata(usbpid));
         if (lnext(usbpid))
         {
-            avrdude_message(MSG_INFO, "%s: WARNING: using PID 0x%04x, ignoring remaining PIDs in list\n",
+            msg_info("%s: WARNING: using PID 0x%04x, ignoring remaining PIDs in list\n",
                 progname, pid);
         }
     }
@@ -396,7 +396,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
                 pdata->hid_handle = hid_open_path(device->path);
                 if (pdata->hid_handle == NULL)
                 {
-                    avrdude_message(MSG_INFO, "%s: ERROR: Found HID device, but hid_open_path() failed.\n", progname);
+                    msg_info("%s: ERROR: Found HID device, but hid_open_path() failed.\n", progname);
                 }
                 else
                 {
@@ -416,16 +416,16 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
             {
                 if (pdata->wait_timout < 0)
                 {
-                    avrdude_message(MSG_INFO, "%s: No device found, waiting for device to be plugged in...\n", progname);
+                    msg_info("%s: No device found, waiting for device to be plugged in...\n", progname);
                 }
                 else
                 {
-                    avrdude_message(MSG_INFO, "%s: No device found, waiting %d seconds for device to be plugged in...\n",
+                    msg_info("%s: No device found, waiting %d seconds for device to be plugged in...\n",
                         progname,
                         pdata->wait_timout);
                 }
 
-                avrdude_message(MSG_INFO, "%s: Press CTRL-C to terminate.\n", progname);
+                msg_info("%s: Press CTRL-C to terminate.\n", progname);
                 show_retry_message = false;
             }
 
@@ -441,7 +441,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
 
     if (!pdata->hid_handle)
     {
-        avrdude_message(MSG_INFO, "%s: ERROR: Could not find device with Teensy bootloader (%04X:%04X)\n",
+        msg_info("%s: ERROR: Could not find device with Teensy bootloader (%04X:%04X)\n",
             progname, vid, pid);
         return -1;
     }
@@ -451,7 +451,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
 
 static void teensy_close(PROGRAMMER* pgm)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_close()\n", progname);
+    msg_debug("%s: teensy_close()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
     if (pdata->hid_handle != NULL)
@@ -464,7 +464,7 @@ static void teensy_close(PROGRAMMER* pgm)
 static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char* value)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_read_byte(desc=%s, addr=0x%0X)\n",
+    msg_debug("%s: teensy_read_byte(desc=%s, addr=0x%0X)\n",
         progname, mem->desc, addr);
 
     if (strcmp(mem->desc, "lfuse") == 0 ||
@@ -477,7 +477,7 @@ static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
     }
     else
     {
-        avrdude_message(MSG_INFO, "%s: Unsupported memory type: %s\n", progname, mem->desc);
+        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
         return -1;
     }
 }
@@ -485,7 +485,7 @@ static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
 static int teensy_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
     unsigned long addr, unsigned char value)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_write_byte(desc=%s, addr=0x%0X)\n",
+    msg_debug("%s: teensy_write_byte(desc=%s, addr=0x%0X)\n",
         progname, mem->desc, addr);
     return -1;
 }
@@ -494,7 +494,7 @@ static int teensy_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
+    msg_debug("%s: teensy_paged_load(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
         progname, page_size, addr, n_bytes);
     return -1;
 }
@@ -503,7 +503,7 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     unsigned int page_size,
     unsigned int addr, unsigned int n_bytes)
 {
-    avrdude_message(MSG_DEBUG, "%s: teensy_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
+    msg_debug("%s: teensy_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n",
         progname, page_size, addr, n_bytes);
 
     if (strcmp(mem->desc, "flash") == 0)
@@ -512,13 +512,13 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
         if (n_bytes > page_size)
         {
-            avrdude_message(MSG_INFO, "%s: Buffer size (%u) exceeds page size (%u)\n", progname, n_bytes, page_size);
+            msg_info("%s: Buffer size (%u) exceeds page size (%u)\n", progname, n_bytes, page_size);
             return -1;
         }
 
         if (addr + n_bytes > pdata->flash_size)
         {
-            avrdude_message(MSG_INFO, "%s: Program size (%u) exceeds flash size (%u)\n", progname, addr + n_bytes, pdata->flash_size);
+            msg_info("%s: Program size (%u) exceeds flash size (%u)\n", progname, addr + n_bytes, pdata->flash_size);
             return -1;
         }
 
@@ -551,13 +551,13 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     }
     else
     {
-        avrdude_message(MSG_INFO, "%s: Unsupported memory type: %s\n", progname, mem->desc);
+        msg_info("%s: Unsupported memory type: %s\n", progname, mem->desc);
         return -1;
     }
 }
 
 static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
-    avrdude_message(MSG_DEBUG, "%s: teensy_parseextparams()\n", progname);
+    msg_debug("%s: teensy_parseextparams()\n", progname);
 
     pdata_t* pdata = PDATA(pgm);
     for (LNODEID node = lfirst(xparams); node != NULL; node = lnext(node))
@@ -576,7 +576,7 @@ static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
         }
         else
         {
-            avrdude_message(MSG_INFO, "%s: Invalid extended parameter '%s'\n", progname, param);
+            msg_info("%s: Invalid extended parameter '%s'\n", progname, param);
             return -1;
         }
     }
@@ -612,7 +612,7 @@ void teensy_initpgm(PROGRAMMER *pgm) {
 
  // Give a proper error if we were not compiled with libhidapi
 static int teensy_nousb_open(PROGRAMMER *pgm, const char *name) {
-    avrdude_message(MSG_INFO, "%s: error: No HID support. Please compile again with libhidapi installed.\n", progname);
+    msg_info("%s: error: No HID support. Please compile again with libhidapi installed.\n", progname);
     return -1;
 }
 

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -359,7 +359,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
     if (port != NULL && dev_name == NULL)
     {
         pmsg_error("invalid -P value: '%s'\n", port);
-        pmsg_error("%sUse -P usb:bus:device\n", progbuf);
+        imsg_error("Use -P usb:bus:device\n");
         return -1;
     }
 

--- a/src/term.c
+++ b/src/term.c
@@ -1360,7 +1360,7 @@ static void update_progress_no_tty(int percent, double etime, const char *hdr, i
       msg_info(finish >= 0? "#": "-");
 
     if(percent == 100) {
-      msg_info(" | %d%% %0.2fs", etime, finish >= 0? 100: last);
+      msg_info(" | %d%% %0.2fs", finish >= 0? 100: last, etime);
       if(finish)
         msg_info("\n\n");
       done = 1;

--- a/src/term.c
+++ b/src/term.c
@@ -195,14 +195,14 @@ static int hexdump_buf(FILE *f, int startaddr, unsigned char *buf, int len) {
   char dst2[80];
 
   int addr = startaddr;
-  unsigned char *p = (unsigned char *)buf;
+  unsigned char *p = (unsigned char *) buf;
   while (len) {
     int n = 16;
     if (n > len)
       n = len;
     hexdump_line(dst1, p, n, 48);
     chardump_line(dst2, p, n, 16);
-    fprintf(stdout, "%04x  %s  |%s|\n", addr, dst1, dst2);
+    fprintf(f, "%04x  %s  |%s|\n", addr, dst1, dst2);
     len -= n;
     addr += n;
     p += n;
@@ -806,7 +806,7 @@ static int cmd_pgerase(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
 
   // terminal_message(MSG_INFO, "%s: %s page erase 0x%05x\n", progname, mem->desc, addr & ~(mem->page_size-1));
   if(pgm->page_erase_cached(pgm, p, mem, (unsigned int) addr) < 0) {
-    terminal_message(MSG_INFO, "%s (pgerase): %s page at 0x%05x could not be erased\n",
+    terminal_message(MSG_INFO, "%s (pgerase): unable to erase %s page at 0x%05x\n",
       progname, mem->desc, addr);
     return -1;
   }
@@ -883,7 +883,7 @@ static int cmd_vtarg(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     return -1;
   }
   if ((rc = pgm->set_vtarget(pgm, v)) != 0) {
-    terminal_message(MSG_INFO, "%s (vtarg): failed to set V[target] (rc = %d)\n",
+    terminal_message(MSG_INFO, "%s (vtarg): unable to set V[target] (rc = %d)\n",
       progname, rc);
     return -3;
   }
@@ -915,7 +915,7 @@ static int cmd_fosc(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
   else if (*endp == 'k' || *endp == 'K')
     v *= 1e3;
   if ((rc = pgm->set_fosc(pgm, v)) != 0) {
-    terminal_message(MSG_INFO, "%s (fosc): failed to set oscillator frequency (rc = %d)\n",
+    terminal_message(MSG_INFO, "%s (fosc): unable to set oscillator frequency (rc = %d)\n",
       progname, rc);
     return -3;
   }
@@ -940,7 +940,7 @@ static int cmd_sck(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
   }
   v *= 1e-6;			/* Convert from microseconds to seconds. */
   if ((rc = pgm->set_sck_period(pgm, v)) != 0) {
-    terminal_message(MSG_INFO, "%s (sck): failed to set SCK period (rc = %d)\n",
+    terminal_message(MSG_INFO, "%s (sck): unable to set SCK period (rc = %d)\n",
       progname, rc);
     return -3;
   }
@@ -981,7 +981,7 @@ static int cmd_varef(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     }
   }
   if ((rc = pgm->set_varef(pgm, chan, v)) != 0) {
-    terminal_message(MSG_INFO, "%s (varef): failed to set V[aref] (rc = %d)\n",
+    terminal_message(MSG_INFO, "%s (varef): unable to set V[aref] (rc = %d)\n",
       progname, rc);
     return -3;
   }
@@ -1223,7 +1223,7 @@ char *terminal_get_input(const char *prompt) {
   return input;
 #else
   char input[256];
-  printf("%s", prompt);
+  fprintf(stdout, "%s", prompt);
   if (fgets(input, sizeof(input), stdin))
   {
     /* FIXME: readline strips the '\n', should this too? */
@@ -1330,8 +1330,7 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
       hashes[i/2] = '#';
     hashes[50] = 0;
 
-    msg_info("\r%s | %s | %d%% %0.2fs",
-            header, hashes, showperc, etime);
+    msg_info("\r%s | %s | %d%% %0.2fs", header, hashes, showperc, etime);
     if(percent == 100) {
       if(finish)
         msg_info("\n\n");

--- a/src/term.c
+++ b/src/term.c
@@ -1309,7 +1309,7 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
   setvbuf(stderr, (char *) NULL, _IONBF, 0);
 
   if(hdr) {
-    avrdude_message(MSG_INFO, "\n");
+    msg_info("\n");
     last = done = 0;
     if(header)
       free(header);
@@ -1330,11 +1330,11 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
       hashes[i/2] = '#';
     hashes[50] = 0;
 
-    avrdude_message(MSG_INFO, "\r%s | %s | %d%% %0.2fs",
+    msg_info("\r%s | %s | %d%% %0.2fs",
             header, hashes, showperc, etime);
     if(percent == 100) {
       if(finish)
-        avrdude_message(MSG_INFO, "\n\n");
+        msg_info("\n\n");
       done = 1;
     }
   }
@@ -1351,18 +1351,18 @@ static void update_progress_no_tty(int percent, double etime, const char *hdr, i
   percent = percent > 100? 100: percent < 0? 0: percent;
 
   if(hdr) {
-    avrdude_message(MSG_INFO, "\n%s | ", hdr);
+    msg_info("\n%s | ", hdr);
     last = done = 0;
   }
 
   if(!done) {
     for(int cnt = percent/2; cnt > last/2; cnt--)
-      avrdude_message(MSG_INFO, finish >= 0? "#": "-");
+      msg_info(finish >= 0? "#": "-");
 
     if(percent == 100) {
-      avrdude_message(MSG_INFO, " | %d%% %0.2fs", etime, finish >= 0? 100: last);
+      msg_info(" | %d%% %0.2fs", etime, finish >= 0? 100: last);
       if(finish)
-        avrdude_message(MSG_INFO, "\n\n");
+        msg_info("\n\n");
       done = 1;
     }
   }

--- a/src/update.c
+++ b/src/update.c
@@ -207,7 +207,7 @@ int memstats(struct avrpart *p, char *memtype, int size, Filestats *fsp) {
     pgsize = 1;
 
   if(size < 0 || size > mem->size) {
-    pmsg_error("memstats(): size %d at odds with %s %s size %d\n", size, p->desc, memtype, mem->size);
+    pmsg_error("size %d at odds with %s %s size %d\n", size, p->desc, memtype, mem->size);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
@@ -337,7 +337,7 @@ static void ioerror(const char *iotype, UPDATE *upd) {
 
   pmsg_ext_error("file %s is not %s", update_outname(upd->filename), iotype);
   if(errnocp)
-    msg_ext_error(": %s", strerror(errnocp));
+    msg_ext_error("memstats(): %s", strerror(errnocp));
   else if(upd->filename && *upd->filename)
     msg_ext_error(" (not a regular or character file?)");
   msg_ext_error("\n");

--- a/src/update.c
+++ b/src/update.c
@@ -492,24 +492,18 @@ int do_op(PROGRAMMER * pgm, struct avrpart * p, UPDATE * upd, enum updateflags f
     if(memstats(p, upd->memtype, size, &fs) < 0)
       return LIBAVRDUDE_GENERAL_FAILURE;
 
-    if(quell_progress < 2) {
-      int level = fs.nsections > 1 || fs.firstaddr > 0 || fs.ntrailing? MSG_INFO: MSG_NOTICE;
-
-      avrdude_message(level, "%*s with %d byte%s in %d section%s within %s\n",
-        (int) strlen(progname)+1, "",
-        fs.nbytes, update_plural(fs.nbytes),
-        fs.nsections, update_plural(fs.nsections),
-        update_interval(fs.firstaddr, fs.lastaddr));
-      if(mem->page_size > 1) {
-        avrdude_message(level, "%*s using %d page%s and %d pad byte%s",
-          (int) strlen(progname)+1, "",
-          fs.npages, update_plural(fs.npages),
-          fs.nfill, update_plural(fs.nfill));
-        if(fs.ntrailing)
-          avrdude_message(level, ", cutting off %d trailing 0xff byte%s",
-            fs.ntrailing, update_plural(fs.ntrailing));
-        avrdude_message(level, "\n");
-      }
+    imsg_info("with %d byte%s in %d section%s within %s\n",
+      fs.nbytes, update_plural(fs.nbytes),
+      fs.nsections, update_plural(fs.nsections),
+      update_interval(fs.firstaddr, fs.lastaddr));
+    if(mem->page_size > 1) {
+      imsg_info("using %d page%s and %d pad byte%s",
+        fs.npages, update_plural(fs.npages),
+        fs.nfill, update_plural(fs.nfill));
+      if(fs.ntrailing)
+        msg_info(", cutting off %d trailing 0xff byte%s",
+          fs.ntrailing, update_plural(fs.ntrailing));
+      msg_info("\n");
     }
 
     // Write the buffer contents to the selected memory type

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -58,11 +58,11 @@ static int updi_physical_open(PROGRAMMER* pgm, int baudrate, unsigned long cflag
   pinfo.serialinfo.baud = baudrate;
   pinfo.serialinfo.cflags = cflags;
 
-  avrdude_message(MSG_DEBUG, "%s: Opening serial port...\n", progname);
+  msg_debug("%s: Opening serial port...\n", progname);
 
   if (serial_open(pgm->port, pinfo, &pgm->fd)==-1) {
 
-    avrdude_message(MSG_DEBUG, "%s: Serial port open failed!\n", progname);
+    msg_debug("%s: Serial port open failed!\n", progname);
     return -1;
   }
 
@@ -90,14 +90,14 @@ static int updi_physical_send(const PROGRAMMER *pgm, unsigned char *buf, size_t 
   size_t i;
   int rv;
 
-  avrdude_message(MSG_DEBUG, "%s: Sending %lu bytes [", progname, len);
+  msg_debug("%s: Sending %lu bytes [", progname, len);
   for (i=0; i<len; i++) {
-    avrdude_message(MSG_DEBUG, "0x%02x", buf[i]);
+    msg_debug("0x%02x", buf[i]);
     if (i<len-1) {
-      avrdude_message(MSG_DEBUG, ", ");
+      msg_debug(", ");
     }
   }
-  avrdude_message(MSG_DEBUG, "]\n");
+  msg_debug("]\n");
 
   rv = serial_send(&pgm->fd, buf, len);
   serial_recv(&pgm->fd, buf, len);
@@ -110,20 +110,20 @@ static int updi_physical_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t 
 
   rv = serial_recv(&pgm->fd, buf, len);
   if (rv < 0) {
-    avrdude_message(MSG_DEBUG,
+    msg_debug(
       "%s: serialupdi_recv(): programmer is not responding\n",
       progname);
     return -1;
   }
 
-  avrdude_message(MSG_DEBUG, "%s: Received %lu bytes [", progname, len);
+  msg_debug("%s: Received %lu bytes [", progname, len);
   for (i=0; i<len; i++) {
-    avrdude_message(MSG_DEBUG, "0x%02x", buf[i]);
+    msg_debug("0x%02x", buf[i]);
     if (i<len-1) {
-      avrdude_message(MSG_DEBUG, ", ");
+      msg_debug(", ");
     }
   }
-  avrdude_message(MSG_DEBUG, "]\n");
+  msg_debug("]\n");
 
   return len;
 }
@@ -131,7 +131,7 @@ static int updi_physical_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t 
 static int updi_physical_send_double_break(const PROGRAMMER *pgm) {
   unsigned char buffer[1];
 
-  avrdude_message(MSG_DEBUG, "%s: Sending double break\n", progname);
+  msg_debug("%s: Sending double break\n", progname);
 
   if (serial_setparams(&pgm->fd, 300, SERIAL_8E1) < 0) {
     return -1;
@@ -184,7 +184,7 @@ int updi_physical_sib(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size
   send_buffer[1] = UPDI_KEY | UPDI_KEY_SIB | UPDI_SIB_32BYTES;
 
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: SIB request send failed\n", progname);
+    msg_debug("%s: SIB request send failed\n", progname);
     return -1;
   }
 
@@ -246,14 +246,14 @@ static int updi_link_check(const PROGRAMMER *pgm) {
   uint8_t value;
   result = updi_link_ldcs(pgm, UPDI_CS_STATUSA, &value);
   if (result < 0) {
-    avrdude_message(MSG_DEBUG, "%s: Check failed\n", progname);
+    msg_debug("%s: Check failed\n", progname);
     return -1;
   } else {
     if (value > 0) {
-      avrdude_message(MSG_DEBUG, "%s: UDPI init OK\n", progname);
+      msg_debug("%s: UDPI init OK\n", progname);
       return 0;
     } else {
-      avrdude_message(MSG_DEBUG, "%s: UDPI not OK - reinitialisation required\n", progname);
+      msg_debug("%s: UDPI not OK - reinitialisation required\n", progname);
       return -1;
     }
   }
@@ -276,22 +276,22 @@ int updi_link_init(const PROGRAMMER *pgm) {
                 raise PymcuprogError("UPDI initialisation failed")
 */
   if (updi_link_init_session_parameters(pgm) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: Session initialisation failed\n", progname);
+    msg_debug("%s: Session initialisation failed\n", progname);
     return -1;
   }
 
   if (updi_link_check(pgm) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: Datalink not active, resetting...\n", progname);
+    msg_debug("%s: Datalink not active, resetting...\n", progname);
     if (updi_physical_send_double_break(pgm) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: Datalink initialisation failed\n", progname);
+      msg_debug("%s: Datalink initialisation failed\n", progname);
       return -1;
     }
     if (updi_link_init_session_parameters(pgm) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: Session initialisation failed\n", progname);
+      msg_debug("%s: Session initialisation failed\n", progname);
       return -1;
     }
     if (updi_link_check(pgm) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: Restoring datalink failed\n", progname);
+      msg_debug("%s: Restoring datalink failed\n", progname);
       return -1;
     }
   }
@@ -318,17 +318,17 @@ int updi_link_ldcs(const PROGRAMMER *pgm, uint8_t address, uint8_t *value)  {
 */
   unsigned char buffer[2];
   int result;
-  avrdude_message(MSG_DEBUG, "%s: LDCS from 0x%02X\n", progname, address);
+  msg_debug("%s: LDCS from 0x%02X\n", progname, address);
   buffer[0]=UPDI_PHY_SYNC;
   buffer[1]=UPDI_LDCS | (address & 0x0F);
   if (updi_physical_send(pgm, buffer, 2) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: LDCS send operation failed\n", progname);
+    msg_debug("%s: LDCS send operation failed\n", progname);
     return -1;
   }
   result = updi_physical_recv(pgm, buffer, 1);
   if (result != 1) {
     if (result >= 0) {
-      avrdude_message(MSG_DEBUG, "%s: Incorrect response size, received %d instead of %d bytes\n", progname, result, 1);
+      msg_debug("%s: Incorrect response size, received %d instead of %d bytes\n", progname, result, 1);
     }
     return -1;
   }
@@ -349,7 +349,7 @@ int updi_link_stcs(const PROGRAMMER *pgm, uint8_t address, uint8_t value) {
         self.updi_phy.send([constants.UPDI_PHY_SYNC, constants.UPDI_STCS | (address & 0x0F), value])
 */
   unsigned char buffer[3];
-  avrdude_message(MSG_DEBUG, "%s: STCS 0x%02X to address 0x%02X\n", progname, value, address);
+  msg_debug("%s: STCS 0x%02X to address 0x%02X\n", progname, value, address);
   buffer[0] = UPDI_PHY_SYNC;
   buffer[1] = UPDI_STCS | (address & 0x0F);
   buffer[2] = value;
@@ -371,11 +371,11 @@ int updi_link_ld_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t 
         return self.updi_phy.receive(size)
 */
   unsigned char send_buffer[2];
-  avrdude_message(MSG_DEBUG, "%s: LD8 from ptr++\n", progname);
+  msg_debug("%s: LD8 from ptr++\n", progname);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LD | UPDI_PTR_INC | UPDI_DATA_8;
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: LD_PTR_INC send operation failed\n", progname);
+    msg_debug("%s: LD_PTR_INC send operation failed\n", progname);
     return -1;
   }
   return updi_physical_recv(pgm, buffer, size);
@@ -396,11 +396,11 @@ int updi_link_ld_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_
         return self.updi_phy.receive(words << 1)
 */
   unsigned char send_buffer[2];
-  avrdude_message(MSG_DEBUG, "%s: LD16 from ptr++\n", progname);
+  msg_debug("%s: LD16 from ptr++\n", progname);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LD | UPDI_PTR_INC | UPDI_DATA_16;
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: LD_PTR_INC send operation failed\n", progname);
+    msg_debug("%s: LD_PTR_INC send operation failed\n", progname);
     return -1;
   }
   return updi_physical_recv(pgm, buffer, words << 2);
@@ -435,32 +435,32 @@ int updi_link_st_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t 
   unsigned char recv_buffer[1];
   int response;
   int num = 1;
-  avrdude_message(MSG_DEBUG, "%s: ST8 to *ptr++\n", progname);
+  msg_debug("%s: ST8 to *ptr++\n", progname);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_ST | UPDI_PTR_INC | UPDI_DATA_8;
   send_buffer[2] = buffer[0];
   if (updi_physical_send(pgm, send_buffer, 3) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST_PTR_INC send operation failed\n", progname);
+    msg_debug("%s: ST_PTR_INC send operation failed\n", progname);
     return -1;
   }
 
   response = updi_physical_recv(pgm, recv_buffer, 1);
 
   if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-    avrdude_message(MSG_DEBUG, "%s: ACK was expected but not received\n", progname);
+    msg_debug("%s: ACK was expected but not received\n", progname);
     return -1;
   }
 
   while (num < size) {
     send_buffer[0]=buffer[num];
     if (updi_physical_send(pgm, send_buffer, 1) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: ST_PTR_INC data send operation failed\n", progname);
+      msg_debug("%s: ST_PTR_INC data send operation failed\n", progname);
       return -1;
     }
     response = updi_physical_recv(pgm, recv_buffer, 1);
 
     if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-      avrdude_message(MSG_DEBUG, "%s: Data ACK was expected but not received\n", progname);
+      msg_debug("%s: Data ACK was expected but not received\n", progname);
       return -1;
     }
     num++;
@@ -498,20 +498,20 @@ int updi_link_st_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_
   unsigned char recv_buffer[1];
   int response;
   int num = 2;
-  avrdude_message(MSG_DEBUG, "%s: ST16 to *ptr++\n", progname);
+  msg_debug("%s: ST16 to *ptr++\n", progname);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_ST | UPDI_PTR_INC | UPDI_DATA_16;
   send_buffer[2] = buffer[0];
   send_buffer[3] = buffer[1];
   if (updi_physical_send(pgm, send_buffer, 4) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST_PTR_INC16 send operation failed\n", progname);
+    msg_debug("%s: ST_PTR_INC16 send operation failed\n", progname);
     return -1;
   }
 
   response = updi_physical_recv(pgm, recv_buffer, 1);
 
   if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-    avrdude_message(MSG_DEBUG, "%s: ACK was expected but not received\n", progname);
+    msg_debug("%s: ACK was expected but not received\n", progname);
     return -1;
   }
 
@@ -519,13 +519,13 @@ int updi_link_st_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_
     send_buffer[0]=buffer[num];
     send_buffer[1]=buffer[num+1];
     if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: ST_PTR_INC data send operation failed\n", progname);
+      msg_debug("%s: ST_PTR_INC data send operation failed\n", progname);
       return -1;
     }
     response = updi_physical_recv(pgm, recv_buffer, 1);
 
     if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-      avrdude_message(MSG_DEBUG, "%s: Data ACK was expected but not received\n", progname);
+      msg_debug("%s: Data ACK was expected but not received\n", progname);
       return -1;
     }
     num+=2;
@@ -577,14 +577,14 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
             self.updi_phy.send(data_slice)
             num += len(data_slice)
 */
-  avrdude_message(MSG_DEBUG, "%s: ST16 to *ptr++ with RSD, data length: 0x%03X in blocks of: %d\n", progname, words * 2, blocksize);
+  msg_debug("%s: ST16 to *ptr++ with RSD, data length: 0x%03X in blocks of: %d\n", progname, words * 2, blocksize);
 
   unsigned int temp_buffer_size = 3 + 3 + 2 + (words * 2) + 3;
   unsigned int num=0;
   unsigned char* temp_buffer = malloc(temp_buffer_size);
 
   if (temp_buffer == 0) {
-    avrdude_message(MSG_DEBUG, "%s: Allocating temporary buffer failed\n", progname);
+    msg_debug("%s: Allocating temporary buffer failed\n", progname);
     return -1;
   }
 
@@ -609,7 +609,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
 
   if (blocksize < 10) {
     if (updi_physical_send(pgm, temp_buffer, 6) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: Failed to send first package\n", progname);
+      msg_debug("%s: Failed to send first package\n", progname);
       free(temp_buffer);
       return -1;
     }
@@ -626,7 +626,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
     }
 
     if (updi_physical_send(pgm, temp_buffer + num, next_package_size) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: Failed to send package\n", progname);
+      msg_debug("%s: Failed to send package\n", progname);
       free(temp_buffer);
       return -1;
     }
@@ -654,9 +654,9 @@ int updi_link_repeat(const PROGRAMMER *pgm, uint16_t repeats) {
                             repeats & 0xFF])
 */
   unsigned char buffer[3];
-  avrdude_message(MSG_DEBUG, "%s: Repeat %d\n", progname, repeats);
+  msg_debug("%s: Repeat %d\n", progname, repeats);
   if ((repeats - 1) > UPDI_MAX_REPEAT_SIZE) {
-    avrdude_message(MSG_DEBUG, "%s: Invalid repeat count of %d\n", progname, repeats);
+    msg_debug("%s: Invalid repeat count of %d\n", progname, repeats);
     return -1;
   }
   repeats-=1;
@@ -695,15 +695,15 @@ int updi_link_key(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size_typ
   unsigned char send_buffer[2];
   unsigned char reversed_key[256];
   int index;
-  avrdude_message(MSG_DEBUG, "%s: UPDI writing key\n", progname);
+  msg_debug("%s: UPDI writing key\n", progname);
   if (size != (8 << size_type)) {
-    avrdude_message(MSG_DEBUG, "%s: Invalid key length\n", progname);
+    msg_debug("%s: Invalid key length\n", progname);
     return -1;
   }
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_KEY | UPDI_KEY_KEY | size_type;
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI key send message failed\n", progname);
+    msg_debug("%s: UPDI key send message failed\n", progname);
     return -1;
   }
   /* reverse key contents */
@@ -730,18 +730,18 @@ int updi_link_ld(const PROGRAMMER *pgm, uint32_t address, uint8_t *value) {
 */
   unsigned char send_buffer[5];
   unsigned char recv_buffer[1];
-  avrdude_message(MSG_DEBUG, "%s: LD from 0x%06X\n", progname, address);
+  msg_debug("%s: LD from 0x%06X\n", progname, address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LDS | UPDI_DATA_8 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: LD operation send failed\n", progname);
+    msg_debug("%s: LD operation send failed\n", progname);
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: LD operation recv failed\n", progname);
+    msg_debug("%s: LD operation recv failed\n", progname);
     return -1;
   }
   * value = recv_buffer[0];
@@ -765,18 +765,18 @@ int updi_link_ld16(const PROGRAMMER *pgm, uint32_t address, uint16_t *value) {
 */
   unsigned char send_buffer[5];
   unsigned char recv_buffer[2];
-  avrdude_message(MSG_DEBUG, "%s: LD16 from 0x%06X\n", progname, address);
+  msg_debug("%s: LD16 from 0x%06X\n", progname, address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LDS | UPDI_DATA_16 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: LD16 operation send failed\n", progname);
+    msg_debug("%s: LD16 operation send failed\n", progname);
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 2) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: LD16 operation recv failed\n", progname);
+    msg_debug("%s: LD16 operation recv failed\n", progname);
     return -1;
   }
   * value = (recv_buffer[0] << 8 | recv_buffer[1]);
@@ -804,23 +804,23 @@ static int updi_link_st_data_phase(const PROGRAMMER *pgm, unsigned char *buffer,
 */
   unsigned char recv_buffer[1];
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI data phase recv failed on first ACK\n", progname);
+    msg_debug("%s: UPDI data phase recv failed on first ACK\n", progname);
     return -1;
   }
   if (recv_buffer[0] != UPDI_PHY_ACK) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI data phase expected first ACK\n", progname);
+    msg_debug("%s: UPDI data phase expected first ACK\n", progname);
     return -1;
   }
   if (updi_physical_send(pgm, buffer, size) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI data phase send failed\n", progname);
+    msg_debug("%s: UPDI data phase send failed\n", progname);
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI data phase recv failed on second ACK\n", progname);
+    msg_debug("%s: UPDI data phase recv failed on second ACK\n", progname);
     return -1;
   }
   if (recv_buffer[0] != UPDI_PHY_ACK) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI data phase expected second ACK\n", progname);
+    msg_debug("%s: UPDI data phase expected second ACK\n", progname);
     return -1;
   }
   return 0;
@@ -842,14 +842,14 @@ int updi_link_st(const PROGRAMMER *pgm, uint32_t address, uint8_t value) {
         return self._st_data_phase([value & 0xFF])
 */
   unsigned char send_buffer[5];
-  avrdude_message(MSG_DEBUG, "%s: ST to 0x%06X\n", progname, address);
+  msg_debug("%s: ST to 0x%06X\n", progname, address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_STS | UPDI_DATA_8 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST operation send failed\n", progname);
+    msg_debug("%s: ST operation send failed\n", progname);
     return -1;
   }
   send_buffer[0] = value;
@@ -872,14 +872,14 @@ int updi_link_st16(const PROGRAMMER *pgm, uint32_t address, uint16_t value) {
         return self._st_data_phase([value & 0xFF, (value >> 8) & 0xFF])
 */
   unsigned char send_buffer[5];
-  avrdude_message(MSG_DEBUG, "%s: ST16 to 0x%06X\n", progname, address);
+  msg_debug("%s: ST16 to 0x%06X\n", progname, address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_STS | UPDI_DATA_16 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST16 operation send failed\n", progname);
+    msg_debug("%s: ST16 operation send failed\n", progname);
     return -1;
   }
   send_buffer[0] = value & 0xFF;
@@ -905,22 +905,22 @@ int updi_link_st_ptr(const PROGRAMMER *pgm, uint32_t address) {
 */
   unsigned char send_buffer[5];
   unsigned char recv_buffer[1];
-  avrdude_message(MSG_DEBUG, "%s: ST_PTR to 0x%06X\n", progname, address);
+  msg_debug("%s: ST_PTR to 0x%06X\n", progname, address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_STS | UPDI_ST | UPDI_PTR_ADDRESS | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_DATA_24 : UPDI_DATA_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST_PTR operation send failed\n", progname);
+    msg_debug("%s: ST_PTR operation send failed\n", progname);
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI ST_PTR recv failed on ACK\n", progname);
+    msg_debug("%s: UPDI ST_PTR recv failed on ACK\n", progname);
     return -1;
   }
   if (recv_buffer[0] != UPDI_PHY_ACK) {
-    avrdude_message(MSG_DEBUG, "%s: UPDI ST_PTR expected ACK\n", progname);
+    msg_debug("%s: UPDI ST_PTR expected ACK\n", progname);
     return -1;
   }
   return 0;

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -58,11 +58,11 @@ static int updi_physical_open(PROGRAMMER* pgm, int baudrate, unsigned long cflag
   pinfo.serialinfo.baud = baudrate;
   pinfo.serialinfo.cflags = cflags;
 
-  msg_debug("%s: Opening serial port...\n", progname);
+  pmsg_debug("opening serial port ...\n");
 
   if (serial_open(pgm->port, pinfo, &pgm->fd)==-1) {
 
-    msg_debug("%s: Serial port open failed!\n", progname);
+    pmsg_debug("serial port open failed!\n");
     return -1;
   }
 
@@ -90,7 +90,7 @@ static int updi_physical_send(const PROGRAMMER *pgm, unsigned char *buf, size_t 
   size_t i;
   int rv;
 
-  msg_debug("%s: Sending %lu bytes [", progname, len);
+  pmsg_debug("sending %lu bytes [", len);
   for (i=0; i<len; i++) {
     msg_debug("0x%02x", buf[i]);
     if (i<len-1) {
@@ -110,13 +110,11 @@ static int updi_physical_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t 
 
   rv = serial_recv(&pgm->fd, buf, len);
   if (rv < 0) {
-    msg_debug(
-      "%s: serialupdi_recv(): programmer is not responding\n",
-      progname);
+    pmsg_debug("serialupdi_recv(): programmer is not responding\n");
     return -1;
   }
 
-  msg_debug("%s: Received %lu bytes [", progname, len);
+  pmsg_debug("received %lu bytes [", len);
   for (i=0; i<len; i++) {
     msg_debug("0x%02x", buf[i]);
     if (i<len-1) {
@@ -131,7 +129,7 @@ static int updi_physical_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t 
 static int updi_physical_send_double_break(const PROGRAMMER *pgm) {
   unsigned char buffer[1];
 
-  msg_debug("%s: Sending double break\n", progname);
+  pmsg_debug("sending double break\n");
 
   if (serial_setparams(&pgm->fd, 300, SERIAL_8E1) < 0) {
     return -1;
@@ -184,7 +182,7 @@ int updi_physical_sib(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size
   send_buffer[1] = UPDI_KEY | UPDI_KEY_SIB | UPDI_SIB_32BYTES;
 
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    msg_debug("%s: SIB request send failed\n", progname);
+    pmsg_debug("SIB request send failed\n");
     return -1;
   }
 
@@ -246,14 +244,14 @@ static int updi_link_check(const PROGRAMMER *pgm) {
   uint8_t value;
   result = updi_link_ldcs(pgm, UPDI_CS_STATUSA, &value);
   if (result < 0) {
-    msg_debug("%s: Check failed\n", progname);
+    pmsg_debug("check failed\n");
     return -1;
   } else {
     if (value > 0) {
-      msg_debug("%s: UDPI init OK\n", progname);
+      pmsg_debug("UDPI init OK\n");
       return 0;
     } else {
-      msg_debug("%s: UDPI not OK - reinitialisation required\n", progname);
+      pmsg_debug("UDPI not OK - reinitialisation required\n");
       return -1;
     }
   }
@@ -276,22 +274,22 @@ int updi_link_init(const PROGRAMMER *pgm) {
                 raise PymcuprogError("UPDI initialisation failed")
 */
   if (updi_link_init_session_parameters(pgm) < 0) {
-    msg_debug("%s: Session initialisation failed\n", progname);
+    pmsg_debug("session initialisation failed\n");
     return -1;
   }
 
   if (updi_link_check(pgm) < 0) {
-    msg_debug("%s: Datalink not active, resetting...\n", progname);
+    pmsg_debug("datalink not active, resetting ...\n");
     if (updi_physical_send_double_break(pgm) < 0) {
-      msg_debug("%s: Datalink initialisation failed\n", progname);
+      pmsg_debug("datalink initialisation failed\n");
       return -1;
     }
     if (updi_link_init_session_parameters(pgm) < 0) {
-      msg_debug("%s: Session initialisation failed\n", progname);
+      pmsg_debug("session initialisation failed\n");
       return -1;
     }
     if (updi_link_check(pgm) < 0) {
-      msg_debug("%s: Restoring datalink failed\n", progname);
+      pmsg_debug("restoring datalink failed\n");
       return -1;
     }
   }
@@ -318,17 +316,17 @@ int updi_link_ldcs(const PROGRAMMER *pgm, uint8_t address, uint8_t *value)  {
 */
   unsigned char buffer[2];
   int result;
-  msg_debug("%s: LDCS from 0x%02X\n", progname, address);
+  pmsg_debug("LDCS from 0x%02X\n", address);
   buffer[0]=UPDI_PHY_SYNC;
   buffer[1]=UPDI_LDCS | (address & 0x0F);
   if (updi_physical_send(pgm, buffer, 2) < 0) {
-    msg_debug("%s: LDCS send operation failed\n", progname);
+    pmsg_debug("LDCS send operation failed\n");
     return -1;
   }
   result = updi_physical_recv(pgm, buffer, 1);
   if (result != 1) {
     if (result >= 0) {
-      msg_debug("%s: Incorrect response size, received %d instead of %d bytes\n", progname, result, 1);
+      pmsg_debug("incorrect response size, received %d instead of %d bytes\n", result, 1);
     }
     return -1;
   }
@@ -349,7 +347,7 @@ int updi_link_stcs(const PROGRAMMER *pgm, uint8_t address, uint8_t value) {
         self.updi_phy.send([constants.UPDI_PHY_SYNC, constants.UPDI_STCS | (address & 0x0F), value])
 */
   unsigned char buffer[3];
-  msg_debug("%s: STCS 0x%02X to address 0x%02X\n", progname, value, address);
+  pmsg_debug("STCS 0x%02X to address 0x%02X\n", value, address);
   buffer[0] = UPDI_PHY_SYNC;
   buffer[1] = UPDI_STCS | (address & 0x0F);
   buffer[2] = value;
@@ -371,11 +369,11 @@ int updi_link_ld_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t 
         return self.updi_phy.receive(size)
 */
   unsigned char send_buffer[2];
-  msg_debug("%s: LD8 from ptr++\n", progname);
+  pmsg_debug("LD8 from ptr++\n");
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LD | UPDI_PTR_INC | UPDI_DATA_8;
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    msg_debug("%s: LD_PTR_INC send operation failed\n", progname);
+    pmsg_debug("LD_PTR_INC send operation failed\n");
     return -1;
   }
   return updi_physical_recv(pgm, buffer, size);
@@ -396,11 +394,11 @@ int updi_link_ld_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_
         return self.updi_phy.receive(words << 1)
 */
   unsigned char send_buffer[2];
-  msg_debug("%s: LD16 from ptr++\n", progname);
+  pmsg_debug("LD16 from ptr++\n");
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LD | UPDI_PTR_INC | UPDI_DATA_16;
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    msg_debug("%s: LD_PTR_INC send operation failed\n", progname);
+    pmsg_debug("LD_PTR_INC send operation failed\n");
     return -1;
   }
   return updi_physical_recv(pgm, buffer, words << 2);
@@ -435,32 +433,32 @@ int updi_link_st_ptr_inc(const PROGRAMMER *pgm, unsigned char *buffer, uint16_t 
   unsigned char recv_buffer[1];
   int response;
   int num = 1;
-  msg_debug("%s: ST8 to *ptr++\n", progname);
+  pmsg_debug("ST8 to *ptr++\n");
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_ST | UPDI_PTR_INC | UPDI_DATA_8;
   send_buffer[2] = buffer[0];
   if (updi_physical_send(pgm, send_buffer, 3) < 0) {
-    msg_debug("%s: ST_PTR_INC send operation failed\n", progname);
+    pmsg_debug("ST_PTR_INC send operation failed\n");
     return -1;
   }
 
   response = updi_physical_recv(pgm, recv_buffer, 1);
 
   if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-    msg_debug("%s: ACK was expected but not received\n", progname);
+    pmsg_debug("ACK was expected but not received\n");
     return -1;
   }
 
   while (num < size) {
     send_buffer[0]=buffer[num];
     if (updi_physical_send(pgm, send_buffer, 1) < 0) {
-      msg_debug("%s: ST_PTR_INC data send operation failed\n", progname);
+      pmsg_debug("ST_PTR_INC data send operation failed\n");
       return -1;
     }
     response = updi_physical_recv(pgm, recv_buffer, 1);
 
     if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-      msg_debug("%s: Data ACK was expected but not received\n", progname);
+      pmsg_debug("data ACK was expected but not received\n");
       return -1;
     }
     num++;
@@ -498,20 +496,20 @@ int updi_link_st_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_
   unsigned char recv_buffer[1];
   int response;
   int num = 2;
-  msg_debug("%s: ST16 to *ptr++\n", progname);
+  pmsg_debug("ST16 to *ptr++\n");
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_ST | UPDI_PTR_INC | UPDI_DATA_16;
   send_buffer[2] = buffer[0];
   send_buffer[3] = buffer[1];
   if (updi_physical_send(pgm, send_buffer, 4) < 0) {
-    msg_debug("%s: ST_PTR_INC16 send operation failed\n", progname);
+    pmsg_debug("ST_PTR_INC16 send operation failed\n");
     return -1;
   }
 
   response = updi_physical_recv(pgm, recv_buffer, 1);
 
   if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-    msg_debug("%s: ACK was expected but not received\n", progname);
+    pmsg_debug("ACK was expected but not received\n");
     return -1;
   }
 
@@ -519,13 +517,13 @@ int updi_link_st_ptr_inc16(const PROGRAMMER *pgm, unsigned char *buffer, uint16_
     send_buffer[0]=buffer[num];
     send_buffer[1]=buffer[num+1];
     if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-      msg_debug("%s: ST_PTR_INC data send operation failed\n", progname);
+      pmsg_debug("ST_PTR_INC data send operation failed\n");
       return -1;
     }
     response = updi_physical_recv(pgm, recv_buffer, 1);
 
     if (response != 1 || recv_buffer[0] != UPDI_PHY_ACK) {
-      msg_debug("%s: Data ACK was expected but not received\n", progname);
+      pmsg_debug("data ACK was expected but not received\n");
       return -1;
     }
     num+=2;
@@ -548,7 +546,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
         """
         self.logger.debug("ST16 to *ptr++ with RSD, data length: 0x%03X in blocks of:  %d", len(data), blocksize)
 
-        #for performance we glob everything together into one USB transfer....
+        #for performance we glob everything together into one USB transfer ...
         repnumber= ((len(data) >> 1) -1)
         data = [*data, *[constants.UPDI_PHY_SYNC, constants.UPDI_STCS | constants.UPDI_CS_CTRLA, 0x06]]
 
@@ -577,14 +575,14 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
             self.updi_phy.send(data_slice)
             num += len(data_slice)
 */
-  msg_debug("%s: ST16 to *ptr++ with RSD, data length: 0x%03X in blocks of: %d\n", progname, words * 2, blocksize);
+  pmsg_debug("ST16 to *ptr++ with RSD, data length: 0x%03X in blocks of: %d\n", words * 2, blocksize);
 
   unsigned int temp_buffer_size = 3 + 3 + 2 + (words * 2) + 3;
   unsigned int num=0;
   unsigned char* temp_buffer = malloc(temp_buffer_size);
 
   if (temp_buffer == 0) {
-    msg_debug("%s: Allocating temporary buffer failed\n", progname);
+    pmsg_debug("allocating temporary buffer failed\n");
     return -1;
   }
 
@@ -609,7 +607,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
 
   if (blocksize < 10) {
     if (updi_physical_send(pgm, temp_buffer, 6) < 0) {
-      msg_debug("%s: Failed to send first package\n", progname);
+      pmsg_debug("failed to send first package\n");
       free(temp_buffer);
       return -1;
     }
@@ -626,7 +624,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
     }
 
     if (updi_physical_send(pgm, temp_buffer + num, next_package_size) < 0) {
-      msg_debug("%s: Failed to send package\n", progname);
+      pmsg_debug("failed to send package\n");
       free(temp_buffer);
       return -1;
     }
@@ -654,9 +652,9 @@ int updi_link_repeat(const PROGRAMMER *pgm, uint16_t repeats) {
                             repeats & 0xFF])
 */
   unsigned char buffer[3];
-  msg_debug("%s: Repeat %d\n", progname, repeats);
+  pmsg_debug("repeat %d\n", repeats);
   if ((repeats - 1) > UPDI_MAX_REPEAT_SIZE) {
-    msg_debug("%s: Invalid repeat count of %d\n", progname, repeats);
+    pmsg_debug("invalid repeat count of %d\n", repeats);
     return -1;
   }
   repeats-=1;
@@ -695,15 +693,15 @@ int updi_link_key(const PROGRAMMER *pgm, unsigned char *buffer, uint8_t size_typ
   unsigned char send_buffer[2];
   unsigned char reversed_key[256];
   int index;
-  msg_debug("%s: UPDI writing key\n", progname);
+  pmsg_debug("UPDI writing key\n");
   if (size != (8 << size_type)) {
-    msg_debug("%s: Invalid key length\n", progname);
+    pmsg_debug("invalid key length\n");
     return -1;
   }
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_KEY | UPDI_KEY_KEY | size_type;
   if (updi_physical_send(pgm, send_buffer, 2) < 0) {
-    msg_debug("%s: UPDI key send message failed\n", progname);
+    pmsg_debug("UPDI key send message failed\n");
     return -1;
   }
   /* reverse key contents */
@@ -730,18 +728,18 @@ int updi_link_ld(const PROGRAMMER *pgm, uint32_t address, uint8_t *value) {
 */
   unsigned char send_buffer[5];
   unsigned char recv_buffer[1];
-  msg_debug("%s: LD from 0x%06X\n", progname, address);
+  pmsg_debug("LD from 0x%06X\n", address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LDS | UPDI_DATA_8 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    msg_debug("%s: LD operation send failed\n", progname);
+    pmsg_debug("LD operation send failed\n");
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    msg_debug("%s: LD operation recv failed\n", progname);
+    pmsg_debug("LD operation recv failed\n");
     return -1;
   }
   * value = recv_buffer[0];
@@ -765,18 +763,18 @@ int updi_link_ld16(const PROGRAMMER *pgm, uint32_t address, uint16_t *value) {
 */
   unsigned char send_buffer[5];
   unsigned char recv_buffer[2];
-  msg_debug("%s: LD16 from 0x%06X\n", progname, address);
+  pmsg_debug("LD16 from 0x%06X\n", address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_LDS | UPDI_DATA_16 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    msg_debug("%s: LD16 operation send failed\n", progname);
+    pmsg_debug("LD16 operation send failed\n");
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 2) < 0) {
-    msg_debug("%s: LD16 operation recv failed\n", progname);
+    pmsg_debug("LD16 operation recv failed\n");
     return -1;
   }
   * value = (recv_buffer[0] << 8 | recv_buffer[1]);
@@ -804,23 +802,23 @@ static int updi_link_st_data_phase(const PROGRAMMER *pgm, unsigned char *buffer,
 */
   unsigned char recv_buffer[1];
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    msg_debug("%s: UPDI data phase recv failed on first ACK\n", progname);
+    pmsg_debug("UPDI data phase recv failed on first ACK\n");
     return -1;
   }
   if (recv_buffer[0] != UPDI_PHY_ACK) {
-    msg_debug("%s: UPDI data phase expected first ACK\n", progname);
+    pmsg_debug("UPDI data phase expected first ACK\n");
     return -1;
   }
   if (updi_physical_send(pgm, buffer, size) < 0) {
-    msg_debug("%s: UPDI data phase send failed\n", progname);
+    pmsg_debug("UPDI data phase send failed\n");
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    msg_debug("%s: UPDI data phase recv failed on second ACK\n", progname);
+    pmsg_debug("UPDI data phase recv failed on second ACK\n");
     return -1;
   }
   if (recv_buffer[0] != UPDI_PHY_ACK) {
-    msg_debug("%s: UPDI data phase expected second ACK\n", progname);
+    pmsg_debug("UPDI data phase expected second ACK\n");
     return -1;
   }
   return 0;
@@ -842,14 +840,14 @@ int updi_link_st(const PROGRAMMER *pgm, uint32_t address, uint8_t value) {
         return self._st_data_phase([value & 0xFF])
 */
   unsigned char send_buffer[5];
-  msg_debug("%s: ST to 0x%06X\n", progname, address);
+  pmsg_debug("ST to 0x%06X\n", address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_STS | UPDI_DATA_8 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    msg_debug("%s: ST operation send failed\n", progname);
+    pmsg_debug("ST operation send failed\n");
     return -1;
   }
   send_buffer[0] = value;
@@ -872,14 +870,14 @@ int updi_link_st16(const PROGRAMMER *pgm, uint32_t address, uint16_t value) {
         return self._st_data_phase([value & 0xFF, (value >> 8) & 0xFF])
 */
   unsigned char send_buffer[5];
-  msg_debug("%s: ST16 to 0x%06X\n", progname, address);
+  pmsg_debug("ST16 to 0x%06X\n", address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_STS | UPDI_DATA_16 | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_ADDRESS_24 : UPDI_ADDRESS_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    msg_debug("%s: ST16 operation send failed\n", progname);
+    pmsg_debug("ST16 operation send failed\n");
     return -1;
   }
   send_buffer[0] = value & 0xFF;
@@ -905,22 +903,22 @@ int updi_link_st_ptr(const PROGRAMMER *pgm, uint32_t address) {
 */
   unsigned char send_buffer[5];
   unsigned char recv_buffer[1];
-  msg_debug("%s: ST_PTR to 0x%06X\n", progname, address);
+  pmsg_debug("ST_PTR to 0x%06X\n", address);
   send_buffer[0] = UPDI_PHY_SYNC;
   send_buffer[1] = UPDI_STS | UPDI_ST | UPDI_PTR_ADDRESS | (updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? UPDI_DATA_24 : UPDI_DATA_16);
   send_buffer[2] = address & 0xFF;
   send_buffer[3] = (address >> 8) & 0xFF;
   send_buffer[4] = (address >> 16) & 0xFF;
   if (updi_physical_send(pgm, send_buffer, updi_get_datalink_mode(pgm) == UPDI_LINK_MODE_24BIT ? 5 : 4) < 0) {
-    msg_debug("%s: ST_PTR operation send failed\n", progname);
+    pmsg_debug("ST_PTR operation send failed\n");
     return -1;
   }
   if (updi_physical_recv(pgm, recv_buffer, 1) < 0) {
-    msg_debug("%s: UPDI ST_PTR recv failed on ACK\n", progname);
+    pmsg_debug("UPDI ST_PTR recv failed on ACK\n");
     return -1;
   }
   if (recv_buffer[0] != UPDI_PHY_ACK) {
-    msg_debug("%s: UPDI ST_PTR expected ACK\n", progname);
+    pmsg_debug("UPDI ST_PTR expected ACK\n");
     return -1;
   }
   return 0;

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -607,7 +607,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
 
   if (blocksize < 10) {
     if (updi_physical_send(pgm, temp_buffer, 6) < 0) {
-      pmsg_debug("failed to send first package\n");
+      pmsg_debug("unable to send first package\n");
       free(temp_buffer);
       return -1;
     }
@@ -624,7 +624,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
     }
 
     if (updi_physical_send(pgm, temp_buffer + num, next_package_size) < 0) {
-      pmsg_debug("failed to send package\n");
+      pmsg_debug("unable to send package\n");
       free(temp_buffer);
       return -1;
     }

--- a/src/updi_nvm.c
+++ b/src/updi_nvm.c
@@ -71,17 +71,17 @@ static int nvm_chip_erase_V0(const PROGRAMMER *pgm, const AVRPART *p) {
 
         return True
 */
-  avrdude_message(MSG_DEBUG, "%s: Chip erase using NVM CTRL\n", progname);
+  msg_debug("%s: Chip erase using NVM CTRL\n", progname);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Chip erase command failed\n", progname);
+    msg_info("%s: Chip erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -113,22 +113,22 @@ static int nvm_erase_flash_page_V0(const PROGRAMMER *pgm, const AVRPART *p, uint
             raise IOError("Timeout waiting for NVM controller to be ready after flash page erase")
 */
   unsigned char data[1];
-  avrdude_message(MSG_DEBUG, "%s: Erase flash page at address 0x%06X\n", progname, address);
+  msg_debug("%s: Erase flash page at address 0x%06X\n", progname, address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    avrdude_message(MSG_INFO, "%s: Dummy write operation failed\n", progname);
+    msg_info("%s: Dummy write operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_PAGE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Flash page erase command failed\n", progname);
+    msg_info("%s: Flash page erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -153,17 +153,17 @@ static int nvm_erase_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p) {
         if not self.wait_nvm_ready():
             raise IOError("Timeout waiting for NVM controller to be ready after EEPROM erase")
 */  
-  avrdude_message(MSG_DEBUG, "%s: Erase EEPROM\n", progname);
+  msg_debug("%s: Erase EEPROM\n", progname);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_EEPROM) < 0) {
-    avrdude_message(MSG_INFO, "%s: EEPROM erase command failed\n", progname);
+    msg_info("%s: EEPROM erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -198,25 +198,25 @@ static int nvm_erase_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32
 */
   uint16_t offset;
   unsigned char data[1];
-  avrdude_message(MSG_DEBUG, "%s: Erase user row\n", progname);
+  msg_debug("%s: Erase user row\n", progname);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   data[0]=0xFF;
   for (offset = 0; offset<size; offset++)
   {
     if (updi_write_data(pgm, address+offset, data, 1) < 0) {
-      avrdude_message(MSG_INFO, "%s: Write data operation failed at offset 0x%04x\n", progname, offset);
+      msg_info("%s: Write data operation failed at offset 0x%04x\n", progname, offset);
       return -1;
     }
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_PAGE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Erase page operation failed\n", progname);
+    msg_info("%s: Erase page operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -303,30 +303,30 @@ static int nvm_write_fuse_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t a
             raise PymcuprogError("Timeout waiting for NVM controller to be ready after fuse write")
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Load NVM address\n", progname);
+  msg_debug("%s: Load NVM address\n", progname);
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_ADDRL, address & 0xFF) < 0) {
-    avrdude_message(MSG_INFO, "%s: Write ADDRL operation failed\n", progname);
+    msg_info("%s: Write ADDRL operation failed\n", progname);
     return -1;
   }
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_ADDRH, (address >> 8) & 0xFF) < 0) {
-    avrdude_message(MSG_INFO, "%s: Write ADDRH operation failed\n", progname);
+    msg_info("%s: Write ADDRH operation failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Load fuse data\n", progname);
+  msg_debug("%s: Load fuse data\n", progname);
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_DATAL, value & 0xFF) < 0) {
-    avrdude_message(MSG_INFO, "%s: Write DATAL operation failed\n", progname);
+    msg_info("%s: Write DATAL operation failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Execute fuse write\n", progname);
+  msg_debug("%s: Execute fuse write\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_WRITE_FUSE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Write fuse operation failed\n", progname);
+    msg_info("%s: Write fuse operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -377,39 +377,39 @@ static int nvm_write_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
             raise PymcuprogError("Timeout waiting for NVM controller to be ready after page write")
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Clear page buffer\n", progname);
+  msg_debug("%s: Clear page buffer\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_PAGE_BUFFER_CLR) < 0) {
-    avrdude_message(MSG_INFO, "%s: Clear page operation failed\n", progname);
+    msg_info("%s: Clear page operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      avrdude_message(MSG_INFO, "%s: Write data words operation failed\n", progname);
+      msg_info("%s: Write data words operation failed\n", progname);
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      avrdude_message(MSG_INFO, "%s: Write data operation failed\n", progname);
+      msg_info("%s: Write data operation failed\n", progname);
       return -1;
     }
   }
-  avrdude_message(MSG_DEBUG, "%s: Committing data\n", progname);
+  msg_debug("%s: Committing data\n", progname);
   if (nvm_command == USE_DEFAULT_COMMAND) {
     nvm_command = UPDI_V0_NVMCTRL_CTRLA_WRITE_PAGE;
   }
   if (updi_nvm_command(pgm, p, nvm_command) < 0) {
-      avrdude_message(MSG_INFO, "%s: Commit data command failed\n", progname);
+      msg_info("%s: Commit data command failed\n", progname);
       return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -438,17 +438,17 @@ static int nvm_chip_erase_V2(const PROGRAMMER *pgm, const AVRPART *p) {
 
         return True
 */
-  avrdude_message(MSG_DEBUG, "%s: Chip erase using NVM CTRL\n", progname);
+  msg_debug("%s: Chip erase using NVM CTRL\n", progname);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Chip erase command failed\n", progname);
+    msg_info("%s: Chip erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -484,22 +484,22 @@ static int nvm_erase_flash_page_V2(const PROGRAMMER *pgm, const AVRPART *p, uint
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   unsigned char data[1];
-  avrdude_message(MSG_DEBUG, "%s: Erase flash page at address 0x%06X\n", progname, address);
+  msg_debug("%s: Erase flash page at address 0x%06X\n", progname, address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    avrdude_message(MSG_INFO, "%s: Dummy write operation failed\n", progname);
+    msg_info("%s: Dummy write operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_FLASH_PAGE_ERASE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Flash page erase command failed\n", progname);
+    msg_info("%s: Flash page erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -528,22 +528,22 @@ static int nvm_erase_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p) {
         self.logger.debug("Clear NVM command")
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
-  avrdude_message(MSG_DEBUG, "%s: Erase EEPROM\n", progname);
+  msg_debug("%s: Erase EEPROM\n", progname);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_EEPROM_ERASE) < 0) {
-    avrdude_message(MSG_INFO, "%s: EEPROM erase command failed\n", progname);
+    msg_info("%s: EEPROM erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Clear NVM command\n", progname);
+  msg_debug("%s: Clear NVM command\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    avrdude_message(MSG_INFO, "%s: Sending empty command failed\n", progname);
+    msg_info("%s: Sending empty command failed\n", progname);
     return -1;
   }
   return 0;
@@ -629,25 +629,25 @@ static int nvm_write_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: NVM EEPROM erase/write command\n", progname);
+  msg_debug("%s: NVM EEPROM erase/write command\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_EEPROM_ERASE_WRITE) < 0) {
-    avrdude_message(MSG_INFO, "%s: EEPROM erase command failed\n", progname);
+    msg_info("%s: EEPROM erase command failed\n", progname);
     return -1;
   }
   if (updi_write_data(pgm, address, buffer, size) < 0) {
-    avrdude_message(MSG_INFO, "%s: Write data operation failed\n", progname);
+    msg_info("%s: Write data operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Clear NVM command\n", progname);
+  msg_debug("%s: Clear NVM command\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    avrdude_message(MSG_INFO, "%s: Clear NVM command failed\n", progname);
+    msg_info("%s: Clear NVM command failed\n", progname);
     return -1;
   }
   return 0;
@@ -708,32 +708,32 @@ static int nvm_write_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: NVM write command\n", progname);
+  msg_debug("%s: NVM write command\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_FLASH_WRITE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Clear page operation failed\n", progname);
+    msg_info("%s: Clear page operation failed\n", progname);
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      avrdude_message(MSG_INFO, "%s: Write data words operation failed\n", progname);
+      msg_info("%s: Write data words operation failed\n", progname);
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      avrdude_message(MSG_INFO, "%s: Write data operation failed\n", progname);
+      msg_info("%s: Write data operation failed\n", progname);
       return -1;
     }
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Clear NVM command\n", progname);
+  msg_debug("%s: Clear NVM command\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    avrdude_message(MSG_INFO, "%s: Clear NVM command failed\n", progname);
+    msg_info("%s: Clear NVM command failed\n", progname);
     return -1;
   }
   return 0;
@@ -768,21 +768,21 @@ static int nvm_chip_erase_V3(const PROGRAMMER *pgm, const AVRPART *p) {
 
         return True
 */
-  avrdude_message(MSG_DEBUG, "%s: Chip erase using NVM CTRL\n", progname);
+  msg_debug("%s: Chip erase using NVM CTRL\n", progname);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Chip erase command failed\n", progname);
+    msg_info("%s: Chip erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    avrdude_message(MSG_INFO, "%s: Sending empty command failed\n", progname);
+    msg_info("%s: Sending empty command failed\n", progname);
     return -1;
   }
   return 0;
@@ -819,22 +819,22 @@ static int nvm_erase_flash_page_V3(const PROGRAMMER *pgm, const AVRPART *p, uint
             raise IOError("Timeout waiting for NVM controller to be ready after flash page erase")
 */  
   unsigned char data[1];
-  avrdude_message(MSG_DEBUG, "%s: Erase flash page at address 0x%06X\n", progname, address);
+  msg_debug("%s: Erase flash page at address 0x%06X\n", progname, address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    avrdude_message(MSG_INFO, "%s: Dummy write operation failed\n", progname);
+    msg_info("%s: Dummy write operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_ERASE) < 0) {
-    avrdude_message(MSG_INFO, "%s: Flash page erase command failed\n", progname);
+    msg_info("%s: Flash page erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   return 0;
@@ -864,21 +864,21 @@ static int nvm_erase_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p) {
         if not status:
             raise IOError("Timeout waiting for NVM controller to be ready after EEPROM erase")
 */
-  avrdude_message(MSG_DEBUG, "%s: Erase EEPROM\n", progname);
+  msg_debug("%s: Erase EEPROM\n", progname);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_EEPROM_ERASE) < 0) {
-    avrdude_message(MSG_INFO, "%s: EEPROM erase command failed\n", progname);
+    msg_info("%s: EEPROM erase command failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    avrdude_message(MSG_INFO, "%s: Sending empty command failed\n", progname);
+    msg_info("%s: Sending empty command failed\n", progname);
     return -1;
   }
   return 0;
@@ -898,7 +898,7 @@ static int nvm_erase_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32
         # On this NVM version user row is implemented as FLASH
         return self.erase_flash_page(self, address)
 */
-  avrdude_message(MSG_DEBUG, "%s: Erase user row at address 0x%06X\n", progname, address);
+  msg_debug("%s: Erase user row at address 0x%06X\n", progname, address);
   
   return nvm_erase_flash_page_V3(pgm, p, address);
 }
@@ -1014,43 +1014,43 @@ static int nvm_write_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
         self.execute_nvm_command(constants.UPDI_V3_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
-  avrdude_message(MSG_DEBUG, "%s: Clear page buffer\n", progname);
+  msg_debug("%s: Clear page buffer\n", progname);
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_BUFFER_CLEAR) < 0) {
-    avrdude_message(MSG_INFO, "%s: Clear page operation failed\n", progname);
+    msg_info("%s: Clear page operation failed\n", progname);
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      avrdude_message(MSG_INFO, "%s: Write data words operation failed\n", progname);
+      msg_info("%s: Write data words operation failed\n", progname);
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      avrdude_message(MSG_INFO, "%s: Write data operation failed\n", progname);
+      msg_info("%s: Write data operation failed\n", progname);
       return -1;
     }
   }
-  avrdude_message(MSG_DEBUG, "%s: Committing data\n", progname);
+  msg_debug("%s: Committing data\n", progname);
   if (nvm_command == USE_DEFAULT_COMMAND) {
     nvm_command = UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_WRITE;
   }
   if (updi_nvm_command(pgm, p, nvm_command) < 0) {
-      avrdude_message(MSG_INFO, "%s: Commit data command failed\n", progname);
+      msg_info("%s: Commit data command failed\n", progname);
       return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    avrdude_message(MSG_INFO, "%s: Wait for ready chip failed\n", progname);
+    msg_info("%s: Wait for ready chip failed\n", progname);
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    avrdude_message(MSG_INFO, "%s: Sending empty command failed\n", progname);
+    msg_info("%s: Sending empty command failed\n", progname);
     return -1;
   }
   return 0;
@@ -1067,7 +1067,7 @@ int updi_nvm_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     case UPDI_NVM_MODE_V3:
       return nvm_chip_erase_V3(pgm, p);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1082,7 +1082,7 @@ int updi_nvm_erase_flash_page(const PROGRAMMER *pgm, const AVRPART *p, uint32_t 
     case UPDI_NVM_MODE_V3:
       return nvm_erase_flash_page_V3(pgm, p, address);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1097,7 +1097,7 @@ int updi_nvm_erase_eeprom(const PROGRAMMER *pgm, const AVRPART *p) {
     case UPDI_NVM_MODE_V3:
       return nvm_erase_eeprom_V3(pgm, p);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1112,7 +1112,7 @@ int updi_nvm_erase_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t ad
     case UPDI_NVM_MODE_V3:
       return nvm_erase_user_row_V3(pgm, p, address, size);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1127,7 +1127,7 @@ int updi_nvm_write_flash(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addre
     case UPDI_NVM_MODE_V3:
       return nvm_write_flash_V3(pgm, p, address, buffer, size);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1142,7 +1142,7 @@ int updi_nvm_write_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t ad
     case UPDI_NVM_MODE_V3:
       return nvm_write_user_row_V3(pgm, p, address, buffer, size);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1157,7 +1157,7 @@ int updi_nvm_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addr
     case UPDI_NVM_MODE_V3:
       return nvm_write_eeprom_V3(pgm, p, address, buffer, size);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1172,7 +1172,7 @@ int updi_nvm_write_fuse(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
     case UPDI_NVM_MODE_V3:
       return nvm_write_fuse_V3(pgm, p, address, value);
     default:
-      avrdude_message(MSG_INFO, "%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1208,7 +1208,7 @@ int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p) {
   do {
     if (updi_read_byte(pgm, p->nvm_base + UPDI_NVMCTRL_STATUS, &status) >= 0) {
       if (status & (1 << UPDI_NVM_STATUS_WRITE_ERROR)) {
-        avrdude_message(MSG_INFO, "%s: NVM error\n", progname);
+        msg_info("%s: NVM error\n", progname);
         return -1;
       }
       if (!(status & ((1 << UPDI_NVM_STATUS_EEPROM_BUSY) | 
@@ -1220,7 +1220,7 @@ int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p) {
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < 10000000);
 
-  avrdude_message(MSG_INFO, "%s: Wait NVM ready timed out\n", progname);
+  msg_info("%s: Wait NVM ready timed out\n", progname);
   return -1;
 }
 
@@ -1235,7 +1235,7 @@ int updi_nvm_command(const PROGRAMMER *pgm, const AVRPART *p, uint8_t command) {
         self.logger.debug("NVMCMD %d executing", command)
         return self.readwrite.write_byte(self.device.nvmctrl_address + constants.UPDI_NVMCTRL_CTRLA, command)
 */
-  avrdude_message(MSG_DEBUG, "%s: NVMCMD %d executing\n", progname, command);
+  msg_debug("%s: NVMCMD %d executing\n", progname, command);
 
   return updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_CTRLA, command);
 }

--- a/src/updi_nvm.c
+++ b/src/updi_nvm.c
@@ -73,15 +73,15 @@ static int nvm_chip_erase_V0(const PROGRAMMER *pgm, const AVRPART *p) {
 */
   pmsg_debug("Chip erase using NVM CTRL\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("Wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    pmsg_info("Chip erase command failed\n");
+    pmsg_error("UPDI chip erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("Wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -115,20 +115,20 @@ static int nvm_erase_flash_page_V0(const PROGRAMMER *pgm, const AVRPART *p, uint
   unsigned char data[1];
   pmsg_debug("erase flash page at address 0x%06X\n", address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    pmsg_info("dummy write operation failed\n");
+    pmsg_error("dummy write operation failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_PAGE) < 0) {
-    pmsg_info("flash page erase command failed\n");
+    pmsg_error("UPDI flash page erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -155,15 +155,15 @@ static int nvm_erase_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p) {
 */  
   pmsg_debug("erase EEPROM\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_EEPROM) < 0) {
-    pmsg_info("EEPROM erase command failed\n");
+    pmsg_error("UPDI EEPROM erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -200,23 +200,23 @@ static int nvm_erase_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32
   unsigned char data[1];
   pmsg_debug("erase user row\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   data[0]=0xFF;
   for (offset = 0; offset<size; offset++)
   {
     if (updi_write_data(pgm, address+offset, data, 1) < 0) {
-      pmsg_info("write data operation failed at offset 0x%04x\n", offset);
+      pmsg_error("write data operation failed at offset 0x%04x\n", offset);
       return -1;
     }
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_PAGE) < 0) {
-    pmsg_info("erase page operation failed\n");
+    pmsg_error("erase page operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -303,30 +303,30 @@ static int nvm_write_fuse_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t a
             raise PymcuprogError("Timeout waiting for NVM controller to be ready after fuse write")
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   pmsg_debug("load NVM address\n");
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_ADDRL, address & 0xFF) < 0) {
-    pmsg_info("write ADDRL operation failed\n");
+    pmsg_error("UPDI write ADDRL operation failed\n");
     return -1;
   }
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_ADDRH, (address >> 8) & 0xFF) < 0) {
-    pmsg_info("write ADDRH operation failed\n");
+    pmsg_error("write ADDRH operation failed\n");
     return -1;
   }
   pmsg_debug("load fuse data\n");
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_DATAL, value & 0xFF) < 0) {
-    pmsg_info("write DATAL operation failed\n");
+    pmsg_error("write DATAL operation failed\n");
     return -1;
   }
   pmsg_debug("execute fuse write\n");
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_WRITE_FUSE) < 0) {
-    pmsg_info("write fuse operation failed\n");
+    pmsg_error("write fuse operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -377,26 +377,26 @@ static int nvm_write_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
             raise PymcuprogError("Timeout waiting for NVM controller to be ready after page write")
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   pmsg_debug("clear page buffer\n");
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_PAGE_BUFFER_CLR) < 0) {
-    pmsg_info("clear page operation failed\n");
+    pmsg_error("clear page operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      pmsg_info("write data words operation failed\n");
+      pmsg_error("write data words operation failed\n");
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      pmsg_info("write data operation failed\n");
+      pmsg_error("write data operation failed\n");
       return -1;
     }
   }
@@ -405,11 +405,11 @@ static int nvm_write_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
     nvm_command = UPDI_V0_NVMCTRL_CTRLA_WRITE_PAGE;
   }
   if (updi_nvm_command(pgm, p, nvm_command) < 0) {
-      pmsg_info("commit data command failed\n");
+      pmsg_error("commit data command failed\n");
       return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -440,15 +440,15 @@ static int nvm_chip_erase_V2(const PROGRAMMER *pgm, const AVRPART *p) {
 */
   pmsg_debug("chip erase using NVM CTRL\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    pmsg_info("chip erase command failed\n");
+    pmsg_error("chip erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -486,20 +486,20 @@ static int nvm_erase_flash_page_V2(const PROGRAMMER *pgm, const AVRPART *p, uint
   unsigned char data[1];
   pmsg_debug("erase flash page at address 0x%06X\n", address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    pmsg_info("dummy write operation failed\n");
+    pmsg_error("dummy write operation failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_FLASH_PAGE_ERASE) < 0) {
-    pmsg_info("flash page erase command failed\n");
+    pmsg_error("flash page erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -530,20 +530,20 @@ static int nvm_erase_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p) {
 */
   pmsg_debug("erase EEPROM\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_EEPROM_ERASE) < 0) {
-    pmsg_info("EEPROM erase command failed\n");
+    pmsg_error("EEPROM erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   pmsg_debug("clear NVM command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    pmsg_info("sending empty command failed\n");
+    pmsg_error("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -629,25 +629,25 @@ static int nvm_write_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   pmsg_debug("NVM EEPROM erase/write command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_EEPROM_ERASE_WRITE) < 0) {
-    pmsg_info("EEPROM erase command failed\n");
+    pmsg_error("EEPROM erase command failed\n");
     return -1;
   }
   if (updi_write_data(pgm, address, buffer, size) < 0) {
-    pmsg_info("write data operation failed\n");
+    pmsg_error("write data operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   pmsg_debug("clear NVM command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    pmsg_info("clear NVM command failed\n");
+    pmsg_error("clear NVM command failed\n");
     return -1;
   }
   return 0;
@@ -708,32 +708,32 @@ static int nvm_write_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   pmsg_debug("NVM write command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_FLASH_WRITE) < 0) {
-    pmsg_info("clear page operation failed\n");
+    pmsg_error("clear page operation failed\n");
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      pmsg_info("write data words operation failed\n");
+      pmsg_error("write data words operation failed\n");
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      pmsg_info("write data operation failed\n");
+      pmsg_error("write data operation failed\n");
       return -1;
     }
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("wait for ready chip failed\n");
     return -1;
   }
   pmsg_debug("clear NVM command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    pmsg_info("clear NVM command failed\n");
+    pmsg_error("clear NVM command failed\n");
     return -1;
   }
   return 0;
@@ -770,19 +770,19 @@ static int nvm_chip_erase_V3(const PROGRAMMER *pgm, const AVRPART *p) {
 */
   pmsg_debug("Chip erase using NVM CTRL\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    pmsg_info("chip erase command failed\n");
+    pmsg_error("chip erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    pmsg_info("sending empty command failed\n");
+    pmsg_error("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -821,20 +821,20 @@ static int nvm_erase_flash_page_V3(const PROGRAMMER *pgm, const AVRPART *p, uint
   unsigned char data[1];
   pmsg_debug("erase flash page at address 0x%06X\n", address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    pmsg_info("dummy write operation failed\n");
+    pmsg_error("dummy write operation failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_ERASE) < 0) {
-    pmsg_info("flash page erase command failed\n");
+    pmsg_error("flash page erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   return 0;
@@ -866,19 +866,19 @@ static int nvm_erase_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p) {
 */
   pmsg_debug("erase EEPROM\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_EEPROM_ERASE) < 0) {
-    pmsg_info("EEPROM erase command failed\n");
+    pmsg_error("EEPROM erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    pmsg_info("sending empty command failed\n");
+    pmsg_error("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -1014,26 +1014,26 @@ static int nvm_write_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
         self.execute_nvm_command(constants.UPDI_V3_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   pmsg_debug("clear page buffer\n");
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_BUFFER_CLEAR) < 0) {
-    pmsg_info("clear page operation failed\n");
+    pmsg_error("clear page operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      pmsg_info("write data words operation failed\n");
+      pmsg_error("write data words operation failed\n");
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      pmsg_info("write data operation failed\n");
+      pmsg_error("write data operation failed\n");
       return -1;
     }
   }
@@ -1042,15 +1042,15 @@ static int nvm_write_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
     nvm_command = UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_WRITE;
   }
   if (updi_nvm_command(pgm, p, nvm_command) < 0) {
-      pmsg_info("commit data command failed\n");
+      pmsg_error("commit data command failed\n");
       return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    pmsg_info("wait for ready chip failed\n");
+    pmsg_error("updi_nvm_wait_ready() failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    pmsg_info("sending empty command failed\n");
+    pmsg_error("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -1067,7 +1067,7 @@ int updi_nvm_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     case UPDI_NVM_MODE_V3:
       return nvm_chip_erase_V3(pgm, p);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1082,7 +1082,7 @@ int updi_nvm_erase_flash_page(const PROGRAMMER *pgm, const AVRPART *p, uint32_t 
     case UPDI_NVM_MODE_V3:
       return nvm_erase_flash_page_V3(pgm, p, address);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1097,7 +1097,7 @@ int updi_nvm_erase_eeprom(const PROGRAMMER *pgm, const AVRPART *p) {
     case UPDI_NVM_MODE_V3:
       return nvm_erase_eeprom_V3(pgm, p);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1112,7 +1112,7 @@ int updi_nvm_erase_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t ad
     case UPDI_NVM_MODE_V3:
       return nvm_erase_user_row_V3(pgm, p, address, size);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1127,7 +1127,7 @@ int updi_nvm_write_flash(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addre
     case UPDI_NVM_MODE_V3:
       return nvm_write_flash_V3(pgm, p, address, buffer, size);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1142,7 +1142,7 @@ int updi_nvm_write_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t ad
     case UPDI_NVM_MODE_V3:
       return nvm_write_user_row_V3(pgm, p, address, buffer, size);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1157,7 +1157,7 @@ int updi_nvm_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addr
     case UPDI_NVM_MODE_V3:
       return nvm_write_eeprom_V3(pgm, p, address, buffer, size);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1172,7 +1172,7 @@ int updi_nvm_write_fuse(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
     case UPDI_NVM_MODE_V3:
       return nvm_write_fuse_V3(pgm, p, address, value);
     default:
-      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1208,7 +1208,7 @@ int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p) {
   do {
     if (updi_read_byte(pgm, p->nvm_base + UPDI_NVMCTRL_STATUS, &status) >= 0) {
       if (status & (1 << UPDI_NVM_STATUS_WRITE_ERROR)) {
-        pmsg_info("NVM error\n");
+        pmsg_error("unable to write NVM status\n");
         return -1;
       }
       if (!(status & ((1 << UPDI_NVM_STATUS_EEPROM_BUSY) | 
@@ -1220,7 +1220,7 @@ int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p) {
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < 10000000);
 
-  pmsg_info("wait NVM ready timed out\n");
+  pmsg_error("wait NVM ready timed out\n");
   return -1;
 }
 

--- a/src/updi_nvm.c
+++ b/src/updi_nvm.c
@@ -71,17 +71,17 @@ static int nvm_chip_erase_V0(const PROGRAMMER *pgm, const AVRPART *p) {
 
         return True
 */
-  msg_debug("%s: Chip erase using NVM CTRL\n", progname);
+  pmsg_debug("Chip erase using NVM CTRL\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("Wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    msg_info("%s: Chip erase command failed\n", progname);
+    pmsg_info("Chip erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("Wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -113,22 +113,22 @@ static int nvm_erase_flash_page_V0(const PROGRAMMER *pgm, const AVRPART *p, uint
             raise IOError("Timeout waiting for NVM controller to be ready after flash page erase")
 */
   unsigned char data[1];
-  msg_debug("%s: Erase flash page at address 0x%06X\n", progname, address);
+  pmsg_debug("erase flash page at address 0x%06X\n", address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    msg_info("%s: Dummy write operation failed\n", progname);
+    pmsg_info("dummy write operation failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_PAGE) < 0) {
-    msg_info("%s: Flash page erase command failed\n", progname);
+    pmsg_info("flash page erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -153,17 +153,17 @@ static int nvm_erase_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p) {
         if not self.wait_nvm_ready():
             raise IOError("Timeout waiting for NVM controller to be ready after EEPROM erase")
 */  
-  msg_debug("%s: Erase EEPROM\n", progname);
+  pmsg_debug("erase EEPROM\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_EEPROM) < 0) {
-    msg_info("%s: EEPROM erase command failed\n", progname);
+    pmsg_info("EEPROM erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -198,25 +198,25 @@ static int nvm_erase_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32
 */
   uint16_t offset;
   unsigned char data[1];
-  msg_debug("%s: Erase user row\n", progname);
+  pmsg_debug("erase user row\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   data[0]=0xFF;
   for (offset = 0; offset<size; offset++)
   {
     if (updi_write_data(pgm, address+offset, data, 1) < 0) {
-      msg_info("%s: Write data operation failed at offset 0x%04x\n", progname, offset);
+      pmsg_info("write data operation failed at offset 0x%04x\n", offset);
       return -1;
     }
   }
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_ERASE_PAGE) < 0) {
-    msg_info("%s: Erase page operation failed\n", progname);
+    pmsg_info("erase page operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -303,30 +303,30 @@ static int nvm_write_fuse_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t a
             raise PymcuprogError("Timeout waiting for NVM controller to be ready after fuse write")
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: Load NVM address\n", progname);
+  pmsg_debug("load NVM address\n");
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_ADDRL, address & 0xFF) < 0) {
-    msg_info("%s: Write ADDRL operation failed\n", progname);
+    pmsg_info("write ADDRL operation failed\n");
     return -1;
   }
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_ADDRH, (address >> 8) & 0xFF) < 0) {
-    msg_info("%s: Write ADDRH operation failed\n", progname);
+    pmsg_info("write ADDRH operation failed\n");
     return -1;
   }
-  msg_debug("%s: Load fuse data\n", progname);
+  pmsg_debug("load fuse data\n");
   if (updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_DATAL, value & 0xFF) < 0) {
-    msg_info("%s: Write DATAL operation failed\n", progname);
+    pmsg_info("write DATAL operation failed\n");
     return -1;
   }
-  msg_debug("%s: Execute fuse write\n", progname);
+  pmsg_debug("execute fuse write\n");
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_WRITE_FUSE) < 0) {
-    msg_info("%s: Write fuse operation failed\n", progname);
+    pmsg_info("write fuse operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -377,39 +377,39 @@ static int nvm_write_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
             raise PymcuprogError("Timeout waiting for NVM controller to be ready after page write")
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: Clear page buffer\n", progname);
+  pmsg_debug("clear page buffer\n");
   if (updi_nvm_command(pgm, p, UPDI_V0_NVMCTRL_CTRLA_PAGE_BUFFER_CLR) < 0) {
-    msg_info("%s: Clear page operation failed\n", progname);
+    pmsg_info("clear page operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      msg_info("%s: Write data words operation failed\n", progname);
+      pmsg_info("write data words operation failed\n");
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      msg_info("%s: Write data operation failed\n", progname);
+      pmsg_info("write data operation failed\n");
       return -1;
     }
   }
-  msg_debug("%s: Committing data\n", progname);
+  pmsg_debug("committing data\n");
   if (nvm_command == USE_DEFAULT_COMMAND) {
     nvm_command = UPDI_V0_NVMCTRL_CTRLA_WRITE_PAGE;
   }
   if (updi_nvm_command(pgm, p, nvm_command) < 0) {
-      msg_info("%s: Commit data command failed\n", progname);
+      pmsg_info("commit data command failed\n");
       return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -438,17 +438,17 @@ static int nvm_chip_erase_V2(const PROGRAMMER *pgm, const AVRPART *p) {
 
         return True
 */
-  msg_debug("%s: Chip erase using NVM CTRL\n", progname);
+  pmsg_debug("chip erase using NVM CTRL\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    msg_info("%s: Chip erase command failed\n", progname);
+    pmsg_info("chip erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -484,22 +484,22 @@ static int nvm_erase_flash_page_V2(const PROGRAMMER *pgm, const AVRPART *p, uint
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   unsigned char data[1];
-  msg_debug("%s: Erase flash page at address 0x%06X\n", progname, address);
+  pmsg_debug("erase flash page at address 0x%06X\n", address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    msg_info("%s: Dummy write operation failed\n", progname);
+    pmsg_info("dummy write operation failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_FLASH_PAGE_ERASE) < 0) {
-    msg_info("%s: Flash page erase command failed\n", progname);
+    pmsg_info("flash page erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -528,22 +528,22 @@ static int nvm_erase_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p) {
         self.logger.debug("Clear NVM command")
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
-  msg_debug("%s: Erase EEPROM\n", progname);
+  pmsg_debug("erase EEPROM\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_EEPROM_ERASE) < 0) {
-    msg_info("%s: EEPROM erase command failed\n", progname);
+    pmsg_info("EEPROM erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: Clear NVM command\n", progname);
+  pmsg_debug("clear NVM command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    msg_info("%s: Sending empty command failed\n", progname);
+    pmsg_info("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -629,25 +629,25 @@ static int nvm_write_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: NVM EEPROM erase/write command\n", progname);
+  pmsg_debug("NVM EEPROM erase/write command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_EEPROM_ERASE_WRITE) < 0) {
-    msg_info("%s: EEPROM erase command failed\n", progname);
+    pmsg_info("EEPROM erase command failed\n");
     return -1;
   }
   if (updi_write_data(pgm, address, buffer, size) < 0) {
-    msg_info("%s: Write data operation failed\n", progname);
+    pmsg_info("write data operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: Clear NVM command\n", progname);
+  pmsg_debug("clear NVM command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    msg_info("%s: Clear NVM command failed\n", progname);
+    pmsg_info("clear NVM command failed\n");
     return -1;
   }
   return 0;
@@ -708,32 +708,32 @@ static int nvm_write_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
         self.execute_nvm_command(constants.UPDI_V2_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: NVM write command\n", progname);
+  pmsg_debug("NVM write command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_FLASH_WRITE) < 0) {
-    msg_info("%s: Clear page operation failed\n", progname);
+    pmsg_info("clear page operation failed\n");
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      msg_info("%s: Write data words operation failed\n", progname);
+      pmsg_info("write data words operation failed\n");
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      msg_info("%s: Write data operation failed\n", progname);
+      pmsg_info("write data operation failed\n");
       return -1;
     }
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: Clear NVM command\n", progname);
+  pmsg_debug("clear NVM command\n");
   if (updi_nvm_command(pgm, p, UPDI_V2_NVMCTRL_CTRLA_NOCMD) < 0) {
-    msg_info("%s: Clear NVM command failed\n", progname);
+    pmsg_info("clear NVM command failed\n");
     return -1;
   }
   return 0;
@@ -768,21 +768,21 @@ static int nvm_chip_erase_V3(const PROGRAMMER *pgm, const AVRPART *p) {
 
         return True
 */
-  msg_debug("%s: Chip erase using NVM CTRL\n", progname);
+  pmsg_debug("Chip erase using NVM CTRL\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_CHIP_ERASE) < 0) {
-    msg_info("%s: Chip erase command failed\n", progname);
+    pmsg_info("chip erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    msg_info("%s: Sending empty command failed\n", progname);
+    pmsg_info("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -819,22 +819,22 @@ static int nvm_erase_flash_page_V3(const PROGRAMMER *pgm, const AVRPART *p, uint
             raise IOError("Timeout waiting for NVM controller to be ready after flash page erase")
 */  
   unsigned char data[1];
-  msg_debug("%s: Erase flash page at address 0x%06X\n", progname, address);
+  pmsg_debug("erase flash page at address 0x%06X\n", address);
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   data[0] = 0xFF;
   if (updi_write_data(pgm, address, data, 1) < 0) {
-    msg_info("%s: Dummy write operation failed\n", progname);
+    pmsg_info("dummy write operation failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_ERASE) < 0) {
-    msg_info("%s: Flash page erase command failed\n", progname);
+    pmsg_info("flash page erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   return 0;
@@ -864,21 +864,21 @@ static int nvm_erase_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p) {
         if not status:
             raise IOError("Timeout waiting for NVM controller to be ready after EEPROM erase")
 */
-  msg_debug("%s: Erase EEPROM\n", progname);
+  pmsg_debug("erase EEPROM\n");
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_EEPROM_ERASE) < 0) {
-    msg_info("%s: EEPROM erase command failed\n", progname);
+    pmsg_info("EEPROM erase command failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    msg_info("%s: Sending empty command failed\n", progname);
+    pmsg_info("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -898,7 +898,7 @@ static int nvm_erase_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32
         # On this NVM version user row is implemented as FLASH
         return self.erase_flash_page(self, address)
 */
-  msg_debug("%s: Erase user row at address 0x%06X\n", progname, address);
+  pmsg_debug("erase user row at address 0x%06X\n", address);
   
   return nvm_erase_flash_page_V3(pgm, p, address);
 }
@@ -1014,43 +1014,43 @@ static int nvm_write_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
         self.execute_nvm_command(constants.UPDI_V3_NVMCTRL_CTRLA_NOCMD)
 */
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
-  msg_debug("%s: Clear page buffer\n", progname);
+  pmsg_debug("clear page buffer\n");
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_BUFFER_CLEAR) < 0) {
-    msg_info("%s: Clear page operation failed\n", progname);
+    pmsg_info("clear page operation failed\n");
     return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (mode == USE_WORD_ACCESS) {
     if (updi_write_data_words(pgm, address, buffer, size) < 0) {
-      msg_info("%s: Write data words operation failed\n", progname);
+      pmsg_info("write data words operation failed\n");
       return -1;
     }
   } else {
     if (updi_write_data(pgm, address, buffer, size) < 0) {
-      msg_info("%s: Write data operation failed\n", progname);
+      pmsg_info("write data operation failed\n");
       return -1;
     }
   }
-  msg_debug("%s: Committing data\n", progname);
+  pmsg_debug("committing data\n");
   if (nvm_command == USE_DEFAULT_COMMAND) {
     nvm_command = UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_WRITE;
   }
   if (updi_nvm_command(pgm, p, nvm_command) < 0) {
-      msg_info("%s: Commit data command failed\n", progname);
+      pmsg_info("commit data command failed\n");
       return -1;
   }
   if (updi_nvm_wait_ready(pgm, p) < 0) {
-    msg_info("%s: Wait for ready chip failed\n", progname);
+    pmsg_info("wait for ready chip failed\n");
     return -1;
   }
   if (updi_nvm_command(pgm, p, UPDI_V3_NVMCTRL_CTRLA_NOCMD) < 0) {
-    msg_info("%s: Sending empty command failed\n", progname);
+    pmsg_info("sending empty command failed\n");
     return -1;
   }
   return 0;
@@ -1067,7 +1067,7 @@ int updi_nvm_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     case UPDI_NVM_MODE_V3:
       return nvm_chip_erase_V3(pgm, p);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1082,7 +1082,7 @@ int updi_nvm_erase_flash_page(const PROGRAMMER *pgm, const AVRPART *p, uint32_t 
     case UPDI_NVM_MODE_V3:
       return nvm_erase_flash_page_V3(pgm, p, address);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1097,7 +1097,7 @@ int updi_nvm_erase_eeprom(const PROGRAMMER *pgm, const AVRPART *p) {
     case UPDI_NVM_MODE_V3:
       return nvm_erase_eeprom_V3(pgm, p);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1112,7 +1112,7 @@ int updi_nvm_erase_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t ad
     case UPDI_NVM_MODE_V3:
       return nvm_erase_user_row_V3(pgm, p, address, size);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1127,7 +1127,7 @@ int updi_nvm_write_flash(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addre
     case UPDI_NVM_MODE_V3:
       return nvm_write_flash_V3(pgm, p, address, buffer, size);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1142,7 +1142,7 @@ int updi_nvm_write_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t ad
     case UPDI_NVM_MODE_V3:
       return nvm_write_user_row_V3(pgm, p, address, buffer, size);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1157,7 +1157,7 @@ int updi_nvm_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addr
     case UPDI_NVM_MODE_V3:
       return nvm_write_eeprom_V3(pgm, p, address, buffer, size);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1172,7 +1172,7 @@ int updi_nvm_write_fuse(const PROGRAMMER *pgm, const AVRPART *p, uint32_t addres
     case UPDI_NVM_MODE_V3:
       return nvm_write_fuse_V3(pgm, p, address, value);
     default:
-      msg_info("%s: Invalid NVM Mode %d\n", progname, updi_get_nvm_mode(pgm));
+      pmsg_info("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
       return -1;
   }
 }
@@ -1208,7 +1208,7 @@ int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p) {
   do {
     if (updi_read_byte(pgm, p->nvm_base + UPDI_NVMCTRL_STATUS, &status) >= 0) {
       if (status & (1 << UPDI_NVM_STATUS_WRITE_ERROR)) {
-        msg_info("%s: NVM error\n", progname);
+        pmsg_info("NVM error\n");
         return -1;
       }
       if (!(status & ((1 << UPDI_NVM_STATUS_EEPROM_BUSY) | 
@@ -1220,7 +1220,7 @@ int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p) {
     current_time = (tv.tv_sec * 1000000) + tv.tv_usec;
   } while ((current_time - start_time) < 10000000);
 
-  msg_info("%s: Wait NVM ready timed out\n", progname);
+  pmsg_info("wait NVM ready timed out\n");
   return -1;
 }
 
@@ -1235,7 +1235,7 @@ int updi_nvm_command(const PROGRAMMER *pgm, const AVRPART *p, uint8_t command) {
         self.logger.debug("NVMCMD %d executing", command)
         return self.readwrite.write_byte(self.device.nvmctrl_address + constants.UPDI_NVMCTRL_CTRLA, command)
 */
-  msg_debug("%s: NVMCMD %d executing\n", progname, command);
+  pmsg_debug("NVMCMD %d executing\n", command);
 
   return updi_write_byte(pgm, p->nvm_base + UPDI_NVMCTRL_CTRLA, command);
 }

--- a/src/updi_readwrite.c
+++ b/src/updi_readwrite.c
@@ -146,21 +146,21 @@ int updi_read_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uin
         # Do the read(s)
         return self.datalink.ld_ptr_inc(size)
 */
-  msg_debug("%s: Reading %d bytes from 0x%06X\n", progname, size, address);
+  pmsg_debug("reading %d bytes from 0x%06X\n", size, address);
 
   if (size > UPDI_MAX_REPEAT_SIZE) {
-    msg_debug("%s: Can't read that many bytes in one go\n", progname);
+    pmsg_debug("cannot read that many bytes in one go\n");
     return -1;
   }
 
   if (updi_link_st_ptr(pgm, address) < 0) {
-    msg_debug("%s: ST_PTR operation failed\n", progname);
+    pmsg_debug("ST_PTR operation failed\n");
     return -1;
   }
 
   if (size > 1) {
     if (updi_link_repeat(pgm, size) < 0) {
-      msg_debug("%s: Repeat operation failed\n", progname);
+      pmsg_debug("repeat operation failed\n");
       return -1;
     }
   }
@@ -200,21 +200,21 @@ int updi_write_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, ui
   }
   if (size == 2) {
     if (updi_link_st(pgm, address, buffer[0]) < 0) {
-      msg_debug("%s: ST operation failed\n", progname);
+      pmsg_debug("ST operation failed\n");
       return -1;
     }
     return updi_link_st(pgm, address+1, buffer[1]);
   }
   if (size > UPDI_MAX_REPEAT_SIZE) {
-    msg_debug("%s: Invalid length\n", progname);
+    pmsg_debug("invalid length\n");
     return -1;
   }
   if (updi_link_st_ptr(pgm, address) < 0) {
-    msg_debug("%s: ST_PTR operation failed\n", progname);
+    pmsg_debug("ST_PTR operation failed\n");
     return -1;
   }
   if (updi_link_repeat(pgm, size) < 0) {
-    msg_debug("%s: Repeat operation failed\n", progname);
+    pmsg_debug("repeat operation failed\n");
     return -1;
   }
   return updi_link_st_ptr_inc(pgm, buffer, size);
@@ -245,21 +245,21 @@ int updi_read_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffe
         # Do the read
         return self.datalink.ld_ptr_inc16(words)
 */
-  msg_debug("%s: Reading %d words from 0x%06X", progname, size, address);
+  pmsg_debug("reading %d words from 0x%06X", size, address);
 
   if (size > (UPDI_MAX_REPEAT_SIZE >> 1)) {
-    msg_debug("%s: Can't read that many words in one go\n", progname);
+    pmsg_debug("cannot read that many words in one go\n");
     return -1;
   }
 
   if (updi_link_st_ptr(pgm, address) < 0) {
-    msg_debug("%s: ST_PTR operation failed\n", progname);
+    pmsg_debug("ST_PTR operation failed\n");
     return -1;
   }
 
   if (size > 1) {
     if (updi_link_repeat(pgm, size) < 0) {
-      msg_debug("%s: Repeat operation failed\n", progname);
+      pmsg_debug("repeat operation failed\n");
       return -1;
     }
   }
@@ -295,11 +295,11 @@ int updi_write_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buff
     return updi_link_st16(pgm, address, buffer[0] + (buffer[1] << 8));
   }
   if (size > UPDI_MAX_REPEAT_SIZE << 1) {
-    msg_debug("%s: Invalid length\n", progname);
+    pmsg_debug("invalid length\n");
     return -1;
   }
   if (updi_link_st_ptr(pgm, address) < 0) {
-    msg_debug("%s: ST_PTR operation failed\n", progname);
+    pmsg_debug("ST_PTR operation failed\n");
     return -1;
   }
   return updi_link_st_ptr_inc16_RSD(pgm, buffer, size >> 1, -1);

--- a/src/updi_readwrite.c
+++ b/src/updi_readwrite.c
@@ -146,21 +146,21 @@ int updi_read_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, uin
         # Do the read(s)
         return self.datalink.ld_ptr_inc(size)
 */
-  avrdude_message(MSG_DEBUG, "%s: Reading %d bytes from 0x%06X\n", progname, size, address);
+  msg_debug("%s: Reading %d bytes from 0x%06X\n", progname, size, address);
 
   if (size > UPDI_MAX_REPEAT_SIZE) {
-    avrdude_message(MSG_DEBUG, "%s: Can't read that many bytes in one go\n", progname);
+    msg_debug("%s: Can't read that many bytes in one go\n", progname);
     return -1;
   }
 
   if (updi_link_st_ptr(pgm, address) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST_PTR operation failed\n", progname);
+    msg_debug("%s: ST_PTR operation failed\n", progname);
     return -1;
   }
 
   if (size > 1) {
     if (updi_link_repeat(pgm, size) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: Repeat operation failed\n", progname);
+      msg_debug("%s: Repeat operation failed\n", progname);
       return -1;
     }
   }
@@ -200,21 +200,21 @@ int updi_write_data(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffer, ui
   }
   if (size == 2) {
     if (updi_link_st(pgm, address, buffer[0]) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: ST operation failed\n", progname);
+      msg_debug("%s: ST operation failed\n", progname);
       return -1;
     }
     return updi_link_st(pgm, address+1, buffer[1]);
   }
   if (size > UPDI_MAX_REPEAT_SIZE) {
-    avrdude_message(MSG_DEBUG, "%s: Invalid length\n", progname);
+    msg_debug("%s: Invalid length\n", progname);
     return -1;
   }
   if (updi_link_st_ptr(pgm, address) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST_PTR operation failed\n", progname);
+    msg_debug("%s: ST_PTR operation failed\n", progname);
     return -1;
   }
   if (updi_link_repeat(pgm, size) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: Repeat operation failed\n", progname);
+    msg_debug("%s: Repeat operation failed\n", progname);
     return -1;
   }
   return updi_link_st_ptr_inc(pgm, buffer, size);
@@ -245,21 +245,21 @@ int updi_read_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buffe
         # Do the read
         return self.datalink.ld_ptr_inc16(words)
 */
-  avrdude_message(MSG_DEBUG, "%s: Reading %d words from 0x%06X", progname, size, address);
+  msg_debug("%s: Reading %d words from 0x%06X", progname, size, address);
 
   if (size > (UPDI_MAX_REPEAT_SIZE >> 1)) {
-    avrdude_message(MSG_DEBUG, "%s: Can't read that many words in one go\n", progname);
+    msg_debug("%s: Can't read that many words in one go\n", progname);
     return -1;
   }
 
   if (updi_link_st_ptr(pgm, address) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST_PTR operation failed\n", progname);
+    msg_debug("%s: ST_PTR operation failed\n", progname);
     return -1;
   }
 
   if (size > 1) {
     if (updi_link_repeat(pgm, size) < 0) {
-      avrdude_message(MSG_DEBUG, "%s: Repeat operation failed\n", progname);
+      msg_debug("%s: Repeat operation failed\n", progname);
       return -1;
     }
   }
@@ -295,11 +295,11 @@ int updi_write_data_words(const PROGRAMMER *pgm, uint32_t address, uint8_t *buff
     return updi_link_st16(pgm, address, buffer[0] + (buffer[1] << 8));
   }
   if (size > UPDI_MAX_REPEAT_SIZE << 1) {
-    avrdude_message(MSG_DEBUG, "%s: Invalid length\n", progname);
+    msg_debug("%s: Invalid length\n", progname);
     return -1;
   }
   if (updi_link_st_ptr(pgm, address) < 0) {
-    avrdude_message(MSG_DEBUG, "%s: ST_PTR operation failed\n", progname);
+    msg_debug("%s: ST_PTR operation failed\n", progname);
     return -1;
   }
   return updi_link_st_ptr_inc16_RSD(pgm, buffer, size >> 1, -1);

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -79,7 +79,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
 
       if (strlen(serno) > 12)
 	{
-	  pmsg_error("usbhid_open(): invalid serial number %s\n", serno);
+	  pmsg_error("invalid serial number %s\n", serno);
 	  return -1;
 	}
 
@@ -112,7 +112,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       }
       if (walk == NULL)
       {
-	pmsg_error("usbhid_open(): no matching device found\n");
+	pmsg_error("no matching device found\n");
 	hid_free_enumeration(list);
 	return -1;
       }
@@ -121,7 +121,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       hid_free_enumeration(list);
       if (dev == NULL)
       {
-	pmsg_error("usbhid_open(): found device, but hid_open_path() failed\n");
+	pmsg_error("found device, but hid_open_path() failed\n");
 	return -1;
       }
     }
@@ -133,7 +133,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       dev = hid_open(pinfo.usbinfo.vid, pinfo.usbinfo.pid, NULL);
       if (dev == NULL)
       {
-	pmsg_error("usbhid_open(): no device found\n");
+	pmsg_error("no device found\n");
 	return -1;
       }
     }
@@ -186,12 +186,12 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
 	res = hid_read_timeout(dev, usbbuf, 10, 50);
       }
       if (res <= 0) {
-	pmsg_error("usbhid_open(): no response from device\n");
+	pmsg_error("no response from device\n");
 	hid_close(dev);
 	return -1;
       }
       if (usbbuf[0] != 0 || usbbuf[1] != 2) {
-	pmsg_error("usbhid_open(): unexpected reply to DAP_Info: 0x%02x 0x%02x\n",
+	pmsg_error("unexpected reply to DAP_Info: 0x%02x 0x%02x\n",
 	  usbbuf[0], usbbuf[1]);
       } else {
 	fd->usb.max_xfer = usbbuf[2] + (usbbuf[3] << 8);
@@ -200,7 +200,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       }
     }
   if (fd->usb.max_xfer > USBDEV_MAX_XFER_3) {
-    pmsg_error("usbhid_open(): unexpected max size %d, reducing to %d\n",
+    pmsg_error("unexpected max size %d, reducing to %d\n",
       fd->usb.max_xfer, USBDEV_MAX_XFER_3);
     fd->usb.max_xfer = USBDEV_MAX_XFER_3;
   }

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -97,7 +97,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
       if (strlen(serno) > 12)
 	{
-	  pmsg_error("usbdev_open(): invalid serial number %s\n", serno);
+	  pmsg_error("invalid serial number %s\n", serno);
 	  return -1;
 	}
     }
@@ -125,7 +125,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 					    dev->descriptor.iSerialNumber,
 					    string, sizeof(string)) < 0)
 		    {
-		      pmsg_error("usb_open(): cannot read serial number: %s\n", usb_strerror());
+		      pmsg_error("cannot read serial number: %s\n", usb_strerror());
 		      /*
 		       * On some systems, libusb appears to have
 		       * problems sending control messages.  Catch the
@@ -143,7 +143,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 					    dev->descriptor.iProduct,
 					    product, sizeof(product)) < 0)
 		    {
-		      pmsg_error("usb_open(): cannot read product name: %s\n", usb_strerror());
+		      pmsg_error("cannot read product name: %s\n", usb_strerror());
 		      strcpy(product, "[unnamed product]");
 		    }
 		  /*
@@ -188,13 +188,13 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
 		  if (dev->config == NULL)
 		    {
-		      pmsg_warning("usbdev_open(): USB device has no configuration\n");
+		      pmsg_warning("USB device has no configuration\n");
 		      goto trynext;
 		    }
 
 		  if (usb_set_configuration(udev, dev->config[0].bConfigurationValue))
 		    {
-		      pmsg_warning("usbdev_open(): unable to set configuration %d: %s\n",
+		      pmsg_warning("unable to set configuration %d: %s\n",
                         dev->config[0].bConfigurationValue, usb_strerror());
 		      /* let's hope it has already been configured */
 		      // goto trynext;
@@ -214,7 +214,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 #endif
 		      if (usb_claim_interface(udev, usb_interface))
 			{
-			  pmsg_error("usbdev_open(): unable to claim interface %d: %s\n",
+			  pmsg_error("unable to claim interface %d: %s\n",
                             usb_interface, usb_strerror());
 			}
 		      else
@@ -232,7 +232,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		    }
 		  if (iface == dev->config[0].bNumInterfaces)
 		    {
-		      pmsg_warning("usbdev_open(): no usable interface found\n");
+		      pmsg_warning("no usable interface found\n");
 		      goto trynext;
 		    }
 
@@ -254,7 +254,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 			}
 		      if (fd->usb.rep == 0)
 			{
-			  pmsg_error("usbdev_open(): cannot find a read endpoint, using 0x%02x\n",
+			  pmsg_error("cannot find a read endpoint, using 0x%02x\n",
                             USBDEV_BULK_EP_READ_MKII);
 			  fd->usb.rep = USBDEV_BULK_EP_READ_MKII;
 			}
@@ -275,14 +275,14 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		  if (pinfo.usbinfo.flags & PINFO_FL_USEHID)
 		    {
 		      if (usb_control_msg(udev, 0x21, 0x0a /* SET_IDLE */, 0, 0, NULL, 0, 100) < 0)
-			pmsg_error("usbdev_open(): SET_IDLE failed\n");
+			pmsg_error("SET_IDLE failed\n");
 		    }
 		  return 0;
 		  trynext:
 		  usb_close(udev);
 		}
 	      else
-		pmsg_error("usbdev_open(): cannot open device: %s\n", usb_strerror());
+		pmsg_error("cannot open device: %s\n", usb_strerror());
 	    }
 	}
     }
@@ -341,7 +341,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
       rv = usb_bulk_write(udev, fd->usb.wep, (char *)bp, tx_size, 10000);
     if (rv != tx_size)
     {
-        pmsg_error("usbdev_send(): wrote %d out of %d bytes, err = %s\n",
+        pmsg_error("wrote %d out of %d bytes, err = %s\n",
           rv, tx_size, usb_strerror());
         return -1;
     }

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -97,7 +97,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
       if (strlen(serno) > 12)
 	{
-	  avrdude_message(MSG_INFO, "%s: usbdev_open(): invalid serial number \"%s\"\n",
+	  msg_info("%s: usbdev_open(): invalid serial number \"%s\"\n",
                           progname, serno);
 	  return -1;
 	}
@@ -126,7 +126,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 					    dev->descriptor.iSerialNumber,
 					    string, sizeof(string)) < 0)
 		    {
-		      avrdude_message(MSG_INFO, "%s: usb_open(): cannot read serial number \"%s\"\n",
+		      msg_info("%s: usb_open(): cannot read serial number \"%s\"\n",
                                       progname, usb_strerror());
 		      /*
 		       * On some systems, libusb appears to have
@@ -145,7 +145,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 					    dev->descriptor.iProduct,
 					    product, sizeof(product)) < 0)
 		    {
-		      avrdude_message(MSG_INFO, "%s: usb_open(): cannot read product name \"%s\"\n",
+		      msg_info("%s: usb_open(): cannot read product name \"%s\"\n",
                                       progname, usb_strerror());
 		      strcpy(product, "[unnamed product]");
 		    }
@@ -172,7 +172,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      fd->usb.wep = 0x02;
 		  }
 
-                  avrdude_message(MSG_NOTICE, "%s: usbdev_open(): Found %s, serno: %s\n",
+                  msg_notice("%s: usbdev_open(): Found %s, serno: %s\n",
                                     progname, product, string);
 		  if (serno != NULL)
 		    {
@@ -184,7 +184,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      x = strlen(string) - strlen(serno);
 		      if (strcasecmp(string + x, serno) != 0)
 			{
-                          avrdude_message(MSG_DEBUG, "%s: usbdev_open(): serial number doesn't match\n",
+                          msg_debug("%s: usbdev_open(): serial number doesn't match\n",
                                             progname);
 			  usb_close(udev);
 			      continue;
@@ -193,14 +193,14 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
 		  if (dev->config == NULL)
 		    {
-		      avrdude_message(MSG_INFO, "%s: usbdev_open(): USB device has no configuration\n",
+		      msg_info("%s: usbdev_open(): USB device has no configuration\n",
                                       progname);
 		      goto trynext;
 		    }
 
 		  if (usb_set_configuration(udev, dev->config[0].bConfigurationValue))
 		    {
-		      avrdude_message(MSG_INFO, "%s: usbdev_open(): WARNING: failed to set configuration %d: %s\n",
+		      msg_info("%s: usbdev_open(): WARNING: failed to set configuration %d: %s\n",
                                       progname, dev->config[0].bConfigurationValue,
                                       usb_strerror());
 		      /* let's hope it has already been configured */
@@ -221,7 +221,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 #endif
 		      if (usb_claim_interface(udev, usb_interface))
 			{
-			  avrdude_message(MSG_INFO, "%s: usbdev_open(): error claiming interface %d: %s\n",
+			  msg_info("%s: usbdev_open(): error claiming interface %d: %s\n",
                                           progname, usb_interface, usb_strerror());
 			}
 		      else
@@ -239,7 +239,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		    }
 		  if (iface == dev->config[0].bNumInterfaces)
 		    {
-		      avrdude_message(MSG_INFO, "%s: usbdev_open(): no usable interface found\n",
+		      msg_info("%s: usbdev_open(): no usable interface found\n",
                                       progname);
 		      goto trynext;
 		    }
@@ -255,7 +255,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
 			  if ((possible_ep & USB_ENDPOINT_DIR_MASK) != 0)
 			    {
-                              avrdude_message(MSG_NOTICE2, "%s: usbdev_open(): using read endpoint 0x%02x\n",
+                              msg_notice2("%s: usbdev_open(): using read endpoint 0x%02x\n",
                                                   progname, possible_ep);
 			      fd->usb.rep = possible_ep;
 			      break;
@@ -263,7 +263,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 			}
 		      if (fd->usb.rep == 0)
 			{
-			  avrdude_message(MSG_INFO, "%s: usbdev_open(): cannot find a read endpoint, using 0x%02x\n",
+			  msg_info("%s: usbdev_open(): cannot find a read endpoint, using 0x%02x\n",
                                           progname, USBDEV_BULK_EP_READ_MKII);
 			  fd->usb.rep = USBDEV_BULK_EP_READ_MKII;
 			}
@@ -274,7 +274,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 			   dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress == fd->usb.wep) &&
 			  dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize < fd->usb.max_xfer)
 			{
-                          avrdude_message(MSG_NOTICE, "%s: max packet size expected %d, but found %d due to EP 0x%02x's wMaxPacketSize\n",
+                          msg_notice("%s: max packet size expected %d, but found %d due to EP 0x%02x's wMaxPacketSize\n",
                                             progname,
                                             fd->usb.max_xfer,
                                             dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize,
@@ -285,21 +285,21 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		  if (pinfo.usbinfo.flags & PINFO_FL_USEHID)
 		    {
 		      if (usb_control_msg(udev, 0x21, 0x0a /* SET_IDLE */, 0, 0, NULL, 0, 100) < 0)
-			avrdude_message(MSG_INFO, "%s: usbdev_open(): SET_IDLE failed\n", progname);
+			msg_info("%s: usbdev_open(): SET_IDLE failed\n", progname);
 		    }
 		  return 0;
 		  trynext:
 		  usb_close(udev);
 		}
 	      else
-		avrdude_message(MSG_INFO, "%s: usbdev_open(): cannot open device: %s\n",
+		msg_info("%s: usbdev_open(): cannot open device: %s\n",
                                 progname, usb_strerror());
 	    }
 	}
     }
 
   if ((pinfo.usbinfo.flags & PINFO_FL_SILENT) == 0)
-      avrdude_message(MSG_NOTICE, "%s: usbdev_open(): did not find any%s USB device \"%s\" (0x%04x:0x%04x)\n",
+      msg_notice("%s: usbdev_open(): did not find any%s USB device \"%s\" (0x%04x:0x%04x)\n",
 	      progname, serno? " (matching)": "", port,
 	      (unsigned)pinfo.usbinfo.vid, (unsigned)pinfo.usbinfo.pid);
   return -1;
@@ -353,7 +353,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
       rv = usb_bulk_write(udev, fd->usb.wep, (char *)bp, tx_size, 10000);
     if (rv != tx_size)
     {
-        avrdude_message(MSG_INFO, "%s: usbdev_send(): wrote %d out of %d bytes, err = %s\n",
+        msg_info("%s: usbdev_send(): wrote %d out of %d bytes, err = %s\n",
                 progname, rv, tx_size, usb_strerror());
         return -1;
     }
@@ -363,22 +363,22 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
 
   if (verbose > 3)
   {
-      avrdude_message(MSG_TRACE, "%s: Sent: ", progname);
+      msg_trace("%s: Sent: ", progname);
 
       while (i) {
         unsigned char c = *p;
         if (isprint(c)) {
-          avrdude_message(MSG_TRACE, "%c ", c);
+          msg_trace("%c ", c);
         }
         else {
-          avrdude_message(MSG_TRACE, ". ");
+          msg_trace(". ");
         }
-        avrdude_message(MSG_TRACE, "[%02x] ", c);
+        msg_trace("[%02x] ", c);
 
         p++;
         i--;
       }
-      avrdude_message(MSG_TRACE, "\n");
+      msg_trace("\n");
   }
   return 0;
 }
@@ -402,7 +402,7 @@ usb_fill_buf(usb_dev_handle *udev, int maxsize, int ep, int use_interrupt_xfer)
     rv = usb_bulk_read(udev, ep, usbbuf, maxsize, 10000);
   if (rv < 0)
     {
-      avrdude_message(MSG_NOTICE2, "%s: usb_fill_buf(): usb_%s_read() error %s\n",
+      msg_notice2("%s: usb_fill_buf(): usb_%s_read() error %s\n",
 		progname, (use_interrupt_xfer? "interrupt": "bulk"),
 		usb_strerror());
       return -1;
@@ -439,22 +439,22 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
 
   if (verbose > 4)
   {
-      avrdude_message(MSG_TRACE2, "%s: Recv: ", progname);
+      msg_trace2("%s: Recv: ", progname);
 
       while (i) {
         unsigned char c = *p;
         if (isprint(c)) {
-          avrdude_message(MSG_TRACE2, "%c ", c);
+          msg_trace2("%c ", c);
         }
         else {
-          avrdude_message(MSG_TRACE2, ". ");
+          msg_trace2(". ");
         }
-        avrdude_message(MSG_TRACE2, "[%02x] ", c);
+        msg_trace2("[%02x] ", c);
 
         p++;
         i--;
       }
-      avrdude_message(MSG_TRACE2, "\n");
+      msg_trace2("\n");
   }
 
   return 0;
@@ -493,7 +493,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
       }
       else if (rv > 0)
       {
-	  avrdude_message(MSG_INFO, "Short event len = %d, ignored.\n", rv);
+	  msg_info("Short event len = %d, ignored.\n", rv);
 	  /* fallthrough */
       }
   }
@@ -509,7 +509,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
 			   fd->usb.max_xfer, 10000);
       if (rv < 0)
 	{
-          avrdude_message(MSG_NOTICE2, "%s: usbdev_recv_frame(): usb_%s_read(): %s\n",
+          msg_notice2("%s: usbdev_recv_frame(): usb_%s_read(): %s\n",
 		    progname, (fd->usb.use_interrupt_xfer? "interrupt": "bulk"),
 		    usb_strerror());
 	  return -1;
@@ -549,22 +549,22 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
   if (verbose > 3)
   {
       i = n & USB_RECV_LENGTH_MASK;
-      avrdude_message(MSG_TRACE, "%s: Recv: ", progname);
+      msg_trace("%s: Recv: ", progname);
 
       while (i) {
         unsigned char c = *p;
         if (isprint(c)) {
-          avrdude_message(MSG_TRACE, "%c ", c);
+          msg_trace("%c ", c);
         }
         else {
-          avrdude_message(MSG_TRACE, ". ");
+          msg_trace(". ");
         }
-        avrdude_message(MSG_TRACE, "[%02x] ", c);
+        msg_trace("[%02x] ", c);
 
         p++;
         i--;
       }
-      avrdude_message(MSG_TRACE, "\n");
+      msg_trace("\n");
   }
   return n;
 }

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -97,8 +97,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
       if (strlen(serno) > 12)
 	{
-	  msg_info("%s: usbdev_open(): invalid serial number \"%s\"\n",
-                          progname, serno);
+	  pmsg_info("usbdev_open(): invalid serial number %s\n", serno);
 	  return -1;
 	}
     }
@@ -126,8 +125,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 					    dev->descriptor.iSerialNumber,
 					    string, sizeof(string)) < 0)
 		    {
-		      msg_info("%s: usb_open(): cannot read serial number \"%s\"\n",
-                                      progname, usb_strerror());
+		      pmsg_info("usb_open(): cannot read serial number: %s\n", usb_strerror());
 		      /*
 		       * On some systems, libusb appears to have
 		       * problems sending control messages.  Catch the
@@ -145,8 +143,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 					    dev->descriptor.iProduct,
 					    product, sizeof(product)) < 0)
 		    {
-		      msg_info("%s: usb_open(): cannot read product name \"%s\"\n",
-                                      progname, usb_strerror());
+		      pmsg_info("usb_open(): cannot read product name: %s\n", usb_strerror());
 		      strcpy(product, "[unnamed product]");
 		    }
 		  /*
@@ -172,8 +169,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      fd->usb.wep = 0x02;
 		  }
 
-                  msg_notice("%s: usbdev_open(): Found %s, serno: %s\n",
-                                    progname, product, string);
+                  pmsg_notice("usbdev_open(): found %s, serno: %s\n", product, string);
 		  if (serno != NULL)
 		    {
 		      /*
@@ -184,8 +180,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      x = strlen(string) - strlen(serno);
 		      if (strcasecmp(string + x, serno) != 0)
 			{
-                          msg_debug("%s: usbdev_open(): serial number doesn't match\n",
-                                            progname);
+                          pmsg_debug("usbdev_open(): serial number doesn't match\n");
 			  usb_close(udev);
 			      continue;
 			}
@@ -193,16 +188,14 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
 		  if (dev->config == NULL)
 		    {
-		      msg_info("%s: usbdev_open(): USB device has no configuration\n",
-                                      progname);
+		      pmsg_info("usbdev_open(): USB device has no configuration\n");
 		      goto trynext;
 		    }
 
 		  if (usb_set_configuration(udev, dev->config[0].bConfigurationValue))
 		    {
-		      msg_info("%s: usbdev_open(): WARNING: failed to set configuration %d: %s\n",
-                                      progname, dev->config[0].bConfigurationValue,
-                                      usb_strerror());
+		      pmsg_info("usbdev_open(): WARNING: failed to set configuration %d: %s\n",
+                        dev->config[0].bConfigurationValue, usb_strerror());
 		      /* let's hope it has already been configured */
 		      // goto trynext;
 		    }
@@ -221,8 +214,8 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 #endif
 		      if (usb_claim_interface(udev, usb_interface))
 			{
-			  msg_info("%s: usbdev_open(): error claiming interface %d: %s\n",
-                                          progname, usb_interface, usb_strerror());
+			  pmsg_info("usbdev_open(): error claiming interface %d: %s\n",
+                            usb_interface, usb_strerror());
 			}
 		      else
 			{
@@ -239,8 +232,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		    }
 		  if (iface == dev->config[0].bNumInterfaces)
 		    {
-		      msg_info("%s: usbdev_open(): no usable interface found\n",
-                                      progname);
+		      pmsg_info("usbdev_open(): no usable interface found\n");
 		      goto trynext;
 		    }
 
@@ -255,16 +247,15 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 
 			  if ((possible_ep & USB_ENDPOINT_DIR_MASK) != 0)
 			    {
-                              msg_notice2("%s: usbdev_open(): using read endpoint 0x%02x\n",
-                                                  progname, possible_ep);
+                              pmsg_notice2("usbdev_open(): using read endpoint 0x%02x\n", possible_ep);
 			      fd->usb.rep = possible_ep;
 			      break;
 			    }
 			}
 		      if (fd->usb.rep == 0)
 			{
-			  msg_info("%s: usbdev_open(): cannot find a read endpoint, using 0x%02x\n",
-                                          progname, USBDEV_BULK_EP_READ_MKII);
+			  pmsg_info("usbdev_open(): cannot find a read endpoint, using 0x%02x\n",
+                            USBDEV_BULK_EP_READ_MKII);
 			  fd->usb.rep = USBDEV_BULK_EP_READ_MKII;
 			}
 		    }
@@ -274,34 +265,31 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 			   dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress == fd->usb.wep) &&
 			  dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize < fd->usb.max_xfer)
 			{
-                          msg_notice("%s: max packet size expected %d, but found %d due to EP 0x%02x's wMaxPacketSize\n",
-                                            progname,
-                                            fd->usb.max_xfer,
-                                            dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize,
-                                            dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress);
+                          pmsg_notice("max packet size expected %d, but found %d due to EP 0x%02x's wMaxPacketSize\n",
+                            fd->usb.max_xfer,
+                            dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize,
+                            dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress);
 			  fd->usb.max_xfer = dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize;
 			}
 		    }
 		  if (pinfo.usbinfo.flags & PINFO_FL_USEHID)
 		    {
 		      if (usb_control_msg(udev, 0x21, 0x0a /* SET_IDLE */, 0, 0, NULL, 0, 100) < 0)
-			msg_info("%s: usbdev_open(): SET_IDLE failed\n", progname);
+			pmsg_info("usbdev_open(): SET_IDLE failed\n");
 		    }
 		  return 0;
 		  trynext:
 		  usb_close(udev);
 		}
 	      else
-		msg_info("%s: usbdev_open(): cannot open device: %s\n",
-                                progname, usb_strerror());
+		pmsg_info("usbdev_open(): cannot open device: %s\n", usb_strerror());
 	    }
 	}
     }
 
   if ((pinfo.usbinfo.flags & PINFO_FL_SILENT) == 0)
-      msg_notice("%s: usbdev_open(): did not find any%s USB device \"%s\" (0x%04x:0x%04x)\n",
-	      progname, serno? " (matching)": "", port,
-	      (unsigned)pinfo.usbinfo.vid, (unsigned)pinfo.usbinfo.pid);
+      pmsg_notice("usbdev_open(): did not find any%s USB device \"%s\" (0x%04x:0x%04x)\n",
+        serno? " (matching)": "", port, (unsigned)pinfo.usbinfo.vid, (unsigned)pinfo.usbinfo.pid);
   return -1;
 }
 
@@ -353,8 +341,8 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
       rv = usb_bulk_write(udev, fd->usb.wep, (char *)bp, tx_size, 10000);
     if (rv != tx_size)
     {
-        msg_info("%s: usbdev_send(): wrote %d out of %d bytes, err = %s\n",
-                progname, rv, tx_size, usb_strerror());
+        pmsg_info("usbdev_send(): wrote %d out of %d bytes, err = %s\n",
+          rv, tx_size, usb_strerror());
         return -1;
     }
     bp += tx_size;
@@ -363,7 +351,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
 
   if (verbose > 3)
   {
-      msg_trace("%s: Sent: ", progname);
+      pmsg_trace("sent: ");
 
       while (i) {
         unsigned char c = *p;
@@ -402,9 +390,8 @@ usb_fill_buf(usb_dev_handle *udev, int maxsize, int ep, int use_interrupt_xfer)
     rv = usb_bulk_read(udev, ep, usbbuf, maxsize, 10000);
   if (rv < 0)
     {
-      msg_notice2("%s: usb_fill_buf(): usb_%s_read() error %s\n",
-		progname, (use_interrupt_xfer? "interrupt": "bulk"),
-		usb_strerror());
+      pmsg_notice2("usb_fill_buf(): usb_%s_read() error %s\n",
+        use_interrupt_xfer? "interrupt": "bulk", usb_strerror());
       return -1;
     }
 
@@ -439,7 +426,7 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
 
   if (verbose > 4)
   {
-      msg_trace2("%s: Recv: ", progname);
+      pmsg_trace2("recv: ");
 
       while (i) {
         unsigned char c = *p;
@@ -493,7 +480,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
       }
       else if (rv > 0)
       {
-	  msg_info("Short event len = %d, ignored.\n", rv);
+	  msg_info("short event len = %d, ignored\n", rv);
 	  /* fallthrough */
       }
   }
@@ -509,9 +496,8 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
 			   fd->usb.max_xfer, 10000);
       if (rv < 0)
 	{
-          msg_notice2("%s: usbdev_recv_frame(): usb_%s_read(): %s\n",
-		    progname, (fd->usb.use_interrupt_xfer? "interrupt": "bulk"),
-		    usb_strerror());
+          pmsg_notice2("usbdev_recv_frame(): usb_%s_read(): %s\n",
+            fd->usb.use_interrupt_xfer? "interrupt": "bulk", usb_strerror());
 	  return -1;
 	}
 
@@ -549,7 +535,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
   if (verbose > 3)
   {
       i = n & USB_RECV_LENGTH_MASK;
-      msg_trace("%s: Recv: ", progname);
+      pmsg_trace("recv: ");
 
       while (i) {
         unsigned char c = *p;

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -265,11 +265,11 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 			   dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress == fd->usb.wep) &&
 			  dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize < fd->usb.max_xfer)
 			{
-                          pmsg_notice("max packet size expected %d, but found %d due to EP 0x%02x's wMaxPacketSize\n",
-                            fd->usb.max_xfer,
-                            dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize,
-                            dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress);
-			  fd->usb.max_xfer = dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize;
+			    pmsg_notice("max packet size expected %d, but found %d due to EP 0x%02x's wMaxPacketSize\n",
+			      fd->usb.max_xfer,
+			      dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize,
+			      dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress);
+			    fd->usb.max_xfer = dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize;
 			}
 		    }
 		  if (pinfo.usbinfo.flags & PINFO_FL_USEHID)
@@ -341,8 +341,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
       rv = usb_bulk_write(udev, fd->usb.wep, (char *)bp, tx_size, 10000);
     if (rv != tx_size)
     {
-        pmsg_error("wrote %d out of %d bytes, err = %s\n",
-          rv, tx_size, usb_strerror());
+        pmsg_error("wrote %d out of %d bytes, err = %s\n", rv, tx_size, usb_strerror());
         return -1;
     }
     bp += tx_size;

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -263,8 +263,7 @@ static int usbasp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 static void usbasp_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: usbasp_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("usbasp_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -284,14 +283,12 @@ static int usbasp_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     extended_param = ldata(ln);
 
     if (strncmp(extended_param, "section_config", strlen("section_config")) == 0) {
-      msg_notice2("%s: usbasp_parseextparms(): set section_e to 1 (config section)\n",
-                      progname);
+      pmsg_notice2("usbasp_parseextparms(): set section_e to 1 (config section)\n");
       PDATA(pgm)->section_e = 1;
       continue;
     }
 
-    msg_info("%s: usbasp_parseextparms(): invalid extended parameter '%s'\n",
-                    progname, extended_param);
+    pmsg_info("usbasp_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 
@@ -336,9 +333,8 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
   int nbytes;
 
   if (verbose > 3) {
-    msg_trace("%s: usbasp_transmit(\"%s\", 0x%02x, 0x%02x, 0x%02x, 0x%02x)\n",
-                    progname,
-                    usbasp_get_funcname(functionid), send[0], send[1], send[2], send[3]);
+    pmsg_trace("usbasp_transmit(\"%s\", 0x%02x, 0x%02x, 0x%02x, 0x%02x)\n",
+      usbasp_get_funcname(functionid), send[0], send[1], send[2], send[3]);
     if (!receive && buffersize > 0) {
       int i;
       msg_trace("%s => ", progbuf);
@@ -358,7 +354,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
 				   buffersize & 0xffff,
 				   5000);
   if(nbytes < 0){
-    msg_info("%s: error: usbasp_transmit: %s\n", progname, errstr(nbytes));
+    pmsg_info("error: usbasp_transmit: %s\n", errstr(nbytes));
     return -1;
   }
 #else
@@ -370,7 +366,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
 			   (char *)buffer, buffersize,
 			   5000);
   if(nbytes < 0){
-    msg_info("%s: error: usbasp_transmit: %s\n", progname, usb_strerror());
+    pmsg_info("error: usbasp_transmit: %s\n", usb_strerror());
     return -1;
   }
 #endif
@@ -421,9 +417,8 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
             r = libusb_open(dev, &handle);
             if (!handle) {
                  errorCode = USB_ERROR_ACCESS;
-                 msg_info("%s: Warning: cannot open USB device: %s\n",
-                                 progname, errstr(r));
-                    continue;
+                 pmsg_info("warning, cannot open USB device: %s\n", errstr(r));
+                 continue;
             }
             errorCode = 0;
             /* now check whether the names match: */
@@ -432,12 +427,10 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
             if (r < 0) {
                 if ((vendorName != NULL) && (vendorName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
-                    msg_info("%s: Warning: cannot query manufacturer for device: %s\n",
-                                    progname, errstr(r));
+                    pmsg_info("warning, cannot query manufacturer for device: %s\n", errstr(r));
 		}
             } else {
-                msg_notice2("%s: seen device from vendor ->%s<-\n",
-                                    progname, string);
+                pmsg_notice2("seen device from vendor >%s<\n", string);
                 if ((vendorName != NULL) && (vendorName[0] != 0) && (strcmp(string, vendorName) != 0))
                     errorCode = USB_ERROR_NOTFOUND;
             }
@@ -446,12 +439,10 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
             if (r < 0) {
                 if ((productName != NULL) && (productName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
-                    msg_info("%s: Warning: cannot query product for device: %s\n",
-                                    progname, errstr(r));
+                    pmsg_info("warning, cannot query product for device: %s\n", errstr(r));
 		}
             } else {
-                msg_notice2("%s: seen product ->%s<-\n",
-                                    progname, string);
+                pmsg_notice2("seen product >%s<\n", string);
                 if((productName != NULL) && (productName[0] != 0) && (strcmp(string, productName) != 0))
                     errorCode = USB_ERROR_NOTFOUND;
             }
@@ -494,8 +485,7 @@ static int           didUsbInit = 0;
                 handle = usb_open(dev);
                 if(!handle){
                     errorCode = USB_ERROR_ACCESS;
-                    msg_info("%s: Warning: cannot open USB device: %s\n",
-                                    progname, usb_strerror());
+                    pmsg_info("warning, cannot open USB device: %s\n", usb_strerror());
                     continue;
                 }
                 errorCode = 0;
@@ -506,12 +496,10 @@ static int           didUsbInit = 0;
                 if(len < 0){
                     if ((vendorName != NULL) && (vendorName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
-                    msg_info("%s: Warning: cannot query manufacturer for device: %s\n",
-                                    progname, usb_strerror());
+                    pmsg_info("warning, cannot query manufacturer for device: %s\n", usb_strerror());
 		    }
                 } else {
-                    msg_notice2("%s: seen device from vendor ->%s<-\n",
-                                        progname, string);
+                    pmsg_notice2("seen device from vendor >%s<\n", string);
                     if((vendorName != NULL) && (vendorName[0] != 0) && (strcmp(string, vendorName) != 0))
                         errorCode = USB_ERROR_NOTFOUND;
                 }
@@ -521,12 +509,10 @@ static int           didUsbInit = 0;
                 if(len < 0){
                     if ((productName != NULL) && (productName[0] != 0)) {
                         errorCode = USB_ERROR_IO;
-                        msg_info("%s: Warning: cannot query product for device: %s\n",
-                                        progname, usb_strerror());
+                        pmsg_info("warning, cannot query product for device: %s\n", usb_strerror());
 		    }
                 } else {
-                    msg_notice2("%s: seen product ->%s<-\n",
-                                        progname, string);
+                    pmsg_notice2("seen product >%s<\n", string);
                     if((productName != NULL) && (productName[0] != 0) && (strcmp(string, productName) != 0))
                         errorCode = USB_ERROR_NOTFOUND;
                 }
@@ -550,8 +536,7 @@ static int           didUsbInit = 0;
 
 /* Interface - prog. */
 static int usbasp_open(PROGRAMMER *pgm, const char *port) {
-  msg_debug("%s: usbasp_open(\"%s\")\n",
-	    progname, port);
+  pmsg_debug("usbasp_open(\"%s\")\n", port);
 
   /* usb_init will be done in usbOpenDevice */
   LNODEID usbpid = lfirst(pgm->usbpid);
@@ -559,8 +544,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
-                      progname, pid);
+      pmsg_info("Warning: using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
   } else {
     pid = USBASP_SHARED_PID;
   }
@@ -570,14 +554,11 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
     if(strcasecmp(ldata(lfirst(pgm->id)), "usbasp") == 0) {
     /* for id usbasp autodetect some variants */
       if(strcasecmp(port, "nibobee") == 0) {
-        msg_info("%s: warning: Using \"-C usbasp -P nibobee\" is deprecated,"
-	        "use \"-C nibobee\" instead.\n",
-	        progname);
+        pmsg_info("using -C usbasp -P nibobee is deprecated, use -C nibobee instead\n");
         if (usbOpenDevice(&PDATA(pgm)->usbhandle, USBASP_NIBOBEE_VID, "www.nicai-systems.com",
 		        USBASP_NIBOBEE_PID, "NIBObee") != 0) {
-          msg_info("%s: error: could not find USB device "
-                          "\"NIBObee\" with vid=0x%x pid=0x%x\n",
-                          progname, USBASP_NIBOBEE_VID, USBASP_NIBOBEE_PID);
+          pmsg_info("could not find USB device NIBObee with vid=0x%x pid=0x%x\n",
+            USBASP_NIBOBEE_VID, USBASP_NIBOBEE_PID);
           return -1;
         }
         return 0;
@@ -586,17 +567,14 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
       if (usbOpenDevice(&PDATA(pgm)->usbhandle, USBASP_OLD_VID, "www.fischl.de",
 		             USBASP_OLD_PID, "USBasp") == 0) {
         /* found USBasp with old IDs */
-        msg_info("%s: Warning: Found USB device \"USBasp\" with "
-                        "old VID/PID! Please update firmware of USBasp!\n",
-                        progname);
+        pmsg_info("found USB device USBasp with old VID/PID; please update firmware of USBasp\n");
 	return 0;
       }
     /* original USBasp is specified in config file, so no need to check it again here */
     /* no alternative found => fall through to generic error message */
     }
 
-    msg_info("%s: error: could not find USB device with vid=0x%x pid=0x%x",
-                    progname, vid, pid);
+    pmsg_info("could not find USB device with vid=0x%x pid=0x%x", vid, pid);
     if (pgm->usbvendor[0] != 0) {
        msg_info(" vendor='%s'", pgm->usbvendor);
     }
@@ -612,7 +590,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
 
 static void usbasp_close(PROGRAMMER * pgm)
 {
-  msg_debug("%s: usbasp_close()\n", progname);
+  pmsg_debug("usbasp_close()\n");
 
   if (PDATA(pgm)->usbhandle!=NULL) {
     unsigned char temp[4];
@@ -665,7 +643,7 @@ static int usbasp_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char res[4];
   IMPORT_PDATA(pgm);
 
-  msg_debug("%s: usbasp_initialize()\n", progname);
+  pmsg_debug("usbasp_initialize()\n");
 
   /* get capabilities */
   memset(temp, 0, sizeof(temp));
@@ -712,9 +690,8 @@ static int usbasp_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 static int usbasp_spi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                    unsigned char *res)
 {
-  msg_debug("%s: usbasp_spi_cmd(0x%02x, 0x%02x, 0x%02x, 0x%02x)%s",
-	    progname, cmd[0], cmd[1], cmd[2], cmd[3],
-	    verbose > 3? "...\n": "");
+  pmsg_debug("usbasp_spi_cmd(0x%02x, 0x%02x, 0x%02x, 0x%02x)%s",
+    cmd[0], cmd[1], cmd[2], cmd[3], verbose > 3? " ...\n": "");
 
   int nbytes =
     usbasp_transmit(pgm, 1, USBASP_FUNC_TRANSMIT, cmd, res, 4);
@@ -723,11 +700,10 @@ static int usbasp_spi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
     if (verbose == 3)
       putc('\n', stderr);
 
-    msg_info("%s: error: wrong response size\n",
-	    progname);
+    pmsg_info("error: wrong response size\n");
     return -1;
   }
-  msg_trace("%s: usbasp_spi_cmd()", progname);
+  pmsg_trace("usbasp_spi_cmd()");
   msg_debug(" => 0x%02x, 0x%02x, 0x%02x, 0x%02x\n",
         res[0], res[1], res[2], res[3]);
 
@@ -742,15 +718,13 @@ static int usbasp_spi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 
   cmd[0] = 0;
 
-  msg_debug("%s: usbasp_program_enable()\n",
-	    progname);
+  pmsg_debug("usbasp_program_enable()\n");
 
   int nbytes =
     usbasp_transmit(pgm, 1, USBASP_FUNC_ENABLEPROG, cmd, res, sizeof(res));
 
   if ((nbytes != 1) | (res[0] != 0)) {
-    msg_info("%s: error: program enable: target doesn't answer. %x \n",
-	    progname, res[0]);
+    pmsg_info("error: program enable: target doesn't answer. %x \n", res[0]);
     return -1;
   }
 
@@ -761,12 +735,10 @@ static int usbasp_spi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char cmd[4];
   unsigned char res[4];
 
-  msg_debug("%s: usbasp_chip_erase()\n",
-	    progname);
+  pmsg_debug("usbasp_chip_erase()\n");
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    msg_info("chip erase instruction not defined for part \"%s\"\n",
-            p->desc);
+    msg_info("chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -790,8 +762,7 @@ static int usbasp_spi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
   unsigned char *buffer = m->buf + address;
   int function;
 
-  msg_debug("%s: usbasp_program_paged_load(\"%s\", 0x%x, %d)\n",
-                    progname, m->desc, address, n_bytes);
+  pmsg_debug("usbasp_program_paged_load(\"%s\", 0x%x, %d)\n", m->desc, address, n_bytes);
 
   if (strcmp(m->desc, "flash") == 0) {
     function = USBASP_FUNC_READFLASH;
@@ -834,8 +805,7 @@ static int usbasp_spi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
     n = usbasp_transmit(pgm, 1, function, cmd, buffer, blocksize);
 
     if (n != blocksize) {
-      msg_info("%s: error: wrong reading bytes %x\n",
-	      progname, n);
+      pmsg_info("wrong reading bytes %x\n", n);
       return -3;
     }
 
@@ -857,8 +827,7 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
   unsigned char blockflags = USBASP_BLOCKFLAG_FIRST;
   int function;
 
-  msg_debug("%s: usbasp_program_paged_write(\"%s\", 0x%x, %d)\n",
-                    progname, m->desc, address, n_bytes);
+  pmsg_debug("usbasp_program_paged_write(\"%s\", 0x%x, %d)\n", m->desc, address, n_bytes);
 
   if (strcmp(m->desc, "flash") == 0) {
     function = USBASP_FUNC_WRITEFLASH;
@@ -905,8 +874,7 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     n = usbasp_transmit(pgm, 0, function, cmd, buffer, blocksize);
 
     if (n != blocksize) {
-      msg_info("%s: error: wrong count at writing %x\n",
-	      progname, n);
+      pmsg_info("wrong count at writing %x\n", n);
       return -3;        
     }
 
@@ -944,8 +912,7 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
   unsigned char res[4];
   unsigned char cmd[4];
 
-  msg_debug("%s: usbasp_spi_set_sck_period(%g)\n",
-                    progname, sckperiod);
+  pmsg_debug("usbasp_spi_set_sck_period(%g)\n", sckperiod);
 
   memset(cmd, 0, sizeof(cmd));
   memset(res, 0, sizeof(res));
@@ -956,22 +923,22 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
   if (sckperiod == 0) {
     /* auto sck set */
 
-    msg_notice("%s: auto set sck period (because given equals null)\n", progname);
+    pmsg_notice("auto set sck period (because given equals null)\n");
 
   } else {
 
     int sckfreq = 1 / sckperiod; /* sck in Hz */
     int usefreq = 0;
 
-    msg_notice2("%s: try to set SCK period to %g s (= %i Hz)\n", progname, sckperiod, sckfreq);
+    pmsg_notice2("try to set SCK period to %g s (= %i Hz)\n", sckperiod, sckfreq);
 
     /* Check if programmer is capable of 3 MHz SCK, if not then ommit 3 MHz setting */
     int i;
     if (PDATA(pgm)->sck_3mhz) {
-      msg_notice2("%s: connected USBasp is capable of 3 MHz SCK\n",progname);
+      pmsg_notice2("connected USBasp is capable of 3 MHz SCK\n");
       i = 0;
     } else {
-      msg_notice2("%s: connected USBasp is not cabable of 3 MHz SCK\n",progname);
+      pmsg_notice2("connected USBasp is not cabable of 3 MHz SCK\n");
       i = 1;
     }
     if (sckfreq >= usbaspSCKoptions[i].frequency) {
@@ -993,7 +960,7 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
     /* save used sck frequency */
     PDATA(pgm)->sckfreq_hz = usefreq;
 
-    msg_info("%s: set SCK frequency to %i Hz\n", progname, usefreq);
+    pmsg_info("set SCK frequency to %i Hz\n", usefreq);
   }
 
   cmd[0] = clockoption;
@@ -1002,8 +969,7 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
     usbasp_transmit(pgm, 1, USBASP_FUNC_SETISPSCK, cmd, res, sizeof(res));
 
   if ((nbytes != 1) | (res[0] != 0)) {
-    msg_info("%s: warning: cannot set sck period. please check for usbasp firmware update.\n",
-      progname);
+    pmsg_info("cannot set sck period; please check for usbasp firmware update\n");
     return -1;
   }
 
@@ -1027,7 +993,7 @@ static int usbasp_tpi_recv_byte(const PROGRAMMER *pgm) {
 
   if(usbasp_transmit(pgm, 1, USBASP_FUNC_TPI_RAWREAD, temp, temp, sizeof(temp)) != 1)
   {
-    msg_info("%s: error: wrong response size\n", progname);
+    pmsg_info("wrong response size\n");
     return -1;
   }
 
@@ -1038,7 +1004,7 @@ static int usbasp_tpi_recv_byte(const PROGRAMMER *pgm) {
 static int usbasp_tpi_nvm_waitbusy(const PROGRAMMER *pgm) {
   int retry;
 
-  msg_debug("%s: usbasp_tpi_nvm_waitbusy() ...", progname);
+  pmsg_debug("usbasp_tpi_nvm_waitbusy() ...");
 
   for(retry=50; retry>0; retry--)
   {
@@ -1057,14 +1023,14 @@ static int usbasp_tpi_nvm_waitbusy(const PROGRAMMER *pgm) {
 }
 
 static int usbasp_tpi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned char *res) {
-  msg_info("%s: error: spi_cmd used in TPI mode: not allowed\n", progname);
+  pmsg_info("spi_cmd used in TPI mode: not allowed\n");
   return -1;
 }
 
 static int usbasp_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   int retry;
 
-  msg_debug("%s: usbasp_tpi_program_enable()\n", progname);
+  pmsg_debug("usbasp_tpi_program_enable()\n");
 
   /* change guard time */
   usbasp_tpi_send_byte(pgm, TPI_OP_SSTCS(TPIPCR));
@@ -1094,7 +1060,7 @@ static int usbasp_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   }
   if(retry >= 10)
   {
-    msg_info("%s: error: program enable: target doesn't answer.\n", progname);
+    pmsg_info("program enable, target does not answer\n");
     return -1;
   }
 
@@ -1112,14 +1078,14 @@ static int usbasp_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     pr_0 = 0x41;
     pr_1 = 0x3F;
     nvm_cmd = NVMCMD_SECTION_ERASE;
-    msg_debug("%s: usbasp_tpi_chip_erase() - section erase\n", progname);
+    pmsg_debug("usbasp_tpi_chip_erase() - section erase\n");
     break;
     /* Chip erase (flash only) */
   default:
     pr_0 = 0x01;
     pr_1 = 0x40;
     nvm_cmd = NVMCMD_CHIP_ERASE;
-    msg_debug("%s: usbasp_tpi_chip_erase() - chip erase\n", progname);
+    pmsg_debug("usbasp_tpi_chip_erase() - chip erase\n");
     break;
   }
 
@@ -1151,8 +1117,7 @@ static int usbasp_tpi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
   uint16_t pr;
 
 
-  msg_debug("%s: usbasp_tpi_paged_load(\"%s\", 0x%0x, %d)\n",
-	    progname, m->desc, addr, n_bytes);
+  pmsg_debug("usbasp_tpi_paged_load(\"%s\", 0x%0x, %d)\n", m->desc, addr, n_bytes);
 
   dptr = addr + m->buf;
   pr = addr + m->offset;
@@ -1172,7 +1137,7 @@ static int usbasp_tpi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
     n = usbasp_transmit(pgm, 1, USBASP_FUNC_TPI_READBLOCK, cmd, dptr, clen);
     if(n != clen)
     {
-      msg_info("%s: error: wrong reading bytes %x\n", progname, n);
+      pmsg_info("wrong reading bytes %x\n", n);
       return -3;
     }
     
@@ -1193,8 +1158,7 @@ static int usbasp_tpi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
   uint16_t pr;
 
 
-  msg_debug("%s: usbasp_tpi_paged_write(\"%s\", 0x%0x, %d)\n",
-	    progname, m->desc, addr, n_bytes);
+  pmsg_debug("usbasp_tpi_paged_write(\"%s\", 0x%0x, %d)\n", m->desc, addr, n_bytes);
 
   sptr = addr + m->buf;
   pr = addr + m->offset;
@@ -1238,7 +1202,7 @@ static int usbasp_tpi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     n = usbasp_transmit(pgm, 0, USBASP_FUNC_TPI_WRITEBLOCK, cmd, sptr, clen);
     if(n != clen)
     {
-      msg_info("%s: error: wrong count at writing %x\n", progname, n);
+      pmsg_info("wrong count at writing %x\n", n);
       return -3;
     }
     
@@ -1260,8 +1224,7 @@ static int usbasp_tpi_read_byte(const PROGRAMMER * pgm, const AVRPART *p, const 
   uint16_t pr;
 
 
-  msg_debug("%s: usbasp_tpi_read_byte(\"%s\", 0x%0lx)\n",
-	    progname, m->desc, addr);
+  pmsg_debug("usbasp_tpi_read_byte(\"%s\", 0x%0lx)\n", m->desc, addr);
 
   pr = m->offset + addr;
 
@@ -1273,7 +1236,7 @@ static int usbasp_tpi_read_byte(const PROGRAMMER * pgm, const AVRPART *p, const 
   n = usbasp_transmit(pgm, 1, USBASP_FUNC_TPI_READBLOCK, cmd, value, 1);
   if(n != 1)
   {
-    msg_info("%s: error: wrong reading bytes %x\n", progname, n);
+    pmsg_info("wrong reading bytes %x\n", n);
     return -3;
   }
   return 0;
@@ -1282,7 +1245,7 @@ static int usbasp_tpi_read_byte(const PROGRAMMER * pgm, const AVRPART *p, const 
 static int usbasp_tpi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
   unsigned long addr, unsigned char data) { // FIXME: use avr_write_byte_cache() when implemented
 
-  msg_info("%s: error: usbasp_write_byte in TPI mode: all writes have to be done at page level\n", progname);
+  pmsg_info("usbasp_write_byte in TPI mode; all writes have to be done at page level\n");
   return -1;
 }
 
@@ -1323,8 +1286,7 @@ void usbasp_initpgm(PROGRAMMER *pgm) {
 #else /* HAVE_LIBUSB */
 
 static int usbasp_nousb_open(PROGRAMMER *pgm, const char *name) {
-  msg_info("%s: error: no usb support. please compile again with libusb installed.\n",
-	  progname);
+  pmsg_info("no usb support; please compile again with libusb installed\n");
 
   return -1;
 }

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -263,7 +263,7 @@ static int usbasp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 static void usbasp_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("usbasp_setup(): out of memory allocating private data\n");
+    pmsg_error(" out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -288,7 +288,7 @@ static int usbasp_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    pmsg_error("usbasp_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 
@@ -354,7 +354,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
 				   buffersize & 0xffff,
 				   5000);
   if(nbytes < 0){
-    pmsg_ext_error("usbasp_transmit: %s\n", errstr(nbytes));
+    pmsg_ext_error("%s\n", errstr(nbytes));
     return -1;
   }
 #else
@@ -366,7 +366,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
 			   (char *)buffer, buffersize,
 			   5000);
   if(nbytes < 0){
-    pmsg_error("usbasp_transmit(): %s\n", usb_strerror());
+    pmsg_error("%s\n", usb_strerror());
     return -1;
   }
 #endif

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -263,7 +263,7 @@ static int usbasp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 static void usbasp_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: usbasp_setup(): Out of memory allocating private data\n",
+    msg_info("%s: usbasp_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -284,13 +284,13 @@ static int usbasp_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     extended_param = ldata(ln);
 
     if (strncmp(extended_param, "section_config", strlen("section_config")) == 0) {
-      avrdude_message(MSG_NOTICE2, "%s: usbasp_parseextparms(): set section_e to 1 (config section)\n",
+      msg_notice2("%s: usbasp_parseextparms(): set section_e to 1 (config section)\n",
                       progname);
       PDATA(pgm)->section_e = 1;
       continue;
     }
 
-    avrdude_message(MSG_INFO, "%s: usbasp_parseextparms(): invalid extended parameter '%s'\n",
+    msg_info("%s: usbasp_parseextparms(): invalid extended parameter '%s'\n",
                     progname, extended_param);
     rv = -1;
   }
@@ -336,15 +336,15 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
   int nbytes;
 
   if (verbose > 3) {
-    avrdude_message(MSG_TRACE, "%s: usbasp_transmit(\"%s\", 0x%02x, 0x%02x, 0x%02x, 0x%02x)\n",
+    msg_trace("%s: usbasp_transmit(\"%s\", 0x%02x, 0x%02x, 0x%02x, 0x%02x)\n",
                     progname,
                     usbasp_get_funcname(functionid), send[0], send[1], send[2], send[3]);
     if (!receive && buffersize > 0) {
       int i;
-      avrdude_message(MSG_TRACE, "%s => ", progbuf);
+      msg_trace("%s => ", progbuf);
       for (i = 0; i < buffersize; i++)
-	avrdude_message(MSG_TRACE, "[%02x] ", buffer[i]);
-      avrdude_message(MSG_TRACE, "\n");
+	msg_trace("[%02x] ", buffer[i]);
+      msg_trace("\n");
     }
   }
 
@@ -358,7 +358,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
 				   buffersize & 0xffff,
 				   5000);
   if(nbytes < 0){
-    avrdude_message(MSG_INFO, "%s: error: usbasp_transmit: %s\n", progname, errstr(nbytes));
+    msg_info("%s: error: usbasp_transmit: %s\n", progname, errstr(nbytes));
     return -1;
   }
 #else
@@ -370,17 +370,17 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
 			   (char *)buffer, buffersize,
 			   5000);
   if(nbytes < 0){
-    avrdude_message(MSG_INFO, "%s: error: usbasp_transmit: %s\n", progname, usb_strerror());
+    msg_info("%s: error: usbasp_transmit: %s\n", progname, usb_strerror());
     return -1;
   }
 #endif
 
   if (verbose > 3 && receive && nbytes > 0) {
     int i;
-    avrdude_message(MSG_TRACE, "%s<= ", progbuf);
+    msg_trace("%s<= ", progbuf);
     for (i = 0; i < nbytes; i++)
-      avrdude_message(MSG_TRACE, "[%02x] ", buffer[i]);
-    avrdude_message(MSG_TRACE, "\n");
+      msg_trace("[%02x] ", buffer[i]);
+    msg_trace("\n");
   }
 
   return nbytes;
@@ -421,7 +421,7 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
             r = libusb_open(dev, &handle);
             if (!handle) {
                  errorCode = USB_ERROR_ACCESS;
-                 avrdude_message(MSG_INFO, "%s: Warning: cannot open USB device: %s\n",
+                 msg_info("%s: Warning: cannot open USB device: %s\n",
                                  progname, errstr(r));
                     continue;
             }
@@ -432,11 +432,11 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
             if (r < 0) {
                 if ((vendorName != NULL) && (vendorName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
-                    avrdude_message(MSG_INFO, "%s: Warning: cannot query manufacturer for device: %s\n",
+                    msg_info("%s: Warning: cannot query manufacturer for device: %s\n",
                                     progname, errstr(r));
 		}
             } else {
-                avrdude_message(MSG_NOTICE2, "%s: seen device from vendor ->%s<-\n",
+                msg_notice2("%s: seen device from vendor ->%s<-\n",
                                     progname, string);
                 if ((vendorName != NULL) && (vendorName[0] != 0) && (strcmp(string, vendorName) != 0))
                     errorCode = USB_ERROR_NOTFOUND;
@@ -446,11 +446,11 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
             if (r < 0) {
                 if ((productName != NULL) && (productName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
-                    avrdude_message(MSG_INFO, "%s: Warning: cannot query product for device: %s\n",
+                    msg_info("%s: Warning: cannot query product for device: %s\n",
                                     progname, errstr(r));
 		}
             } else {
-                avrdude_message(MSG_NOTICE2, "%s: seen product ->%s<-\n",
+                msg_notice2("%s: seen product ->%s<-\n",
                                     progname, string);
                 if((productName != NULL) && (productName[0] != 0) && (strcmp(string, productName) != 0))
                     errorCode = USB_ERROR_NOTFOUND;
@@ -494,7 +494,7 @@ static int           didUsbInit = 0;
                 handle = usb_open(dev);
                 if(!handle){
                     errorCode = USB_ERROR_ACCESS;
-                    avrdude_message(MSG_INFO, "%s: Warning: cannot open USB device: %s\n",
+                    msg_info("%s: Warning: cannot open USB device: %s\n",
                                     progname, usb_strerror());
                     continue;
                 }
@@ -506,11 +506,11 @@ static int           didUsbInit = 0;
                 if(len < 0){
                     if ((vendorName != NULL) && (vendorName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
-                    avrdude_message(MSG_INFO, "%s: Warning: cannot query manufacturer for device: %s\n",
+                    msg_info("%s: Warning: cannot query manufacturer for device: %s\n",
                                     progname, usb_strerror());
 		    }
                 } else {
-                    avrdude_message(MSG_NOTICE2, "%s: seen device from vendor ->%s<-\n",
+                    msg_notice2("%s: seen device from vendor ->%s<-\n",
                                         progname, string);
                     if((vendorName != NULL) && (vendorName[0] != 0) && (strcmp(string, vendorName) != 0))
                         errorCode = USB_ERROR_NOTFOUND;
@@ -521,11 +521,11 @@ static int           didUsbInit = 0;
                 if(len < 0){
                     if ((productName != NULL) && (productName[0] != 0)) {
                         errorCode = USB_ERROR_IO;
-                        avrdude_message(MSG_INFO, "%s: Warning: cannot query product for device: %s\n",
+                        msg_info("%s: Warning: cannot query product for device: %s\n",
                                         progname, usb_strerror());
 		    }
                 } else {
-                    avrdude_message(MSG_NOTICE2, "%s: seen product ->%s<-\n",
+                    msg_notice2("%s: seen product ->%s<-\n",
                                         progname, string);
                     if((productName != NULL) && (productName[0] != 0) && (strcmp(string, productName) != 0))
                         errorCode = USB_ERROR_NOTFOUND;
@@ -550,7 +550,7 @@ static int           didUsbInit = 0;
 
 /* Interface - prog. */
 static int usbasp_open(PROGRAMMER *pgm, const char *port) {
-  avrdude_message(MSG_DEBUG, "%s: usbasp_open(\"%s\")\n",
+  msg_debug("%s: usbasp_open(\"%s\")\n",
 	    progname, port);
 
   /* usb_init will be done in usbOpenDevice */
@@ -559,7 +559,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      avrdude_message(MSG_INFO, "%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
+      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
                       progname, pid);
   } else {
     pid = USBASP_SHARED_PID;
@@ -570,12 +570,12 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
     if(strcasecmp(ldata(lfirst(pgm->id)), "usbasp") == 0) {
     /* for id usbasp autodetect some variants */
       if(strcasecmp(port, "nibobee") == 0) {
-        avrdude_message(MSG_INFO, "%s: warning: Using \"-C usbasp -P nibobee\" is deprecated,"
+        msg_info("%s: warning: Using \"-C usbasp -P nibobee\" is deprecated,"
 	        "use \"-C nibobee\" instead.\n",
 	        progname);
         if (usbOpenDevice(&PDATA(pgm)->usbhandle, USBASP_NIBOBEE_VID, "www.nicai-systems.com",
 		        USBASP_NIBOBEE_PID, "NIBObee") != 0) {
-          avrdude_message(MSG_INFO, "%s: error: could not find USB device "
+          msg_info("%s: error: could not find USB device "
                           "\"NIBObee\" with vid=0x%x pid=0x%x\n",
                           progname, USBASP_NIBOBEE_VID, USBASP_NIBOBEE_PID);
           return -1;
@@ -586,7 +586,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
       if (usbOpenDevice(&PDATA(pgm)->usbhandle, USBASP_OLD_VID, "www.fischl.de",
 		             USBASP_OLD_PID, "USBasp") == 0) {
         /* found USBasp with old IDs */
-        avrdude_message(MSG_INFO, "%s: Warning: Found USB device \"USBasp\" with "
+        msg_info("%s: Warning: Found USB device \"USBasp\" with "
                         "old VID/PID! Please update firmware of USBasp!\n",
                         progname);
 	return 0;
@@ -595,15 +595,15 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
     /* no alternative found => fall through to generic error message */
     }
 
-    avrdude_message(MSG_INFO, "%s: error: could not find USB device with vid=0x%x pid=0x%x",
+    msg_info("%s: error: could not find USB device with vid=0x%x pid=0x%x",
                     progname, vid, pid);
     if (pgm->usbvendor[0] != 0) {
-       avrdude_message(MSG_INFO, " vendor='%s'", pgm->usbvendor);
+       msg_info(" vendor='%s'", pgm->usbvendor);
     }
     if (pgm->usbproduct[0] != 0) {
-       avrdude_message(MSG_INFO, " product='%s'", pgm->usbproduct);
+       msg_info(" product='%s'", pgm->usbproduct);
     }
-    avrdude_message(MSG_INFO, "\n");
+    msg_info("\n");
     return -1;
   }
 
@@ -612,7 +612,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
 
 static void usbasp_close(PROGRAMMER * pgm)
 {
-  avrdude_message(MSG_DEBUG, "%s: usbasp_close()\n", progname);
+  msg_debug("%s: usbasp_close()\n", progname);
 
   if (PDATA(pgm)->usbhandle!=NULL) {
     unsigned char temp[4];
@@ -665,7 +665,7 @@ static int usbasp_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char res[4];
   IMPORT_PDATA(pgm);
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_initialize()\n", progname);
+  msg_debug("%s: usbasp_initialize()\n", progname);
 
   /* get capabilities */
   memset(temp, 0, sizeof(temp));
@@ -712,7 +712,7 @@ static int usbasp_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 static int usbasp_spi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
                    unsigned char *res)
 {
-  avrdude_message(MSG_DEBUG, "%s: usbasp_spi_cmd(0x%02x, 0x%02x, 0x%02x, 0x%02x)%s",
+  msg_debug("%s: usbasp_spi_cmd(0x%02x, 0x%02x, 0x%02x, 0x%02x)%s",
 	    progname, cmd[0], cmd[1], cmd[2], cmd[3],
 	    verbose > 3? "...\n": "");
 
@@ -723,12 +723,12 @@ static int usbasp_spi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
     if (verbose == 3)
       putc('\n', stderr);
 
-    avrdude_message(MSG_INFO, "%s: error: wrong response size\n",
+    msg_info("%s: error: wrong response size\n",
 	    progname);
     return -1;
   }
-  avrdude_message(MSG_TRACE, "%s: usbasp_spi_cmd()", progname);
-  avrdude_message(MSG_DEBUG, " => 0x%02x, 0x%02x, 0x%02x, 0x%02x\n",
+  msg_trace("%s: usbasp_spi_cmd()", progname);
+  msg_debug(" => 0x%02x, 0x%02x, 0x%02x, 0x%02x\n",
         res[0], res[1], res[2], res[3]);
 
   return 0;
@@ -742,14 +742,14 @@ static int usbasp_spi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 
   cmd[0] = 0;
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_program_enable()\n",
+  msg_debug("%s: usbasp_program_enable()\n",
 	    progname);
 
   int nbytes =
     usbasp_transmit(pgm, 1, USBASP_FUNC_ENABLEPROG, cmd, res, sizeof(res));
 
   if ((nbytes != 1) | (res[0] != 0)) {
-    avrdude_message(MSG_INFO, "%s: error: program enable: target doesn't answer. %x \n",
+    msg_info("%s: error: program enable: target doesn't answer. %x \n",
 	    progname, res[0]);
     return -1;
   }
@@ -761,11 +761,11 @@ static int usbasp_spi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char cmd[4];
   unsigned char res[4];
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_chip_erase()\n",
+  msg_debug("%s: usbasp_chip_erase()\n",
 	    progname);
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    avrdude_message(MSG_INFO, "chip erase instruction not defined for part \"%s\"\n",
+    msg_info("chip erase instruction not defined for part \"%s\"\n",
             p->desc);
     return -1;
   }
@@ -790,7 +790,7 @@ static int usbasp_spi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
   unsigned char *buffer = m->buf + address;
   int function;
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_program_paged_load(\"%s\", 0x%x, %d)\n",
+  msg_debug("%s: usbasp_program_paged_load(\"%s\", 0x%x, %d)\n",
                     progname, m->desc, address, n_bytes);
 
   if (strcmp(m->desc, "flash") == 0) {
@@ -834,7 +834,7 @@ static int usbasp_spi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
     n = usbasp_transmit(pgm, 1, function, cmd, buffer, blocksize);
 
     if (n != blocksize) {
-      avrdude_message(MSG_INFO, "%s: error: wrong reading bytes %x\n",
+      msg_info("%s: error: wrong reading bytes %x\n",
 	      progname, n);
       return -3;
     }
@@ -857,7 +857,7 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
   unsigned char blockflags = USBASP_BLOCKFLAG_FIRST;
   int function;
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_program_paged_write(\"%s\", 0x%x, %d)\n",
+  msg_debug("%s: usbasp_program_paged_write(\"%s\", 0x%x, %d)\n",
                     progname, m->desc, address, n_bytes);
 
   if (strcmp(m->desc, "flash") == 0) {
@@ -905,7 +905,7 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     n = usbasp_transmit(pgm, 0, function, cmd, buffer, blocksize);
 
     if (n != blocksize) {
-      avrdude_message(MSG_INFO, "%s: error: wrong count at writing %x\n",
+      msg_info("%s: error: wrong count at writing %x\n",
 	      progname, n);
       return -3;        
     }
@@ -944,7 +944,7 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
   unsigned char res[4];
   unsigned char cmd[4];
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_spi_set_sck_period(%g)\n",
+  msg_debug("%s: usbasp_spi_set_sck_period(%g)\n",
                     progname, sckperiod);
 
   memset(cmd, 0, sizeof(cmd));
@@ -956,22 +956,22 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
   if (sckperiod == 0) {
     /* auto sck set */
 
-    avrdude_message(MSG_NOTICE, "%s: auto set sck period (because given equals null)\n", progname);
+    msg_notice("%s: auto set sck period (because given equals null)\n", progname);
 
   } else {
 
     int sckfreq = 1 / sckperiod; /* sck in Hz */
     int usefreq = 0;
 
-    avrdude_message(MSG_NOTICE2, "%s: try to set SCK period to %g s (= %i Hz)\n", progname, sckperiod, sckfreq);
+    msg_notice2("%s: try to set SCK period to %g s (= %i Hz)\n", progname, sckperiod, sckfreq);
 
     /* Check if programmer is capable of 3 MHz SCK, if not then ommit 3 MHz setting */
     int i;
     if (PDATA(pgm)->sck_3mhz) {
-      avrdude_message(MSG_NOTICE2, "%s: connected USBasp is capable of 3 MHz SCK\n",progname);
+      msg_notice2("%s: connected USBasp is capable of 3 MHz SCK\n",progname);
       i = 0;
     } else {
-      avrdude_message(MSG_NOTICE2, "%s: connected USBasp is not cabable of 3 MHz SCK\n",progname);
+      msg_notice2("%s: connected USBasp is not cabable of 3 MHz SCK\n",progname);
       i = 1;
     }
     if (sckfreq >= usbaspSCKoptions[i].frequency) {
@@ -993,7 +993,7 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
     /* save used sck frequency */
     PDATA(pgm)->sckfreq_hz = usefreq;
 
-    avrdude_message(MSG_INFO, "%s: set SCK frequency to %i Hz\n", progname, usefreq);
+    msg_info("%s: set SCK frequency to %i Hz\n", progname, usefreq);
   }
 
   cmd[0] = clockoption;
@@ -1002,7 +1002,7 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
     usbasp_transmit(pgm, 1, USBASP_FUNC_SETISPSCK, cmd, res, sizeof(res));
 
   if ((nbytes != 1) | (res[0] != 0)) {
-    avrdude_message(MSG_INFO, "%s: warning: cannot set sck period. please check for usbasp firmware update.\n",
+    msg_info("%s: warning: cannot set sck period. please check for usbasp firmware update.\n",
       progname);
     return -1;
   }
@@ -1027,7 +1027,7 @@ static int usbasp_tpi_recv_byte(const PROGRAMMER *pgm) {
 
   if(usbasp_transmit(pgm, 1, USBASP_FUNC_TPI_RAWREAD, temp, temp, sizeof(temp)) != 1)
   {
-    avrdude_message(MSG_INFO, "%s: error: wrong response size\n", progname);
+    msg_info("%s: error: wrong response size\n", progname);
     return -1;
   }
 
@@ -1038,7 +1038,7 @@ static int usbasp_tpi_recv_byte(const PROGRAMMER *pgm) {
 static int usbasp_tpi_nvm_waitbusy(const PROGRAMMER *pgm) {
   int retry;
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_tpi_nvm_waitbusy() ...", progname);
+  msg_debug("%s: usbasp_tpi_nvm_waitbusy() ...", progname);
 
   for(retry=50; retry>0; retry--)
   {
@@ -1046,25 +1046,25 @@ static int usbasp_tpi_nvm_waitbusy(const PROGRAMMER *pgm) {
     if(usbasp_tpi_recv_byte(pgm) & NVMCSR_BSY)
       continue;
 
-    avrdude_message(MSG_DEBUG, " ready\n");
+    msg_debug(" ready\n");
 
     return 0;
   }
 
-  avrdude_message(MSG_DEBUG, " failure\n");
+  msg_debug(" failure\n");
 
   return -1;
 }
 
 static int usbasp_tpi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned char *res) {
-  avrdude_message(MSG_INFO, "%s: error: spi_cmd used in TPI mode: not allowed\n", progname);
+  msg_info("%s: error: spi_cmd used in TPI mode: not allowed\n", progname);
   return -1;
 }
 
 static int usbasp_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   int retry;
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_tpi_program_enable()\n", progname);
+  msg_debug("%s: usbasp_tpi_program_enable()\n", progname);
 
   /* change guard time */
   usbasp_tpi_send_byte(pgm, TPI_OP_SSTCS(TPIPCR));
@@ -1094,7 +1094,7 @@ static int usbasp_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   }
   if(retry >= 10)
   {
-    avrdude_message(MSG_INFO, "%s: error: program enable: target doesn't answer.\n", progname);
+    msg_info("%s: error: program enable: target doesn't answer.\n", progname);
     return -1;
   }
 
@@ -1112,14 +1112,14 @@ static int usbasp_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     pr_0 = 0x41;
     pr_1 = 0x3F;
     nvm_cmd = NVMCMD_SECTION_ERASE;
-    avrdude_message(MSG_DEBUG, "%s: usbasp_tpi_chip_erase() - section erase\n", progname);
+    msg_debug("%s: usbasp_tpi_chip_erase() - section erase\n", progname);
     break;
     /* Chip erase (flash only) */
   default:
     pr_0 = 0x01;
     pr_1 = 0x40;
     nvm_cmd = NVMCMD_CHIP_ERASE;
-    avrdude_message(MSG_DEBUG, "%s: usbasp_tpi_chip_erase() - chip erase\n", progname);
+    msg_debug("%s: usbasp_tpi_chip_erase() - chip erase\n", progname);
     break;
   }
 
@@ -1151,7 +1151,7 @@ static int usbasp_tpi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
   uint16_t pr;
 
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_tpi_paged_load(\"%s\", 0x%0x, %d)\n",
+  msg_debug("%s: usbasp_tpi_paged_load(\"%s\", 0x%0x, %d)\n",
 	    progname, m->desc, addr, n_bytes);
 
   dptr = addr + m->buf;
@@ -1172,7 +1172,7 @@ static int usbasp_tpi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
     n = usbasp_transmit(pgm, 1, USBASP_FUNC_TPI_READBLOCK, cmd, dptr, clen);
     if(n != clen)
     {
-      avrdude_message(MSG_INFO, "%s: error: wrong reading bytes %x\n", progname, n);
+      msg_info("%s: error: wrong reading bytes %x\n", progname, n);
       return -3;
     }
     
@@ -1193,7 +1193,7 @@ static int usbasp_tpi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
   uint16_t pr;
 
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_tpi_paged_write(\"%s\", 0x%0x, %d)\n",
+  msg_debug("%s: usbasp_tpi_paged_write(\"%s\", 0x%0x, %d)\n",
 	    progname, m->desc, addr, n_bytes);
 
   sptr = addr + m->buf;
@@ -1238,7 +1238,7 @@ static int usbasp_tpi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     n = usbasp_transmit(pgm, 0, USBASP_FUNC_TPI_WRITEBLOCK, cmd, sptr, clen);
     if(n != clen)
     {
-      avrdude_message(MSG_INFO, "%s: error: wrong count at writing %x\n", progname, n);
+      msg_info("%s: error: wrong count at writing %x\n", progname, n);
       return -3;
     }
     
@@ -1260,7 +1260,7 @@ static int usbasp_tpi_read_byte(const PROGRAMMER * pgm, const AVRPART *p, const 
   uint16_t pr;
 
 
-  avrdude_message(MSG_DEBUG, "%s: usbasp_tpi_read_byte(\"%s\", 0x%0lx)\n",
+  msg_debug("%s: usbasp_tpi_read_byte(\"%s\", 0x%0lx)\n",
 	    progname, m->desc, addr);
 
   pr = m->offset + addr;
@@ -1273,7 +1273,7 @@ static int usbasp_tpi_read_byte(const PROGRAMMER * pgm, const AVRPART *p, const 
   n = usbasp_transmit(pgm, 1, USBASP_FUNC_TPI_READBLOCK, cmd, value, 1);
   if(n != 1)
   {
-    avrdude_message(MSG_INFO, "%s: error: wrong reading bytes %x\n", progname, n);
+    msg_info("%s: error: wrong reading bytes %x\n", progname, n);
     return -3;
   }
   return 0;
@@ -1282,7 +1282,7 @@ static int usbasp_tpi_read_byte(const PROGRAMMER * pgm, const AVRPART *p, const 
 static int usbasp_tpi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
   unsigned long addr, unsigned char data) { // FIXME: use avr_write_byte_cache() when implemented
 
-  avrdude_message(MSG_INFO, "%s: error: usbasp_write_byte in TPI mode: all writes have to be done at page level\n", progname);
+  msg_info("%s: error: usbasp_write_byte in TPI mode: all writes have to be done at page level\n", progname);
   return -1;
 }
 
@@ -1323,7 +1323,7 @@ void usbasp_initpgm(PROGRAMMER *pgm) {
 #else /* HAVE_LIBUSB */
 
 static int usbasp_nousb_open(PROGRAMMER *pgm, const char *name) {
-  avrdude_message(MSG_INFO, "%s: error: no usb support. please compile again with libusb installed.\n",
+  msg_info("%s: error: no usb support. please compile again with libusb installed.\n",
 	  progname);
 
   return -1;

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -337,7 +337,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
       usbasp_get_funcname(functionid), send[0], send[1], send[2], send[3]);
     if (!receive && buffersize > 0) {
       int i;
-      msg_trace("%s => ", progbuf);
+      imsg_trace(" => ");
       for (i = 0; i < buffersize; i++)
 	msg_trace("[%02x] ", buffer[i]);
       msg_trace("\n");
@@ -373,7 +373,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
 
   if (verbose > 3 && receive && nbytes > 0) {
     int i;
-    msg_trace("%s<= ", progbuf);
+    imsg_trace("<= ");
     for (i = 0; i < nbytes; i++)
       msg_trace("[%02x] ", buffer[i]);
     msg_trace("\n");

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -79,8 +79,7 @@ struct pdata
 static void usbtiny_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    msg_info("%s: usbtiny_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("usbtiny_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -136,15 +135,14 @@ static int usb_in (const PROGRAMMER *pgm,
     PDATA(pgm)->retries++;
   }
   msg_info("\n%s: error: usbtiny_receive: %s (expected %d, got %d)\n",
-          progname, usb_strerror(), buflen, nbytes);
+    progname, usb_strerror(), buflen, nbytes);
   return -1;
 }
 
 // Report the number of retries, and reset the counter.
 static void check_retries (const PROGRAMMER *pgm, const char *operation) {
   if (PDATA(pgm)->retries > 0 && quell_progress < 2) {
-    msg_info("%s: %d retries during %s\n", progname,
-           PDATA(pgm)->retries, operation);
+    pmsg_info("%d retries during %s\n", PDATA(pgm)->retries, operation);
   }
   PDATA(pgm)->retries = 0;
 }
@@ -169,7 +167,7 @@ static int usb_out (const PROGRAMMER *pgm,
 			    timeout);
   if (nbytes != buflen) {
     msg_info("\n%s: error: usbtiny_send: %s (expected %d, got %d)\n",
-	    progname, usb_strerror(), buflen, nbytes);
+      progname, usb_strerror(), buflen, nbytes);
     return -1;
   }
 
@@ -288,7 +286,7 @@ static int usbtiny_avr_op (const PROGRAMMER *pgm, const AVRPART *p,
   unsigned char	cmd[4];
 
   if (p->op[op] == NULL) {
-    msg_info("Operation %d not defined for this chip!\n", op );
+    msg_info("Operation %d not defined for this chip!\n", op);
     return -1;
   }
   memset(cmd, 0, sizeof(cmd));
@@ -337,8 +335,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
-                      progname, pid);
+      pmsg_info("warning; using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
   } else {
     pid = USBTINY_PRODUCT_DEFAULT;
   }
@@ -349,8 +346,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
     for	( dev = bus->devices; dev; dev = dev->next ) {
       if (dev->descriptor.idVendor == vid
 	  && dev->descriptor.idProduct == pid ) {   // found match?
-    msg_notice("%s: usbdev_open(): Found USBtinyISP, bus:device: %s:%s\n",
-                      progname, bus->dirname, dev->filename);
+    pmsg_notice("usbdev_open(): Found USBtinyISP, bus:device: %s:%s\n", bus->dirname, dev->filename);
     // if -P was given, match device by device name and bus name
     if(name != NULL &&
       (NULL == dev_name ||
@@ -361,8 +357,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
 
 	// wrong permissions or something?
 	if (!PDATA(pgm)->usb_handle) {
-	  msg_info("%s: Warning: cannot open USB device: %s\n",
-		  progname, usb_strerror());
+	  pmsg_info("warning; cannot open USB device: %s\n", usb_strerror());
 	  continue;
 	}
       }
@@ -370,13 +365,12 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   }
 
   if(NULL != name && NULL == dev_name) {
-    msg_info("%s: Error: Invalid -P value: '%s'\n", progname, name);
+    pmsg_info("invalid -P value: '%s'\n", name);
     msg_info("%sUse -P usb:bus:device\n", progbuf);
     return -1;
   }
   if (!PDATA(pgm)->usb_handle) {
-    msg_info("%s: Error: Could not find USBtiny device (0x%x/0x%x)\n",
-	     progname, vid, pid );
+    pmsg_info("could not find USBtiny device (0x%x/0x%x)\n", vid, pid );
     return -1;
   }
 
@@ -418,7 +412,7 @@ static int usbtiny_set_sck_period (const PROGRAMMER *pgm, double v) {
   if  (PDATA(pgm)->sck_period > SCK_MAX)
     PDATA(pgm)->sck_period = SCK_MAX;
 
-  msg_notice("%s: Setting SCK period to %d usec\n", progname,
+  pmsg_notice("setting SCK period to %d usec\n",
 	    PDATA(pgm)->sck_period );
 
   // send the command to the usbtiny device.
@@ -443,8 +437,7 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
   } else {
     // -B option not specified: use default
     PDATA(pgm)->sck_period = SCK_DEFAULT;
-    msg_notice("%s: Using SCK period of %d usec\n",
-	      progname, PDATA(pgm)->sck_period );
+    pmsg_notice("using SCK period of %d usec\n", PDATA(pgm)->sck_period );
     if (usb_control(pgm,  USBTINY_POWERUP,
 		    PDATA(pgm)->sck_period, RESET_LOW ) < 0)
       return -1;
@@ -470,8 +463,8 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
     if (res[0] != 0x12 || res[1] != 0x34 || res[2] != 0x56 || res[3] != 0x78) {
       fprintf(stderr,
 	      "MOSI->MISO check failed (got 0x%02x 0x%02x 0x%02x 0x%02x)\n"
-	      "\tPlease verify that MISO is connected directly to TPIDATA and\n"
-	      "\tMOSI is connected to TPIDATA through a 1kOhm resistor.\n",
+	      "\tplease verify that MISO is connected directly to TPIDATA and\n"
+	      "\tMOSI is connected to TPIDATA through a 1kOhm resistor\n",
 	      res[0], res[1], res[2], res[3]);
       return -1;
     }
@@ -609,8 +602,7 @@ static int usbtiny_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return avr_tpi_chip_erase(pgm, p);
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    msg_info("Chip erase instruction not defined for part \"%s\"\n",
-            p->desc);
+    msg_info("chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -818,8 +810,7 @@ void usbtiny_initpgm(PROGRAMMER *pgm) {
 // Give a proper error if we were not compiled with libusb
 
 static int usbtiny_nousb_open(PROGRAMMER *pgm, const char *name) {
-  msg_info("%s: error: no usb support. Please compile again with libusb installed.\n",
-	  progname);
+  pmsg_info("no usb support; please compile again with libusb installed\n");
 
   return -1;
 }

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -79,7 +79,7 @@ struct pdata
 static void usbtiny_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_info("usbtiny_setup(): Out of memory allocating private data\n");
+    pmsg_error("usbtiny_setup(): out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -102,7 +102,8 @@ static int usb_control (const PROGRAMMER *pgm,
 			    NULL, 0,              // no data buffer in control message
 			    USB_TIMEOUT );        // default timeout
   if(nbytes < 0){
-    msg_info("\n%s: error: usbtiny_transmit: %s\n", progname, usb_strerror());
+    msg_error("\n");
+    pmsg_error("usbtiny_transmit: %s\n", usb_strerror());
     return -1;
   }
 
@@ -134,16 +135,15 @@ static int usb_in (const PROGRAMMER *pgm,
     }
     PDATA(pgm)->retries++;
   }
-  msg_info("\n%s: error: usbtiny_receive: %s (expected %d, got %d)\n",
-    progname, usb_strerror(), buflen, nbytes);
+  msg_error("\n");
+  pmsg_error("usbtiny_receive: %s (expected %d, got %d)\n", usb_strerror(), buflen, nbytes);
   return -1;
 }
 
 // Report the number of retries, and reset the counter.
 static void check_retries (const PROGRAMMER *pgm, const char *operation) {
-  if (PDATA(pgm)->retries > 0 && quell_progress < 2) {
+  if (PDATA(pgm)->retries > 0)
     pmsg_info("%d retries during %s\n", PDATA(pgm)->retries, operation);
-  }
   PDATA(pgm)->retries = 0;
 }
 
@@ -166,8 +166,8 @@ static int usb_out (const PROGRAMMER *pgm,
 			    (char *)buffer, buflen,
 			    timeout);
   if (nbytes != buflen) {
-    msg_info("\n%s: error: usbtiny_send: %s (expected %d, got %d)\n",
-      progname, usb_strerror(), buflen, nbytes);
+    msg_error("\n");
+    pmsg_error("usbtiny_send: %s (expected %d, got %d)\n", usb_strerror(), buflen, nbytes);
     return -1;
   }
 
@@ -221,8 +221,7 @@ static int usbtiny_tpi_tx(const PROGRAMMER *pgm, unsigned char b0) {
   if (usb_in(pgm, USBTINY_SPI, tpi_frame(b0), 0xffff,
 	     res, sizeof(res), 8 * sizeof(res) * PDATA(pgm)->sck_period) < 0)
     return -1;
-  if (verbose > 1)
-    fprintf(stderr, "CMD_TPI_TX: [0x%02x]\n", b0);
+  msg_notice2("CMD_TPI_TX: [0x%02x]\n", b0);
   return 1;
 }
 
@@ -236,8 +235,7 @@ static int usbtiny_tpi_txtx(const PROGRAMMER *pgm,
   if (usb_in(pgm, USBTINY_SPI, tpi_frame(b0), tpi_frame(b1),
 	     res, sizeof(res), 8 * sizeof(res) * PDATA(pgm)->sck_period) < 0)
     return -1;
-  if (verbose > 1)
-    fprintf(stderr, "CMD_TPI_TX_TX: [0x%02x 0x%02x]\n", b0, b1);
+  msg_notice2("CMD_TPI_TX_TX: [0x%02x 0x%02x]\n", b0, b1);
   return 1;
 }
 
@@ -262,16 +260,15 @@ static int usbtiny_tpi_txrx(const PROGRAMMER *pgm, unsigned char b0) {
      bit and the 8 data bits, but the latter in reverse order. */
   r = reverse(w >> 7);
   if (tpi_parity(r) != ((w >> 6) & 1)) {
-    fprintf(stderr, "%s: parity bit is wrong\n", __func__);
+    pmsg_error("%s: parity bit is wrong\n", __func__);
     return -1;
   }
   if (((w >> 4) & 0x3) != TPI_STOP_BITS) {
-    fprintf(stderr, "%s: stop bits not received correctly\n", __func__);
+    pmsg_error("%s: stop bits not received correctly\n", __func__);
     return -1;
   }
 
-  if (verbose > 1)
-    fprintf(stderr, "CMD_TPI_TX_RX: [0x%02x -> 0x%02x]\n", b0, r);
+  msg_notice2("CMD_TPI_TX_RX: [0x%02x -> 0x%02x]\n", b0, r);
   return r;
 }
 
@@ -286,7 +283,7 @@ static int usbtiny_avr_op (const PROGRAMMER *pgm, const AVRPART *p,
   unsigned char	cmd[4];
 
   if (p->op[op] == NULL) {
-    msg_info("Operation %d not defined for this chip!\n", op);
+    pmsg_error("operation %d not defined for this chip\n", op);
     return -1;
   }
   memset(cmd, 0, sizeof(cmd));
@@ -335,7 +332,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      pmsg_info("warning; using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
+      pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
   } else {
     pid = USBTINY_PRODUCT_DEFAULT;
   }
@@ -346,7 +343,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
     for	( dev = bus->devices; dev; dev = dev->next ) {
       if (dev->descriptor.idVendor == vid
 	  && dev->descriptor.idProduct == pid ) {   // found match?
-    pmsg_notice("usbdev_open(): Found USBtinyISP, bus:device: %s:%s\n", bus->dirname, dev->filename);
+    pmsg_notice("usbdev_open(): found USBtinyISP, bus:device: %s:%s\n", bus->dirname, dev->filename);
     // if -P was given, match device by device name and bus name
     if(name != NULL &&
       (NULL == dev_name ||
@@ -357,7 +354,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
 
 	// wrong permissions or something?
 	if (!PDATA(pgm)->usb_handle) {
-	  pmsg_info("warning; cannot open USB device: %s\n", usb_strerror());
+	  pmsg_warning("cannot open USB device: %s\n", usb_strerror());
 	  continue;
 	}
       }
@@ -365,12 +362,12 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   }
 
   if(NULL != name && NULL == dev_name) {
-    pmsg_info("invalid -P value: '%s'\n", name);
-    msg_info("%sUse -P usb:bus:device\n", progbuf);
+    pmsg_error("invalid -P value: '%s'\n", name);
+    msg_error("%suse -P usb:bus:device\n", progbuf);
     return -1;
   }
   if (!PDATA(pgm)->usb_handle) {
-    pmsg_info("could not find USBtiny device (0x%x/0x%x)\n", vid, pid );
+    pmsg_error("cannot find USBtiny device (0x%x/0x%x)\n", vid, pid );
     return -1;
   }
 
@@ -451,21 +448,19 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
     /* Since there is a single TPIDATA line, MOSI and MISO must be
        linked together through a 1kOhm resistor.  Verify that
        everything we send on MOSI gets mirrored back on MISO.  */
-    if (verbose >= 2)
-      fprintf(stderr, "doing MOSI-MISO link check\n");
+    msg_notice2("doing MOSI-MISO link check\n");
 
     memset(res, 0xaa, sizeof(res));
     if (usb_in(pgm, USBTINY_SPI, LITTLE_TO_BIG_16(0x1234), LITTLE_TO_BIG_16(0x5678),
 	       res, 4, 32 * PDATA(pgm)->sck_period) < 0) {
-      fprintf(stderr, "usb_in() failed\n");
+      pmsg_error("usb_in() failed\n");
       return -1;
     }
     if (res[0] != 0x12 || res[1] != 0x34 || res[2] != 0x56 || res[3] != 0x78) {
-      fprintf(stderr,
-	      "MOSI->MISO check failed (got 0x%02x 0x%02x 0x%02x 0x%02x)\n"
-	      "\tplease verify that MISO is connected directly to TPIDATA and\n"
-	      "\tMOSI is connected to TPIDATA through a 1kOhm resistor\n",
-	      res[0], res[1], res[2], res[3]);
+      pmsg_error("MOSI->MISO check failed (got 0x%02x 0x%02x 0x%02x 0x%02x)\n"
+        "\tplease verify that MISO is connected directly to TPIDATA and\n"
+        "\tMOSI is connected to TPIDATA through a 1kOhm resistor\n",
+        res[0], res[1], res[2], res[3]);
       return -1;
     }
 
@@ -473,7 +468,7 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
     if (usb_in(pgm, USBTINY_SPI, 0xffff, 0xffff, res, 4,
 	       32 * PDATA(pgm)->sck_period) < 0)
     {
-      fprintf(stderr, "Unable to switch chip into TPI mode\n");
+      pmsg_error("unable to switch chip into TPI mode\n");
       return -1;
     }
   }
@@ -567,8 +562,7 @@ int usbtiny_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
   }
 
   if (rx < res_len) {
-    fprintf(stderr, "%s: unexpected cmd_len=%d/res_len=%d\n",
-	    __func__, cmd_len, res_len);
+    pmsg_error("%s: unexpected cmd_len=%d/res_len=%d\n", __func__, cmd_len, res_len);
     return -1;
   }
   return 0;
@@ -581,8 +575,7 @@ static int usbtiny_spi(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned
   memset(res, 0, count);
 
   if (count % 4) {
-    msg_info("Direct SPI write must be a multiple of 4 bytes for %s\n",
-            pgm->type);
+    pmsg_error("direct SPI write must be a multiple of 4 bytes for %s\n", pgm->type);
     return -1;
   }
 
@@ -602,7 +595,7 @@ static int usbtiny_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return avr_tpi_chip_erase(pgm, p);
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    msg_info("chip erase instruction not defined for part %s\n", p->desc);
+    pmsg_error("chip erase instruction not defined for part %s\n", p->desc);
     return -1;
   }
 
@@ -810,7 +803,7 @@ void usbtiny_initpgm(PROGRAMMER *pgm) {
 // Give a proper error if we were not compiled with libusb
 
 static int usbtiny_nousb_open(PROGRAMMER *pgm, const char *name) {
-  pmsg_info("no usb support; please compile again with libusb installed\n");
+  pmsg_error("no usb support; please compile again with libusb installed\n");
 
   return -1;
 }

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -79,7 +79,7 @@ struct pdata
 static void usbtiny_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error("usbtiny_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
@@ -103,7 +103,7 @@ static int usb_control (const PROGRAMMER *pgm,
 			    USB_TIMEOUT );        // default timeout
   if(nbytes < 0){
     msg_error("\n");
-    pmsg_error("usbtiny_transmit: %s\n", usb_strerror());
+    pmsg_error("%s\n", usb_strerror());
     return -1;
   }
 
@@ -136,7 +136,7 @@ static int usb_in (const PROGRAMMER *pgm,
     PDATA(pgm)->retries++;
   }
   msg_error("\n");
-  pmsg_error("usbtiny_receive: %s (expected %d, got %d)\n", usb_strerror(), buflen, nbytes);
+  pmsg_error("%s (expected %d, got %d)\n", usb_strerror(), buflen, nbytes);
   return -1;
 }
 
@@ -167,7 +167,7 @@ static int usb_out (const PROGRAMMER *pgm,
 			    timeout);
   if (nbytes != buflen) {
     msg_error("\n");
-    pmsg_error("usbtiny_send: %s (expected %d, got %d)\n", usb_strerror(), buflen, nbytes);
+    pmsg_error("%s (expected %d, got %d)\n", usb_strerror(), buflen, nbytes);
     return -1;
   }
 
@@ -260,11 +260,11 @@ static int usbtiny_tpi_txrx(const PROGRAMMER *pgm, unsigned char b0) {
      bit and the 8 data bits, but the latter in reverse order. */
   r = reverse(w >> 7);
   if (tpi_parity(r) != ((w >> 6) & 1)) {
-    pmsg_error("%s: parity bit is wrong\n", __func__);
+    pmsg_error("parity bit is wrong\n");
     return -1;
   }
   if (((w >> 4) & 0x3) != TPI_STOP_BITS) {
-    pmsg_error("%s: stop bits not received correctly\n", __func__);
+    pmsg_error("stop bits not received correctly\n");
     return -1;
   }
 
@@ -562,7 +562,7 @@ int usbtiny_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
   }
 
   if (rx < res_len) {
-    pmsg_error("%s: unexpected cmd_len=%d/res_len=%d\n", __func__, cmd_len, res_len);
+    pmsg_error("unexpected cmd_len=%d/res_len=%d\n", cmd_len, res_len);
     return -1;
   }
   return 0;

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -363,7 +363,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
 
   if(NULL != name && NULL == dev_name) {
     pmsg_error("invalid -P value: '%s'\n", name);
-    msg_error("%suse -P usb:bus:device\n", progbuf);
+    imsg_error("use -P usb:bus:device\n");
     return -1;
   }
   if (!PDATA(pgm)->usb_handle) {

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -79,7 +79,7 @@ struct pdata
 static void usbtiny_setup(PROGRAMMER * pgm)
 {
   if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: usbtiny_setup(): Out of memory allocating private data\n",
+    msg_info("%s: usbtiny_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -103,7 +103,7 @@ static int usb_control (const PROGRAMMER *pgm,
 			    NULL, 0,              // no data buffer in control message
 			    USB_TIMEOUT );        // default timeout
   if(nbytes < 0){
-    avrdude_message(MSG_INFO, "\n%s: error: usbtiny_transmit: %s\n", progname, usb_strerror());
+    msg_info("\n%s: error: usbtiny_transmit: %s\n", progname, usb_strerror());
     return -1;
   }
 
@@ -135,7 +135,7 @@ static int usb_in (const PROGRAMMER *pgm,
     }
     PDATA(pgm)->retries++;
   }
-  avrdude_message(MSG_INFO, "\n%s: error: usbtiny_receive: %s (expected %d, got %d)\n",
+  msg_info("\n%s: error: usbtiny_receive: %s (expected %d, got %d)\n",
           progname, usb_strerror(), buflen, nbytes);
   return -1;
 }
@@ -143,7 +143,7 @@ static int usb_in (const PROGRAMMER *pgm,
 // Report the number of retries, and reset the counter.
 static void check_retries (const PROGRAMMER *pgm, const char *operation) {
   if (PDATA(pgm)->retries > 0 && quell_progress < 2) {
-    avrdude_message(MSG_INFO, "%s: %d retries during %s\n", progname,
+    msg_info("%s: %d retries during %s\n", progname,
            PDATA(pgm)->retries, operation);
   }
   PDATA(pgm)->retries = 0;
@@ -168,7 +168,7 @@ static int usb_out (const PROGRAMMER *pgm,
 			    (char *)buffer, buflen,
 			    timeout);
   if (nbytes != buflen) {
-    avrdude_message(MSG_INFO, "\n%s: error: usbtiny_send: %s (expected %d, got %d)\n",
+    msg_info("\n%s: error: usbtiny_send: %s (expected %d, got %d)\n",
 	    progname, usb_strerror(), buflen, nbytes);
     return -1;
   }
@@ -288,7 +288,7 @@ static int usbtiny_avr_op (const PROGRAMMER *pgm, const AVRPART *p,
   unsigned char	cmd[4];
 
   if (p->op[op] == NULL) {
-    avrdude_message(MSG_INFO, "Operation %d not defined for this chip!\n", op );
+    msg_info("Operation %d not defined for this chip!\n", op );
     return -1;
   }
   memset(cmd, 0, sizeof(cmd));
@@ -337,7 +337,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   if (usbpid) {
     pid = *(int *)(ldata(usbpid));
     if (lnext(usbpid))
-      avrdude_message(MSG_INFO, "%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
+      msg_info("%s: Warning: using PID 0x%04x, ignoring remaining PIDs in list\n",
                       progname, pid);
   } else {
     pid = USBTINY_PRODUCT_DEFAULT;
@@ -349,7 +349,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
     for	( dev = bus->devices; dev; dev = dev->next ) {
       if (dev->descriptor.idVendor == vid
 	  && dev->descriptor.idProduct == pid ) {   // found match?
-    avrdude_message(MSG_NOTICE, "%s: usbdev_open(): Found USBtinyISP, bus:device: %s:%s\n",
+    msg_notice("%s: usbdev_open(): Found USBtinyISP, bus:device: %s:%s\n",
                       progname, bus->dirname, dev->filename);
     // if -P was given, match device by device name and bus name
     if(name != NULL &&
@@ -361,7 +361,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
 
 	// wrong permissions or something?
 	if (!PDATA(pgm)->usb_handle) {
-	  avrdude_message(MSG_INFO, "%s: Warning: cannot open USB device: %s\n",
+	  msg_info("%s: Warning: cannot open USB device: %s\n",
 		  progname, usb_strerror());
 	  continue;
 	}
@@ -370,12 +370,12 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   }
 
   if(NULL != name && NULL == dev_name) {
-    avrdude_message(MSG_INFO, "%s: Error: Invalid -P value: '%s'\n", progname, name);
-    avrdude_message(MSG_INFO, "%sUse -P usb:bus:device\n", progbuf);
+    msg_info("%s: Error: Invalid -P value: '%s'\n", progname, name);
+    msg_info("%sUse -P usb:bus:device\n", progbuf);
     return -1;
   }
   if (!PDATA(pgm)->usb_handle) {
-    avrdude_message(MSG_INFO, "%s: Error: Could not find USBtiny device (0x%x/0x%x)\n",
+    msg_info("%s: Error: Could not find USBtiny device (0x%x/0x%x)\n",
 	     progname, vid, pid );
     return -1;
   }
@@ -418,7 +418,7 @@ static int usbtiny_set_sck_period (const PROGRAMMER *pgm, double v) {
   if  (PDATA(pgm)->sck_period > SCK_MAX)
     PDATA(pgm)->sck_period = SCK_MAX;
 
-  avrdude_message(MSG_NOTICE, "%s: Setting SCK period to %d usec\n", progname,
+  msg_notice("%s: Setting SCK period to %d usec\n", progname,
 	    PDATA(pgm)->sck_period );
 
   // send the command to the usbtiny device.
@@ -443,7 +443,7 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
   } else {
     // -B option not specified: use default
     PDATA(pgm)->sck_period = SCK_DEFAULT;
-    avrdude_message(MSG_NOTICE, "%s: Using SCK period of %d usec\n",
+    msg_notice("%s: Using SCK period of %d usec\n",
 	      progname, PDATA(pgm)->sck_period );
     if (usb_control(pgm,  USBTINY_POWERUP,
 		    PDATA(pgm)->sck_period, RESET_LOW ) < 0)
@@ -538,7 +538,7 @@ static int usbtiny_cmd(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned
     return -1;
   check_retries(pgm, "SPI command");
   // print out the data we sent and received
-  avrdude_message(MSG_NOTICE2, "CMD: [%02x %02x %02x %02x] [%02x %02x %02x %02x]\n",
+  msg_notice2("CMD: [%02x %02x %02x %02x] [%02x %02x %02x %02x]\n",
 	    cmd[0], cmd[1], cmd[2], cmd[3],
 	    res[0], res[1], res[2], res[3] );
   return ((nbytes == 4) &&      // should have read 4 bytes
@@ -588,7 +588,7 @@ static int usbtiny_spi(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned
   memset(res, 0, count);
 
   if (count % 4) {
-    avrdude_message(MSG_INFO, "Direct SPI write must be a multiple of 4 bytes for %s\n",
+    msg_info("Direct SPI write must be a multiple of 4 bytes for %s\n",
             pgm->type);
     return -1;
   }
@@ -609,7 +609,7 @@ static int usbtiny_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return avr_tpi_chip_erase(pgm, p);
 
   if (p->op[AVR_OP_CHIP_ERASE] == NULL) {
-    avrdude_message(MSG_INFO, "Chip erase instruction not defined for part \"%s\"\n",
+    msg_info("Chip erase instruction not defined for part \"%s\"\n",
             p->desc);
     return -1;
   }
@@ -818,7 +818,7 @@ void usbtiny_initpgm(PROGRAMMER *pgm) {
 // Give a proper error if we were not compiled with libusb
 
 static int usbtiny_nousb_open(PROGRAMMER *pgm, const char *name) {
-  avrdude_message(MSG_INFO, "%s: error: no usb support. Please compile again with libusb installed.\n",
+  msg_info("%s: error: no usb support. Please compile again with libusb installed.\n",
 	  progname);
 
   return -1;

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -85,7 +85,7 @@ static void wiring_setup(PROGRAMMER * pgm)
    * Now prepare our data
    */
   if ((mycookie = malloc(sizeof(struct wiringpdata))) == 0) {
-    avrdude_message(MSG_INFO, "%s: wiring_setup(): Out of memory allocating private data\n",
+    msg_info("%s: wiring_setup(): Out of memory allocating private data\n",
                     progname);
     exit(1);
   }
@@ -122,19 +122,19 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int newsnooze;
       if (sscanf(extended_param, "snooze=%i", &newsnooze) != 1 ||
           newsnooze < 0) {
-        avrdude_message(MSG_INFO, "%s: wiring_parseextparms(): invalid snooze time '%s'\n",
+        msg_info("%s: wiring_parseextparms(): invalid snooze time '%s'\n",
                         progname, extended_param);
         rv = -1;
         continue;
       }
-      avrdude_message(MSG_NOTICE2, "%s: wiring_parseextparms(): snooze time set to %d ms\n",
+      msg_notice2("%s: wiring_parseextparms(): snooze time set to %d ms\n",
                       progname, newsnooze);
       WIRINGPDATA(mycookie)->snoozetime = newsnooze;
 
       continue;
     }
 
-    avrdude_message(MSG_INFO, "%s: wiring_parseextparms(): invalid extended parameter '%s'\n",
+    msg_info("%s: wiring_parseextparms(): invalid extended parameter '%s'\n",
                     progname, extended_param);
     rv = -1;
   }
@@ -157,11 +157,11 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
   if (WIRINGPDATA(mycookie)->snoozetime > 0) {
     timetosnooze = WIRINGPDATA(mycookie)->snoozetime;
 
-    avrdude_message(MSG_NOTICE2, "%s: wiring_open(): snoozing for %d ms\n",
+    msg_notice2("%s: wiring_open(): snoozing for %d ms\n",
                     progname, timetosnooze);
     while (timetosnooze--)
       usleep(1000);
-    avrdude_message(MSG_NOTICE2, "%s: wiring_open(): done snoozing\n",
+    msg_notice2("%s: wiring_open(): done snoozing\n",
                     progname);
   } else {
     /* Perform Wiring programming mode RESET.           */
@@ -169,7 +169,7 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
     /* i.e. both DTR and RTS rise to a HIGH logic level */
     /* since they are active LOW signals.               */
 
-    avrdude_message(MSG_NOTICE2, "%s: wiring_open(): releasing DTR/RTS\n",
+    msg_notice2("%s: wiring_open(): releasing DTR/RTS\n",
                     progname);
 
     serial_set_dtr_rts(&pgm->fd, 0);
@@ -178,7 +178,7 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
     /* After releasing for 50 milliseconds, DTR and RTS */
     /* are asserted (i.e. logic LOW) again.             */
 
-    avrdude_message(MSG_NOTICE2, "%s: wiring_open(): asserting DTR/RTS\n",
+    msg_notice2("%s: wiring_open(): asserting DTR/RTS\n",
                     progname);
 
     serial_set_dtr_rts(&pgm->fd, 1);

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -85,8 +85,7 @@ static void wiring_setup(PROGRAMMER * pgm)
    * Now prepare our data
    */
   if ((mycookie = malloc(sizeof(struct wiringpdata))) == 0) {
-    msg_info("%s: wiring_setup(): Out of memory allocating private data\n",
-                    progname);
+    pmsg_info("wiring_setup(): Out of memory allocating private data\n");
     exit(1);
   }
   memset(mycookie, 0, sizeof(struct wiringpdata));
@@ -122,20 +121,17 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int newsnooze;
       if (sscanf(extended_param, "snooze=%i", &newsnooze) != 1 ||
           newsnooze < 0) {
-        msg_info("%s: wiring_parseextparms(): invalid snooze time '%s'\n",
-                        progname, extended_param);
+        pmsg_info("wiring_parseextparms(): invalid snooze time '%s'\n", extended_param);
         rv = -1;
         continue;
       }
-      msg_notice2("%s: wiring_parseextparms(): snooze time set to %d ms\n",
-                      progname, newsnooze);
+      pmsg_notice2("wiring_parseextparms(): snooze time set to %d ms\n", newsnooze);
       WIRINGPDATA(mycookie)->snoozetime = newsnooze;
 
       continue;
     }
 
-    msg_info("%s: wiring_parseextparms(): invalid extended parameter '%s'\n",
-                    progname, extended_param);
+    pmsg_info("wiring_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 
@@ -157,20 +153,17 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
   if (WIRINGPDATA(mycookie)->snoozetime > 0) {
     timetosnooze = WIRINGPDATA(mycookie)->snoozetime;
 
-    msg_notice2("%s: wiring_open(): snoozing for %d ms\n",
-                    progname, timetosnooze);
+    pmsg_notice2("wiring_open(): snoozing for %d ms\n", timetosnooze);
     while (timetosnooze--)
       usleep(1000);
-    msg_notice2("%s: wiring_open(): done snoozing\n",
-                    progname);
+    pmsg_notice2("wiring_open(): done snoozing\n");
   } else {
     /* Perform Wiring programming mode RESET.           */
     /* This effectively *releases* both DTR and RTS.    */
     /* i.e. both DTR and RTS rise to a HIGH logic level */
     /* since they are active LOW signals.               */
 
-    msg_notice2("%s: wiring_open(): releasing DTR/RTS\n",
-                    progname);
+    pmsg_notice2("wiring_open(): releasing DTR/RTS\n");
 
     serial_set_dtr_rts(&pgm->fd, 0);
     usleep(50*1000);
@@ -178,8 +171,7 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
     /* After releasing for 50 milliseconds, DTR and RTS */
     /* are asserted (i.e. logic LOW) again.             */
 
-    msg_notice2("%s: wiring_open(): asserting DTR/RTS\n",
-                    progname);
+    pmsg_notice2("wiring_open(): asserting DTR/RTS\n");
 
     serial_set_dtr_rts(&pgm->fd, 1);
     usleep(50*1000);

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -85,7 +85,7 @@ static void wiring_setup(PROGRAMMER * pgm)
    * Now prepare our data
    */
   if ((mycookie = malloc(sizeof(struct wiringpdata))) == 0) {
-    pmsg_error("wiring_setup(): out of memory allocating private data\n");
+    pmsg_error("out of memory allocating private data\n");
     exit(1);
   }
   memset(mycookie, 0, sizeof(struct wiringpdata));
@@ -121,7 +121,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int newsnooze;
       if (sscanf(extended_param, "snooze=%i", &newsnooze) != 1 ||
           newsnooze < 0) {
-        pmsg_error("wiring_parseextparms(): invalid snooze time '%s'\n", extended_param);
+        pmsg_error("invalid snooze time '%s'\n", extended_param);
         rv = -1;
         continue;
       }
@@ -131,7 +131,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    pmsg_error("wiring_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -85,7 +85,7 @@ static void wiring_setup(PROGRAMMER * pgm)
    * Now prepare our data
    */
   if ((mycookie = malloc(sizeof(struct wiringpdata))) == 0) {
-    pmsg_info("wiring_setup(): Out of memory allocating private data\n");
+    pmsg_error("wiring_setup(): out of memory allocating private data\n");
     exit(1);
   }
   memset(mycookie, 0, sizeof(struct wiringpdata));
@@ -121,7 +121,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int newsnooze;
       if (sscanf(extended_param, "snooze=%i", &newsnooze) != 1 ||
           newsnooze < 0) {
-        pmsg_info("wiring_parseextparms(): invalid snooze time '%s'\n", extended_param);
+        pmsg_error("wiring_parseextparms(): invalid snooze time '%s'\n", extended_param);
         rv = -1;
         continue;
       }
@@ -131,7 +131,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    pmsg_info("wiring_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("wiring_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rv = -1;
   }
 

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -110,7 +110,7 @@ static int xbee_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AV
   /* Signature byte reads are always 3 bytes. */
 
   if (m->size < 3) {
-    avrdude_message(MSG_INFO, "%s: memsize too small for sig byte read\n",
+    msg_info("%s: memsize too small for sig byte read\n",
                     progname);
     return -1;
   }
@@ -123,18 +123,18 @@ static int xbee_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if (serial_recv(&pgm->fd, buf, 5) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    avrdude_message(MSG_INFO, "%s: stk500_cmd(): programmer is out of sync\n",
+    msg_info("%s: stk500_cmd(): programmer is out of sync\n",
                     progname);
     return -1;
   } else if (buf[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO,
+    msg_info(
                     "\n%s: xbee_read_sig_bytes(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_INSYNC, buf[0]);
     return -2;
   }
   if (buf[4] != Resp_STK_OK) {
-    avrdude_message(MSG_INFO,
+    msg_info(
                     "\n%s: xbee_read_sig_bytes(): (a) protocol error, "
                     "expect=0x%02x, resp=0x%02x\n",
                     progname, Resp_STK_OK, buf[4]);
@@ -252,9 +252,9 @@ static void xbeeStatsAdd(struct XBeeStaticticsSummary *summary,
 
 static void xbeeStatsSummarise(struct XBeeStaticticsSummary const *summary)
 {
-  avrdude_message(MSG_NOTICE, "%s:   Minimum response time: %lu.%06lu\n",
+  msg_notice("%s:   Minimum response time: %lu.%06lu\n",
                   progname, summary->minimum.tv_sec, summary->minimum.tv_usec);
-  avrdude_message(MSG_NOTICE, "%s:   Maximum response time: %lu.%06lu\n",
+  msg_notice("%s:   Maximum response time: %lu.%06lu\n",
                   progname, summary->maximum.tv_sec, summary->maximum.tv_usec);
 
   struct timeval average;
@@ -268,7 +268,7 @@ static void xbeeStatsSummarise(struct XBeeStaticticsSummary const *summary)
   average.tv_sec += usecs / 1000000;
   average.tv_usec = usecs % 1000000;
 
-  avrdude_message(MSG_NOTICE, "%s:   Average response time: %lu.%06lu\n",
+  msg_notice("%s:   Average response time: %lu.%06lu\n",
                   progname, average.tv_sec, average.tv_usec);
 }
 
@@ -319,7 +319,7 @@ static void xbeedev_stats_send(struct XBeeBootSession *xbs,
     stats->sendTime = *sendTime;
 
   if (detailSequence >= 0) {
-    avrdude_message(MSG_NOTICE2,
+    msg_notice2(
                     "%s: Stats: Send Group %s Sequence %u : "
                     "Send %lu.%06lu %s Sequence %d\n",
                     progname, groupNames[group],
@@ -328,7 +328,7 @@ static void xbeedev_stats_send(struct XBeeBootSession *xbs,
                     (unsigned long)sendTime->tv_usec,
                     detail, detailSequence);
   } else {
-    avrdude_message(MSG_NOTICE2,
+    msg_notice2(
                     "%s: Stats: Send Group %s Sequence %u : "
                     "Send %lu.%06lu %s\n",
                     progname, groupNames[group],
@@ -361,7 +361,7 @@ static void xbeedev_stats_receive(struct XBeeBootSession *xbs,
   delay.tv_sec = secs;
   delay.tv_usec = usecs;
 
-  avrdude_message(MSG_NOTICE2,
+  msg_notice2(
                   "%s: Stats: Receive Group %s Sequence %u : "
                   "Send %lu.%06lu Receive %lu.%06lu Delay %lu.%06lu %s\n",
                   progname, groupNames[group],
@@ -403,7 +403,7 @@ static int sendAPIRequest(struct XBeeBootSession *xbs,
 
   gettimeofday(&time, NULL);
 
-  avrdude_message(MSG_NOTICE2,
+  msg_notice2(
                   "%s: sendAPIRequest(): %lu.%06lu %d, %d, %d, %d %s\n",
                   progname, (unsigned long)time.tv_sec,
                   (unsigned long)time.tv_usec,
@@ -453,7 +453,7 @@ static int sendAPIRequest(struct XBeeBootSession *xbs,
      * instructions.
      */
     if (apiType != 0x21 && xbs->sourceRouteChanged) {
-      avrdude_message(MSG_NOTICE2, "%s: sendAPIRequest(): "
+      msg_notice2("%s: sendAPIRequest(): "
                       "Issuing Create Source Route request with %d hops\n",
                       progname, xbs->sourceRouteHops);
 
@@ -583,7 +583,7 @@ static void xbeedev_record16Bit(struct XBeeBootSession *xbs,
   unsigned char * const tx16Bit =
     &xbs->xbee_address[XBEE_ADDRESS_64BIT_LEN];
   if (memcmp(rx16Bit, tx16Bit, XBEE_ADDRESS_16BIT_LEN) != 0) {
-    avrdude_message(MSG_NOTICE2, "%s: xbeedev_record16Bit(): "
+    msg_notice2("%s: xbeedev_record16Bit(): "
                     "New 16-bit address: %02x%02x\n",
                     progname,
                     (unsigned int)rx16Bit[0],
@@ -666,7 +666,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
 
       if (checksum) {
         /* Checksum didn't match */
-        avrdude_message(MSG_NOTICE2,
+        msg_notice2(
                         "%s: xbeedev_poll(): Bad checksum %d\n",
                         progname, (int)checksum);
         continue;
@@ -678,7 +678,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
     struct timeval receiveTime;
     gettimeofday(&receiveTime, NULL);
 
-    avrdude_message(MSG_NOTICE2,
+    msg_notice2(
                     "%s: xbeedev_poll(): %lu.%06lu Received frame type %x\n",
                     progname, (unsigned long)receiveTime.tv_sec,
                     (unsigned long)receiveTime.tv_usec,
@@ -692,7 +692,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       xbeedev_stats_receive(xbs, "Remote AT command response",
                             XBEE_STATS_FRAME_REMOTE, txSequence, &receiveTime);
 
-      avrdude_message(MSG_NOTICE,
+      msg_notice(
                       "%s: xbeedev_poll(): Remote command %d result code %d\n",
                       progname, (int)txSequence, (int)resultCode);
 
@@ -706,7 +706,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       xbeedev_stats_receive(xbs, "Local AT command response",
                             XBEE_STATS_FRAME_LOCAL, txSequence, &receiveTime);
 
-      avrdude_message(MSG_NOTICE,
+      msg_notice(
                       "%s: xbeedev_poll(): Local command %c%c result code %d\n",
                       progname, frame[4], frame[5], (int)frame[6]);
 
@@ -720,7 +720,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       xbeedev_stats_receive(xbs, "Transmit status", XBEE_STATS_FRAME_REMOTE,
                             txSequence, &receiveTime);
 
-      avrdude_message(MSG_NOTICE2,
+      msg_notice2(
                       "%s: xbeedev_poll(): Transmit status %d result code %d\n",
                       progname, (int)frame[3], (int)frame[7]);
     } else if (frameType == 0xa1 &&
@@ -731,7 +731,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       if (memcmp(&frame[XBEE_LENGTH_LEN + XBEE_APITYPE_LEN],
                  xbs->xbee_address, XBEE_ADDRESS_64BIT_LEN) != 0) {
         /* Not from our target device */
-        avrdude_message(MSG_NOTICE2, "%s: xbeedev_poll(): "
+        msg_notice2("%s: xbeedev_poll(): "
                         "Route Record Indicator from other XBee\n");
         continue;
       }
@@ -755,7 +755,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       const unsigned char receiveOptions = frame[header];
       const unsigned char hops = frame[header + 1];
 
-      avrdude_message(MSG_NOTICE2, "%s: xbeedev_poll(): "
+      msg_notice2("%s: xbeedev_poll(): "
                       "Route Record Indicator from target XBee: "
                       "hops=%d options=%d\n",
                       progname, (int)hops, (int)receiveOptions);
@@ -768,7 +768,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
 
       unsigned char index;
       for (index = 0; index < hops; index++) {
-        avrdude_message(MSG_NOTICE2, "%s: xbeedev_poll(): "
+        msg_notice2("%s: xbeedev_poll(): "
                         "Route Intermediate Hop %d : %02x%02x\n",
                         progname, (int)index,
                         (int)frame[tableOffset + index * 2],
@@ -782,7 +782,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
           xbs->sourceRouteHops = hops;
           xbs->sourceRouteChanged = 1;
 
-          avrdude_message(MSG_NOTICE2, "%s: xbeedev_poll(): "
+          msg_notice2("%s: xbeedev_poll(): "
                           "Route has changed\n",
                           progname);
         }
@@ -844,7 +844,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
         const unsigned char protocolType = dataStart[0];
         const unsigned char sequence = dataStart[1];
 
-        avrdude_message(MSG_NOTICE2, "%s: xbeedev_poll(): "
+        msg_notice2("%s: xbeedev_poll(): "
                         "%lu.%06lu Packet %d #%d\n",
                         progname, (unsigned long)receiveTime.tv_sec,
                         (unsigned long)receiveTime.tv_usec,
@@ -887,14 +887,14 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
                   xbs->inInIndex = 0;
                 if (xbs->inInIndex == xbs->inOutIndex) {
                   /* Should be impossible */
-                  avrdude_message(MSG_INFO, "%s: Buffer overrun\n", progname);
+                  msg_info("%s: Buffer overrun\n", progname);
                   xbs->transportUnusable = 1;
                   return -1;
                 }
               }
             }
 
-            /*avrdude_message(MSG_INFO, "ACK %x\n", (unsigned int)sequence);*/
+            /*msg_info("ACK %x\n", (unsigned int)sequence);*/
             sendPacket(xbs, "Transmit Request ACK for RECEIVE",
                        XBEEBOOT_PACKET_TYPE_ACK, sequence,
                        XBEE_STATS_NOT_RETRY,
@@ -952,7 +952,7 @@ static int localAsyncAT(struct XBeeBootSession *xbs, char const *detail,
   if (value >= 0)
     buf[length++] = (unsigned char)value;
 
-  avrdude_message(MSG_NOTICE, "%s: Local AT command: %c%c\n",
+  msg_notice("%s: Local AT command: %c%c\n",
                   progname, at1, at2);
 
   /* Local AT command 0x08 */
@@ -1016,7 +1016,7 @@ static int sendAT(struct XBeeBootSession *xbs, char const *detail,
   if (value >= 0)
     buf[length++] = (unsigned char)value;
 
-  avrdude_message(MSG_NOTICE,
+  msg_notice(
                   "%s: Remote AT command: %c%c\n", progname, at1, at2);
 
   /* Remote AT command 0x17 with Apply Changes 0x02 */
@@ -1051,22 +1051,22 @@ static int xbeeATError(int rc) {
     return 0;
 
   if (xbeeRc == 1) {
-    avrdude_message(MSG_INFO, "%s: Error communicating with Remote XBee\n",
+    msg_info("%s: Error communicating with Remote XBee\n",
                     progname);
   } else if (xbeeRc == 2) {
-    avrdude_message(MSG_INFO, "%s: Remote XBee command error: "
+    msg_info("%s: Remote XBee command error: "
                     "Invalid command\n",
                     progname);
   } else if (xbeeRc == 3) {
-    avrdude_message(MSG_INFO, "%s: Remote XBee command error: "
+    msg_info("%s: Remote XBee command error: "
                     "Invalid parameter\n",
                     progname);
   } else if (xbeeRc == 4) {
-    avrdude_message(MSG_INFO, "%s: Remote XBee error: "
+    msg_info("%s: Remote XBee error: "
                     "Transmission failure\n",
                     progname);
   } else {
-    avrdude_message(MSG_INFO, "%s: Unrecognised remote XBee error code %d\n",
+    msg_info("%s: Unrecognised remote XBee error code %d\n",
                     progname, xbeeRc);
   }
   return 1;
@@ -1100,7 +1100,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
    */
   char *ttySeparator = strchr(port, '@');
   if (ttySeparator == NULL) {
-    avrdude_message(MSG_INFO,
+    msg_info(
                     "%s: XBee: Bad port syntax: "
                     "require \"<xbee-address>@<serial-device>\"\n",
                     progname);
@@ -1109,7 +1109,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
 
   struct XBeeBootSession *xbs = malloc(sizeof(struct XBeeBootSession));
   if (xbs == NULL) {
-    avrdude_message(MSG_INFO, "%s: xbeedev_open(): out of memory\n",
+    msg_info("%s: xbeedev_open(): out of memory\n",
                     progname);
     return -1;
   }
@@ -1149,7 +1149,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
     }
 
     if (addrIndex != 8 || address != ttySeparator || nybble != -1) {
-      avrdude_message(MSG_INFO,
+      msg_info(
                       "%s: XBee: Bad XBee address: "
                       "require 16-character hexadecimal address\"\n",
                       progname);
@@ -1164,7 +1164,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
   xbs->xbee_address[8] = 0xff;
   xbs->xbee_address[9] = 0xfe;
 
-  avrdude_message(MSG_TRACE,
+  msg_trace(
                   "%s: XBee address: %02x%02x%02x%02x%02x%02x%02x%02x\n",
                   progname,
                   (unsigned int)xbs->xbee_address[0],
@@ -1216,7 +1216,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
   }
   pinfo.serialinfo.cflags = SERIAL_8N1;
 
-  avrdude_message(MSG_NOTICE, "%s: Baud %ld\n", progname, (long)pinfo.serialinfo.baud);
+  msg_notice("%s: Baud %ld\n", progname, (long)pinfo.serialinfo.baud);
 
   {
     const int rc = xbs->serialDevice->open(tty, pinfo,
@@ -1232,7 +1232,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
     {
       const int rc = localAT(xbs, "AT AP=2", 'A', 'P', 2);
       if (rc < 0) {
-        avrdude_message(MSG_INFO, "%s: Local XBee is not responding.\n",
+        msg_info("%s: Local XBee is not responding.\n",
                         progname);
         xbeedev_free(xbs);
         return rc;
@@ -1273,7 +1273,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
     {
       const int rc = localAT(xbs, "AT AR=0", 'A', 'R', 0);
       if (rc < 0) {
-        avrdude_message(MSG_INFO, "%s: Local XBee is not responding.\n",
+        msg_info("%s: Local XBee is not responding.\n",
                         progname);
         xbeedev_free(xbs);
         return rc;
@@ -1296,7 +1296,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
       if (xbeeATError(rc))
         return -1;
 
-      avrdude_message(MSG_INFO, "%s: Remote XBee is not responding.\n",
+      msg_info("%s: Remote XBee is not responding.\n",
                       progname);
       return rc;
     }
@@ -1544,7 +1544,7 @@ static int xbeedev_set_dtr_rts(const union filedescriptor *fdp, int is_on)
     if (xbeeATError(rc))
       return -1;
 
-    avrdude_message(MSG_INFO,
+    msg_info(
                     "%s: Remote XBee is not responding.\n", progname);
     return rc;
   }
@@ -1578,7 +1578,7 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
 
   int sendRc = serial_send(&pgm->fd, buf, 2);
   if (sendRc < 0) {
-    avrdude_message(MSG_INFO,
+    msg_info(
                     "%s: xbee_getsync(): failed to deliver STK_GET_SYNC "
                     "to the remote XBeeBoot bootloader\n",
                     progname);
@@ -1591,7 +1591,7 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
    */
   int recvRc = serial_recv(&pgm->fd, resp, 2);
   if (recvRc < 0) {
-    avrdude_message(MSG_INFO,
+    msg_info(
                     "%s: xbee_getsync(): no response to STK_GET_SYNC "
                     "from the remote XBeeBoot bootloader\n",
                     progname);
@@ -1599,13 +1599,13 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
   }
 
   if (resp[0] != Resp_STK_INSYNC) {
-    avrdude_message(MSG_INFO, "%s: xbee_getsync(): not in sync: resp=0x%02x\n",
+    msg_info("%s: xbee_getsync(): not in sync: resp=0x%02x\n",
                     progname, (unsigned int)resp[0]);
     return -1;
   }
 
   if (resp[1] != Resp_STK_OK) {
-    avrdude_message(MSG_INFO, "%s: xbee_getsync(): in sync, not OK: "
+    msg_info("%s: xbee_getsync(): in sync, not OK: "
                     "resp=0x%02x\n",
                     progname, (unsigned int)resp[1]);
     return -1;
@@ -1676,16 +1676,16 @@ static void xbee_close(PROGRAMMER *pgm)
     xbeeATError(rc);
   }
 
-  avrdude_message(MSG_NOTICE, "%s: Statistics for FRAME_LOCAL requests - %s->XBee(local)\n", progname, progname);
+  msg_notice("%s: Statistics for FRAME_LOCAL requests - %s->XBee(local)\n", progname, progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_FRAME_LOCAL]);
 
-  avrdude_message(MSG_NOTICE, "%s: Statistics for FRAME_REMOTE requests - %s->XBee(local)->XBee(target)\n", progname, progname);
+  msg_notice("%s: Statistics for FRAME_REMOTE requests - %s->XBee(local)->XBee(target)\n", progname, progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_FRAME_REMOTE]);
 
-  avrdude_message(MSG_NOTICE, "%s: Statistics for TRANSMIT requests - %s->XBee(local)->XBee(target)->XBeeBoot\n", progname, progname);
+  msg_notice("%s: Statistics for TRANSMIT requests - %s->XBee(local)->XBee(target)->XBeeBoot\n", progname, progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_TRANSMIT]);
 
-  avrdude_message(MSG_NOTICE, "%s: Statistics for RECEIVE requests - XBeeBoot->XBee(target)->XBee(local)->%s\n", progname, progname);
+  msg_notice("%s: Statistics for RECEIVE requests - XBeeBoot->XBee(target)->XBee(local)->%s\n", progname, progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_RECEIVE]);
 
   xbeedev_free(xbs);
@@ -1706,7 +1706,7 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int resetpin;
       if (sscanf(extended_param, "xbeeresetpin=%i", &resetpin) != 1 ||
           resetpin <= 0 || resetpin > 7) {
-        avrdude_message(MSG_INFO, "%s: xbee_parseextparms(): "
+        msg_info("%s: xbee_parseextparms(): "
                         "invalid xbeeresetpin '%s'\n",
                         progname, extended_param);
         rc = -1;
@@ -1717,7 +1717,7 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    avrdude_message(MSG_INFO, "%s: xbee_parseextparms(): "
+    msg_info("%s: xbee_parseextparms(): "
                     "invalid extended parameter '%s'\n",
                     progname, extended_param);
     rc = -1;

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -122,16 +122,16 @@ static int xbee_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if (serial_recv(&pgm->fd, buf, 5) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    pmsg_error("stk500_cmd(): programmer is out of sync\n");
+    pmsg_error("programmer is out of sync\n");
     return -1;
   } else if (buf[0] != Resp_STK_INSYNC) {
     msg_error("\n");
-    pmsg_error("xbee_read_sig_bytes(): protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
     return -2;
   }
   if (buf[4] != Resp_STK_OK) {
     msg_error("\n");
-    pmsg_error("xbee_read_sig_bytes(): protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[4]);
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[4]);
     return -3;
   }
 
@@ -1066,7 +1066,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
 
   struct XBeeBootSession *xbs = malloc(sizeof(struct XBeeBootSession));
   if (xbs == NULL) {
-    pmsg_error("xbeedev_open(): out of memory\n");
+    pmsg_error("out of memory\n");
     return -1;
   }
 
@@ -1524,7 +1524,7 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
 
   int sendRc = serial_send(&pgm->fd, buf, 2);
   if (sendRc < 0) {
-    pmsg_error("xbee_getsync(): unable to deliver STK_GET_SYNC to the remote XBeeBoot bootloader\n");
+    pmsg_error("unable to deliver STK_GET_SYNC to the remote XBeeBoot bootloader\n");
     return sendRc;
   }
 
@@ -1534,17 +1534,17 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
    */
   int recvRc = serial_recv(&pgm->fd, resp, 2);
   if (recvRc < 0) {
-    pmsg_error("xbee_getsync(): no response to STK_GET_SYNC from the remote XBeeBoot bootloader\n");
+    pmsg_error("no response to STK_GET_SYNC from the remote XBeeBoot bootloader\n");
     return recvRc;
   }
 
   if (resp[0] != Resp_STK_INSYNC) {
-    pmsg_error("xbee_getsync(): not in sync, resp=0x%02x\n", (unsigned int) resp[0]);
+    pmsg_error("not in sync, resp=0x%02x\n", (unsigned int) resp[0]);
     return -1;
   }
 
   if (resp[1] != Resp_STK_OK) {
-    pmsg_error("xbee_getsync(): in sync, not OK, resp=0x%02x\n", (unsigned int) resp[1]);
+    pmsg_error("in sync, not OK, resp=0x%02x\n", (unsigned int) resp[1]);
     return -1;
   }
 
@@ -1643,7 +1643,7 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int resetpin;
       if (sscanf(extended_param, "xbeeresetpin=%i", &resetpin) != 1 ||
           resetpin <= 0 || resetpin > 7) {
-        pmsg_error("xbee_parseextparms(): invalid xbeeresetpin '%s'\n", extended_param);
+        pmsg_error("invalid xbeeresetpin '%s'\n", extended_param);
         rc = -1;
         continue;
       }
@@ -1652,7 +1652,7 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    pmsg_error("xbee_parseextparms(): invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
     rc = -1;
   }
 

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -110,8 +110,7 @@ static int xbee_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AV
   /* Signature byte reads are always 3 bytes. */
 
   if (m->size < 3) {
-    msg_info("%s: memsize too small for sig byte read\n",
-                    progname);
+    pmsg_info("memsize too small for sig byte read\n");
     return -1;
   }
 
@@ -123,21 +122,18 @@ static int xbee_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if (serial_recv(&pgm->fd, buf, 5) < 0)
     return -1;
   if (buf[0] == Resp_STK_NOSYNC) {
-    msg_info("%s: stk500_cmd(): programmer is out of sync\n",
-                    progname);
+    pmsg_info("stk500_cmd(): programmer is out of sync\n");
     return -1;
   } else if (buf[0] != Resp_STK_INSYNC) {
-    msg_info(
-                    "\n%s: xbee_read_sig_bytes(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_INSYNC, buf[0]);
+    msg_info("\n%s: xbee_read_sig_bytes(): (a) protocol error, "
+      "expect=0x%02x, resp=0x%02x\n",
+      progname, Resp_STK_INSYNC, buf[0]);
     return -2;
   }
   if (buf[4] != Resp_STK_OK) {
-    msg_info(
-                    "\n%s: xbee_read_sig_bytes(): (a) protocol error, "
-                    "expect=0x%02x, resp=0x%02x\n",
-                    progname, Resp_STK_OK, buf[4]);
+    msg_info("\n%s: xbee_read_sig_bytes(): (a) protocol error, "
+      "expect=0x%02x, resp=0x%02x\n",
+      progname, Resp_STK_OK, buf[4]);
     return -3;
   }
 
@@ -252,10 +248,8 @@ static void xbeeStatsAdd(struct XBeeStaticticsSummary *summary,
 
 static void xbeeStatsSummarise(struct XBeeStaticticsSummary const *summary)
 {
-  msg_notice("%s:   Minimum response time: %lu.%06lu\n",
-                  progname, summary->minimum.tv_sec, summary->minimum.tv_usec);
-  msg_notice("%s:   Maximum response time: %lu.%06lu\n",
-                  progname, summary->maximum.tv_sec, summary->maximum.tv_usec);
+  pmsg_notice("  Minimum response time: %lu.%06lu\n", summary->minimum.tv_sec, summary->minimum.tv_usec);
+  pmsg_notice("  Maximum response time: %lu.%06lu\n", summary->maximum.tv_sec, summary->maximum.tv_usec);
 
   struct timeval average;
 
@@ -268,8 +262,7 @@ static void xbeeStatsSummarise(struct XBeeStaticticsSummary const *summary)
   average.tv_sec += usecs / 1000000;
   average.tv_usec = usecs % 1000000;
 
-  msg_notice("%s:   Average response time: %lu.%06lu\n",
-                  progname, average.tv_sec, average.tv_usec);
+  pmsg_notice("  Average response time: %lu.%06lu\n", average.tv_sec, average.tv_usec);
 }
 
 static void XBeeBootSessionInit(struct XBeeBootSession *xbs) {
@@ -319,23 +312,21 @@ static void xbeedev_stats_send(struct XBeeBootSession *xbs,
     stats->sendTime = *sendTime;
 
   if (detailSequence >= 0) {
-    msg_notice2(
-                    "%s: Stats: Send Group %s Sequence %u : "
-                    "Send %lu.%06lu %s Sequence %d\n",
-                    progname, groupNames[group],
-                    (unsigned int)sequence,
-                    (unsigned long)sendTime->tv_sec,
-                    (unsigned long)sendTime->tv_usec,
-                    detail, detailSequence);
+    pmsg_notice2("stats: Send Group %s Sequence %u : "
+      "Send %lu.%06lu %s Sequence %d\n",
+      groupNames[group],
+      (unsigned int) sequence,
+      (unsigned long) sendTime->tv_sec,
+      (unsigned long) sendTime->tv_usec,
+      detail, detailSequence);
   } else {
-    msg_notice2(
-                    "%s: Stats: Send Group %s Sequence %u : "
-                    "Send %lu.%06lu %s\n",
-                    progname, groupNames[group],
-                    (unsigned int)sequence,
-                    (unsigned long)sendTime->tv_sec,
-                    (unsigned long)sendTime->tv_usec,
-                    detail);
+    pmsg_notice2("stats: Send Group %s Sequence %u : "
+      "Send %lu.%06lu %s\n",
+      groupNames[group],
+      (unsigned int) sequence,
+      (unsigned long) sendTime->tv_sec,
+      (unsigned long) sendTime->tv_usec,
+      detail);
   }
 }
 
@@ -361,18 +352,17 @@ static void xbeedev_stats_receive(struct XBeeBootSession *xbs,
   delay.tv_sec = secs;
   delay.tv_usec = usecs;
 
-  msg_notice2(
-                  "%s: Stats: Receive Group %s Sequence %u : "
-                  "Send %lu.%06lu Receive %lu.%06lu Delay %lu.%06lu %s\n",
-                  progname, groupNames[group],
-                  (unsigned int)sequence,
-                  (unsigned long)stats->sendTime.tv_sec,
-                  (unsigned long)stats->sendTime.tv_usec,
-                  (unsigned long)receiveTime->tv_sec,
-                  (unsigned long)receiveTime->tv_usec,
-                  (unsigned long)secs,
-                  (unsigned long)usecs,
-                  detail);
+  pmsg_notice2("stats: Receive Group %s Sequence %u : "
+    "Send %lu.%06lu Receive %lu.%06lu Delay %lu.%06lu %s\n",
+    groupNames[group],
+    (unsigned int) sequence,
+    (unsigned long) stats->sendTime.tv_sec,
+    (unsigned long) stats->sendTime.tv_usec,
+    (unsigned long) receiveTime->tv_sec,
+    (unsigned long) receiveTime->tv_usec,
+    (unsigned long) secs,
+    (unsigned long) usecs,
+    detail);
 
   xbeeStatsAdd(&xbs->groupSummary[group], &delay);
 }
@@ -403,12 +393,11 @@ static int sendAPIRequest(struct XBeeBootSession *xbs,
 
   gettimeofday(&time, NULL);
 
-  msg_notice2(
-                  "%s: sendAPIRequest(): %lu.%06lu %d, %d, %d, %d %s\n",
-                  progname, (unsigned long)time.tv_sec,
-                  (unsigned long)time.tv_usec,
-                  (int)packetType, (int)sequence, appType,
-                  data == NULL ? -1 : (int)*data, detail);
+  pmsg_notice2("sendAPIRequest(): %lu.%06lu %d, %d, %d, %d %s\n",
+    (unsigned long) time.tv_sec,
+    (unsigned long) time.tv_usec,
+    (int) packetType, (int)sequence, appType,
+    data == NULL ? -1 : (int)*data, detail);
 
 #define fpput(x)                                                \
   do {                                                          \
@@ -453,9 +442,7 @@ static int sendAPIRequest(struct XBeeBootSession *xbs,
      * instructions.
      */
     if (apiType != 0x21 && xbs->sourceRouteChanged) {
-      msg_notice2("%s: sendAPIRequest(): "
-                      "Issuing Create Source Route request with %d hops\n",
-                      progname, xbs->sourceRouteHops);
+      pmsg_notice2("sendAPIRequest(): Issuing Create Source Route request with %d hops\n", xbs->sourceRouteHops);
 
       int rc = sendAPIRequest(xbs, 0x21, /* Create Source Route */
                               0, -1, 0, xbs->sourceRouteHops,
@@ -583,9 +570,7 @@ static void xbeedev_record16Bit(struct XBeeBootSession *xbs,
   unsigned char * const tx16Bit =
     &xbs->xbee_address[XBEE_ADDRESS_64BIT_LEN];
   if (memcmp(rx16Bit, tx16Bit, XBEE_ADDRESS_16BIT_LEN) != 0) {
-    msg_notice2("%s: xbeedev_record16Bit(): "
-                    "New 16-bit address: %02x%02x\n",
-                    progname,
+    pmsg_notice2("xbeedev_record16Bit(): New 16-bit address: %02x%02x\n",
                     (unsigned int)rx16Bit[0],
                     (unsigned int)rx16Bit[1]);
     memcpy(tx16Bit, rx16Bit, XBEE_ADDRESS_16BIT_LEN);
@@ -666,9 +651,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
 
       if (checksum) {
         /* Checksum didn't match */
-        msg_notice2(
-                        "%s: xbeedev_poll(): Bad checksum %d\n",
-                        progname, (int)checksum);
+        pmsg_notice2("xbeedev_poll(): Bad checksum %d\n", (int)checksum);
         continue;
       }
     }
@@ -678,11 +661,10 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
     struct timeval receiveTime;
     gettimeofday(&receiveTime, NULL);
 
-    msg_notice2(
-                    "%s: xbeedev_poll(): %lu.%06lu Received frame type %x\n",
-                    progname, (unsigned long)receiveTime.tv_sec,
-                    (unsigned long)receiveTime.tv_usec,
-                    (unsigned int)frameType);
+    pmsg_notice2("xbeedev_poll(): %lu.%06lu Received frame type %x\n",
+      (unsigned long) receiveTime.tv_sec,
+      (unsigned long) receiveTime.tv_usec,
+      (unsigned int) frameType);
 
     if (frameType == 0x97 && frameSize > 16) {
       /* Remote command response */
@@ -692,9 +674,8 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       xbeedev_stats_receive(xbs, "Remote AT command response",
                             XBEE_STATS_FRAME_REMOTE, txSequence, &receiveTime);
 
-      msg_notice(
-                      "%s: xbeedev_poll(): Remote command %d result code %d\n",
-                      progname, (int)txSequence, (int)resultCode);
+      pmsg_notice("xbeedev_poll(): Remote command %d result code %d\n",
+        (int) txSequence, (int) resultCode);
 
       if (waitForSequence >= 0 && waitForSequence == frame[3])
         /* Received result for our sequence numbered request */
@@ -706,9 +687,8 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       xbeedev_stats_receive(xbs, "Local AT command response",
                             XBEE_STATS_FRAME_LOCAL, txSequence, &receiveTime);
 
-      msg_notice(
-                      "%s: xbeedev_poll(): Local command %c%c result code %d\n",
-                      progname, frame[4], frame[5], (int)frame[6]);
+      pmsg_notice("xbeedev_poll(): Local command %c%c result code %d\n",
+        frame[4], frame[5], (int)frame[6]);
 
       if (waitForSequence >= 0 && waitForSequence == txSequence)
         /* Received result for our sequence numbered request */
@@ -720,9 +700,8 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       xbeedev_stats_receive(xbs, "Transmit status", XBEE_STATS_FRAME_REMOTE,
                             txSequence, &receiveTime);
 
-      msg_notice2(
-                      "%s: xbeedev_poll(): Transmit status %d result code %d\n",
-                      progname, (int)frame[3], (int)frame[7]);
+      pmsg_notice2("xbeedev_poll(): Transmit status %d result code %d\n",
+        (int) frame[3], (int) frame[7]);
     } else if (frameType == 0xa1 &&
                frameSize >= XBEE_LENGTH_LEN + XBEE_APITYPE_LEN +
                XBEE_ADDRESS_64BIT_LEN +
@@ -731,8 +710,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       if (memcmp(&frame[XBEE_LENGTH_LEN + XBEE_APITYPE_LEN],
                  xbs->xbee_address, XBEE_ADDRESS_64BIT_LEN) != 0) {
         /* Not from our target device */
-        msg_notice2("%s: xbeedev_poll(): "
-                        "Route Record Indicator from other XBee\n");
+        pmsg_notice2("xbeedev_poll(): Route Record Indicator from other XBee\n");
         continue;
       }
 
@@ -755,10 +733,9 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
       const unsigned char receiveOptions = frame[header];
       const unsigned char hops = frame[header + 1];
 
-      msg_notice2("%s: xbeedev_poll(): "
-                      "Route Record Indicator from target XBee: "
-                      "hops=%d options=%d\n",
-                      progname, (int)hops, (int)receiveOptions);
+      pmsg_notice2("xbeedev_poll(): "
+        "Route Record Indicator from target XBee: "
+        "hops=%d options=%d\n", (int)hops, (int)receiveOptions);
 
       if (frameSize < header + 2 + hops * 2 + XBEE_CHECKSUM_LEN)
         /* Bounds check: Frame is too small */
@@ -768,11 +745,10 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
 
       unsigned char index;
       for (index = 0; index < hops; index++) {
-        msg_notice2("%s: xbeedev_poll(): "
-                        "Route Intermediate Hop %d : %02x%02x\n",
-                        progname, (int)index,
-                        (int)frame[tableOffset + index * 2],
-                        (int)frame[tableOffset + index * 2 + 1]);
+        pmsg_notice2("xbeedev_poll(): "
+          "Route Intermediate Hop %d : %02x%02x\n", (int)index,
+          (int)frame[tableOffset + index * 2],
+          (int)frame[tableOffset + index * 2 + 1]);
       }
 
       if (hops <= XBEE_MAX_INTERMEDIATE_HOPS) {
@@ -782,9 +758,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
           xbs->sourceRouteHops = hops;
           xbs->sourceRouteChanged = 1;
 
-          msg_notice2("%s: xbeedev_poll(): "
-                          "Route has changed\n",
-                          progname);
+          pmsg_notice2("xbeedev_poll(): Route has changed\n");
         }
       }
     } else if (frameType == 0x10 || frameType == 0x90) {
@@ -844,11 +818,10 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
         const unsigned char protocolType = dataStart[0];
         const unsigned char sequence = dataStart[1];
 
-        msg_notice2("%s: xbeedev_poll(): "
-                        "%lu.%06lu Packet %d #%d\n",
-                        progname, (unsigned long)receiveTime.tv_sec,
-                        (unsigned long)receiveTime.tv_usec,
-                        (int)protocolType, (int)sequence);
+        pmsg_notice2("xbeedev_poll(): "
+          "%lu.%06lu Packet %d #%d\n", (unsigned long)receiveTime.tv_sec,
+          (unsigned long)receiveTime.tv_usec,
+          (int)protocolType, (int)sequence);
 
         if (protocolType == XBEEBOOT_PACKET_TYPE_ACK) {
           /* ACK */
@@ -878,7 +851,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
             for (index = 0; index < textLength; index++) {
               const unsigned char data = dataStart[3 + index];
               if (buflen != NULL && *buflen > 0) {
-                /* If we are receiving right now, and have a buffer... */
+                /* If we are receiving right now, and have a buffer ... */
                 *(*buf)++ = data;
                 (*buflen)--;
               } else {
@@ -887,7 +860,7 @@ static int xbeedev_poll(struct XBeeBootSession *xbs,
                   xbs->inInIndex = 0;
                 if (xbs->inInIndex == xbs->inOutIndex) {
                   /* Should be impossible */
-                  msg_info("%s: Buffer overrun\n", progname);
+                  pmsg_info("buffer overrun\n");
                   xbs->transportUnusable = 1;
                   return -1;
                 }
@@ -952,8 +925,7 @@ static int localAsyncAT(struct XBeeBootSession *xbs, char const *detail,
   if (value >= 0)
     buf[length++] = (unsigned char)value;
 
-  msg_notice("%s: Local AT command: %c%c\n",
-                  progname, at1, at2);
+  pmsg_notice("local AT command: %c%c\n", at1, at2);
 
   /* Local AT command 0x08 */
   int rc = sendAPIRequest(xbs, 0x08, sequence, -1, -1, -1, -1, -1, -1,
@@ -1016,8 +988,7 @@ static int sendAT(struct XBeeBootSession *xbs, char const *detail,
   if (value >= 0)
     buf[length++] = (unsigned char)value;
 
-  msg_notice(
-                  "%s: Remote AT command: %c%c\n", progname, at1, at2);
+  pmsg_notice("remote AT command: %c%c\n", at1, at2);
 
   /* Remote AT command 0x17 with Apply Changes 0x02 */
   sendAPIRequest(xbs, 0x17, sequence, -1,
@@ -1051,23 +1022,15 @@ static int xbeeATError(int rc) {
     return 0;
 
   if (xbeeRc == 1) {
-    msg_info("%s: Error communicating with Remote XBee\n",
-                    progname);
+    pmsg_info("error communicating with Remote XBee\n");
   } else if (xbeeRc == 2) {
-    msg_info("%s: Remote XBee command error: "
-                    "Invalid command\n",
-                    progname);
+    pmsg_info("remote XBee command error, invalid command\n");
   } else if (xbeeRc == 3) {
-    msg_info("%s: Remote XBee command error: "
-                    "Invalid parameter\n",
-                    progname);
+    pmsg_info("remote XBee command error, invalid parameter\n");
   } else if (xbeeRc == 4) {
-    msg_info("%s: Remote XBee error: "
-                    "Transmission failure\n",
-                    progname);
+    pmsg_info("remote XBee error, transmission failure\n");
   } else {
-    msg_info("%s: Unrecognised remote XBee error code %d\n",
-                    progname, xbeeRc);
+    pmsg_info("unrecognised remote XBee error code %d\n", xbeeRc);
   }
   return 1;
 }
@@ -1100,17 +1063,13 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
    */
   char *ttySeparator = strchr(port, '@');
   if (ttySeparator == NULL) {
-    msg_info(
-                    "%s: XBee: Bad port syntax: "
-                    "require \"<xbee-address>@<serial-device>\"\n",
-                    progname);
+    pmsg_info("XBee: bad port syntax, require <xbee-address>@<serial-device>\n");
     return -1;
   }
 
   struct XBeeBootSession *xbs = malloc(sizeof(struct XBeeBootSession));
   if (xbs == NULL) {
-    msg_info("%s: xbeedev_open(): out of memory\n",
-                    progname);
+    pmsg_info("xbeedev_open(): out of memory\n");
     return -1;
   }
 
@@ -1149,10 +1108,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
     }
 
     if (addrIndex != 8 || address != ttySeparator || nybble != -1) {
-      msg_info(
-                      "%s: XBee: Bad XBee address: "
-                      "require 16-character hexadecimal address\"\n",
-                      progname);
+      pmsg_info("XBee: bad XBee address, require 16-character hexadecimal address\n");
       free(xbs);
       return -1;
     }
@@ -1164,17 +1120,15 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
   xbs->xbee_address[8] = 0xff;
   xbs->xbee_address[9] = 0xfe;
 
-  msg_trace(
-                  "%s: XBee address: %02x%02x%02x%02x%02x%02x%02x%02x\n",
-                  progname,
-                  (unsigned int)xbs->xbee_address[0],
-                  (unsigned int)xbs->xbee_address[1],
-                  (unsigned int)xbs->xbee_address[2],
-                  (unsigned int)xbs->xbee_address[3],
-                  (unsigned int)xbs->xbee_address[4],
-                  (unsigned int)xbs->xbee_address[5],
-                  (unsigned int)xbs->xbee_address[6],
-                  (unsigned int)xbs->xbee_address[7]);
+  pmsg_trace("XBee address: %02x%02x%02x%02x%02x%02x%02x%02x\n",
+    (unsigned int) xbs->xbee_address[0],
+    (unsigned int) xbs->xbee_address[1],
+    (unsigned int) xbs->xbee_address[2],
+    (unsigned int) xbs->xbee_address[3],
+    (unsigned int) xbs->xbee_address[4],
+    (unsigned int) xbs->xbee_address[5],
+    (unsigned int) xbs->xbee_address[6],
+    (unsigned int) xbs->xbee_address[7]);
 
   if (pinfo.serialinfo.baud) {
     /*
@@ -1216,7 +1170,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
   }
   pinfo.serialinfo.cflags = SERIAL_8N1;
 
-  msg_notice("%s: Baud %ld\n", progname, (long)pinfo.serialinfo.baud);
+  pmsg_notice("baud %ld\n", (long)pinfo.serialinfo.baud);
 
   {
     const int rc = xbs->serialDevice->open(tty, pinfo,
@@ -1232,8 +1186,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
     {
       const int rc = localAT(xbs, "AT AP=2", 'A', 'P', 2);
       if (rc < 0) {
-        msg_info("%s: Local XBee is not responding.\n",
-                        progname);
+        pmsg_info("local XBee is not responding\n");
         xbeedev_free(xbs);
         return rc;
       }
@@ -1273,8 +1226,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
     {
       const int rc = localAT(xbs, "AT AR=0", 'A', 'R', 0);
       if (rc < 0) {
-        msg_info("%s: Local XBee is not responding.\n",
-                        progname);
+        pmsg_info("local XBee is not responding\n");
         xbeedev_free(xbs);
         return rc;
       }
@@ -1296,8 +1248,7 @@ static int xbeedev_open(const char *port, union pinfo pinfo,
       if (xbeeATError(rc))
         return -1;
 
-      msg_info("%s: Remote XBee is not responding.\n",
-                      progname);
+      pmsg_info("remote XBee is not responding\n");
       return rc;
     }
   }
@@ -1544,8 +1495,7 @@ static int xbeedev_set_dtr_rts(const union filedescriptor *fdp, int is_on)
     if (xbeeATError(rc))
       return -1;
 
-    msg_info(
-                    "%s: Remote XBee is not responding.\n", progname);
+    pmsg_info("remote XBee is not responding\n");
     return rc;
   }
 
@@ -1578,10 +1528,7 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
 
   int sendRc = serial_send(&pgm->fd, buf, 2);
   if (sendRc < 0) {
-    msg_info(
-                    "%s: xbee_getsync(): failed to deliver STK_GET_SYNC "
-                    "to the remote XBeeBoot bootloader\n",
-                    progname);
+    pmsg_info("xbee_getsync(): failed to deliver STK_GET_SYNC to the remote XBeeBoot bootloader\n");
     return sendRc;
   }
 
@@ -1591,23 +1538,17 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
    */
   int recvRc = serial_recv(&pgm->fd, resp, 2);
   if (recvRc < 0) {
-    msg_info(
-                    "%s: xbee_getsync(): no response to STK_GET_SYNC "
-                    "from the remote XBeeBoot bootloader\n",
-                    progname);
+    pmsg_info("xbee_getsync(): no response to STK_GET_SYNC from the remote XBeeBoot bootloader\n");
     return recvRc;
   }
 
   if (resp[0] != Resp_STK_INSYNC) {
-    msg_info("%s: xbee_getsync(): not in sync: resp=0x%02x\n",
-                    progname, (unsigned int)resp[0]);
+    pmsg_info("xbee_getsync(): not in sync, resp=0x%02x\n", (unsigned int) resp[0]);
     return -1;
   }
 
   if (resp[1] != Resp_STK_OK) {
-    msg_info("%s: xbee_getsync(): in sync, not OK: "
-                    "resp=0x%02x\n",
-                    progname, (unsigned int)resp[1]);
+    pmsg_info("xbee_getsync(): in sync, not OK, resp=0x%02x\n", (unsigned int) resp[1]);
     return -1;
   }
 
@@ -1676,16 +1617,16 @@ static void xbee_close(PROGRAMMER *pgm)
     xbeeATError(rc);
   }
 
-  msg_notice("%s: Statistics for FRAME_LOCAL requests - %s->XBee(local)\n", progname, progname);
+  pmsg_notice("statistics for FRAME_LOCAL requests - %s->XBee(local)\n", progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_FRAME_LOCAL]);
 
-  msg_notice("%s: Statistics for FRAME_REMOTE requests - %s->XBee(local)->XBee(target)\n", progname, progname);
+  pmsg_notice("statistics for FRAME_REMOTE requests - %s->XBee(local)->XBee(target)\n", progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_FRAME_REMOTE]);
 
-  msg_notice("%s: Statistics for TRANSMIT requests - %s->XBee(local)->XBee(target)->XBeeBoot\n", progname, progname);
+  pmsg_notice("statistics for TRANSMIT requests - %s->XBee(local)->XBee(target)->XBeeBoot\n", progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_TRANSMIT]);
 
-  msg_notice("%s: Statistics for RECEIVE requests - XBeeBoot->XBee(target)->XBee(local)->%s\n", progname, progname);
+  pmsg_notice("statistics for RECEIVE requests - XBeeBoot->XBee(target)->XBee(local)->%s\n", progname);
   xbeeStatsSummarise(&xbs->groupSummary[XBEE_STATS_RECEIVE]);
 
   xbeedev_free(xbs);
@@ -1706,9 +1647,7 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int resetpin;
       if (sscanf(extended_param, "xbeeresetpin=%i", &resetpin) != 1 ||
           resetpin <= 0 || resetpin > 7) {
-        msg_info("%s: xbee_parseextparms(): "
-                        "invalid xbeeresetpin '%s'\n",
-                        progname, extended_param);
+        pmsg_info("xbee_parseextparms(): invalid xbeeresetpin '%s'\n", extended_param);
         rc = -1;
         continue;
       }
@@ -1717,9 +1656,7 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    msg_info("%s: xbee_parseextparms(): "
-                    "invalid extended parameter '%s'\n",
-                    progname, extended_param);
+    pmsg_info("xbee_parseextparms(): invalid extended parameter '%s'\n", extended_param);
     rc = -1;
   }
 


### PR DESCRIPTION
Fixes Issues #1084 and #1114

[edited to add the checkmark table of when these functions print output]

- Introduced new levels `MSG_WARNING`, `MSG_ERROR` and `MSG_EXT_ERROR`
- Shortened `avrdude_message(MSG_XYZ, ...)` to `msg_xyz(...)`
- Reviewed and changed levels; they are now distributed in the code base as follows
  | N | Print function | When to use |
  | --: | :-- | :-- |
  |  54 | `msg_ext_error()` | External OS errors (file not found, permissions, ...), not shown with `-qqqqq` |
  |1102 | `msg_error()` | AVRDUDE and programmer error messages, mostly fatal, not shown with `-qqqq` |
  | 118 | `msg_warning()` | AVRDUDE and programmer warnings, typical OK, not shown with `-qqq` |
  | 297 | `msg_info()` | To keep the user appraised, not shown with `-qq`|
  | 162 | `msg_notice()` | More detail that is likely to assist in trouble shooting `-v`|
  | 292 | `msg_notice2()` | Even more detail shown on `-vv` |
  | 271 | `msg_debug()` | Debug messages `-vvv` |
  |  86 | `msg_trace()` | Trace messages `-vvvv` |
  |  22 | `msg_trace2()` | For those very difficult debug sessions `-vvvvv` |
- Introduced `pmsg_level(...)` instead of `msg_level("%s: ...", progname, ...)`
- Unified (somewhat) grammar, punctuation and style of messages
- Introduced `imsg_level()` to print indented messages
- Show function name in *all* errors and warnings on `-v`; less than half did before, and some were wrong (copy and paste)
- Gradually reduce effective verbosity by number of -q above one


The new message system has above 9 levels. There are three different independent message printing modes

  | Message mode  | Arguments as in | When to use |
  | --: | :-- | :-- |
  | `msg_level(...)` | `printf(...)` | `if(`*level condition*`) fprintf(stderr, ...);` |
  | `pmsg_level(...)` | `printf(...)` | like `msg_level()` but print `progname` first (see also notes below) |
  | `imsg_level(...)` |  `printf(...)` | like `msg_level()` but indent to line up with `progname` |

Here an overview of command line arguments that trigger printing (a neat upper triangle matrix)
| Level \ Opts|`-qqqq` | `-qqq` |  `-qq` | &nbsp; &nbsp; &nbsp; &nbsp; | &nbsp;`-v`&nbsp; | `-vv` | `-vvv` |`-vvvv` |`-vvvvv` |
| --: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
|`ext_error`|✔(m)|✔(m)|✔(m)|✔(m)|✔(m, f)|✔(m, f)|✔(m, f)|✔(m, f)|✔(m, f)|
|`error`||✔(m)|✔(m)|✔(m)|✔(m, f)|✔(m, f)|✔(m, f)|✔(m, f)|✔(m, f)|
|`warning`|||✔(m)|✔(m)|✔(m, f)|✔(m, f)|✔(m, f)|✔(m, f)|✔(m, f)|
|`info`||||✔|✔|✔|✔|✔|✔|
|`notice`|||||✔|✔|✔|✔|✔|
|`notice2`||||||✔|✔|✔|✔|
|`debug`|||||||✔|✔|✔|
|`trace`||||||||✔|✔|
|`trace2`|||||||||✔|

Notes for `pmsg_level()` functions: 
 (m) `pmsg_level()` functions also print the message type after `progname`, eg, `avrdude warning: `
 (f) When at least one `-v` is present, the `pmsg_level()` functions sandwich the function name between the `progname` and the message type, eg,`avrdude jtag3_edbg_prepare() error: unable to read from serial port (-1)`

With these new functions, messaging is somewhat more elegant:
```
    avrdude_message(MSG_INFO, "%s: WARNING: requested verification for %d bytes\n"
                    "%s%s memory region only contains %d bytes\n"
                    "%sOnly %d bytes will be verified.\n",
                    progname, size,
                    progbuf, memtype, vsize,
                    progbuf, vsize);
```
becomes
```
    pmsg_warning("requested verification for %d bytes\n", size);
    imsg_warning("%s memory region only contains %d bytes\n", memtype, vsize);
    imsg_warning("only %d bytes will be verified\n", vsize);
```


It's a *large* PR. Please test and see whether you like the gradual drop in verbosity:

```
$ avrdude -c usb-bub-ii -p m328

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: device signature = 0x1e950f (probably m328p)
avrdude error: expected signature for ATmega328 is 1E 95 14
        double check chip or use -F to override this check

avrdude done.  Thank you.

```
```
$ avrdude -c usb-bub-ii -p m328 -q

avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e950f (probably m328p)
avrdude error: expected signature for ATmega328 is 1E 95 14
        double check chip or use -F to override this check

avrdude done.  Thank you.

```
```
$ avrdude -c usb-bub-ii -p m328 -qq
avrdude error: expected signature for ATmega328 is 1E 95 14
        double check chip or use -F to override this check
```
```
$ avrdude -c usb-bub-ii -p m328 -qqq
avrdude error: expected signature for ATmega328 is 1E 95 14
        double check chip or use -F to override this check
```
```
$ avrdude -c usb-bub-ii -p m328 -qqqq
```

It's been done semi-automatically (my black belt in `sed` has to be good for something!), so I don't expect a lot of errors, but please give it a good whirl.
