### PR TITLE
Correct memory mode, delay and readback for classic parts

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2744,7 +2744,7 @@ part
         max_write_delay    = 20000;
         readback           = 0xff 0xff;
         mode               = 0x04;
-        delay              = 8;
+        delay              = 20;
         blocksize          = 64;
         readsize           = 256;
         read               = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
@@ -2755,9 +2755,9 @@ part
         size               = 1024;
         min_write_delay    = 4500;
         max_write_delay    = 20000;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x04;
-        delay              = 5;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
@@ -2847,7 +2847,6 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 5;
         blocksize          = 4;
@@ -2865,9 +2864,8 @@ part
         num_pages          = 32;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.000a--aaaa.aaaa--oooo.oooo";
@@ -2970,7 +2968,7 @@ part
         max_write_delay    = 8200;
         readback           = 0xff 0xff;
         mode               = 0x04;
-        delay              = 10;
+        delay              = 20;
         blocksize          = 64;
         readsize           = 256;
         read               = "1010.0000--xxxx.xxxx--xxaa.aaaa--oooo.oooo";
@@ -2981,9 +2979,9 @@ part
         size               = 1024;
         min_write_delay    = 4100;
         max_write_delay    = 4100;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x04;
-        delay              = 5;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--xxxx.xxxa--aaaa.aaaa--oooo.oooo";
@@ -3905,9 +3903,9 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x21;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4023,7 +4021,7 @@ part
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
         mode               = 0x04;
-        delay              = 12;
+        delay              = 20;
         blocksize          = 64;
         readsize           = 256;
         read               = "1010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4037,9 +4035,9 @@ part
         num_pages          = 512;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x21;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4154,7 +4152,6 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
@@ -4172,9 +4169,9 @@ part
         num_pages          = 512;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 256;
         readsize           = 256;
         read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4279,7 +4276,6 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
@@ -4297,9 +4293,8 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 256;
         readsize           = 256;
         read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4404,7 +4399,6 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
@@ -4422,9 +4416,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 256;
         readsize           = 256;
         read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4531,7 +4524,7 @@ part
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
         mode               = 0x04;
-        delay              = 10;
+        delay              = 20;
         blocksize          = 128;
         readsize           = 256;
         read               = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
@@ -4547,9 +4540,9 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x21;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4656,7 +4649,6 @@ part
         page_size          = 4;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
@@ -4674,9 +4666,8 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
-        mode               = 0x21;
-        delay              = 6;
+        mode               = 0x41;
+        delay              = 10;
         blocksize          = 256;
         readsize           = 256;
         read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -4742,6 +4733,7 @@ part parent "m324p"
 
     memory "eeprom"
         size               = 512;
+        delay              = 20;
     ;
 
     memory "flash"
@@ -4854,7 +4846,6 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
@@ -4872,9 +4863,8 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
-        mode               = 0x21;
-        delay              = 6;
+        mode               = 0x41;
+        delay              = 10;
         blocksize          = 256;
         readsize           = 256;
         read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -5015,7 +5005,6 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
@@ -5033,7 +5022,6 @@ part
         num_pages          = 512;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 256;
@@ -5149,7 +5137,6 @@ part
         page_size          = 4;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
@@ -5167,7 +5154,6 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
@@ -5539,9 +5525,8 @@ part
         page_size          = 4;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 20;
+        delay              = 10;
         blocksize          = 8;
         readsize           = 256;
         read               = "1010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
@@ -5557,9 +5542,8 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 256;
         readsize           = 256;
         read_lo            = "0010.0000--xaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -5744,9 +5728,8 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 20;
+        delay              = 10;
         blocksize          = 8;
         readsize           = 256;
         read               = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
@@ -5762,9 +5745,8 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 256;
         readsize           = 256;
         read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -5926,7 +5908,7 @@ part
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
         mode               = 0x04;
-        delay              = 10;
+        delay              = 20;
         blocksize          = 64;
         readsize           = 256;
         read               = "1010.0000--00xx.xxaa--aaaa.aaaa--oooo.oooo";
