### PR TITLE
Consider libreadline/libedit only in interactive mode

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1403,7 +1403,8 @@ int terminal_mode(PROGRAMMER *pgm, struct avrpart *p) {
   // GNU libreadline can also work if input is a pipe.
   // EditLine (NetBSD, MacOS) has issues with that, so only use it when
   // running interactively.
-  if (isatty(fileno(stdin)) || (strstr(rl_library_version, "EditLine wrapper") != 0))
+  // EditLine uses version 4.2 (0x0402).
+  if (isatty(fileno(stdin)) || (rl_readline_version >= 0x0500))
     return terminal_mode_interactive(pgm, p);
 #endif
   return terminal_mode_noninteractive(pgm, p);

--- a/src/term.c
+++ b/src/term.c
@@ -1400,7 +1400,10 @@ int terminal_mode_noninteractive(PROGRAMMER *pgm, struct avrpart *p) {
 
 int terminal_mode(PROGRAMMER *pgm, struct avrpart *p) {
 #if defined(HAVE_LIBREADLINE)
-  if (isatty(fileno(stdin)))
+  // GNU libreadline can also work if input is a pipe.
+  // EditLine (NetBSD, MacOS) has issues with that, so only use it when
+  // running interactively.
+  if (isatty(fileno(stdin)) || (strstr(rl_library_version, "EditLine wrapper") != 0))
     return terminal_mode_interactive(pgm, p);
 #endif
   return terminal_mode_noninteractive(pgm, p);

--- a/src/term.c
+++ b/src/term.c
@@ -1357,7 +1357,7 @@ void term_gotline(char *cmdstr) {
 }
 
 
-int terminal_mode(PROGRAMMER *pgm, struct avrpart *p) {
+int terminal_mode_interactive(PROGRAMMER *pgm, struct avrpart *p) {
   term_pgm = pgm;               // For callback routine
   term_p = p;
 
@@ -1379,10 +1379,10 @@ int terminal_mode(PROGRAMMER *pgm, struct avrpart *p) {
   return pgm->flush_cache(pgm, p);
 }
 
-#else
+#endif
 
 
-int terminal_mode(PROGRAMMER *pgm, struct avrpart *p) {
+int terminal_mode_noninteractive(PROGRAMMER *pgm, struct avrpart *p) {
   char *cmdbuf;
   int rc = 0;
 
@@ -1398,7 +1398,13 @@ int terminal_mode(PROGRAMMER *pgm, struct avrpart *p) {
   return pgm->flush_cache(pgm, p);
 }
 
+int terminal_mode(PROGRAMMER *pgm, struct avrpart *p) {
+#if defined(HAVE_LIBREADLINE)
+  if (isatty(fileno(stdin)))
+    return terminal_mode_interactive(pgm, p);
 #endif
+  return terminal_mode_noninteractive(pgm, p);
+}
 
 static void update_progress_tty(int percent, double etime, const char *hdr, int finish) {
   static char *header;


### PR DESCRIPTION
There's not much point in running the entire terminal mode session on top of libreadline or libedit, unless it is clear the session is really running interactively on a terminal.

Thus, only use the libreadline/libedit version if stdin points to a terminal. Otherwise, resort to the simple version without readline support. That ensures everything works well when running it within a pipeline.