### PR TITLE
Print meaningful error when a too slow ISP clock is detected

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1242,8 +1242,11 @@ int main(int argc, char * argv [])
   init_ok = (rc = pgm->initialize(pgm, p)) >= 0;
   if (!init_ok) {
     pmsg_error("initialization failed, rc=%d\n", rc);
-    imsg_error("- double check the connections and try again\n");
-    imsg_error("- use -B to set lower ISP clock frequency, e.g. -B 200kHz\n");
+    if(rc == -2)
+      imsg_error("The programmer ISP clock is too fast for the target\n");
+    else
+      imsg_error("- double check the connections and try again\n");
+    imsg_error("- use -B to set lower ISP clock frequency, e.g. -B 125kHz\n");
     if (!ovsigck) {
       imsg_error("- use -F to override this check\n\n");
       exitrc = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -1243,7 +1243,7 @@ int main(int argc, char * argv [])
   if (!init_ok) {
     pmsg_error("initialization failed, rc=%d\n", rc);
     if(rc == -2)
-      imsg_error("The programmer ISP clock is too fast for the target\n");
+      imsg_error("the programmer ISP clock is too fast for the target\n");
     else
       imsg_error("- double check the connections and try again\n");
     imsg_error("- use -B to set lower ISP clock frequency, e.g. -B 125kHz\n");

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -795,6 +795,11 @@ retry:
   // attempt to read the status back
   status = stk500v2_recv(pgm,buf,maxlen);
 
+  DEBUG("STK500V2: stk500v2_command() received content: [ ");
+  for (size_t i=0; i<len; i++)
+    DEBUG("0x%02x ",buf[i]);
+  DEBUG("], length %d\n", (int) len);
+
   // if we got a successful readback, return
   if (status > 0) {
     DEBUG(" = %d\n",status);
@@ -858,6 +863,9 @@ retry:
             return status;
         } else if (buf[1] == STATUS_CMD_FAILED) {
             pmsg_error("command failed\n");
+        } else if (buf[1] == STATUS_CLOCK_ERROR) {
+            pmsg_error("target clock speed error\n");
+            return -2;
         } else if (buf[1] == STATUS_CMD_UNKNOWN) {
             pmsg_error("unknown command\n");
         } else {

--- a/src/stk500v2_private.h
+++ b/src/stk500v2_private.h
@@ -138,6 +138,9 @@
 #define STATUS_CKSUM_ERROR                  0xC1
 #define STATUS_CMD_UNKNOWN                  0xC9
 #define STATUS_CMD_ILLEGAL_PARAMETER        0xCA
+#define STATUS_PHY_ERROR                    0xCB
+#define STATUS_CLOCK_ERROR                  0xCC
+#define STATUS_BAUD_INVALID                 0xCD
 
 // Status
 #define STATUS_ISP_READY                    0x00


### PR DESCRIPTION
Some JTAG3 compatible programmers can actually detect if the connected target is too slow for the (a) default ISP clock or (b) user-specified ISP clock using -B.

This includes the PICkit4, Atmel ICE and Power Debugger. I don't think the SNAP has this capability. At least I've not been able to get it to detect it.

The thing is that the programmer returns a 0xCC if the target is too slow to communicate. This will only work when the target _has_ a clock. If no clock is preset, we'll get the usual 0xC0 error.

Here's an example where the ATmega16 is running at 1 MHz
```
$ ./avrdude -catmelice_isp -patmega16 -B2

avrdude error: target clock speed error
avrdude error: initialization failed, rc=-2
        The programmer ISP clock is too fast for the target
        - use -B to set lower ISP clock frequency, e.g. -B 125kHz
        - use -F to override this check


avrdude done.  Thank you.

$ ./avrdude -catmelice_isp -patmega16 -B4

avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9403 (probably m16)

avrdude done.  Thank you.
```

