### PR TITLE
Terminal read improvements

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -306,16 +306,13 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
         read_mem[i].addr = 0;
       read_mem[i].len = maxsize - read_mem[i].addr;
     } else if (argc == 4) {
-      unsigned long ul = strtol(argv[3], &end_ptr, 0);
+      unsigned long ul = strtoul(argv[3], &end_ptr, 0);
       if (*end_ptr || (end_ptr == argv[3])) {
         pmsg_error("(dump) cannot parse length %s\n", argv[3]);
         return -1;
       }
-      if (ul > INT_MAX) {
-        pmsg_error("(dump) %s cannot read 0x%lx bytes from start address 0x%0*x\n", mem->desc, ul,
-          mem->size > 0x10000? 5: 4, maxsize-1);
-        return -1;
-      }
+      if (ul == 0 || ul > INT_MAX) // Not positive if used as int, make it 1
+        ul = 1;
       read_mem[i].len = (int) ul;
     }
   }
@@ -345,6 +342,7 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
       pmsg_error("(dump) error reading %s address 0x%05lx of part %s\n", mem->desc, (long) read_mem[i].addr + j, p->desc);
       if (rc == -1)
         imsg_error("%*sread operation not supported on memory type %s\n", 7, "", mem->desc);
+      free(buf);
       return -1;
     }
     report_progress(j, read_mem[i].len, NULL);

--- a/src/term.c
+++ b/src/term.c
@@ -213,8 +213,9 @@ static int hexdump_buf(FILE *f, AVRMEM *m, int startaddr, unsigned char *buf, in
     int n = 16;
     if (n > len)
       n = len;
-    else if(addr + n > m->size)
+    if(addr + n > m->size)
       n = m->size - addr;
+
     hexdump_line(dst1, p, n, 48);
     chardump_line(dst2, p, n, 16);
     term_out("%0*x  %s  |%s|\n", m->size > 0x10000 ? 5: 4, addr, dst1, dst2);

--- a/src/term.c
+++ b/src/term.c
@@ -334,7 +334,7 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
   }
 
   if(argc < 4 && verbose)
-    term_out(">>> %s %s 0x%x 0x%x", argv[0], read_mem[i].mem->desc, read_mem[i].addr, read_mem[i].len);
+    term_out(">>> %s %s 0x%x 0x%x\n", argv[0], read_mem[i].mem->desc, read_mem[i].addr, read_mem[i].len);
 
   report_progress(0, 1, "Reading");
   for (int j = 0; j < read_mem[i].len; j++) {

--- a/src/term.c
+++ b/src/term.c
@@ -331,7 +331,7 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     return -1;
   }
 
-  if(argc < 4)
+  if(argc < 4 && verbose)
     term_out(">>> %s %s 0x%x 0x%x", argv[0], read_mem[i].mem->desc, read_mem[i].addr, read_mem[i].len);
 
   report_progress(0, 1, "Reading");

--- a/src/term.c
+++ b/src/term.c
@@ -314,7 +314,9 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
       if (ul > INT_MAX) {
         pmsg_error("(dump) %s cannot read 0x%lx bytes from start address 0x%0*x\n", mem->desc, ul,
           mem->size > 0x10000? 5: 4, maxsize-1);
+        return -1;
       }
+      read_mem[i].len = (int) ul;
     }
   }
   // Wrap around if the memory address is greater than the maximum size

--- a/src/term.c
+++ b/src/term.c
@@ -248,15 +248,26 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
   int maxsize = mem->size;
 
   // Preserve memory start address and length info for every readable memory
-  static struct mem_addr_len {
+  struct mem_addr_len {
     int addr;
     int len;
     AVRMEM *mem;
-  } read_mem[32];
+  };
+  static struct mem_addr_len* read_mem;
+  int n_mems = 0;
+  if (read_mem == NULL) {
+    for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln))
+      n_mems++;
+    read_mem = calloc(n_mems, sizeof(struct mem_addr_len));
+    if (read_mem == NULL) {
+      pmsg_error("(dump) out of memory\n");
+      return -1;
+    }
+  }
 
   // Iterate though the structs to find relevant address and length info
   int i;
