### PR TITLE
Temporarily disable brew update in macOS github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install prerequisites
         run: >-
-          brew update
+          # brew update
 
           brew install
           cmake


### PR DESCRIPTION
This is to workaround the current problem that macOS github action is broken. 
`brew update` as of now is not needed as the macOS github image has been updated. We can revert this later once the issue is fixed or we encounter new issues.