### PR TITLE
Add a "q" command to the terminal

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -85,6 +85,7 @@ static int cmd_quell  (PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]);
 #define _fo(x) offsetof(PROGRAMMER, x)
 
 struct command cmd[] = {
+  { "q",     cmd_quit,  _fo(open),              "abbreviation for 'quit'" },
   { "dump",  cmd_dump,  _fo(read_byte_cached),  "%s <memory> [<addr> <len> | <addr> ... | <addr> | ...]" },
   { "read",  cmd_dump,  _fo(read_byte_cached),  "alias for dump" },
   { "write", cmd_write, _fo(write_byte_cached), "write <memory> <addr> <data>[,] {<data>[,]}" },

--- a/src/term.c
+++ b/src/term.c
@@ -85,7 +85,6 @@ static int cmd_quell  (PROGRAMMER *pgm, AVRPART *p, int argc, char *argv[]);
 #define _fo(x) offsetof(PROGRAMMER, x)
 
 struct command cmd[] = {
-  { "q",     cmd_quit,  _fo(open),              "abbreviation for 'quit'" },
   { "dump",  cmd_dump,  _fo(read_byte_cached),  "%s <memory> [<addr> <len> | <addr> ... | <addr> | ...]" },
   { "read",  cmd_dump,  _fo(read_byte_cached),  "alias for dump" },
   { "write", cmd_write, _fo(write_byte_cached), "write <memory> <addr> <data>[,] {<data>[,]}" },
@@ -108,7 +107,8 @@ struct command cmd[] = {
   { "quell", cmd_quell, _fo(open),              "set quell level for progress bars" },
   { "help",  cmd_help,  _fo(open),              "show help message" },
   { "?",     cmd_help,  _fo(open),              "same as help" },
-  { "quit",  cmd_quit,  _fo(open),              "quit after writing out cache for flash & EEPROM" }
+  { "quit",  cmd_quit,  _fo(open),              "quit after writing out cache for flash & EEPROM" },
+  { "q",     cmd_quit,  _fo(open),              "abbreviation for quit" },
 };
 
 #define NCMDS ((int)(sizeof(cmd)/sizeof(struct command)))


### PR DESCRIPTION
"q" used to be a unique abbrevation for "quit" before the introduction of the "quell" command, and it was an easy way to exit terminal mode.

By adding it as an explicit command (must be before all longer commands starting with "q"), this functionality is regained.