@@ -5942,9 +5924,9 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x21;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -6273,9 +6255,9 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x21;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -6380,9 +6362,9 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x21;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -6474,7 +6456,7 @@ part
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
         mode               = 0x04;
-        delay              = 10;
+        delay              = 20;
         blocksize          = 64;
         readsize           = 256;
         read               = "1010.0000--xxxx.xxxx--xaaa.aaaa--oooo.oooo";
@@ -6488,9 +6470,9 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
+        readback           = 0xff 0x00;
         mode               = 0x21;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 16;
         readsize           = 256;
         read_lo            = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
@@ -6590,7 +6572,6 @@ part
         num_pages          = 32;
         min_write_delay    = 4000;
         max_write_delay    = 4000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
@@ -6608,9 +6589,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--xxxx.xxaa--aaaa.aaaa--oooo.oooo";
@@ -6728,7 +6708,6 @@ part
         num_pages          = 64;
         min_write_delay    = 4000;
         max_write_delay    = 4000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
@@ -6746,9 +6725,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
@@ -6866,7 +6844,6 @@ part
         num_pages          = 128;
         min_write_delay    = 4000;
         max_write_delay    = 4000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
@@ -6884,9 +6861,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--xxxx.aaaa--aaaa.aaaa--oooo.oooo";
@@ -7058,7 +7034,6 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
@@ -7077,7 +7052,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
@@ -7234,7 +7209,6 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
@@ -7252,9 +7226,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -7411,7 +7384,6 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
@@ -7429,9 +7401,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
@@ -7587,9 +7558,8 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 5;
+        delay              = 20;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
@@ -7605,9 +7575,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -7724,7 +7693,6 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
@@ -7742,7 +7710,6 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 64;
@@ -7852,7 +7819,6 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
@@ -7870,7 +7836,6 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 64;
@@ -7982,7 +7947,6 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
@@ -8000,9 +7964,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -8112,7 +8075,6 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
@@ -8130,9 +8092,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 64;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -8244,7 +8205,6 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
@@ -8262,9 +8222,8 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -8382,6 +8341,7 @@ part parent "m328"
     memory "eeprom"
         size               = 2048;
         page_size          = 8;
+        delay              = 10;
         read               = "1010.0000--000x.xaaa--aaaa.aaaa--oooo.oooo";
         write              = "1100.0000--000x.xaaa--aaaa.aaaa--iiii.iiii";
         loadpage_lo        = "1100.0001--0000.0000--0000.0aaa--iiii.iiii";
@@ -8460,7 +8420,6 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
@@ -8478,9 +8437,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
@@ -8606,7 +8564,6 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
@@ -8624,9 +8581,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
@@ -8862,7 +8818,8 @@ part parent "pwm3b"
     memory "flash"
         size               = 0x4000;
         page_size          = 128;
-        mode               = 0x21;
+        readback           = 0x00 0x00;
+        delay              = 10;
         blocksize          = 128;
         read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
         read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -8942,9 +8899,8 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 5;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
@@ -8960,9 +8916,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
@@ -9073,9 +9028,8 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 5;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
@@ -9091,9 +9045,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
@@ -9205,9 +9158,8 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 5;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
@@ -9223,9 +9175,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -9698,7 +9649,7 @@ part parent "m2561"
         num_pages          = 512;
         min_write_delay    = 50000;
         max_write_delay    = 50000;
-        delay              = 20;
+        delay              = 50;
         load_ext_addr      = NULL;
     ;
 ;
@@ -9720,6 +9671,7 @@ part parent "m2561"
         size               = 8192;
         min_write_delay    = 13000;
         max_write_delay    = 13000;
+        delay              = 50;
         read               = "1010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
         write              = "1100.0000--xxxa.aaaa--aaaa.aaaa--iiii.iiii";
         writepage          = "1100.0010--00xa.aaaa--aaaa.a000--xxxx.xxxx";
@@ -9753,6 +9705,7 @@ part parent "m128rfa1"
         size               = 2048;
         min_write_delay    = 13000;
         max_write_delay    = 13000;
+        delay              = 50;
         read               = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
         write              = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
         writepage          = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";
