### PR TITLE
Look for ~/.config/avrdude/config configuration file

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1332,22 +1332,22 @@ On all other systems, the file is first looked up in
 relative to the path of the executable, then in the same directory as
 the executable itself, and finally in the system default location
 .Pa ${PREFIX}/etc/avrdude.conf .
-.It Pa ${HOME}/.avrduderc
-Local programmer and parts configuration file (per-user overrides)
 .It Pa ${XDG_CONFIG_HOME}/avrdude/avrdude.rc
-Used as local configuration file if
-.Pa ${HOME}/.avrduderc
-does not exist; if the
+Local programmer and parts configuration file (per-user overrides); it follows the same syntax as
+.Pa avrdude.conf ;
+if the
 .Pa ${XDG_CONFIG_HOME}
-environment variable is either not set or empty, the directory
+environment variable is not set or empty, the directory
 .Pa ${HOME}/.config/
 is used instead.
+.It Pa ${HOME}/.avrduderc
+Alternative location of the per-user configuration file if above file does not exist
 .It Pa ~/.inputrc
 Initialization file for the
 .Xr readline 3
 library
-.It Pa ${PREFIX}/share/doc/avrdude/avrdude.pdf
-Schematic of programming hardware
+.It Pa <prefix>/doc/avrdude/avrdude.pdf
+User manual
 .El
 .\" .Sh EXAMPLES
 .Sh DIAGNOSTICS

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1333,7 +1333,12 @@ relative to the path of the executable, then in the same directory as
 the executable itself, and finally in the system default location
 .Pa ${PREFIX}/etc/avrdude.conf .
 .It Pa ${HOME}/.avrduderc
-programmer and parts configuration file (per-user overrides)
+.It Pa ${XDG_CONFIG_HOME}/avrdude/config
+programmer and parts configuration file (per-user overrides). If
+.Pa ${XDG_CONFIG_HOME}
+environment variable is either not set or empty, a default value
+.Pa ${HOME}/.config/
+is used.
 .It Pa ~/.inputrc
 Initialization file for the
 .Xr readline 3

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1320,10 +1320,10 @@ the CS line being managed outside the application.
 .Sh FILES
 .Bl -tag -offset indent -width /dev/ppi0XXX
 .It Pa /dev/ppi0
-default device to be used for communication with the programming
+Default device to be used for communication with the programming
 hardware
 .It Pa avrdude.conf
-programmer and parts configuration file
+Programmer and parts configuration file
 .Pp
 On Windows systems, this file is looked up in the same directory as the
 executable file.
@@ -1333,12 +1333,15 @@ relative to the path of the executable, then in the same directory as
 the executable itself, and finally in the system default location
 .Pa ${PREFIX}/etc/avrdude.conf .
 .It Pa ${HOME}/.avrduderc
-.It Pa ${XDG_CONFIG_HOME}/avrdude/config
-programmer and parts configuration file (per-user overrides). If
+Local programmer and parts configuration file (per-user overrides)
+.It Pa ${XDG_CONFIG_HOME}/avrdude/avrdude.rc
+Used as local configuration file if
+.Pa ${HOME}/.avrduderc
+does not exist; if the
 .Pa ${XDG_CONFIG_HOME}
-environment variable is either not set or empty, a default value
+environment variable is either not set or empty, the directory
 .Pa ${HOME}/.config/
-is used.
+is used instead.
 .It Pa ~/.inputrc
 Initialization file for the
 .Xr readline 3

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -389,7 +389,7 @@
 # ATmega169     0x78
 
 #
-# Overall avrdude defaults; suitable for ~/.avrduderc
+# Overall avrdude defaults; suitable for ~/.config/avrdude/config
 #
 default_parallel   = "@DEFAULT_PAR_PORT@";
 default_serial     = "@DEFAULT_SER_PORT@";

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -26,6 +26,7 @@
 #define USER_CONF_FILE "avrdude.rc"
 #else
 #define USER_CONF_FILE ".avrduderc"
+#define XDG_USER_CONF_FILE "avrdude/avrdude.rc"
 #endif
 
 extern char *progname;       // name of program, for messages

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1721,15 +1721,15 @@ programmer work with AVRDUDE.
 
 AVRDUDE first looks for a system wide configuration file in a platform
 dependent location.  On Unix, this is usually
-@code{/usr/local/etc/avrdude.conf}, while on Windows it is usually in the
+@code{/usr/local/etc/avrdude.conf}, whilst on Windows it is usually in the
 same location as the executable file.  The name of this file can be
 changed using the @option{-C} command line option.  After the system wide
 configuration file is parsed, AVRDUDE looks for a per-user configuration
 file to augment or override the system wide defaults.  On Unix, the
 per-user file is @code{.avrduderc} within the user's home directory or,
