### PR TITLE
Add readline for MSYS2 mingw32/mingw64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,7 @@ jobs:
             mingw-w64-${{matrix.env}}-libusb-compat-git
             mingw-w64-${{matrix.env}}-hidapi
             mingw-w64-${{matrix.env}}-libftdi
+            mingw-w64-${{matrix.env}}-readline
       - name: Configure
         run: >-
           cmake


### PR DESCRIPTION
This pull request adds the support for readline for the github action mingw32/mingw64 build.

Sign-off by xiaofanc@gmail.com