-  for(i = 0; i < 32; i++) {
+  for(i = 0; i < n_mems; i++) {
     if (read_mem[i].mem == NULL) { // Memory not read / no match
       read_mem[i].mem = mem;
       if (read_mem[i].len == 0)

--- a/src/term.c
+++ b/src/term.c
@@ -308,7 +308,7 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     }
   }
   // No address or length specified
-  else if (argc == 2) {
+  else {
     if (strncmp(prevmem, memtype, strlen(memtype)) != 0) {
       prevmem = cache_string(mem->desc);
     }

--- a/src/term.c
+++ b/src/term.c
@@ -230,15 +230,14 @@ static int hexdump_buf(FILE *f, AVRMEM *m, int startaddr, unsigned char *buf, in
 
 
 static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
-  struct mem_addr_len {
+  static struct mem_addr_len {
     int addr;
     int len;
     AVRMEM *mem;
-  };
-  static struct mem_addr_len* read_mem;
+  } read_mem[32];
   static int i;
 
-  if ((argc < 2 && read_mem == NULL) || argc > 4) {
+  if ((argc < 2 && read_mem[0].mem == NULL) || argc > 4) {
     msg_error(
       "Usage: %s <memory> <addr> <len>\n"
       "       %s <memory> <addr> ...\n"
@@ -263,20 +262,8 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
   }
   int maxsize = mem->size;
 
-  // Preserve memory start address and length info for every readable memory
-  static int n_mems = 0;
-  if (read_mem == NULL) {
-    for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln))
-      n_mems++;
-    read_mem = calloc(n_mems, sizeof(struct mem_addr_len));
-    if (read_mem == NULL) {
-      pmsg_error("(dump) out of memory\n");
-      return -1;
-    }
-  }
-
   // Iterate through the read_mem structs to find relevant address and length info
-  for(i = 0; i < n_mems; i++) {
+  for(i = 0; i < 32; i++) {
     if (read_mem[i].mem == NULL) {
       read_mem[i].mem = mem;
       if (read_mem[i].len == 0)

--- a/src/term.c
+++ b/src/term.c
@@ -354,7 +354,7 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
 
   free(buf);
 
-  read_mem[i].addr = read_mem[i].addr + read_mem[i].len;
+  read_mem[i].addr = (read_mem[i].addr + read_mem[i].len) % maxsize;
 
   return 0;
 }

--- a/src/term.c
+++ b/src/term.c
@@ -217,7 +217,7 @@ static int hexdump_buf(FILE *f, AVRMEM *m, int startaddr, unsigned char *buf, in
       n = m->size - addr;
     hexdump_line(dst1, p, n, 48);
     chardump_line(dst2, p, n, 16);
-    term_out("%0*x  %s  |%s|\n", m->size > 0xffff ? 5: 4, addr, dst1, dst2);
+    term_out("%0*x  %s  |%s|\n", m->size > 0x10000 ? 5: 4, addr, dst1, dst2);
     len -= n;
     addr += n;
     if (addr >= m->size)

--- a/src/term.c
+++ b/src/term.c
@@ -319,6 +319,9 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     return -1;
   }
 
+  if(argc < 4)
+    term_out(">>> %s %s 0x%x 0x%x", argv[0], read_mem[i].mem->desc, read_mem[i].addr, read_mem[i].len);
+
   report_progress(0, 1, "Reading");
   for (int j = 0; j < read_mem[i].len; j++) {
     int addr = (read_mem[i].addr + j) % mem->size;
@@ -1281,13 +1284,6 @@ static int process_line(char *cmdbuf, PROGRAMMER *pgm, struct avrpart *p) {
 
   if(!argv)
     return -1;
-
-#if !defined(HAVE_LIBREADLINE) || defined(WIN32) || defined(__APPLE__)
-    term_out(">>> ");
-    for (int i=0; i<argc; i++)
-      term_out("%s ", argv[i]);
-    term_out("\n");
-#endif
 
   // Run the command
   rc = do_cmd(pgm, p, argc, argv);

--- a/src/term.c
+++ b/src/term.c
@@ -250,7 +250,6 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
   }
 
   enum { read_size = 256 };
-  static const char *prevmem = "";
   char *memtype;
   if(argc > 1)
     memtype = argv[1];
@@ -292,7 +291,6 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
 
   // Get no. bytes to read if present
   if (argc >= 3) {
-    prevmem = cache_string("");
     if (strcmp(argv[argc - 1], "...") == 0) {
       if (argc == 3)
         read_mem[i].addr = 0;
@@ -308,13 +306,8 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     }
   }
   // No address or length specified
-  else {
-    if (strncmp(prevmem, memtype, strlen(memtype)) != 0) {
-      prevmem = cache_string(mem->desc);
-    }
-    if (read_mem[i].addr >= maxsize)
-      read_mem[i].addr = 0; // Wrap around
-  }
+  else if(read_mem[i].addr >= maxsize)
+    read_mem[i].addr = 0; // Wrap around
 
   // Trim len if nessary to prevent reading from the same memory address twice
   if (read_mem[i].len > maxsize)

--- a/src/term.c
+++ b/src/term.c
@@ -264,16 +264,18 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
 
   // Iterate through the read_mem structs to find relevant address and length info
   for(i = 0; i < 32; i++) {
-    if (read_mem[i].mem == NULL) {
+    if(read_mem[i].mem == NULL)
       read_mem[i].mem = mem;
-      if (read_mem[i].len == 0)
-        read_mem[i].len = maxsize > read_size? read_size: maxsize;
-      break;
-    } else if (read_mem[i].mem == mem) {
-      if (read_mem[i].len == 0)
+    if(read_mem[i].mem == mem) {
+      if(read_mem[i].len == 0)
         read_mem[i].len = maxsize > read_size? read_size: maxsize;
       break;
     }
+  }
+
+  if(i >= 32) { // Catch highly unlikely case
+    pmsg_error("read_mem[] under-dimensioned; increase and recompile\n");
+    return -1;
   }
 
   // Get start address if present

--- a/src/term.c
+++ b/src/term.c
@@ -267,11 +267,11 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     if (read_mem[i].mem == NULL) {
       read_mem[i].mem = mem;
       if (read_mem[i].len == 0)
-        read_mem[i].len = read_size;
+        read_mem[i].len = maxsize > read_size? read_size: maxsize;
       break;
     } else if (read_mem[i].mem == mem) {
       if (read_mem[i].len == 0)
-        read_mem[i].len = read_size;
+        read_mem[i].len = maxsize > read_size? read_size: maxsize;
       break;
     }
   }

--- a/src/term.c
+++ b/src/term.c
@@ -217,7 +217,7 @@ static int hexdump_buf(FILE *f, AVRMEM *m, int startaddr, unsigned char *buf, in
       n = m->size - addr;
     hexdump_line(dst1, p, n, 48);
     chardump_line(dst2, p, n, 16);
-    term_out("%04x  %s  |%s|\n", addr, dst1, dst2);
+    term_out("%0*x  %s  |%s|\n", m->size > 0xffff ? 5: 4, addr, dst1, dst2);
     len -= n;
     addr += n;
     if (addr >= m->size)

--- a/src/term.c
+++ b/src/term.c
@@ -315,9 +315,9 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
       read_mem[i].addr = 0; // Wrap around
   }
 
-  // Trim len if nessary to not read past the end of memory
-  //if ((read_mem[i].addr + read_mem[i].len) > maxsize)
-  //  read_mem[i].len = maxsize - read_mem[i].addr;
+  // Trim len if nessary to prevent reading from the same memory address twice
+  if (read_mem[i].len > maxsize)
+    read_mem[i].len = maxsize;
 
   uint8_t *buf = malloc(read_mem[i].len);
   if (buf == NULL) {

--- a/src/term.c
+++ b/src/term.c
@@ -260,7 +260,12 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
     pmsg_error("(dump) %s memory type not defined for part %s\n", memtype, p->desc);
     return -1;
   }
+
   int maxsize = mem->size;
+  if(maxsize <= 0) { // Sanity check
+    pmsg_error("cannot read memory %s of size %d\n", mem->desc, maxsize);
+    return -1;
+  }
 
   // Iterate through the read_mem structs to find relevant address and length info
   for(i = 0; i < 32; i++) {
@@ -281,14 +286,17 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
   // Get start address if present
   char *end_ptr;
   if (argc >= 3 && strcmp(argv[2], "...") != 0) {
-    read_mem[i].addr = strtoul(argv[2], &end_ptr, 0);
-    if (*end_ptr || (end_ptr == argv[2])) {
+    unsigned long ul = strtoul(argv[2], &end_ptr, 0);
+    if(*end_ptr || (end_ptr == argv[2])) {
       pmsg_error("(dump) cannot parse address %s\n", argv[2]);
       return -1;
-    } else if (read_mem[i].addr < 0 || read_mem[i].addr >= maxsize) {
-      pmsg_error("(dump) %s address 0x%05x is out of range [0, 0x%05x]\n", mem->desc, read_mem[i].addr, maxsize-1);
+    }
+    if(ul > INT_MAX || ul >= (unsigned long) maxsize) {
+      pmsg_error("(dump) %s address 0x%lx is out of range [0, 0x%0*x]\n", mem->desc, ul,
+        mem->size > 0x10000? 5: 4, maxsize-1);
       return -1;
     }
+    read_mem[i].addr = (int) ul;
   }
 
   // Get no. bytes to read if present
@@ -298,17 +306,19 @@ static int cmd_dump(PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]) {
         read_mem[i].addr = 0;
       read_mem[i].len = maxsize - read_mem[i].addr;
     } else if (argc == 4) {
-      read_mem[i].len = strtol(argv[3], &end_ptr, 0);
+      unsigned long ul = strtol(argv[3], &end_ptr, 0);
       if (*end_ptr || (end_ptr == argv[3])) {
         pmsg_error("(dump) cannot parse length %s\n", argv[3]);
         return -1;
       }
-    } else {
-      read_mem[i].len = read_size;
+      if (ul > INT_MAX) {
+        pmsg_error("(dump) %s cannot read 0x%lx bytes from start address 0x%0*x\n", mem->desc, ul,
+          mem->size > 0x10000? 5: 4, maxsize-1);
+      }
     }
   }
-  // No address or length specified
-  else if(read_mem[i].addr >= maxsize)
+  // Wrap around if the memory address is greater than the maximum size
+  if(read_mem[i].addr >= maxsize)
     read_mem[i].addr = 0; // Wrap around
 
   // Trim len if nessary to prevent reading from the same memory address twice


### PR DESCRIPTION
Addresses issue #1201.

This PR improves the terminal read functionality.

<details>
<summary>It's now possible to run <b>read</b> or <b>read [mem]</b>, and the command will continue where the previous left off</summary>

```
$ ./avrdude -pavr128db48 -cpkobn_updi -t -B0.5

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 2000 kHz
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e970c (probably avr128db48)
avrdude> read
>>> read 
Usage: read <memory> <addr> <len>
       read <memory> <addr> ...
       read <memory> <addr>
       read <memory> ...
       read <memory>
avrdude> read flash 0 0x20
>>> read flash 0 0x20 

Reading | ################################################## | 100% 0.03 s 

00000  47 c0 00 00 55 c0 00 00  53 c0 00 00 51 c0 00 00  |G...U...S...Q...|
00010  4f c0 00 00 4d c0 00 00  4b c0 00 00 49 c0 00 00  |O...M...K...I...|

avrdude> read flash
>>> read flash 

Reading | ################################################## | 100% 0.00 s 

00020  47 c0 00 00 45 c0 00 00  43 c0 00 00 41 c0 00 00  |G...E...C...A...|
00030  3f c0 00 00 3d c0 00 00  3b c0 00 00 39 c0 00 00  |?...=...;...9...|

avrdude> read
>>> read 

Reading | ################################################## | 100% 0.00 s 

00040  37 c0 00 00 35 c0 00 00  33 c0 00 00 31 c0 00 00  |7...5...3...1...|
00050  2f c0 00 00 2d c0 00 00  2b c0 00 00 29 c0 00 00  |/...-...+...)...|

avrdude> read eeprom 0 0x10
>>> read eeprom 0 0x10 

Reading | ################################################## | 100% 0.06 s 

0000  48 65 6c 6c 6f 20 57 6f  72 6c 64 20 45 45 50 52  |Hello World EEPR|

avrdude> read
>>> read 

Reading | ################################################## | 100% 0.06 s 

0010  4f 4d 20 77 72 69 74 65  20 74 65 73 74 00 ff ff  |OM write test...|

avrdude> read flash
>>> read flash 

Reading | ################################################## | 100% 0.00 s 

00060  27 c0 00 00 97 c0 00 00  23 c0 00 00 21 c0 00 00  |'.......#...!...|
00070  1f c0 00 00 1d c0 00 00  1b c0 00 00 19 c0 00 00  |................|

avrdude> read
>>> read 

Reading | ################################################## | 100% 0.00 s 

00080  17 c0 00 00 15 c0 00 00  13 c0 00 00 11 c0 00 00  |................|
00090  11 24 1f be cf ef cd bf  df e3 de bf 28 e2 a0 e0  |.$..........(...|

avrdude> quit
>>> quit 
avrdude> 
avrdude done.  Thank you.
```

</details>


<details>
<summary><b>read/dump</b> now support memory rollover</summary>

```
$ ./avrdude -pavr128db48 -cpkobn_updi -t -B0.5

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 2000 kHz
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e970c (probably avr128db48)
avrdude> read flash 0x1ffd3 0x100
>>> read flash 0x1ffd3 0x100 

Reading | ################################################## | 100% 0.06 s 

1ffd3  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
1ffe3  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
1fff3  ff ff ff ff ff ff ff ff  ff ff ff ff ff           |.............   |
00000  47 c0 00 00 55 c0 00 00  53 c0 00 00 51 c0 00 00  |G...U...S...Q...|
00010  4f c0 00 00 4d c0 00 00  4b c0 00 00 49 c0 00 00  |O...M...K...I...|
00020  47 c0 00 00 45 c0 00 00  43 c0 00 00 41 c0 00 00  |G...E...C...A...|
00030  3f c0 00 00 3d c0 00 00  3b c0 00 00 39 c0 00 00  |?...=...;...9...|
00040  37 c0 00 00 35 c0 00 00  33 c0 00 00 31 c0 00 00  |7...5...3...1...|
00050  2f c0 00 00 2d c0 00 00  2b c0 00 00 29 c0 00 00  |/...-...+...)...|
00060  27 c0 00 00 97 c0 00 00  23 c0 00 00 21 c0 00 00  |'.......#...!...|
00070  1f c0 00 00 1d c0 00 00  1b c0 00 00 19 c0 00 00  |................|
00080  17 c0 00 00 15 c0 00 00  13 c0 00 00 11 c0 00 00  |................|
00090  11 24 1f be cf ef cd bf  df e3 de bf 28 e2 a0 e0  |.$..........(...|
000a0  b8 e2 01 c0 1d 92 a4 30  b2 07 e1 f7 9b d0 26 c1  |.......0......&.|
000b0  a7 cf 90 91 01 0a 9f 7e  90 93 01 0a 90 91 60 04  |..... .~... ..`.|
000c0  93 ff 0a c0 81 11 04 c0  88 e0 80 93 66 04 08 95  |.. .........f...|
000d0  88 e0 80                                          |...             |

avrdude> read fuse0 0 0x10
>>> read fuse0 0 0x10 

Reading | ################################################## | 100% 0.00 s 

0000  00                                                |.               |

avrdude> read sig
>>> read sig 

Reading | ################################################## | 100% 0.00 s 

0000  1e 97 0c                                          |..              |

avrdude> read flash 0x1ffdc ...
>>> read flash 0x1ffdc ... 

Reading | ################################################## | 100% 0.00 s 

1ffdc  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
1ffec  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
1fffc  ff ff ff ff                                       |....            |

avrdude> quit
>>> quit 
avrdude> 
avrdude done.  Thank you.
```

</details>

<details>
<summary>Add a pad byte to the address if the memory that's being read from is greater than 64kiB</summary>

See how the number of padding bytes varies between flash and EEPROM read:

```
$ ./avrdude -pavr128db48 -cpkobn_updi -t -B0.5

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 2000 kHz
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e970c (probably avr128db48)
avrdude> read flash 0 0x100
>>> read flash 0 0x100 

Reading | ################################################## | 100% 0.03 s 

00000  47 c0 00 00 55 c0 00 00  53 c0 00 00 51 c0 00 00  |G...U...S...Q...|
00010  4f c0 00 00 4d c0 00 00  4b c0 00 00 49 c0 00 00  |O...M...K...I...|
00020  47 c0 00 00 45 c0 00 00  43 c0 00 00 41 c0 00 00  |G...E...C...A...|
00030  3f c0 00 00 3d c0 00 00  3b c0 00 00 39 c0 00 00  |?...=...;...9...|
00040  37 c0 00 00 35 c0 00 00  33 c0 00 00 31 c0 00 00  |7...5...3...1...|
00050  2f c0 00 00 2d c0 00 00  2b c0 00 00 29 c0 00 00  |/...-...+...)...|
00060  27 c0 00 00 97 c0 00 00  23 c0 00 00 21 c0 00 00  |'.......#...!...|
00070  1f c0 00 00 1d c0 00 00  1b c0 00 00 19 c0 00 00  |................|
00080  17 c0 00 00 15 c0 00 00  13 c0 00 00 11 c0 00 00  |................|
00090  11 24 1f be cf ef cd bf  df e3 de bf 28 e2 a0 e0  |.$..........(...|
000a0  b8 e2 01 c0 1d 92 a4 30  b2 07 e1 f7 9b d0 26 c1  |.......0......&.|
000b0  a7 cf 90 91 01 0a 9f 7e  90 93 01 0a 90 91 60 04  |..... .~... ..`.|
000c0  93 ff 0a c0 81 11 04 c0  88 e0 80 93 66 04 08 95  |.. .........f...|
000d0  88 e0 80 93 65 04 08 95  9f b7 f8 94 81 11 07 c0  |....e...........|
000e0  80 91 73 04 87 7f 80 93  73 04 9f bf 08 95 80 91  |..s.....s.......|
000f0  73 04 88 60 f8 cf 8f b7  f8 94 20 91 00 28 30 91  |s..`...... ..(0.|

avrdude> read eeprom 0 0x80
>>> read eeprom 0 0x80 

Reading | ################################################## | 100% 0.52 s 

0000  48 65 6c 6c 6f 20 57 6f  72 6c 64 20 45 45 50 52  |Hello World EEPR|
0010  4f 4d 20 77 72 69 74 65  20 74 65 73 74 00 ff ff  |OM write test...|
0020  41 56 52 44 55 44 45 20  2d 20 41 56 52 20 44 6f  |AVRDUDE - AVR Do|
0030  77 6e 6c 6f 61 64 65 72  20 55 70 6c 6f 61 64 65  |wnloader Uploade|
0040  72 20 2d 20 69 73 20 61  20 70 72 6f 67 72 61 6d  |r - is a program|
0050  20 66 6f 72 20 64 6f 77  6e 6c 6f 61 64 69 6e 67  | for downloading|
0060  20 61 6e 64 20 75 70 6c  6f 61 64 69 6e 67 20 74  | and uploading t|
0070  68 65 20 6f 6e 2d 63 68  69 70 20 6d 65 6d 6f 72  |he on-chip memor|

avrdude> quit
>>> quit 
avrdude> 
avrdude done.  Thank you.
```

</details>


#### What I'd like to add to this PR if @dl8dtl and/or @stefanrueger agree:

* Remove the `>>>` echo. Why is this needed? It only takes up screen estate, and only prints exactly what you just typed, which is also printed on the screen, on the line above.
* Add a dedicated `>>>` output to terminal read to show the user what the **read** or **read [mem]** command is actually doing, (and print this if verbosity level is 1 or greater?)

<details>
<summary>Example output:</summary>

```
$ ./avrdude -pavr128db48 -cpkobn_updi -t -B0.5

         Vtarget                      : 3.31 V
         PDI/UPDI clock Xmega/megaAVR : 2000 kHz
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e970c (probably avr128db48)
avrdude> read flash 0 0x20
>>> read flash 0 0x20 

Reading | ################################################## | 100% 0.03 s 

00000  47 c0 00 00 55 c0 00 00  53 c0 00 00 51 c0 00 00  |G...U...S...Q...|
00010  4f c0 00 00 4d c0 00 00  4b c0 00 00 49 c0 00 00  |O...M...K...I...|

avrdude> read 
>>> read 

Reading | ################################################## | 100% 0.00 s 

00020  47 c0 00 00 45 c0 00 00  43 c0 00 00 41 c0 00 00  |G...E...C...A...|
00030  3f c0 00 00 3d c0 00 00  3b c0 00 00 39 c0 00 00  |?...=...;...9...|

avrdude> verbose 1
>>> verbose 1 
New verbosity level: 1
avrdude> read
>>> read 
>>> read flash 0x40 0x20
Reading | ################################################## | 100% 0.00 s 

00040  37 c0 00 00 35 c0 00 00  33 c0 00 00 31 c0 00 00  |7...5...3...1...|
00050  2f c0 00 00 2d c0 00 00  2b c0 00 00 29 c0 00 00  |/...-...+...)...|

avrdude> read
>>> read 
>>> read flash 0x60 0x20
Reading | ################################################## | 100% 0.00 s 

00060  27 c0 00 00 97 c0 00 00  23 c0 00 00 21 c0 00 00  |'.......#...!...|
00070  1f c0 00 00 1d c0 00 00  1b c0 00 00 19 c0 00 00  |................|

avrdude> read
>>> read 
>>> read flash 0x80 0x20
Reading | ################################################## | 100% 0.00 s 

00080  17 c0 00 00 15 c0 00 00  13 c0 00 00 11 c0 00 00  |................|
00090  11 24 1f be cf ef cd bf  df e3 de bf 28 e2 a0 e0  |.$..........(...|

avrdude> read eeprom
>>> read eeprom 
>>> read eeprom 0x0 0x100
Reading | ################################################## | 100% 1.03 s 

0000  48 65 6c 6c 6f 20 57 6f  72 6c 64 20 45 45 50 52  |Hello World EEPR|
0010  4f 4d 20 77 72 69 74 65  20 74 65 73 74 00 ff ff  |OM write test...|
0020  41 56 52 44 55 44 45 20  2d 20 41 56 52 20 44 6f  |AVRDUDE - AVR Do|
0030  77 6e 6c 6f 61 64 65 72  20 55 70 6c 6f 61 64 65  |wnloader Uploade|
0040  72 20 2d 20 69 73 20 61  20 70 72 6f 67 72 61 6d  |r - is a program|
0050  20 66 6f 72 20 64 6f 77  6e 6c 6f 61 64 69 6e 67  | for downloading|
0060  20 61 6e 64 20 75 70 6c  6f 61 64 69 6e 67 20 74  | and uploading t|
0070  68 65 20 6f 6e 2d 63 68  69 70 20 6d 65 6d 6f 72  |he on-chip memor|
0080  69 65 73 20 6f 66 20 4d  69 63 72 6f 63 68 69 70  |ies of Microchip|
0090  e2 80 99 73 20 41 56 52  20 6d 69 63 72 6f 63 6f  |...s AVR microco|
00a0  6e 74 72 6f 6c 6c 65 72  73 2e 20 49 74 20 63 61  |ntrollers. It ca|
00b0  6e 20 70 72 6f 67 72 61  6d 20 74 68 65 20 46 6c  |n program the Fl|
00c0  61 73 68 20 61 6e 64 20  45 45 50 52 4f 4d 2c 20  |ash and EEPROM, |
00d0  61 6e 64 20 77 68 65 72  65 20 73 75 70 70 6f 72  |and where suppor|
00e0  74 65 64 20 62 79 20 74  68 65 20 70 72 6f 67 72  |ted by the progr|
00f0  61 6d 6d 69 6e 67 20 70  72 6f 74 6f 63 6f 6c 2c  |amming protocol,|

avrdude> read eeprom
>>> read eeprom 
>>> read eeprom 0x100 0x100
Reading | ################################################## | 100% 1.03 s 

0100  20 69 74 20 63 61 6e 20  70 72 6f 67 72 61 6d 20  | it can program |
0110  66 75 73 65 20 61 6e 64  20 6c 6f 63 6b 20 62 69  |fuse and lock bi|
0120  74 73 2e 20 41 56 52 44  55 44 45 20 61 6c 73 6f  |ts. AVRDUDE also|
0130  20 73 75 70 70 6c 69 65  73 20 61 20 64 69 72 65  | supplies a dire|
0140  63 74 20 69 6e 73 74 72  75 63 74 69 6f 6e 20 6d  |ct instruction m|
0150  6f 64 65 20 61 6c 6c 6f  77 69 6e 67 20 6f 6e 65  |ode allowing one|
0160  20 74 6f 20 69 73 73 75  65 20 61 6e 79 20 70 72  | to issue any pr|
0170  6f 67 72 61 6d 6d 69 6e  67 20 69 6e 73 74 72 75  |ogramming instru|
0180  63 74 69 6f 6e 20 74 6f  20 74 68 65 20 41 56 52  |ction to the AVR|
0190  20 63 68 69 70 20 72 65  67 61 72 64 6c 65 73 73  | chip regardless|
01a0  20 6f 66 20 77 68 65 74  68 65 72 20 41 56 52 44  | of whether AVRD|
01b0  55 44 45 20 69 6d 70 6c  65 6d 65 6e 74 73 20 74  |UDE implements t|
01c0  68 61 74 20 73 70 65 63  69 66 69 63 20 66 65 61  |hat specific fea|
01d0  74 75 72 65 20 6f 66 20  61 20 70 61 72 74 69 63  |ture of a partic|
01e0  75 6c 61 72 20 63 68 69  70 2e 00 ff ff ff ff ff  |ular chip.......|
01f0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|

avrdude> read
>>> read 
>>> read eeprom 0x200 0x100
Reading | ################################################## | 100% 0.00 s 

0000  48 65 6c 6c 6f 20 57 6f  72 6c 64 20 45 45 50 52  |Hello World EEPR|
0010  4f 4d 20 77 72 69 74 65  20 74 65 73 74 00 ff ff  |OM write test...|
0020  41 56 52 44 55 44 45 20  2d 20 41 56 52 20 44 6f  |AVRDUDE - AVR Do|
0030  77 6e 6c 6f 61 64 65 72  20 55 70 6c 6f 61 64 65  |wnloader Uploade|
0040  72 20 2d 20 69 73 20 61  20 70 72 6f 67 72 61 6d  |r - is a program|
0050  20 66 6f 72 20 64 6f 77  6e 6c 6f 61 64 69 6e 67  | for downloading|
0060  20 61 6e 64 20 75 70 6c  6f 61 64 69 6e 67 20 74  | and uploading t|
0070  68 65 20 6f 6e 2d 63 68  69 70 20 6d 65 6d 6f 72  |he on-chip memor|
0080  69 65 73 20 6f 66 20 4d  69 63 72 6f 63 68 69 70  |ies of Microchip|
0090  e2 80 99 73 20 41 56 52  20 6d 69 63 72 6f 63 6f  |...s AVR microco|
00a0  6e 74 72 6f 6c 6c 65 72  73 2e 20 49 74 20 63 61  |ntrollers. It ca|
00b0  6e 20 70 72 6f 67 72 61  6d 20 74 68 65 20 46 6c  |n program the Fl|
00c0  61 73 68 20 61 6e 64 20  45 45 50 52 4f 4d 2c 20  |ash and EEPROM, |
00d0  61 6e 64 20 77 68 65 72  65 20 73 75 70 70 6f 72  |and where suppor|
00e0  74 65 64 20 62 79 20 74  68 65 20 70 72 6f 67 72  |ted by the progr|
00f0  61 6d 6d 69 6e 67 20 70  72 6f 74 6f 63 6f 6c 2c  |amming protocol,|

avrdude> quit
>>> quit 
avrdude> 
avrdude done.  Thank you.
```

</details>