### PR TITLE
Add fallback for EM_AVR

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ case "${ostype}" in
 	    build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/opt/local/include -D CMAKE_EXE_LINKER_FLAGS=-L/opt/local/lib"
 	else
             # Apple M1 (may be new version of homebrew also)
-            if [ -d /opt/homebrew ]  
+            if [ -d /opt/homebrew ]
             then
                 build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/opt/homebrew/include -D CMAKE_EXE_LINKER_FLAGS=-L/opt/homebrew/Cellar -D HAVE_LIBREADLINE:FILEPATH=/opt/homebrew/opt/readline/lib/libreadline.dylib"
             else
@@ -60,7 +60,11 @@ case "${ostype}" in
 	fi
 	;;
 
-    freebsd)
+    netbsd)
+	build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/usr/pkg/include -D CMAKE_EXE_LINKER_FLAGS=-L/usr/pkg/lib"
+	;;
+
+    *bsd)
 	build_flags="${build_flags} -D CMAKE_C_FLAGS=-I/usr/local/include -D CMAKE_EXE_LINKER_FLAGS=-L/usr/local/lib"
 	;;
 esac

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -37,6 +37,9 @@
 #ifndef EM_AVR32
 #  define EM_AVR32 0x18ad         /* unofficial */
 #endif
+#ifndef EM_AVR
+#  define EM_AVR 83               /* OpenBSD lacks it */
+#endif
 #endif
 
 #include "avrdude.h"

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -36,6 +36,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <netdb.h>
 

--- a/src/term.c
+++ b/src/term.c
@@ -44,6 +44,8 @@
 
 #ifdef WIN32
 #include <windows.h>
+#else
+#include <sys/select.h>
 #endif
 #endif
 


### PR DESCRIPTION
OpenBSD still lacks this definition, so provide our own for them.