### PR TITLE
Add libreadline-dev for Linux github action build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
           libusb-1.0-0-dev
           libhidapi-dev
           libftdi1-dev
+          libreadline-dev
           texinfo
           texlive
           texi2html
@@ -110,6 +111,7 @@ jobs:
           libusb-1.0-0-dev:${{matrix.arch}}
           libhidapi-dev:${{matrix.arch}}
           libftdi1-dev:${{matrix.arch}}
+          libreadline-dev:${{matrix.arch}}
       - name: Configure
         run: >-
           cmake


### PR DESCRIPTION
This commit adds libreadline-dev for Linux github action build.

Background from @stefanrueger 
* https://github.com/avrdudes/avrdude/pull/1132#issuecomment-1287849627

Signed-off by xiaofanc@gmail.com