@@ -9859,9 +9812,8 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxx--xaaa.aaaa--oooo.oooo";
@@ -9877,9 +9829,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.00aa--aaaa.aaaa--oooo.oooo";
@@ -10001,9 +9952,8 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxx--aaaa.aaaa--oooo.oooo";
@@ -10019,9 +9969,8 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.0aaa--aaaa.aaaa--oooo.oooo";
@@ -10143,9 +10092,8 @@ part
         page_size          = 4;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
@@ -10161,9 +10109,8 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 32;
         readsize           = 256;
         read_lo            = "0010.0000--0000.aaaa--aaaa.aaaa--oooo.oooo";
@@ -10336,9 +10283,8 @@ part
         num_pages          = 16;
         min_write_delay    = 4000;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 5;
+        delay              = 10;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxx--00aa.aaaa--oooo.oooo";
@@ -10354,7 +10300,6 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 64;
@@ -11770,7 +11715,6 @@ part
         page_size          = 4;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
@@ -11788,7 +11732,6 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
@@ -11929,7 +11872,6 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 8;
@@ -11947,7 +11889,6 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
@@ -13435,9 +13376,8 @@ part
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 5;
+        delay              = 20;
         blocksize          = 4;
         readsize           = 256;
         read               = "1010.0000--000x.xxxa--aaaa.aaaa--oooo.oooo";
@@ -13453,9 +13393,8 @@ part
         num_pages          = 512;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        readback           = 0xff 0xff;
         mode               = 0x41;
-        delay              = 6;
+        delay              = 10;
         blocksize          = 128;
         readsize           = 256;
         read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2743,7 +2743,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 8;
         blocksize          = 64;
         readsize           = 256;
@@ -2756,7 +2756,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 20000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 5;
         blocksize          = 128;
         readsize           = 256;
@@ -2848,7 +2848,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 5;
         blocksize          = 4;
         readsize           = 256;
@@ -2866,7 +2866,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -2969,7 +2969,7 @@ part
         min_write_delay    = 8200;
         max_write_delay    = 8200;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 10;
         blocksize          = 64;
         readsize           = 256;
@@ -2982,7 +2982,7 @@ part
         min_write_delay    = 4100;
         max_write_delay    = 4100;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 5;
         blocksize          = 128;
         readsize           = 256;
@@ -3061,7 +3061,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 9000;
         readback           = 0x00 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 20;
         blocksize          = 32;
         readsize           = 256;
@@ -3074,7 +3074,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 2;
+        mode               = 0x02;
         delay              = 15;
         blocksize          = 128;
         readsize           = 256;
@@ -3141,7 +3141,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0x80 0x7f;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 64;
         readsize           = 256;
@@ -3154,7 +3154,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0x7f 0x7f;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 64;
         readsize           = 256;
@@ -3221,7 +3221,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 9000;
         readback           = 0x80 0x7f;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 64;
         readsize           = 256;
@@ -3234,7 +3234,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 9000;
         readback           = 0x7f 0x7f;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3302,7 +3302,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0x00 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3315,7 +3315,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3393,7 +3393,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0x00 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 64;
         readsize           = 256;
@@ -3406,7 +3406,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 128;
@@ -3478,7 +3478,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0x00 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3491,7 +3491,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3625,7 +3625,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 9000;
         readback           = 0x80 0x7f;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3638,7 +3638,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 9000;
         readback           = 0x7f 0x7f;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3705,7 +3705,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0x00 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3718,7 +3718,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 128;
         readsize           = 256;
@@ -3790,7 +3790,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 9000;
         readback           = 0x80 0x7f;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 64;
         readsize           = 256;
@@ -3806,7 +3806,7 @@ part
         min_write_delay    = 22000;
         max_write_delay    = 56000;
         readback           = 0xff 0xff;
-        mode               = 17;
+        mode               = 0x11;
         delay              = 70;
         blocksize          = 256;
         readsize           = 256;
@@ -3890,7 +3890,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 20;
         blocksize          = 64;
         readsize           = 256;
@@ -3906,7 +3906,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -4022,7 +4022,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 12;
         blocksize          = 64;
         readsize           = 256;
