### PR TITLE
Silence page erase in cache code

### DIFF
--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -318,6 +318,9 @@ static int guessBootStart(const PROGRAMMER *pgm, const AVRPART *p) {
   int bootstart = 0;
   const AVR_Cache *cp = pgm->cp_flash;
 
+  if(p->prog_modes & PM_UPDI)   // Modern AVRs put the bootloader at 0
+    return 0;
+
   if(p->n_boot_sections > 0 && p->boot_section_size > 0)
     bootstart = cp->size - (p->boot_section_size<<(p->n_boot_sections-1));
 


### PR DESCRIPTION
The cache code that is used in the terminal utilises the page erase function if the programmer has one. Some programmers don't follow through, though. The cache code recognises that and still does "the right thing". However, one can get false-alarm error messages such as 
```
avrdude> q
avrdude: synching cache to device ... avrdude jtag3_page_erase() error: page erase not supported

Reading | ################################################## | 100% 0.89 s
Erasing | ################################################## | 100% 0.01 s
Writing | ################################################## | 100% 0.07 s

avrdude done.  Thank you.
```

This PR silences the page erase at the cache level. 