### PR TITLE
Read programmer serial number from libusb or hidusb

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2380,17 +2380,18 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   msg_info("%sICE HW version  : %d\n", p, parms[0]);
   msg_info("%sICE FW version  : %d.%02d (rel. %d)\n", p, parms[1], parms[2],
            (parms[3] | (parms[4] << 8)));
-  msg_info("%sSerial number   : %s\n", p, sn);
+  msg_info("%sSerial number   : %s", p, sn);
   free(resp);
-
-  if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, parms, 2) < 0)
-    return;
-  msg_info("%sVtarget         : %.2f V", p, b2_to_u16(parms)/1000.0);
 }
 
 
 void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
+  unsigned char prog_mode[2];
   unsigned char buf[3];
+
+  if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
+    return;
+  msg_info("%sVtarget         : %.2f V\n", p, b2_to_u16(buf)/1000.0);
 
   // Print features unique to the Power Debugger
   for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
@@ -2401,8 +2402,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
         return;
       analog_raw_data = b2_to_u16(buf);
-      fmsg_out(fp, "%sVout set        %s: %.2f V\n", p,
-               verbose? "": "             ", analog_raw_data / 1000.0);
+      fmsg_out(fp, "%sVout set        : %.2f V\n", p, analog_raw_data / 1000.0);
 
       // Read measured generator voltage value (VOUT)
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_TSUP_VOLTAGE_MEAS, buf, 2) < 0)
@@ -2413,8 +2413,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sVout measured   %s: %.02f V\n", p,
-                 verbose? "": "             ", ((float) analog_raw_data / -200.0));
+        fmsg_out(fp, "%sVout measured   : %.02f V\n", p, (float) analog_raw_data / -200.0);
       }
 
       // Read channel A voltage
@@ -2426,8 +2425,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh A voltage    %s: %.03f V\n", p,
-                 verbose? "": "             ", ((float) analog_raw_data / -200.0));
+        fmsg_out(fp, "%sCh A voltage    : %.03f V\n", p, (float) analog_raw_data / -200.0);
       }
 
       // Read channel A current
@@ -2437,8 +2435,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       if (buf[0] != 0x90)
         pmsg_error("invalid PARM3_ANALOG_A_CURRENT data packet format\n");
       else
-        fmsg_out(fp, "%sCh A current    %s: %.3f mA\n", p,
-                 verbose? "": "             ", (float) analog_raw_data * 0.003472);
+        fmsg_out(fp, "%sCh A current    : %.3f mA\n", p, (float) analog_raw_data * 0.003472);
 
       // Read channel B voltage
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_B_VOLTAGE, buf, 2) < 0)
@@ -2449,8 +2446,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh B voltage    %s: %.03f V\n", p,
-                 verbose? "": "             ", (float) analog_raw_data / -200.0);
+        fmsg_out(fp, "%sCh B voltage    : %.03f V\n", p, (float) analog_raw_data / -200.0);
       }
 
       // Read channel B current
@@ -2462,8 +2458,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh B current    %s: %.3f mA\n", p,
-                 verbose? "": "             ", (float) analog_raw_data * 0.555556);
+        fmsg_out(fp, "%sCh B current    : %.3f mA\n", p, (float) analog_raw_data * 0.555556);
       }
       break;
     }
@@ -2471,34 +2466,37 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
 
   // Print clocks if programmer typ is not TPI
   if (strcmp(pgm->type, "JTAGICE3_TPI")) {
-    if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_PROG, buf, 2) < 0)
+    // Get current programming mode and target type from to determine what data to print
+    if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, prog_mode, 1) < 0)
       return;
+    if (jtag3_getparm(pgm, SCOPE_AVR, 0, PARM3_ARCH, &prog_mode[1], 1) < 0)
+      return;
+    if (prog_mode[0] == PARM3_CONN_JTAG) {
+      if (prog_mode[1] == PARM3_ARCH_XMEGA) {
+        if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_JTAG, buf, 2) < 0)
+          return;
+        if (b2_to_u16(buf) > 0)
+          fmsg_out(fp, "%sJTAG clk Xmega  : %u kHz\n", p, b2_to_u16(buf));
+      } else {
+        if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_PROG, buf, 2) < 0)
+          return;
+        if (b2_to_u16(buf) > 0)
+          fmsg_out(fp, "%sJTAG clk prog.  : %u kHz\n", p, b2_to_u16(buf));
 
