### PR TITLE
Add FT2232H support for Windows, Tigard programmer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ if(USE_EXTERNAL)
 
     FetchContent_Declare(libftdi
         GIT_REPOSITORY https://github.com/avrdudes/libftdi.git
-        GIT_TAG f3a54da710002a7d25a32a69e667a69ef84cc120
+        GIT_TAG f9fe6e96b97c3a08efd081632c1859cb83aa14e3
         )
 
     message(STATUS "Fetching external libraries, please wait...")

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -855,6 +855,24 @@ programmer parent "ft2232h"
 ;
 
 #------------------------------------------------------------
+# tigard
+#------------------------------------------------------------
+
+# Tigard - FT2232H based multi-protocol tool for hardware hacking.
+# https://github.com/tigard-tools/tigard
+
+programmer parent "ft2232h"
+    id                     = "tigard";
+    desc                   = "Tigard interface board";
+    usbdev                 = "B";
+# ISP-signals
+    reset                  = 5; # BD5 (GPIOL1)
+    sck                    = 0; # BD0 (TCK)
+    sdo                    = 1; # BD1 (TDI)
+    sdi                    = 2; # BD2 (TDO)
+;
+
+#------------------------------------------------------------
 # ft4232h
 #------------------------------------------------------------
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -843,25 +843,11 @@ programmer parent "ft2232h"
 # This is an implementation of the above with a buffer IC (74AC244) and
 # 4 LEDs directly attached, all active low.
 
-programmer
-    id                     = "2232HIO";
+programmer parent "ft2232h"
+    id                     = "2232hio";
     desc                   = "FT2232H based generic programmer";
-    type                   = "avrftdi";
-    prog_modes             = PM_TPI | PM_ISP;
-    connection_type        = usb;
-    usbvid                 = 0x0403;
-# Note: This PID is reserved for generic H devices and
-# should be programmed into the EEPROM
-#   usbpid                 = 0x8A48;
-    usbpid                 = 0x6010;
-    usbdev                 = "A";
     buff                   = ~4;
-#ISP-signals
-    reset                  = 3;
-    sck                    = 0;
-    sdo                    = 1;
-    sdi                    = 2;
-#LED SIGNALs
+# LED SIGNALs
     errled                 = ~11;
     rdyled                 = ~14;
     pgmled                 = ~13;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -869,16 +869,25 @@ programmer
 ;
 
 #------------------------------------------------------------
-# 4232h
+# ft4232h
 #------------------------------------------------------------
 
 #The FT4232H can be treated as FT2232H, but it has a different USB
 #device ID of 0x6011.
 
-programmer parent "avrftdi"
-    id                     = "4232h";
+programmer parent "ft2232h"
+    id                     = "ft4232h";
     desc                   = "FT4232H based generic programmer";
     usbpid                 = 0x6011;
+;
+
+#------------------------------------------------------------
+# 4232h
+#------------------------------------------------------------
+
+programmer parent "ft4232h"
+    id                     = "4232h";
+    desc                   = "FT4232H based generic programmer";
 ;
 
 #------------------------------------------------------------

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -788,7 +788,7 @@ programmer
 ;
 
 #------------------------------------------------------------
-# avrftdi
+# ft2232h
 #------------------------------------------------------------
 
 # this will interface with the chips on these programmers:
@@ -812,26 +812,28 @@ programmer
 # these FTDI ICs has been designed.
 
 programmer
-    id                     = "avrftdi";
-    desc                   = "FT2232D based generic programmer";
+    id                     = "ft2232h";
+    desc                   = "FT2232H based generic programmer";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6010;
     usbdev                 = "A";
-#   ISP-signals - lower ADBUS-Nibble (default)
-    reset                  = 3;
-    sck                    = 0;
-    sdo                    = 1;
-    sdi                    = 2;
-#   LED SIGNALs - higher ADBUS-Nibble
-#   errled                 = 4;
-#   rdyled                 = 5;
-#   pgmled                 = 6;
-#   vfyled                 = 7;
-#   Buffer Signal - ACBUS - Nibble
-#   buff                   = 8;
+# ISP-signals - lower ADBUS-Nibble (default)
+    reset                  = 3; # AD3 (TMS)
+    sck                    = 0; # AD0 (TCK)
+    sdo                    = 1; # AD1 (TDI)
+    sdi                    = 2; # AD2 (TDO)
+;
+
+#------------------------------------------------------------
+# avrftdi
+#------------------------------------------------------------
+
+programmer parent "ft2232h"
+    id                     = "avrftdi";
+    desc                   = "FT2232D based generic programmer";
 ;
 
 #------------------------------------------------------------

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -907,14 +907,14 @@ programmer
 
 programmer
     id                     = "ft232h";
-    desc                   = "FT232H in MPSSE mode";
+    desc                   = "FT232H based generic programmer";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6014;
     usbdev                 = "A";
-#ISP-signals
+# ISP-signals
     reset                  = 3; # AD3 (TMS)
     sck                    = 0; # AD0 (TCK)
     sdo                    = 1; # AD1 (TDI)
@@ -1024,7 +1024,7 @@ programmer
     usbproduct             = "LM3S811 Evaluation Board";
 # Enable correct buffers
     buff                   = 7;
-#ISP-signals - lower ACBUS-Nibble (default)
+# ISP-signals - lower ACBUS-Nibble (default)
     reset                  = 3;
     sck                    = 0;
     sdo                    = 1;
@@ -1332,7 +1332,7 @@ programmer
 
 programmer
     id                     = "ft245r";
-    desc                   = "FT245R Synchronous BitBang";
+    desc                   = "FT245R based generic programmer";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
@@ -1348,7 +1348,7 @@ programmer
 
 programmer
     id                     = "ft232r";
-    desc                   = "FT232R Synchronous BitBang";
+    desc                   = "FT232R based generic programmer";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;


### PR DESCRIPTION
Fixes #1197

Other changes:

- Harmonize FTDI programmer IDs
- Add support for [Tigard programmer](https://github.com/tigard-tools/tigard#avr-isp)