@@ -4038,7 +4038,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -4155,7 +4155,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
         readsize           = 256;
@@ -4173,7 +4173,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -4280,7 +4280,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
         readsize           = 256;
@@ -4298,7 +4298,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -4405,7 +4405,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
         readsize           = 256;
@@ -4423,7 +4423,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -4530,7 +4530,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -4548,7 +4548,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -4657,7 +4657,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -4675,7 +4675,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -4855,7 +4855,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -4873,7 +4873,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -5016,7 +5016,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -5034,7 +5034,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 256;
         readsize           = 256;
@@ -5150,7 +5150,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -5168,7 +5168,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -5266,7 +5266,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -5282,7 +5282,7 @@ part
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         readback           = 0xff 0xff;
-        mode               = 17;
+        mode               = 0x11;
         delay              = 20;
         blocksize          = 128;
         readsize           = 256;
@@ -5379,7 +5379,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -5397,7 +5397,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -5540,7 +5540,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
         readsize           = 256;
@@ -5558,7 +5558,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -5745,7 +5745,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 8;
         readsize           = 256;
@@ -5763,7 +5763,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -5925,7 +5925,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 10;
         blocksize          = 64;
         readsize           = 256;
@@ -5943,7 +5943,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -6033,7 +6033,7 @@ part
         min_write_delay    = 3400;
         max_write_delay    = 3400;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 5;
         blocksize          = 128;
         readsize           = 256;
@@ -6049,7 +6049,7 @@ part
         min_write_delay    = 14000;
         max_write_delay    = 14000;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 16;
         blocksize          = 128;
         readsize           = 256;
@@ -6143,7 +6143,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 20;
         blocksize          = 128;
         readsize           = 256;
@@ -6159,7 +6159,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0x00;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 10;
         blocksize          = 64;
         readsize           = 256;
@@ -6258,7 +6258,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 20;
         blocksize          = 128;
         readsize           = 256;
@@ -6274,7 +6274,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -6365,7 +6365,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 20;
         blocksize          = 128;
         readsize           = 256;
@@ -6381,7 +6381,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -6473,7 +6473,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 4;
+        mode               = 0x04;
         delay              = 10;
         blocksize          = 64;
         readsize           = 256;
@@ -6489,7 +6489,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 33;
+        mode               = 0x21;
         delay              = 6;
         blocksize          = 16;
         readsize           = 256;
@@ -6591,7 +6591,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
         readsize           = 256;
@@ -6609,7 +6609,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -6729,7 +6729,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
         readsize           = 256;
@@ -6747,7 +6747,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -6867,7 +6867,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
         readsize           = 256;
@@ -6885,7 +6885,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -7059,7 +7059,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -7076,7 +7076,7 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -7235,7 +7235,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -7253,7 +7253,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -7412,7 +7412,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -7430,7 +7430,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -7588,7 +7588,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 5;
         blocksize          = 4;
         readsize           = 256;
@@ -7606,7 +7606,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -7725,7 +7725,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
         readsize           = 256;
@@ -7743,7 +7743,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 64;
         readsize           = 256;
@@ -7853,7 +7853,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
         readsize           = 256;
@@ -7871,7 +7871,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 64;
         readsize           = 256;
@@ -7983,7 +7983,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 64;
@@ -8001,7 +8001,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -8113,7 +8113,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 64;
@@ -8131,7 +8131,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -8245,7 +8245,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -8263,7 +8263,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -8461,7 +8461,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -8479,7 +8479,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -8607,7 +8607,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -8625,7 +8625,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -8737,7 +8737,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -8755,7 +8755,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 64;
         readsize           = 256;
@@ -8862,7 +8862,7 @@ part parent "pwm3b"
     memory "flash"
         size               = 0x4000;
         page_size          = 128;
-        mode               = 33;
+        mode               = 0x21;
         blocksize          = 128;
         read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
         read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
@@ -8943,7 +8943,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -8961,7 +8961,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -9074,7 +9074,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -9092,7 +9092,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -9206,7 +9206,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -9224,7 +9224,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -9333,7 +9333,7 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 8;
         readsize           = 256;