-    if (b2_to_u16(buf) > 0) {
-      fmsg_out(fp, "%sJTAG clock megaAVR/program   : %u kHz\n", p, b2_to_u16(buf));
+        if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_DEBUG, buf, 2) < 0)
+          return;
+        if (b2_to_u16(buf) > 0)
+          fmsg_out(fp, "%sJTAG clk debug  : %u kHz\n", p, b2_to_u16(buf));
+      }
     }
-
-    if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_DEBUG, buf, 2) < 0)
-      return;
-
-    if (b2_to_u16(buf) > 0) {
-      fmsg_out(fp, "%sJTAG clock megaAVR/debug     : %u kHz\n", p, b2_to_u16(buf));
-    }
-
-    if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_JTAG, buf, 2) < 0)
-      return;
-
-    if (b2_to_u16(buf) > 0) {
-      fmsg_out(fp, "%sJTAG clock Xmega             : %u kHz\n", p, b2_to_u16(buf));
-    }
-
-    if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_PDI, buf, 2) < 0)
-      return;
-
-    if (b2_to_u16(buf) > 0) {
-      fmsg_out(fp, "%sPDI/UPDI clock Xmega/megaAVR : %u kHz\n", p, b2_to_u16(buf));
+    else if (prog_mode[0] == PARM3_CONN_PDI || prog_mode[0] == PARM3_CONN_UPDI) {
+      if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_PDI, buf, 2) < 0)
+        return;
+      if (b2_to_u16(buf) > 0)
+        fmsg_out(fp, "%sPDI/UPDI clk    : %u kHz\n", p, b2_to_u16(buf));
     }
   }
+  fmsg_out(fp, "\n");
 }
 
 static void jtag3_print_parms(const PROGRAMMER *pgm, FILE *fp) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2324,6 +2324,7 @@ int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
 
 void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   unsigned char parms[5];
