### PR TITLE
STK600 supports programming using PDI

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1270,7 +1270,7 @@ programmer
     id                     = "stk600";
     desc                   = "Atmel STK600";
     type                   = "stk600";
-    prog_modes             = PM_TPI | PM_ISP;
+    prog_modes             = PM_TPI | PM_ISP | PM_PDI;
     connection_type        = usb;
 ;
 


### PR DESCRIPTION
Just a minor fix.

The STK600 does support PDI programming using Avrdude. Tested with real hardware:

#1047 related

```
$ ./avrdude -patxmega128a3u -cstk600 -v

avrdude: Version 7.0-20220508
         Copyright (c) Brian Dean, http://www.bdmicro.com/
         Copyright (c) Joerg Wunsch

         System wide configuration file is /Users/hans/Downloads/avrdude/src/avrdude.conf
         User configuration file is /Users/hans/.avrduderc

         Using Port                    : usb
         Using Programmer              : stk600
avrdude: usbdev_open(): found STK600, serno: 0045E550833E
         AVR Part                      : ATxmega128A3U
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           fuse1                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse4                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5                   0     0     0    0 no          1    1      0     0     0 0x00 0x00
           lock                    0     0     0    0 no          1    1      0     0     0 0x00 0x00
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig                 0     0     0    0 no         50   50      0     0     0 0x00 0x00
           data                    0     0     0    0 no          0    1      0     0     0 0x00 0x00
           eeprom                  0     0     0    0 no       2048   32      0     0     0 0x00 0x00
           flash                   0     0     0    0 no     139264  512      0     0     0 0x00 0x00
           application             0     0     0    0 no     131072  512      0     0     0 0x00 0x00
           apptable                0     0     0    0 no       8192  512      0     0     0 0x00 0x00
           boot                    0     0     0    0 no       8192  512      0     0     0 0x00 0x00
           usersig                 0     0     0    0 no        512  512      0     0     0 0x00 0x00
           fuse0                   0     0     0    0 no          1    1      0     0     0 0x00 0x00

         Programmer Type : STK600
         Description     : Atmel STK600
         Programmer Model: STK600
         Hardware Version: 3
         Firmware Version Master : 2.45
         Firmware Version Slave 1: 2.03
         Firmware Version Slave 2: 2.02
         Routing card    : Not present
         Socket card     : STK600-ATMEGA2560
         RC_ID table rev : 245
         EC_ID table rev : 1
         Vtarget         : 4.8 V
         Varef 0         : 2.99 V
         Varef 1         : 3.29 V
         SCK period      : 3.25 us
         Oscillator      : 15.992 MHz

avrdude: AVR device initialized and ready to accept instructions

Reading | ################################################## | 100% 0.00s

avrdude: device signature = 0x1e9742 (probably x128a3u)

avrdude done.  Thank you.
```