-if that does not exists, @code{$@{XDG_CONFIG_HOME@}/avrdude/config},
+if that does not exists, @code{$@{XDG_CONFIG_HOME@}/avrdude/avrdude.rc},
 whereas if @code{$@{XDG_CONFIG_HOME@}} is either not set or empty,
-@code{$@{HOME@}/.config/} is used by default.  On Windows, this file is
+@code{$@{HOME@}/.config/} is used instead.  On Windows, this file is
 the @code{avrdude.rc} file located in the same directory as the
 executable.
 

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1714,24 +1714,24 @@ AVRDUDE reads a configuration file upon startup which describes all of
 the parts and programmers that it knows about.  The advantage of this is
 that if you have a chip that is not currently supported by AVRDUDE, you
 can add it to the configuration file without waiting for a new release
-of AVRDUDE.  Likewise, if you have a parallel port programmer that is
-not supported by AVRDUDE, chances are good that you can copy and
-existing programmer definition, and with only a few changes, make your
-programmer work with AVRDUDE.
+of AVRDUDE. Likewise, if you have a parallel port programmer that is
+not supported, chances are that you can copy an
+existing programmer definition and, with only a few changes, make your
+programmer work.
 
 AVRDUDE first looks for a system wide configuration file in a platform
 dependent location.  On Unix, this is usually
 @code{/usr/local/etc/avrdude.conf}, whilst on Windows it is usually in the
-same location as the executable file.  The name of this file can be
-changed using the @option{-C} command line option.  After the system wide
-configuration file is parsed, AVRDUDE looks for a per-user configuration
+same location as the executable file.  The full name of this file can be
+specified using the @option{-C} command line option.  After parsing the system wide
+configuration file, AVRDUDE looks for a per-user configuration
 file to augment or override the system wide defaults.  On Unix, the
-per-user file is @code{.avrduderc} within the user's home directory or,
-if that does not exists, @code{$@{XDG_CONFIG_HOME@}/avrdude/avrdude.rc},
-whereas if @code{$@{XDG_CONFIG_HOME@}} is either not set or empty,
-@code{$@{HOME@}/.config/} is used instead.  On Windows, this file is
-the @code{avrdude.rc} file located in the same directory as the
-executable.
+per-user file is @code{$@{XDG_CONFIG_HOME@}/avrdude/avrdude.rc}, whereas
+if @code{$@{XDG_CONFIG_HOME@}} is either not set or empty,
+@code{$@{HOME@}/.config/} is used instead. If that does not exists
+@code{.avrduderc} within the user's home directory is used. On Windows,
+this file is the @code{avrdude.rc} file located in the same directory as
+the executable.
 
 @menu
 * AVRDUDE Defaults::            

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1726,9 +1726,12 @@ same location as the executable file.  The name of this file can be
 changed using the @option{-C} command line option.  After the system wide
 configuration file is parsed, AVRDUDE looks for a per-user configuration
 file to augment or override the system wide defaults.  On Unix, the
-per-user file is @code{.avrduderc} within the user's home directory.  On
-Windows, this file is the @code{avrdude.rc} file located in the same
-directory as the executable.
+per-user file is @code{.avrduderc} within the user's home directory or,
+if that does not exists, @code{$@{XDG_CONFIG_HOME@}/avrdude/config},
+whereas if @code{$@{XDG_CONFIG_HOME@}} is either not set or empty,
+@code{$@{HOME@}/.config/} is used by default.  On Windows, this file is
+the @code{avrdude.rc} file located in the same directory as the
+executable.
 
 @menu
 * AVRDUDE Defaults::            

--- a/src/main.c
+++ b/src/main.c
@@ -467,6 +467,7 @@ int main(int argc, char * argv [])
 
 #if !defined(WIN32)
   char  * homedir;
+  char  * xdg_config_home;
 #endif
 
 #ifdef _MSC_VER
@@ -863,6 +864,23 @@ int main(int argc, char * argv [])
     if (i && (usr_config[i - 1] != '/'))
       strcat(usr_config, "/");
     strcat(usr_config, USER_CONF_FILE);
+    rc = stat(usr_config, &sb);
+    if ((rc < 0) || ((sb.st_mode & S_IFREG) == 0)) {
+      xdg_config_home = getenv("XDG_CONFIG_HOME");
+      if (xdg_config_home != NULL && *xdg_config_home != '\0') {
+        strcpy(usr_config, xdg_config_home);
+        i = strlen(usr_config);
+        if (i && (usr_config[i - 1] != '/'))
+          strcat(usr_config, "/");
+      } else {
+        strcpy(usr_config, homedir);
+        i = strlen(usr_config);
+        if (i && (usr_config[i - 1] != '/'))
+          strcat(usr_config, "/");
+        strcat(usr_config, ".config/");
+      }
+      strcat(usr_config, "avrdude/config");
+    }
   }
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -425,6 +425,7 @@ static void exit_part_not_found(const char *partdesc) {
 }
 
 
