### PR TITLE
Print HAVE_LIBREADLINE status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,12 @@ else()
     message(STATUS "DON'T HAVE libftdi1")
 endif()
 
+if(HAVE_LIBREADLINE)
+    message(STATUS "DO HAVE    libreadline")
+else()
+    message(STATUS "DON'T HAVE libreadline")
+endif()
+
 if(BUILD_DOC)
 	message(STATUS "ENABLED    doc")
 else()

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -577,6 +577,12 @@ else
    echo "DON'T HAVE libhidapi"
 fi
 
+if test x$have_readline = xyes; then
+   echo "DO HAVE    libreadline"
+else
+   echo "DON'T HAVE libreadline"
+fi
+
 if test x$have_pthread = xyes; then
    echo "DO HAVE    pthread"
 else


### PR DESCRIPTION
Readline is now required for better functionality when available. It is better to print out the status during CMake configure stage.