+  unsigned char *resp = NULL;
   const char *sn;
 
   /*
@@ -2340,7 +2341,7 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   if (pgm->usbsn && *pgm->usbsn)
     sn = pgm->usbsn;
   else {
-    unsigned char cmd[4], *resp, c;
+    unsigned char cmd[4], c;
     int status;
     cmd[0] = SCOPE_INFO;
     cmd[1] = CMD3_GET_INFO;
@@ -2372,6 +2373,8 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   msg_info("%sICE FW version  : %d.%02d (rel. %d)\n", p, parms[1], parms[2],
            (parms[3] | (parms[4] << 8)));
   msg_info("%sSerial number   : %s", p, sn);
+
+  free(resp);
 }
 
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2869,7 +2869,7 @@ static int jtag3_paged_load_tpi(const PROGRAMMER *pgm, const AVRPART *p,
       return -1;
     }
 
-    if (status < 0) {
+    if (status < 2) {
       pmsg_error("unexpected return value %d from jtag3_paged_load_tpi()\n", status);
       free(resp);
       return -1;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1542,7 +1542,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
   }
 
   // Store USB serial number
-  serial_serno(pgm->usbsn);
+  pgm->usbsn = serial_serno();
 
   /*
    * drain any extraneous input

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1541,7 +1541,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
     pmsg_notice("found CMSIS-DAP compliant device, using EDBG protocol\n");
   }
 
-  // Store USB serial number
+  // Get USB serial number
   pgm->usbsn = serial_serno();
 
   /*
@@ -2317,7 +2317,7 @@ static void jtag3_display(const PROGRAMMER *pgm, const char *p) {
     return;
 
   // Use serial number pulled from the USB driver. If not present, query the programmer
-  if(pgm->usbsn)
+  if (pgm->usbsn && *pgm->usbsn)
     sn = pgm->usbsn;
   else {
     unsigned char cmd[4], *resp, c;
@@ -2334,6 +2334,10 @@ static void jtag3_display(const PROGRAMMER *pgm, const char *p) {
     if (c != RSP3_INFO) {
       pmsg_error("response is not RSP3_INFO\n");
       free(resp);
+      return;
+    }
+    if (status < 3) {
+      msg_error("unexpected response from PARM3_HW_VER command");
       return;
     }
     memmove(resp, resp + 3, status - 3);

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2346,6 +2346,7 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
     memmove(resp, resp + 3, status - 3);
     resp[status - 3] = 0;
     sn = (const char*)resp;
+    free(resp);
   }
 
   msg_info("%sICE HW version  : %d\n", p, parms[0]);

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2328,8 +2328,10 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
     cmd[2] = 0;
     cmd[3] = CMD3_INFO_SERIAL;
 
-    if ((status = jtag3_command(pgm, cmd, 4, &resp, "get info (serial number)")) < 0)
+    if ((status = jtag3_command(pgm, cmd, 4, &resp, "get info (serial number)")) < 0) {
+      free(resp);
       return;
+    }
 
     c = resp[1];
     if (c != RSP3_INFO) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2380,19 +2380,17 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   msg_info("%sICE HW version  : %d\n", p, parms[0]);
   msg_info("%sICE FW version  : %d.%02d (rel. %d)\n", p, parms[1], parms[2],
            (parms[3] | (parms[4] << 8)));
-  msg_info("%sSerial number   : %s", p, sn);
-
+  msg_info("%sSerial number   : %s\n", p, sn);
   free(resp);
+
+  if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, parms, 2) < 0)
+    return;
+  msg_info("%sVtarget         : %.2f V", p, b2_to_u16(parms)/1000.0);
 }
 
 
 void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
   unsigned char buf[3];
-
-  if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
-    return;
-  fmsg_out(fp, "%sVtarget         %s: %.2f V\n", p,
-           verbose? "": "             ", b2_to_u16(buf)/1000.0);
 
   // Print features unique to the Power Debugger
   for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2669,7 +2669,7 @@ static int jtag3_initialize_tpi(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   free(resp);
 
-  jtag3_print_parms(pgm, stderr);
+  jtag3_print_parms1(pgm, progbuf, stderr);
 
   return 0;
 }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1541,8 +1541,8 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
     pmsg_notice("found CMSIS-DAP compliant device, using EDBG protocol\n");
   }
 
-  // Get USB serial number
-  serial_serno(pinfo, pgm->usbsn);
+  // Store USB serial number
+  serial_serno(pgm->usbsn);
 
   /*
    * drain any extraneous input

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -104,6 +104,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                                 unsigned long addr, unsigned char data);
 static int jtag3_set_sck_period(const PROGRAMMER *pgm, double v);
+void jtag3_display(const PROGRAMMER *pgm, const char *p);
 void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp);
 static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                                 unsigned int page_size,
@@ -2302,7 +2303,7 @@ int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
   return 0;
 }
 
-static void jtag3_display(const PROGRAMMER *pgm, const char *p) {
+void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   unsigned char parms[5];
   const char *sn;
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2229,7 +2229,7 @@ int jtag3_getparm(const PROGRAMMER *pgm, unsigned char scope,
   }
 
   status -= 3;
-  if (status < 3) {
+  if (status < 0) {
     pmsg_error("unexpected return value %d from jtag3_command()\n", status);
     free(resp);
     return -1;
@@ -2865,6 +2865,13 @@ static int jtag3_paged_load_tpi(const PROGRAMMER *pgm, const AVRPART *p,
       free(resp);
       return -1;
     }
+
+    if (status < 0) {
+      pmsg_error("unexpected return value %d from jtag3_paged_load_tpi()\n", status);
+      free(resp);
+      return -1;
+    }
+
     memcpy(m->buf + addr, resp + 2, status - 2);
     free(resp);
   }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2340,7 +2340,7 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
       return;
     }
     if (status < 3) {
-      msg_error("unexpected response from PARM3_HW_VER command");
+      msg_error("unexpected response from CMD3_GET_INFO command\n");
       return;
     }
     memmove(resp, resp + 3, status - 3);

--- a/src/jtag3.h
+++ b/src/jtag3.h
@@ -38,6 +38,7 @@ int jtag3_setparm(const PROGRAMMER *pgm, unsigned char scope,
                   unsigned char *value, unsigned char length);
 int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen,
                   unsigned char **resp, const char *descr);
+void jtag3_display(const PROGRAMMER *pgm, const char *p);
 void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp);
 int jtag3_set_vtarget(const PROGRAMMER *pgm, double voltage);
 extern const char jtag3_desc[];

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -649,6 +649,7 @@ union pinfo
 struct serial_device {
   // open should return -1 on error, other values on success
   int (*open)(const char *port, union pinfo pinfo, union filedescriptor *fd);
+  int (*serno)(union pinfo pinfo, const char *sn);
   int (*setparams)(const union filedescriptor *fd, long baud, unsigned long cflags);
   void (*close)(union filedescriptor *fd);
 
@@ -671,6 +672,7 @@ extern struct serial_device avrdoper_serdev;
 extern struct serial_device usbhid_serdev;
 
 #define serial_open (serdev->open)
+#define serial_serno (serdev->serno)
 #define serial_setparams (serdev->setparams)
 #define serial_close (serdev->close)
 #define serial_send (serdev->send)

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -649,7 +649,7 @@ union pinfo
 struct serial_device {
   // open should return -1 on error, other values on success
   int (*open)(const char *port, union pinfo pinfo, union filedescriptor *fd);
-  int (*serno)(union pinfo pinfo, const char *sn);
+  int (*serno)(const char *sn);
   int (*setparams)(const union filedescriptor *fd, long baud, unsigned long cflags);
   void (*close)(union filedescriptor *fd);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -649,7 +649,7 @@ union pinfo
 struct serial_device {
   // open should return -1 on error, other values on success
   int (*open)(const char *port, union pinfo pinfo, union filedescriptor *fd);
-  int (*serno)(const char *sn);
+  const char *(*serno)();
   int (*setparams)(const union filedescriptor *fd, long baud, unsigned long cflags);
   void (*close)(union filedescriptor *fd);
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3083,7 +3083,7 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
     pgmcp->cookie = PDATA(pgm)->chained_pdata;
     jtag3_display(pgmcp, p);
     msg_info("\n");
-    free(pgmcp);
+    pgm_free(pgmcp);
   }
   stk500v2_print_parms1(pgm, p, stderr);
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1569,6 +1569,9 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
+  // Store USB serial number
+  pgm->usbsn = serial_serno();
+
   /*
    * drain any extraneous input
    */