+#if !defined(WIN32)
 // Safely concatenate dir/file into dst that has size n
 static char *concatpath(char *dst, char *dir, char *file, size_t n) {
   // Has dir or file not at least one character?
@@ -447,6 +448,7 @@ static char *concatpath(char *dst, char *dir, char *file, size_t n) {
 
   return dst;
 }
+#endif
 
 
 /*
@@ -461,6 +463,7 @@ int main(int argc, char * argv [])
   int              len;         /* length for various strings */
   struct avrpart * p;           /* which avr part we are programming */
   AVRMEM         * sig;         /* signature data */
+  struct stat      sb;
   UPDATE         * upd;
   LNODEID        * ln;
 
@@ -874,7 +877,6 @@ int main(int argc, char * argv [])
 #if defined(WIN32)
   win_usr_config_set(usr_config);
 #else
-  struct stat sb;
   usr_config[0] = 0;
   if(!concatpath(usr_config, getenv("HOME"), USER_CONF_FILE, sizeof usr_config-1)
      || stat(usr_config, &sb) < 0

--- a/src/main.c
+++ b/src/main.c
@@ -878,11 +878,11 @@ int main(int argc, char * argv [])
   win_usr_config_set(usr_config);
 #else
   usr_config[0] = 0;
-  if(!concatpath(usr_config, getenv("HOME"), USER_CONF_FILE, sizeof usr_config-1)
+  if(!concatpath(usr_config, getenv("HOME"), USER_CONF_FILE, sizeof usr_config)
      || stat(usr_config, &sb) < 0
      || (sb.st_mode & S_IFREG) == 0)
-    if(!concatpath(usr_config, getenv("XDG_CONFIG_HOME"), XDG_USER_CONF_FILE, sizeof usr_config-1))
-      concatpath(usr_config, getenv("HOME"), ".config/" XDG_USER_CONF_FILE, sizeof usr_config-1);
+    if(!concatpath(usr_config, getenv("XDG_CONFIG_HOME"), XDG_USER_CONF_FILE, sizeof usr_config))
+      concatpath(usr_config, getenv("HOME"), ".config/" XDG_USER_CONF_FILE, sizeof usr_config);
 #endif
 
   if (quell_progress == 0)

--- a/src/main.c
+++ b/src/main.c
@@ -428,7 +428,7 @@ static void exit_part_not_found(const char *partdesc) {
 #if !defined(WIN32)
 // Safely concatenate dir/file into dst that has size n
 static char *concatpath(char *dst, char *dir, char *file, size_t n) {
-  // Has dir or file not at least one character?
+  // Dir or file empty?
   if(!dir || !*dir || !file || !*file)
     return NULL;
 
@@ -878,11 +878,10 @@ int main(int argc, char * argv [])
   win_usr_config_set(usr_config);
 #else
   usr_config[0] = 0;
-  if(!concatpath(usr_config, getenv("HOME"), USER_CONF_FILE, sizeof usr_config)
-     || stat(usr_config, &sb) < 0
-     || (sb.st_mode & S_IFREG) == 0)
-    if(!concatpath(usr_config, getenv("XDG_CONFIG_HOME"), XDG_USER_CONF_FILE, sizeof usr_config))
-      concatpath(usr_config, getenv("HOME"), ".config/" XDG_USER_CONF_FILE, sizeof usr_config);
+  if(!concatpath(usr_config, getenv("XDG_CONFIG_HOME"), XDG_USER_CONF_FILE, sizeof usr_config))
+    concatpath(usr_config, getenv("HOME"), ".config/" XDG_USER_CONF_FILE, sizeof usr_config);
+  if(stat(usr_config, &sb) < 0 || (sb.st_mode & S_IFREG) == 0)
+    concatpath(usr_config, getenv("HOME"), USER_CONF_FILE, sizeof usr_config);
 #endif
 
   if (quell_progress == 0)


### PR DESCRIPTION
Traditionally per-user configuration files have been placed in user's home directory with their names beginnig with a dot to hide them from some tools like ls(1). However, the number of programs following this convention have grown over time to the point where the number of hidden files becomes inconvenient to some users. For this reason the XDG Base Directory Specification[1] specifies an alternate place to store configuration files under ~/.config directory.

This patch enables avrdude to look for ~/.config/avrdude/config configuration file, if ~/.avrduderc doesn't exist.

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.8.html