### PR TITLE
Fix reading of .elf files

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -118,10 +118,9 @@ char * fileio_fmtstr(FILEFMT format)
 }
 
 
-static int b2ihex(const unsigned char *inbuf, int bufsize,
-           int recsize, int startaddr,
-           const char *outfile, FILE *outf, FILEFMT ffmt)
-{
+static int b2ihex(const unsigned char *inbuf, int bufsize, int recsize,
+  int startaddr, const char *outfile_unused, FILE *outf, FILEFMT ffmt) {
+
   const unsigned char *buf;
   unsigned int nextaddr;
   int n, nbytes, n_64k;
@@ -397,10 +396,9 @@ static int ihex2b(const char *infile, FILE *inf,
   }
 }
 
-static int b2srec(const unsigned char *inbuf, int bufsize,
-           int recsize, int startaddr,
-           const char *outfile, FILE *outf)
-{
+static int b2srec(const unsigned char *inbuf, int bufsize, int recsize,
+  int startaddr, const char *outfile_unused, FILE *outf) {
+
   const unsigned char *buf;
   unsigned int nextaddr;
   int n, nbytes, addr_width;
@@ -767,10 +765,9 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
 }
 
 
-static int elf2b(const char *infile, FILE *inf,
-                 const AVRMEM *mem, const AVRPART *p,
-                 int bufsize, unsigned int fileoffset)
-{
+static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
+  const AVRPART *p, int bufsize_unused, unsigned int fileoffset_unused) {
+
   Elf *e;
   int rv = 0, size = 0;
   unsigned int low, high, foff;
@@ -1045,9 +1042,9 @@ static int fileio_rbin(struct fioparms *fio,
 }
 
 
-static int fileio_imm(struct fioparms *fio,
-             const char *fname, FILE *f, const AVRMEM *mem, int size)
-{
+static int fileio_imm(struct fioparms *fio, const char *fname, FILE *f_unused,
+ const AVRMEM *mem, int size) {
+
   int rc = 0;
   char *e, *p, *filename;
   unsigned long b;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -728,11 +728,11 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
         strcmp(mem->desc, "application") == 0 ||
         strcmp(mem->desc, "apptable") == 0) {
       *lowbound = 0;
-      *highbound = 0x7ffff;       /* max 8 MiB */
+      *highbound = 0x7Fffff;    // Max 8 MiB
       *fileoff = 0;
     } else if (strcmp(mem->desc, "eeprom") == 0) {
       *lowbound = 0x810000;
-      *highbound = 0x81ffff;      /* max 64 KiB */
+      *highbound = 0x81ffff;    // Max 64 KiB
       *fileoff = 0;
     } else if (strcmp(mem->desc, "lfuse") == 0) {
       *lowbound = 0x820000;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -730,7 +730,7 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       *lowbound = 0;
       *highbound = 0x7Fffff;    // Max 8 MiB
       *fileoff = 0;
-    } else if (strcmp(mem->desc, "data") == 0) { // Volatile SRAM for XMEGA (not the .data section)
+    } else if (strcmp(mem->desc, "data") == 0) { // SRAM for XMEGAs
       *lowbound = 0x802000;
       *highbound = 0x80ffff;
       *fileoff = 0;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -959,7 +959,6 @@ static int elf2b(const char *infile, FILE *inf,
           memset(mem->tags + idx, TAG_ALLOCATED, d->d_size);
         }
       }
-      break;                  // Stop after first section in program header
     }
   }
 done:

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -887,8 +887,8 @@ static int elf2b(const char *infile, FILE *inf,
     if (ph[i].p_type != PT_LOAD || ph[i].p_filesz == 0)
       continue;
 
-    pmsg_notice2("considering PT_LOAD program header entry #%d:\n"
-      "    p_vaddr 0x%x, p_paddr 0x%x, p_filesz %d\n", (int) i, ph[i].p_vaddr, ph[i].p_paddr, ph[i].p_filesz);
+    pmsg_notice2("considering PT_LOAD program header entry #%d\n", (int) i);
+    imsg_notice2("p_vaddr 0x%x, p_paddr 0x%x, p_filesz %d\n", ph[i].p_vaddr, ph[i].p_paddr, ph[i].p_filesz);
 
     Elf_Scn *scn = NULL;
     while ((scn = elf_nextscn(e, scn)) != NULL) {
@@ -916,7 +916,7 @@ static int elf2b(const char *infile, FILE *inf,
       pmsg_notice2("found section %s, LMA 0x%x, sh_size %u\n", sname, lma, sh->sh_size);
 
       if(!(lma >= low && lma + sh->sh_size < high)) {
-        msg_notice2("    => skipping, inappropriate for %s memory region\n", mem->desc);
+        imsg_notice2("skipping %s (inappropriate for %s)\n", sname, mem->desc);
         continue;
       }
       /*
@@ -936,7 +936,7 @@ static int elf2b(const char *infile, FILE *inf,
 
       Elf_Data *d = NULL;
       while ((d = elf_getdata(scn, d)) != NULL) {
-        msg_notice2("    Data block: d_buf %p, d_off 0x%x, d_size %ld\n",
+        imsg_notice2("data block: d_buf %p, d_off 0x%x, d_size %ld\n",
           d->d_buf, (unsigned int)d->d_off, (long) d->d_size);
         if (mem->size == 1) {
           if (d->d_off != 0) {
@@ -946,7 +946,7 @@ static int elf2b(const char *infile, FILE *inf,
             pmsg_error("ELF file section does not contain byte at offset %d\n", foff);
             rv = -1;
           } else {
-            msg_notice2("    Extracting one byte from file offset %d\n", foff);
+            imsg_notice2("extracting one byte from file offset %d\n", foff);
             mem->buf[0] = ((unsigned char *)d->d_buf)[foff];
             mem->tags[0] = TAG_ALLOCATED;
             size = 1;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -730,11 +730,15 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       *lowbound = 0;
       *highbound = 0x7Fffff;    // Max 8 MiB
       *fileoff = 0;
+    } else if (strcmp(mem->desc, "data") == 0) { // Volatile SRAM for XMEGA (not the .data section)
+      *lowbound = 0x802000;
+      *highbound = 0x80ffff;
+      *fileoff = 0;
     } else if (strcmp(mem->desc, "eeprom") == 0) {
       *lowbound = 0x810000;
       *highbound = 0x81ffff;    // Max 64 KiB
       *fileoff = 0;
-    } else if (strcmp(mem->desc, "lfuse") == 0) {
+    } else if (strcmp(mem->desc, "lfuse") == 0 || strcmp(mem->desc, "fuses") == 0) {
       *lowbound = 0x820000;
       *highbound = 0x82ffff;
       *fileoff = 0;
@@ -752,9 +756,17 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       *lowbound = 0x820000;
       *highbound = 0x82ffff;
       *fileoff = mem->desc[4] - '0';
-    } else if (strncmp(mem->desc, "lock", 4) == 0) {
+    } else if (strncmp(mem->desc, "lock", 4) == 0) { // Lock or lockbits
       *lowbound = 0x830000;
       *highbound = 0x83ffff;
+      *fileoff = 0;
+    } else if (strcmp(mem->desc, "signature") == 0) { // Read only
+      *lowbound = 0x840000;
+      *highbound = 0x84ffff;
+      *fileoff = 0;
+    } else if (strncmp(mem->desc, "user", 4) == 0) { // Usersig or userrow
+      *lowbound = 0x850000;
+      *highbound = 0x85ffff;
       *fileoff = 0;
     } else {
       rv = -1;


### PR DESCRIPTION
This PR fixes Issue #1204

`elf2b()` only considers the first suitable section in any one program segment. However, the ELF format allows for a series of sections in segments; this PR fixes `elf2b()`'s deficiency.

The PR consists of 2 commits, the first of which rewrites `elf2b()` in an equivalent way by pulling in the function `elf_get_scn()` that used to find the *first* suitable section of a program segment.

The second commit changes the behaviour of `elf2b()` to do the right thing.