@@ -3035,6 +3038,8 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
     stk500v2_getparm(pgm, PARAM_SW_MAJOR, &maj);
     stk500v2_getparm(pgm, PARAM_SW_MINOR, &min);
     msg_info("%sHardware Version: %d\n", p, hdw);
+    if(pgm->usbsn)
+      msg_info("%sSerial number   : %s\n", p, pgm->usbsn);
     msg_info("%sFirmware Version Controller : %d.%02d\n", p, maj, min);
     if (PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
       stk500v2_getparm(pgm, PARAM_SW_MAJOR_PERIPHERY1, &maj_s1);

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3078,6 +3078,12 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
     msg_info("%sRC_ID table rev : %d\n", p, rev);
     stk500v2_getparm2(pgm, PARAM2_EC_ID_TABLE_REV, &rev);
     msg_info("%sEC_ID table rev : %d\n", p, rev);
+  } else if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE3) {
+    PROGRAMMER *pgmcp = pgm_dup(pgm);
+    pgmcp->cookie = PDATA(pgm)->chained_pdata;
+    jtag3_display(pgmcp, p);
+    msg_info("\n");
+    free(pgmcp);
   }
   stk500v2_print_parms1(pgm, p, stderr);
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1569,7 +1569,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
-  // Store USB serial number
+  // Get USB serial number
   pgm->usbsn = serial_serno();
 
   /*
@@ -3038,7 +3038,7 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
     stk500v2_getparm(pgm, PARAM_SW_MAJOR, &maj);
     stk500v2_getparm(pgm, PARAM_SW_MINOR, &min);
     msg_info("%sHardware Version: %d\n", p, hdw);
-    if(pgm->usbsn)
+    if (pgm->usbsn && *pgm->usbsn)
       msg_info("%sSerial number   : %s\n", p, pgm->usbsn);
     msg_info("%sFirmware Version Controller : %d.%02d\n", p, maj, min);
     if (PDATA(pgm)->pgmtype == PGMTYPE_STK600) {

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -847,6 +847,7 @@ retry:
             case STATUS_SET_PARAM_MISSING:
                 msg = "The `Set Device Parameters' have not been "
                     "executed in advance of this command";
+                break;
 
             default:
                 sprintf(msgbuf, "unknown, code 0x%02x", buf[1]);

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -42,11 +42,12 @@
 
 #include "usbdevs.h"
 
-static int usbhid_get_serno(union pinfo pinfo, const char *sn) {
-  struct hid_device_info *list;
-  list = hid_enumerate(pinfo.usbinfo.vid, pinfo.usbinfo.pid);
-  wcstombs((char *)sn, list->serial_number, 15);
-  hid_free_enumeration(list);
+static char usbsn[15];
+
+static int usbhid_get_serno(const char* sn) {
+  if (!*usbsn)
+    return -1;
+  strncpy((char *)sn, usbsn, 15);
   return 0;
 }
 
@@ -136,6 +137,11 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       return -1;
     }
   }
+
+  // Store USB serial number to usbsn string
+  wchar_t sn[15];
+  hid_get_serial_number_string(dev, sn, 15);
+  wcstombs((char *)usbsn, sn, 15);
 
   fd->usb.handle = dev;
 

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -44,11 +44,10 @@
 
 static char usbsn[15];
 
-static int usbhid_get_serno(const char* sn) {
+const char *usbhid_get_serno() {
   if (!*usbsn)
-    return -1;
-  strncpy((char *)sn, usbsn, 15);
-  return 0;
+    return NULL;
+  return usbsn;
 }
 
 /*

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -42,6 +42,14 @@
 
 #include "usbdevs.h"
 
+static int usbhid_get_serno(union pinfo pinfo, const char *sn) {
+  struct hid_device_info *list;
+  list = hid_enumerate(pinfo.usbinfo.vid, pinfo.usbinfo.pid);
+  wcstombs((char *)sn, list->serial_number, 15);
+  hid_free_enumeration(list);
+  return 0;
+}
+
 /*
  * The "baud" parameter is meaningless for USB devices, so we reuse it
  * to pass the desired USB device ID.
@@ -120,7 +128,6 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       return -1;
     }
   } else {
-    /* No serial number requested, pass straight to hid_open() */
     dev = hid_open(pinfo.usbinfo.vid, pinfo.usbinfo.pid, NULL);
     if (dev == NULL)
     {
@@ -302,6 +309,7 @@ static int usbhid_drain(const union filedescriptor *fd, int display) {
  */
 struct serial_device usbhid_serdev = {
   .open = usbhid_open,
+  .serno = usbhid_get_serno,
   .close = usbhid_close,
   .send = usbhid_send,
   .recv = usbhid_recv,

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -58,6 +58,14 @@ static int buflen = -1, bufptr;
 
 static int usb_interface;
 
+static char usbsn[15];
+
+const char *usbdev_get_serno() {
+  if (!*usbsn)
+    return NULL;
+  return usbsn;
+}
+
 /*
  * The "baud" parameter is meaningless for USB devices, so we reuse it
  * to pass the desired USB device ID.
@@ -138,7 +146,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      else
 			strcpy(string, "[unknown]");
 		    }
-
+		  strncpy((char *)usbsn, string, 15);
 		  if (usb_get_string_simple(udev,
 					    dev->descriptor.iProduct,
 					    product, sizeof(product)) < 0)
@@ -576,6 +584,7 @@ static int usbdev_drain(const union filedescriptor *fd, int display)
 struct serial_device usb_serdev =
 {
   .open = usbdev_open,
+  .serno = usbdev_get_serno,
   .close = usbdev_close,
   .send = usbdev_send,
   .recv = usbdev_recv,
@@ -589,6 +598,7 @@ struct serial_device usb_serdev =
 struct serial_device usb_serdev_frame =
 {
   .open = usbdev_open,
+  .serno = usbdev_get_serno,
   .close = usbdev_close,
   .send = usbdev_send,
   .recv = usbdev_recv_frame,

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -58,11 +58,9 @@ static int buflen = -1, bufptr;
 
 static int usb_interface;
 
-static char usbsn[15];
+static const char *usbsn = "";
 
 const char *usbdev_get_serno() {
-  if (!*usbsn)
-    return NULL;
   return usbsn;
 }
 
@@ -146,7 +144,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      else
 			strcpy(string, "[unknown]");
 		    }
-		  strncpy((char *)usbsn, string, 15);
+		  usbsn = cache_string(string);
 		  if (usb_get_string_simple(udev,
 					    dev->descriptor.iProduct,
 					    product, sizeof(product)) < 0)

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -340,7 +340,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
    * 0.
    */
   do {
-    tx_size = (mlen < fd->usb.max_xfer)? mlen: fd->usb.max_xfer;
+    tx_size = ((int) mlen < fd->usb.max_xfer)? (int) mlen: fd->usb.max_xfer;
     if (fd->usb.use_interrupt_xfer)
       rv = usb_interrupt_write(udev, fd->usb.wep, (char *)bp, tx_size, 10000);
     else
@@ -422,7 +422,7 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
 	  if (usb_fill_buf(udev, fd->usb.max_xfer, fd->usb.rep, fd->usb.use_interrupt_xfer) < 0)
 	    return -1;
 	}
-      amnt = buflen - bufptr > nbytes? nbytes: buflen - bufptr;
+      amnt = buflen - bufptr > (int) nbytes? (int) nbytes: buflen - bufptr;
       memcpy(buf + i, usbbuf + bufptr, amnt);
       bufptr += amnt;
       nbytes -= amnt;
@@ -506,7 +506,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
 	  return -1;
 	}
 
-      if (rv <= nbytes)
+      if (rv <= (int) nbytes)
 	{
 	  memcpy (buf, usbbuf, rv);
 	  buf += rv;


### PR DESCRIPTION
This PR makes it possible to read the serial number from JTAG3-compatible programmers using libusb or hidusb.
Without this PR, Avrdude is not able to read the serial number from the AVRISPmkII, PICkit4, or SNAP.