### PR TITLE
Always use paged access for programmers that serve bootloaders

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -377,8 +377,9 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     return avr_mem_hiaddr(mem);
   }
 
-  if (pgm->paged_load != NULL && mem->page_size > 1 &&
-      mem->size % mem->page_size == 0) {
+  // HW programmers need a page size > 1, bootloader typ only offer paged r/w
+  if ((pgm->paged_load && mem->page_size > 1 && mem->size % mem->page_size == 0) ||
+     ((pgm->prog_modes & PM_SPM) && avr_has_paged_access(pgm, mem))) {
     /*
      * the programmer supports a paged mode read
      */
@@ -894,7 +895,9 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     return i;
   }
 
-  if (pgm->paged_write != NULL && m->page_size > 1) {
+  // HW programmers need a page size > 1, bootloader typ only offer paged r/w
+  if ((pgm->paged_load && m->page_size > 1 && m->size % m->page_size == 0) ||
+     ((pgm->prog_modes & PM_SPM) && avr_has_paged_access(pgm, m))) {
     /*
      * the programmer supports a paged mode write
      */


### PR DESCRIPTION
Supposed to fix Issue #970

I have made another stab at this and implemented Option 1 of https://github.com/avrdudes/avrdude/issues/970#issue-1242132857. Now writing to EEPROM works, in principle. The chosen example of #970 is not great b/c optiboot only ever uses word addresses. With a page size of 1 (as in the EEPROM of ATmega161) this will *out of necessity* write to even addresses only yielding a verification error.

```
$ yes hello, world | head -512c | avrdude -qq -p m161 -F -c arduino -b 115200 -P /dev/ttyUSB0 -U eeprom:w:-:r
avrdude warning: expected signature for ATmega161 is 1E 94 01
avrdude error: verification mismatch, first encountered at addr 0x0000
        device 0x65 != input 0x68
avrdude error: verification mismatch
```

Reading purports a doubling of characters b/c the even addresses are all read twice:

```
$ avrdude -qq -p m161 -F -c arduino -b 115200 -P /dev/ttyUSB0 -U eeprom:r:-:I
avrdude warning: expected signature for ATmega161 is 1E 94 01
:2000000065656C6C2C2C77777272646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2CC2 // 00000> eell,,wwrrddhhlloo__ooll..eell,,
:2000200077777272646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777272646402 // 00020> wwrrddhhlloo__ooll..eell,,wwrrdd
:2000400068686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777272646468686C6C6F6FF6 // 00040> hhlloo__ooll..eell,,wwrrddhhlloo
:2000600020206F6F6C6C0A0A65656C6C2C2C77777272646468686C6C6F6F20206F6F6C6C66 // 00060> __ooll..eell,,wwrrddhhlloo__ooll
:200080000A0A65656C6C2C2C77777272646468686C6C6F6F20206F6F6C6C0A0A65656C6C86 // 00080> ..eell,,wwrrddhhlloo__ooll..eell
:2000A0002C2C77777272646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777272F2 // 000a0> ,,wwrrddhhlloo__ooll..eell,,wwrr
:2000C000646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777272646468686C6C8C // 000c0> ddhhlloo__ooll..eell,,wwrrddhhll
:2000E0006F6F20206F6F6C6C0A0A65656C6C2C2C77777272646468686C6C6F6F20206F6FE0 // 000e0> oo__ooll..eell,,wwrrddhhlloo__oo
:200100006C6C0A0A65656C6C2C2C77777272646468686C6C6F6F20206F6F6C6C0A0A656505 // 00100> ll..eell,,wwrrddhhlloo__ooll..ee
:200120006C6C2C2C77777272646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777D // 00120> ll,,wwrrddhhlloo__ooll..eell,,ww
:200140007272646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C7777727264646868FF // 00140> rrddhhlloo__ooll..eell,,wwrrddhh
:200160006C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777272646468686C6C6F6F202065 // 00160> lloo__ooll..eell,,wwrrddhhlloo__
:200180006F6F6C6C0A0A65656C6C2C2C77777272646468686C6C6F6F20206F6F6C6C0A0A71 // 00180> ooll..eell,,wwrrddhhlloo__ooll..
:2001A00065656C6C2C2C77777272646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C21 // 001a0> eell,,wwrrddhhlloo__ooll..eell,,
:2001C00077777272646468686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777272646461 // 001c0> wwrrddhhlloo__ooll..eell,,wwrrdd
:2001E00068686C6C6F6F20206F6F6C6C0A0A65656C6C2C2C77777272646468686C6C6F6F55 // 001e0> hhlloo__ooll..eell,,wwrrddhhlloo
:00000001FF
```

Actually, bytes at odd addresses have never been modified:

```
$ avrdude -qq -p m328p -c arduino -b 115200 -P /dev/ttyUSB0 -U eeprom:r:-:I
:2000000065FF6CFF2CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF61 // 00000> e.l.,.w.r.d.h.l.o._.o.l...e.l.,.
:2000200077FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FFF1 // 00020> w.r.d.h.l.o._.o.l...e.l.,.w.r.d.
:2000400068FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FF6CFF6FFFDB // 00040> h.l.o._.o.l...e.l.,.w.r.d.h.l.o.
:2000600020FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF03 // 00060> _.o.l...e.l.,.w.r.d.h.l.o._.o.l.
:200080000AFE65FE6CFE2CFE77FE72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF08 // 00080> .~e~l~,~w~r.d.h.l.o._.o.l...e.l.
:2000A0002CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FFA9 // 000a0> ,.w.r.d.h.l.o._.o.l...e.l.,.w.r.
:2000C00064FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FF6CFF66 // 000c0> d.h.l.o._.o.l...e.l.,.w.r.d.h.l.
:2000E0006FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF80 // 000e0> o._.o.l...e.l.,.w.r.d.h.l.o._.o.
:200100006C630AD365006C4B2CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FFFD // 00100> lc.Se.lK,.w.r.d.h.l.o._.o.l...e.
:200120006CFF2CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF2E // 00120> l.,.w.r.d.h.l.o._.o.l...e.l.,.w.
:2001400072FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FFDF // 00140> r.d.h.l.o._.o.l...e.l.,.w.r.d.h.
:200160006CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FF6CFF6FFF20FF02 // 00160> l.o._.o.l...e.l.,.w.r.d.h.l.o._.
:200180006FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFFF8 // 00180> o.l...e.l.,.w.r.d.h.l.o._.o.l...
:2001A00065FF6CFF2CFF77FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFFC0 // 001a0> e.l.,.w.r.d.h.l.o._.o.l...e.l.,.
:2001C00077FF72FF64FF68FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF50 // 001c0> w.r.d.h.l.o._.o.l...e.l.,.w.r.d.
:2001E00068FF6CFF6FFF20FF6FFF6CFF0AFF65FF6CFF2CFF77FF72FF64FF68FF6CFF6FFF3A // 001e0> h.l.o._.o.l...e.l.,.w.r.d.h.l.o.
:20020000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE // 00200> ................................
:20022000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDE // 00220> ................................
:20024000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBE // 00240> ................................
:20026000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF9E // 00260> ................................
:20028000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7E // 00280> ................................
:2002A000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5E // 002a0> ................................
:2002C000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3E // 002c0> ................................
:2002E000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1E // 002e0> ................................
:20030000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD // 00300> ................................
:20032000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFDD // 00320> ................................
:20034000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBD // 00340> ................................
:20036000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF9D // 00360> ................................
:20038000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7D // 00380> ................................
:2003A000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D // 003a0> ................................
:2003C000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF3D // 003c0> ................................
:2003E000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1D // 003e0> ................................
:00000001FF
```

*However,* this is outside the remit of this PR. Optiboot_x and optiboot_dx that use byte addresses throughout should be OK once PR #1140 is merged.
