### PR TITLE
Add readline and shared build for mingw -- WIP DNM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,12 +266,14 @@ jobs:
             mingw-w64-${{matrix.env}}-libusb-compat-git
             mingw-w64-${{matrix.env}}-hidapi
             mingw-w64-${{matrix.env}}-libftdi
+            mingw-w64-${{matrix.env}}-readline
       - name: Configure
         run: >-
           cmake
           -G"MSYS Makefiles"
           -D DEBUG_CMAKE=1
           -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -D USE_STATIC_LIBS=OFF
           -B build
       - name: Build
         run: cmake --build build


### PR DESCRIPTION
1) Add readline dependancy
2) Use dynamic link in order to avoid readline MSYS2 issue
https://github.com/msys2/MINGW-packages/issues/8105

This is probably not the right fix. Please DO NOT MERGE now.

Reference:
* https://github.com/avrdudes/avrdude/issues/1155