### PR TITLE
Fix userrow size and page_size for ATtiny3216 and ATtiny3217

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -14491,32 +14491,26 @@ part parent ".avr8x_tiny"
         offset             = 0x8000;
         readsize           = 256;
     ;
+
+    memory "userrow"
+        size               = 64;
+        page_size          = 64;
+    ;
+
+    memory "usersig"
+        alias "userrow";
+    ;
 ;
 
 #------------------------------------------------------------
 # ATtiny3217
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent "t3216"
     desc                   = "ATtiny3217";
     id                     = "t3217";
     mcuid                  = 315;
-    n_interrupts           = 31;
     signature              = 0x1e 0x95 0x22;
-
-    memory "eeprom"
-        size               = 256;
-        page_size          = 64;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
-
-    memory "flash"
-        size               = 0x8000;
-        page_size          = 128;
-        offset             = 0x8000;
-        readsize           = 256;
-    ;
 ;
 
 #------------------------------------------------------------


### PR DESCRIPTION
Fixes Issue #1183

Proof:
``` sh
avrdude_git_main -p*/At >/tmp/1
avrdude_pr__1199 -p*/At >/tmp/2
diff /tmp/[12]

88912,88913c88912,88913
< .ptmm	ATtiny3216	userrow	size	32
< .ptmm	ATtiny3216	userrow	page_size	32
---
> .ptmm	ATtiny3216	userrow	size	64
> .ptmm	ATtiny3216	userrow	page_size	64
89590,89591c89590,89591
< .ptmm	ATtiny3217	userrow	size	32
< .ptmm	ATtiny3217	userrow	page_size	32
---
> .ptmm	ATtiny3217	userrow	size	64
> .ptmm	ATtiny3217	userrow	page_size	64
```
