### PR TITLE
To support MinGW cross compiler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 add_compile_definitions(CONFIG_DIR=\"${CONFIG_DIR}\")
 
-if(WIN32)
+if(WIN32 OR MINGW)
     set(EXTRA_WINDOWS_RESOURCES "${PROJECT_BINARY_DIR}/src/windows.rc")
     set(EXTRA_WINDOWS_LIBRARIES setupapi ws2_32)
 endif()
@@ -107,7 +107,7 @@ endif()
 
 configure_file(cmake_config.h.in ac_cfg.h)
 configure_file(avrdude.spec.in avrdude.spec)
-if(WIN32)
+if(WIN32 OR MINGW)
     configure_file(windows.rc.in windows.rc)
 endif()
 


### PR DESCRIPTION
This patch is necessary to support MinGW cross compiler.

It is adapted from Arduino avrdude-packing project.
https://github.com/arduino/avrdude-packing/blob/main/patches/0007-Cmake-fix-build-not-working-with-mingw-toolchain.patch