### PR TITLE
Fix #1167 removing the initialize call following the CMD_CHIP_ERASE_ISP command

### DIFF
--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -948,8 +948,10 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   memset(buf+3, 0, 4);
   avr_set_bits(p->op[AVR_OP_CHIP_ERASE], buf+3);
   result = stk500v2_command(pgm, buf, 7, sizeof(buf));
-  usleep(p->chip_erase_delay);
-  pgm->initialize(pgm, p);
+  usleep(p->chip_erase_delay); // should not be needed
+  if (PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE_MKII) { // skip for JTAGICE mkII (FW v7.39)
+    pgm->initialize(pgm, p); // should not be needed
+  }
 
   pgm->pgm_led(pgm, OFF);
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -948,6 +948,8 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   memset(buf+3, 0, 4);
   avr_set_bits(p->op[AVR_OP_CHIP_ERASE], buf+3);
   result = stk500v2_command(pgm, buf, 7, sizeof(buf));
+  usleep(p->chip_erase_delay);
+  pgm->initialize(pgm, p);
 
   pgm->pgm_led(pgm, OFF);
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -948,8 +948,6 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   memset(buf+3, 0, 4);
   avr_set_bits(p->op[AVR_OP_CHIP_ERASE], buf+3);
   result = stk500v2_command(pgm, buf, 7, sizeof(buf));
-  usleep(p->chip_erase_delay);
-  pgm->initialize(pgm, p);
 
   pgm->pgm_led(pgm, OFF);
 


### PR DESCRIPTION
This call ends up sending another CMD_ENTER_PROGMODE_ISP which is not needed and causes a flash verification mismatch using the JTAGICE mkII in ISP mode. Also removed the call to usleep following the CMD_CHIP_ERASE_ISP command. This is not needed as the chip erase delay is a field of the CMD_CHIP_ERASE_ISP command that AVRISP mkII-compatible programmers are expected to honor.