### PR TITLE
Update to latest MSVC fork of hidapi to include bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if(USE_EXTERNAL_LIBS)
 
     FetchContent_Declare(libhidapi
         GIT_REPOSITORY https://github.com/avrdudes/libhidapi.git
-        GIT_TAG e3700e951f762ef92871ff4fc94586e4d1c042a6
+        GIT_TAG d1307487973c857bc158e27ecc99644b2f5e68ea
         )
 
     FetchContent_Declare(libftdi


### PR DESCRIPTION
There was a bug in the MSVC fork of hidapi-0.11.0 that causes programmer such as Atmel ICE to crash. This PR updates to the latest version hidapi-0.13.0.