@@ -9350,7 +9350,7 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 256;
         readsize           = 256;
@@ -9458,7 +9458,7 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 8;
         readsize           = 256;
@@ -9475,7 +9475,7 @@ part
         num_pages          = 512;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 256;
         readsize           = 256;
@@ -9595,7 +9595,7 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 8;
         readsize           = 256;
@@ -9612,7 +9612,7 @@ part
         num_pages          = 1024;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 256;
         readsize           = 256;
@@ -9860,7 +9860,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -9878,7 +9878,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -10002,7 +10002,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -10020,7 +10020,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -10144,7 +10144,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 4;
         readsize           = 256;
@@ -10162,7 +10162,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 32;
         readsize           = 256;
@@ -10337,7 +10337,7 @@ part
         min_write_delay    = 4000;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 5;
         blocksize          = 4;
         readsize           = 256;
@@ -10355,7 +10355,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 64;
         readsize           = 256;
@@ -10464,7 +10464,7 @@ part
         page_size          = 4;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -10481,7 +10481,7 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -10590,7 +10590,7 @@ part
         page_size          = 4;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -10607,7 +10607,7 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -10716,7 +10716,7 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 8;
         readsize           = 256;
@@ -10733,7 +10733,7 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -10853,7 +10853,7 @@ part
         page_size          = 8;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 8;
         readsize           = 256;
@@ -10870,7 +10870,7 @@ part
         num_pages          = 512;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 256;
         readsize           = 256;
@@ -10989,7 +10989,7 @@ part
         num_pages          = 128;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -11006,7 +11006,7 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -11114,7 +11114,7 @@ part
         num_pages          = 128;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -11131,7 +11131,7 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -11239,7 +11239,7 @@ part
         num_pages          = 256;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -11256,7 +11256,7 @@ part
         num_pages          = 256;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -11364,7 +11364,7 @@ part
         num_pages          = 128;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -11381,7 +11381,7 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -11489,7 +11489,7 @@ part
         num_pages          = 128;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -11506,7 +11506,7 @@ part
         num_pages          = 64;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;
@@ -11613,7 +11613,7 @@ part
         num_pages          = 128;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 20;
         blocksize          = 4;
         readsize           = 256;
@@ -11630,7 +11630,7 @@ part
         num_pages          = 128;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -11771,7 +11771,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 4;
         readsize           = 256;
@@ -11789,7 +11789,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -11930,7 +11930,7 @@ part
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 8;
         readsize           = 256;
@@ -11948,7 +11948,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 10;
         blocksize          = 128;
         readsize           = 256;
@@ -13436,7 +13436,7 @@ part
         min_write_delay    = 3600;
         max_write_delay    = 3600;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 5;
         blocksize          = 4;
         readsize           = 256;
@@ -13454,7 +13454,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         readback           = 0xff 0xff;
-        mode               = 65;
+        mode               = 0x41;
         delay              = 6;
         blocksize          = 128;
         readsize           = 256;

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -763,7 +763,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
     _if_memout(intcmp, "%d", max_write_delay);
     _if_memout_yn(pwroff_after_write);
     _if_n_memout_str(memcmp, 2, dev_sprintf("0x%02x 0x%02x", m->readback[0], m->readback[1]), readback);
-    _if_memout(intcmp, "%d", mode);
+    _if_memout(intcmp, "0x%02x", mode);
     _if_memout(intcmp, "%d", delay);
     _if_memout(intcmp, "%d", blocksize);
     _if_memout(intcmp, "%d", readsize);


### PR DESCRIPTION
I noted that some of classic parts have wrong values here. These parameters are used for the STK500 v2 programming and given in the ATDF files. I injected them using an automated mechanism (so either all is wrong or all is OK).

As mode is a bitfield I decided to give it as a hex number as it is easier to read. See Table 5-23, pg 11 in [AVR068](https://github.com/stefanrueger/avrdude/blob/mode_memdelay/atmel-docs/STK500v2-AVR068.pdf). That's the first commit. If you want to see which values have been corrected review the second commit. 