### PR TITLE
Readline macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,7 @@ jobs:
           libusb
           hidapi
           libftdi
+          readline
       - name: Configure
         run: >-
           cmake
@@ -168,6 +169,7 @@ jobs:
           -D CMAKE_EXE_LINKER_FLAGS=-L/usr/local/Cellar
           -D DEBUG_CMAKE=1
           -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -D HAVE_LIBREADLINE:FILEPATH=/usr/local/opt/readline/lib/libreadline.dylib
           -B build
       - name: Build
         run: cmake --build build

--- a/build.sh
+++ b/build.sh
@@ -53,9 +53,9 @@ case "${ostype}" in
             # Apple M1 (may be new version of homebrew also)
             if [ -d /opt/homebrew ]  
             then
-                build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/opt/homebrew/include -D CMAKE_EXE_LINKER_FLAGS=-L/opt/homebrew/Cellar -D HAVE_LIBREADLINE:FILEPATH=/opt/homebrew/lib/libreadline.dylib"
+                build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/opt/homebrew/include -D CMAKE_EXE_LINKER_FLAGS=-L/opt/homebrew/Cellar -D HAVE_LIBREADLINE:FILEPATH=/opt/homebrew/opt/readline/lib/libreadline.dylib"
             else
-                build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/usr/local/include -D CMAKE_EXE_LINKER_FLAGS=-L/usr/local/Cellar -D HAVE_LIBREADLINE:FILEPATH=/usr/local/lib/libreadline.dylib"
+                build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/usr/local/include -D CMAKE_EXE_LINKER_FLAGS=-L/usr/local/Cellar -D HAVE_LIBREADLINE:FILEPATH=/usr/local/opt/readline/lib/libreadline.dylib"
             fi
 	fi
 	;;


### PR DESCRIPTION
This pull request adds the support for readline for the github action macOS Homebrew build. It will use readline keg instead of the system provided libedit.

It also updated `build.sh` to use readline keg (no need to use `brew link readline --force`.

It should not affect MacPorts users.

Sign-off by [xiaofanc@gmail.com](mailto:xiaofanc@gmail.com)