### PR TITLE
CMake: Include readline library for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,12 +250,18 @@ if(USE_EXTERNAL_LIBS)
         GIT_TAG f9fe6e96b97c3a08efd081632c1859cb83aa14e3
         )
 
+    FetchContent_Declare(libreadline
+        GIT_REPOSITORY https://github.com/avrdudes/libreadline.git
+        GIT_TAG 9322168c71d798dc0dcdec5ad5187b4205dce185
+        )
+
     message(STATUS "Fetching external libraries, please wait...")
     FetchContent_MakeAvailable(
         libelf
         libusb
         libhidapi
         libftdi
+        libreadline
         )
 
     message(STATUS "Using external library 'libelf'")
@@ -277,6 +283,10 @@ if(USE_EXTERNAL_LIBS)
     set(LIB_LIBFTDI libftdi)
     set(HAVE_LIBFTDI 1)
     set(HAVE_LIBFTDI_TYPE_232H 1)
+
+    message(STATUS "Using external library 'libreadline'")
+    set(LIB_LIBREADLINE libreadline)
+    set(HAVE_LIBREADLINE 1)
 endif()
 
 add_subdirectory(src)


### PR DESCRIPTION
Happy new year, everybody! :partying_face:

Here is my first shot at readline support for MSVC.

Basically, its based on readline 5.0, with the Windows patches from [Readline for Windows](https://gnuwin32.sourceforge.net/packages/readline.htm), plus some additions from me, including:

- CMake support
- Some Windows 64-bit pointer fixes

I have not spent much time with this library, but some things appear to work:

- I can connect via `-c urclock - t`
- I can pipe input to avrdude
- I can redirect an input file to it
- The readline library does not crash anymore on Ctrl-R

However, there are also a few issues with it, so I do not think its production ready:

- The readline history is not preserved over sessions
- The keep alive feature is not very reliable, it seems to eventually time out after some 20 to 30 seconds or so
- The reconnect feature does not seem to work (using manual reset): I typically get messages such as 

```console
avrdude error: protocol expects sync byte 0x20 but got 0x00 in ur_readEF()
avrdude error: unable to read flash page at addr 0x0100
avrdude error: (dump) error reading flash address 0x00100 of part ATtiny167
               read operation not supported on memory type flash
avrdude> avrdude error: protocol expects sync byte 0x20 but got 0xea in urclock_term_keep_alive()
avrdude error: protocol expects sync byte 0x20 but got 0xfc in urclock_term_keep_alive()
dump flash

Reading | -------------------------------------------------- | 0% 0.01 s

avrdude error: protocol expects OK byte 0x1d but got 0xff in urclock_paged_load()
avrdude error: protocol expects sync byte 0x20 but got 0xff in ur_readEF()
avrdude error: unable to read flash page at addr 0x0100
avrdude error: (dump) error reading flash address 0x00100 of part ATtiny167
               read operation not supported on memory type flash
avrdude> avrdude error: protocol expects sync byte 0x20 but got 0x1d in urclock_term_keep_alive()
avrdude error: protocol expects OK byte 0x1d but got 0xff in urclock_term_keep_alive()
avrdude error: protocol expects sync byte 0x20 but got 0x1d in urclock_term_keep_alive()

avrdude> avrdude error: protocol expects sync byte 0x20 but got 0x00 in urclock_term_keep_alive()
avrdude error: protocol expects sync byte 0x20 but got 0xea in urclock_term_keep_alive()
avrdude error: protocol expects sync byte 0x20 but got 0xfc in urclock_term_keep_alive()
```

@stefanrueger If you have a Windows PC at your hands, could you give this PR a try? Is there anything specific you would like me to try?

Closes #1186