### PR TITLE
Print expected signature when the one read by the programmer doesn't match the expected one

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1348,6 +1348,8 @@ int main(int argc, char * argv [])
         msg_info("\n");
         pmsg_error("Yikes!  Invalid device signature.\n");
         if (!ovsigck) {
+          pmsg_error("expected signature for %s is %02X %02X %02X\n", p->desc,
+            p->signature[0], p->signature[1], p->signature[2]);
           imsg_error("Double check connections and try again, or use -F to override\n");
           imsg_error("this check.\n\n");
           exitrc = 1;


### PR DESCRIPTION
This is useful when using the *Arduino as ISP* programmer, which most beginners use. The issue with this programmer is that it tells Avrdude that it can communicate with the target even if this isn't true. That's why this is the only programmer that can _tell_ the user that the device signature is read as 0x000000 or 0xFFFFFF.

Other times, the user doesn't understand that they are communicating with the wrong target, even though they have a working connection.

Every time a user of the Arduino as ISP programmer has connection issues the user has to enable verbose output in the Arduino settings before the error message is helpful. By default, Arduino IDE doesn't print the Avrdude command either, so it's impossible to guess which part the user are trying to communicate with by looking at the output.

This PR will make troubleshooting easier when helping users that use Arduino IDE. Hopefully, it can be merged before the v7.1 release.

Without this PR:
```
$ ./avrdude -cstk500v1 -P /dev/cu.usbserial-AH00M3HQ -patmega328pb -b19200

avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x000000 (retrying)
avrdude: device signature = 0x000000 (retrying)
avrdude: device signature = 0x000000
avrdude error: Yikes!  Invalid device signature.
        Double check connections and try again, or use -F to override
        this check.


avrdude done.  Thank you.
```

With this PR:
```
$ ./avrdude -cstk500v1 -P /dev/cu.usbserial-AH00M3HQ -patmega328pb -b19200 -F

avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x000000 (retrying)
avrdude: device signature = 0x000000 (retrying)
avrdude: device signature = 0x000000
avrdude error: Yikes!  Invalid device signature.
avrdude warning: expected signature for ATmega328PB is 1E 95 16

avrdude done.  Thank you.
```