### PR TITLE
CMake updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
           -D CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO="/DEBUG /INCREMENTAL:NO /LTCG /OPT:REF /OPT:ICF"
           -D HAVE_LIBREADLINE=HAVE_LIBREADLINE-NOTFOUND
           -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-          -D USE_EXTERNAL=1
+          -D USE_EXTERNAL_LIBS=1
           -B build
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 #     cmake -B build
 #     cmake --build build
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 project(avrdude VERSION 7.0 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ option(BUILD_DOC "Enable building documents" OFF)
 option(HAVE_LINUXGPIO "Enable Linux sysfs GPIO support" OFF)
 option(HAVE_LINUXSPI "Enable Linux SPI support" OFF)
 option(HAVE_PARPORT "Enable parallel port support" OFF)
-option(USE_EXTERNAL "Use external libraries from AVRDUDE GitHub repositories" OFF)
+option(USE_EXTERNAL_LIBS "Use external libraries from AVRDUDE GitHub repositories" OFF)
 option(USE_LIBUSBWIN32 "Prefer libusb-win32 over libusb" OFF)
 option(DEBUG_CMAKE "Enable debugging output for this CMake project" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
@@ -229,7 +229,7 @@ endif()
 # Use external libraries if requested
 # =====================================
 
-if(USE_EXTERNAL)
+if(USE_EXTERNAL_LIBS)
     FetchContent_Declare(libelf
         GIT_REPOSITORY https://github.com/avrdudes/libelf.git
         GIT_TAG e5a39bf19bd6598c42e09172be5a78ceec2a065c
@@ -299,7 +299,7 @@ if (DEBUG_CMAKE)
     message(STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
     message(STATUS "CONFIG_DIR: ${CONFIG_DIR}")
     message(STATUS "AVRDUDE_FULL_VERSION: ${AVRDUDE_FULL_VERSION}")
-    message(STATUS "USE_EXTERNAL: ${USE_EXTERNAL}")
+    message(STATUS "USE_EXTERNAL_LIBS: ${USE_EXTERNAL_LIBS}")
     message(STATUS "USE_LIBUSBWIN32: ${USE_LIBUSBWIN32}")
     message(STATUS "HAVE_LIBELF: ${HAVE_LIBELF}")
     message(STATUS "HAVE_LIBUSB: ${HAVE_LIBUSB}")

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,40 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "USE_EXTERNAL_LIBS",
+          "value": "true",
+          "type": "BOOL"
+        }
+      ]
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        {
+          "name": "USE_EXTERNAL_LIBS",
+          "value": "true",
+          "type": "BOOL"
+        }
+      ]
+    }
+  ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,8 +65,6 @@ if(MSVC)
     add_compile_options(/wd4018) # warning C4018: signed/unsigned mismatch
     add_compile_options(/wd4244) # warning C4244: conversion from '...' to '...', possible loss of data
     add_compile_options(/wd4267) # warning C4267: conversion from '...' to '...', possible loss of data
-    add_compile_options(/wd5105) # warning C5105: macro expansion producing 'xxx' has undefined behavior
-    add_compile_options(/wd6255) # warning C6255: _alloca indicates failure by raising a stack overflow exception. Consider using _malloca instead
 
     set(EXTRA_WINDOWS_SOURCES ${EXTRA_WINDOWS_SOURCES}
         "msvc/getopt.c"


### PR DESCRIPTION
Some minor updates:

- Fixes #1067
- Rename option from USE_EXTERNAL to USE_EXTERNAL_LIBS to make it more descriptive
- Remove some superfluous MSVC compiler options
- Add CMake options file for Visual Studio