### PR TITLE
Silence gcc compiler warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,7 +77,7 @@ if(MSVC)
         )
 else()
     set(LIB_MATH m)
-    add_compile_options(-Wall) # -Wextra
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter)
 endif()
 
 # =====================================

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -653,9 +653,9 @@ static int avr910_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     avr910_set_addr(pgm, addr / rd_size);
 
     while (addr < max_addr) {
-      if ((max_addr - addr) < blocksize) {
+      if (max_addr - addr < (unsigned int) blocksize)
         blocksize = max_addr - addr;
-      }
+
       cmd[1] = (blocksize >> 8) & 0xff;
       cmd[2] = blocksize & 0xff;
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -662,7 +662,7 @@ static int butterfly_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
       butterfly_set_addr(pgm, addr / rd_size);
     }
     while (addr < max_addr) {
-      if ((max_addr - addr) < blocksize) {
+      if ((max_addr - addr) < (unsigned int) blocksize) {
         blocksize = max_addr - addr;
       };
       cmd[1] = (blocksize >> 8) & 0xff;

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -429,7 +429,7 @@ fi
 
 # If we are compiling with gcc, enable all warnings and make warnings errors.
 if test "$GCC" = yes; then
-    ENABLE_WARNINGS="-Wall"
+    ENABLE_WARNINGS="-Wall -Wextra -Wno-unused-parameter"
 
 	# does this compiler support -Wno-pointer-sign ?
 	AC_MSG_CHECKING([if gcc accepts -Wno-pointer-sign ])

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -275,12 +275,12 @@ int dfu_getstatus(struct dfu_dev *dfu, struct dfu_status *status)
     return -1;
   }
 
-  if (result < sizeof(struct dfu_status)) {
+  if (result < (int) sizeof(struct dfu_status)) {
     pmsg_error("unable to get DFU status: %s\n", "short read");
     return -1;
   }
 
-  if (result > sizeof(struct dfu_status)) {
+  if (result > (int) sizeof(struct dfu_status)) {
     pmsg_error("oversize read (should not happen); exiting\n");
     exit(1);
   }

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -374,7 +374,7 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   if (strcmp(mem->desc, "signature") == 0) {
     if (flip1_read_sig_bytes(pgm, part, mem) < 0)
       return -1;
-    if (addr >= mem->size) {
+    if (addr >= (unsigned long) mem->size) {
       pmsg_error("signature address %lu out of range [0, %d]\n", addr, mem->size-1);
       return -1;
     }
@@ -461,7 +461,7 @@ int flip1_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
   result = flip1_write_memory(FLIP1(pgm)->dfu, mem_unit, addr,
     mem->buf + addr, n_bytes);
 
-  return (result == 0) ? n_bytes : -1;
+  return result == 0? (int) n_bytes: -1;
 }
 
 int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {
@@ -470,7 +470,7 @@ int flip1_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
   if (FLIP1(pgm)->dfu == NULL)
     return -1;
 
-  if (mem->size < sizeof(FLIP1(pgm)->part_sig)) {
+  if (mem->size < (int) sizeof(FLIP1(pgm)->part_sig)) {
     pmsg_error("signature read must be at least %u bytes\n", (unsigned int) sizeof(FLIP1(pgm)->part_sig));
     return -1;
   }

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -652,7 +652,7 @@ int flip1_write_memory(struct dfu_dev *dfu,
   int cmd_result = 0;
   int aux_result;
   struct flip1_cmd_header cmd_header = {
-    FLIP1_CMD_PROG_START, mem_unit
+    FLIP1_CMD_PROG_START, mem_unit, {0}, {0}, {0},
   };
   struct flip1_prog_footer cmd_footer = {
     { 0, 0, 0, 0 },             /* CRC */

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -459,7 +459,7 @@ int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
   result = flip2_read_memory(FLIP2(pgm)->dfu, mem_unit, addr,
     mem->buf + addr, n_bytes);
 
-  return (result == 0) ? n_bytes : -1;
+  return result == 0? (int) n_bytes: -1;
 }
 
 int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem,
@@ -490,7 +490,7 @@ int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
   result = flip2_write_memory(FLIP2(pgm)->dfu, mem_unit, addr,
     mem->buf + addr, n_bytes);
 
-  return (result == 0) ? n_bytes : -1;
+  return result == 0? (int) n_bytes: -1;
 }
 
 // Parse the -E option flag
@@ -520,7 +520,7 @@ int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRME
   if (FLIP2(pgm)->dfu == NULL)
     return -1;
 
-  if (mem->size < sizeof(FLIP2(pgm)->part_sig)) {
+  if (mem->size < (int) sizeof(FLIP2(pgm)->part_sig)) {
     pmsg_error("signature read must be at least %u bytes\n", (unsigned int) sizeof(FLIP2(pgm)->part_sig));
     return -1;
   }

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -276,7 +276,7 @@ static int ft245r_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
     ft245r_fill(pgm);
 
 #if FT245R_DEBUG
-    msg_info("%s: discarding %d, consuming %zu bytes\n", __func__, rx.discard, len);
+    msg_info("%s: discarding %d, consuming %lu bytes\n", __func__, rx.discard, (unsigned long) len);
 #endif
     while (rx.discard > 0) {
         int result = ft245r_rx_buf_fill_and_get(pgm);

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -166,14 +166,14 @@ static void ft245r_rx_buf_purge(const PROGRAMMER *pgm) {
 static void ft245r_rx_buf_put(const PROGRAMMER *pgm, uint8_t byte) {
     rx.len++;
     rx.buf[rx.wr++] = byte;
-    if (rx.wr >= sizeof(rx.buf))
+    if (rx.wr >= (int) sizeof(rx.buf))
 	rx.wr = 0;
 }
 
 static uint8_t ft245r_rx_buf_get(const PROGRAMMER *pgm) {
     rx.len--;
     uint8_t byte = rx.buf[rx.rd++];
-    if (rx.rd >= sizeof(rx.buf))
+    if (rx.rd >= (int) sizeof(rx.buf))
 	rx.rd = 0;
     return byte;
 }
@@ -246,10 +246,8 @@ static int ft245r_flush(const PROGRAMMER *pgm) {
 
 static int ft245r_send2(const PROGRAMMER *pgm, unsigned char *buf, size_t len,
 			bool discard_rx_data) {
-    int i, j;
-
-    for (i = 0; i < len; ++i) {
-	for (j = 0; j < baud_multiplier; ++j) {
+    for (size_t i = 0; i < len; ++i) {
+	for (int j = 0; j < baud_multiplier; ++j) {
 	    if (discard_rx_data)
 		++rx.discard;
 	    tx.buf[tx.len++] = buf[i];
@@ -270,8 +268,6 @@ static int ft245r_send_and_discard(const PROGRAMMER *pgm, unsigned char *buf,
 }
 
 static int ft245r_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
-    int i, j;
-
     ft245r_flush(pgm);
     ft245r_fill(pgm);
 
@@ -288,7 +284,7 @@ static int ft245r_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
         --rx.discard;
     }
 
-    for (i = 0; i < len; ++i)
+    for (size_t i = 0; i < len; ++i)
     {
         int result = ft245r_rx_buf_fill_and_get(pgm);
         if (result < 0)
@@ -297,7 +293,7 @@ static int ft245r_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
         }
 
         buf[i] = (uint8_t)result;
-        for (j = 1; j < baud_multiplier; ++j)
+        for (int j = 1; j < baud_multiplier; ++j)
         {
             result = ft245r_rx_buf_fill_and_get(pgm);
             if (result < 0)
@@ -1054,7 +1050,7 @@ static int ft245r_paged_write_flash(const PROGRAMMER *pgm, const AVRPART *p, con
         avr_set_bits(m->op[spi], cmd);
         avr_set_addr(m->op[spi], cmd, addr/2);
         avr_set_input(m->op[spi], cmd, m->buf[addr]);
-        for(int k=0; k<sizeof cmd; k++)
+        for(size_t k=0; k<sizeof cmd; k++)
            buf_pos += set_data(pgm, buf+buf_pos, cmd[k]);
 
         i++; j++; addr++;
@@ -1064,7 +1060,7 @@ static int ft245r_paged_write_flash(const PROGRAMMER *pgm, const AVRPART *p, con
 
         // page boundary, finished or buffer exhausted? queue up requests
         if(do_page_write || i >= (int) n_bytes || j >= FT245R_FRAGMENT_SIZE/FT245R_CMD_SIZE) {
-            if(i >= n_bytes) {
+            if(i >= (int) n_bytes) {
                 ft245r_out = SET_BITS_0(ft245r_out, pgm, PIN_AVR_SCK, 0); // SCK down
                 buf[buf_pos++] = ft245r_out;
             } else {
@@ -1150,7 +1146,7 @@ static int ft245r_paged_load_flash(const PROGRAMMER *pgm, const AVRPART *p, cons
 	avr_set_addr(m->op[AVR_OP_LOAD_EXT_ADDR], cmd, addr/2);
 
         buf_pos = 0;
-        for(int k=0; k<sizeof cmd; k++)
+        for(size_t k=0; k<sizeof cmd; k++)
             buf_pos += set_data(pgm, buf+buf_pos, cmd[k]);
         ft245r_send_and_discard(pgm, buf, buf_pos);
     }
@@ -1164,7 +1160,7 @@ static int ft245r_paged_load_flash(const PROGRAMMER *pgm, const AVRPART *p, cons
         memset(cmd, 0, sizeof cmd);
         avr_set_bits(m->op[spi], cmd);
         avr_set_addr(m->op[spi], cmd, addr/2);
-        for(int k=0; k<sizeof cmd; k++)
+        for(size_t k=0; k<sizeof cmd; k++)
            buf_pos += set_data(pgm, buf+buf_pos, cmd[k]);
 
         i++; j++; addr++;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2586,7 +2586,7 @@ static int jtag3_send_tpi(const PROGRAMMER *pgm, unsigned char *data, size_t len
 
   cmdbuf[0] = SCOPE_AVR_TPI;
   if (len > INT_MAX) {
-    pmsg_error("invalid jtag3_send_tpi() packet length %zu\n", len);
+    pmsg_error("invalid jtag3_send_tpi() packet length %lu\n", (unsigned long) len);
     free(cmdbuf);
     return -1;
   }

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -182,6 +182,7 @@ static void jtagmkI_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len
 
   case RESP_POWER:
     msg_info("target power lost\n");
+    break;
 
   default:
     msg_info("unknown message 0x%02x\n", data[0]);

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -83,7 +83,7 @@ struct pdata
  * to try connecting at startup, we keep these two entries on top to
  * speedup the program start.
  */
-const static struct {
+static const struct {
   long baud;
   unsigned char val;
 } baudtab[] = {
@@ -139,11 +139,10 @@ u16_to_b2(unsigned char *b, unsigned short l)
 }
 
 static void jtagmkI_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
-  int i;
-
   if (verbose >= 4) {
     msg_trace("Raw message:\n");
 
+    size_t i;
     for (i = 0; i < len; i++) {
       msg_trace("0x%02x ", data[i]);
       if (i % 16 == 15)
@@ -472,9 +471,7 @@ static int jtagmkI_program_disable(const PROGRAMMER *pgm) {
 
 static unsigned char jtagmkI_get_baud(long baud)
 {
-  int i;
-
-  for (i = 0; i < sizeof baudtab / sizeof baudtab[0]; i++)
+  for (size_t i = 0; i < sizeof baudtab / sizeof baudtab[0]; i++)
     if (baud == baudtab[i].baud)
       return baudtab[i].val;
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -795,7 +795,7 @@ lget ( LISTID lid )
 void * 
 lget_n ( LISTID lid, unsigned int n )
 {
-  int i;
+  unsigned int i;
   LIST * l;
   LISTNODE * ln;
 
@@ -803,7 +803,7 @@ lget_n ( LISTID lid, unsigned int n )
 
   CKLMAGIC(l);
 
-  if ((n<1)||(n>lsize(l))) {
+  if (n < 1 || n > (unsigned int) lsize(l)) {
     return NULL;
   }
 
@@ -836,7 +836,7 @@ lget_n ( LISTID lid, unsigned int n )
 LNODEID
 lget_ln ( LISTID lid, unsigned int n )
 {
-  int i;
+  unsigned int i;
   LIST * l;
   LISTNODE * ln;
 
@@ -844,7 +844,7 @@ lget_ln ( LISTID lid, unsigned int n )
 
   CKLMAGIC(l);
 
-  if ((n<1)||(n>lsize(l))) {
+  if (n < 1 || n > (unsigned int) lsize(l)) {
     return NULL;
   }
 
@@ -944,7 +944,7 @@ insert_ln ( LIST * l, LISTNODE * ln, void * data_ptr )
 int 
 lins_n ( LISTID lid, void * data_ptr, unsigned int n )
 {
-  int i;
+  unsigned int i;
   LIST * l;
   LISTNODE * ln;
 
@@ -952,7 +952,7 @@ lins_n ( LISTID lid, void * data_ptr, unsigned int n )
 
   CKLMAGIC(l);
 
-  if ((n<1)||(n>(l->num+1))) {
+  if (n < 1 || n > (unsigned int) (l->num+1)) {
     return -1;
   }
 
@@ -1185,7 +1185,7 @@ lrmv_ln ( LISTID lid, LNODEID lnid )
 void * 
 lrmv_n ( LISTID lid, unsigned int n )
 {
-  int i;
+  unsigned int i;
   LIST * l;
   LISTNODE * ln;
 
@@ -1193,7 +1193,7 @@ lrmv_n ( LISTID lid, unsigned int n )
 
   CKLMAGIC(l);
 
-  if ((n<1)||(n>l->num)) {
+  if (n < 1 || n > (unsigned int) l->num) {
     return NULL;
   }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -191,7 +191,7 @@ static int micronucleus_get_bootloader_info_v1(pdata_t* pdata)
         pmsg_warning("unable to get bootloader info block: %s\n", usb_strerror());
         return result;
     }
-    else if (result < sizeof(buffer))
+    else if ((size_t) result < sizeof(buffer))
     {
         pmsg_warning("received invalid bootloader info block size: %d\n", result);
         return -1;
@@ -258,7 +258,7 @@ static int micronucleus_get_bootloader_info_v2(pdata_t* pdata)
         pmsg_warning("unable to get bootloader info block: %s\n", usb_strerror());
         return result;
     }
-    else if (result < sizeof(buffer))
+    else if ((size_t) result < sizeof(buffer))
     {
         pmsg_warning("received invalid bootloader info block size: %d\n", result);
         return -1;
@@ -449,7 +449,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
         return result;
     }
 
-    for (int i = 0; i < size; i += 4)
+    for (uint32_t i = 0; i < size; i += 4)
     {
         int w1 = (buffer[i + 1] << 8) | (buffer[i + 0] << 0);
         int w2 = (buffer[i + 3] << 8) | (buffer[i + 2] << 0);
@@ -491,7 +491,7 @@ static int micronucleus_write_page(pdata_t* pdata, uint32_t address, uint8_t* bu
         // Require software start.
         pdata->start_program = true;
     }
-    else if (address >= pdata->bootloader_start - pdata->page_size)
+    else if (address >= (uint32_t) (pdata->bootloader_start - pdata->page_size))
     {
         if (pdata->major_version >= 2)
         {

--- a/src/pgm_type.c
+++ b/src/pgm_type.c
@@ -111,29 +111,17 @@ const PROGRAMMER_TYPE programmers_types[] = { // Name(s) the programmers call th
   {"xbee", xbee_initpgm, xbee_desc}, // "XBee"
 };
 
-const PROGRAMMER_TYPE * locate_programmer_type(const char * id)
-{
-  const PROGRAMMER_TYPE * p = NULL;
-  int i;
-  int found;
-
-  found = 0;
-
-  for (i = 0; i < sizeof(programmers_types)/sizeof(programmers_types[0]) && !found; i++) {
-    p = &(programmers_types[i]);
-    if (strcasecmp(id, p->id) == 0)
-        found = 1;
-  }
-
-  if (found)
-    return p;
+const PROGRAMMER_TYPE *locate_programmer_type(const char *id) {
+  for(size_t i = 0; i < sizeof programmers_types/sizeof*programmers_types; i++)
+    if(strcasecmp(id, programmers_types[i].id) == 0)
+      return programmers_types + i;
 
   return NULL;
 }
 
 // Return type id given the init function or "" if not found
 const char *locate_programmer_type_id(void (*initpgm)(PROGRAMMER *pgm)) {
-  for (int i=0; i < sizeof programmers_types/sizeof*programmers_types; i++)
+  for(size_t i=0; i < sizeof programmers_types/sizeof*programmers_types; i++)
     if(programmers_types[i].initpgm == initpgm)
       return programmers_types[i].id;
 
@@ -142,35 +130,15 @@ const char *locate_programmer_type_id(void (*initpgm)(PROGRAMMER *pgm)) {
 
 
 /*
- * Iterate over the list of programmers given as "programmers", and
- * call the callback function cb for each entry found.  cb is being
+ * Iterate over the list of programmer types given in the table above and
+ * call the callback function cb for each entry found. cb is being
  * passed the following arguments:
- * . the name of the programmer (for -c)
- * . the descriptive text given in the config file
- * . the name of the config file this programmer has been defined in
- * . the line number of the config file this programmer has been defined at
- * . the "cookie" passed into walk_programmers() (opaque client data)
+ *  - Name of the programmer
+ *  - Descriptive text
+ *  - "Cookie" passed into walk_programmer_types() for opaque client data
  */
- /*
-void walk_programmer_types(LISTID programmer_types, walk_programmer_types_cb cb, void *cookie)
-{
-  LNODEID ln1;
-  PROGRAMMER * p;
 
-  for (ln1 = lfirst(programmers); ln1; ln1 = lnext(ln1)) {
-    p = ldata(ln1);
-      cb(p->id, p->desc, cookie);
-    }
-  }
-}*/
-
-void walk_programmer_types(walk_programmer_types_cb cb, void *cookie)
-{
-  const PROGRAMMER_TYPE * p;
-  int i;
-
-  for (i = 0; i < sizeof(programmers_types)/sizeof(programmers_types[0]); i++) {
-    p = &(programmers_types[i]);
-    cb(p->id, p->desc, cookie);
-  }
+void walk_programmer_types(walk_programmer_types_cb cb, void *cookie) {
+  for (size_t i = 0; i < sizeof(programmers_types)/sizeof(programmers_types[0]); i++)
+    cb(programmers_types[i].id, programmers_types[i].desc, cookie);
 }

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -199,7 +199,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
           strcpy(cbuf, pgm->desc);
 
         // Convert from wide chars and overlay over initial part of desc
-        for (int i = 0; i < sizeof wbuf/sizeof*wbuf && wbuf[i]; i++)
+        for(size_t i = 0; i < sizeof wbuf/sizeof*wbuf && wbuf[i]; i++)
           cbuf[i] = (char) wbuf[i]; // TODO what about little/big endian???
         pgm->desc = cache_string(cbuf);
     }
@@ -1058,7 +1058,7 @@ static int usb_read_interrupt(const PROGRAMMER *pgm, void *buff, int size, int t
 
     GetOverlappedResult(PDATA(pgm)->usb_handle, &ovr, &bytesRead, 0);
 
-    return bytesRead > 0 ? bytesRead : -1;
+    return bytesRead > 0? (int) bytesRead: -1;
 }
 
 // simple write with timeout
@@ -1083,7 +1083,7 @@ static int usb_write_interrupt(const PROGRAMMER *pgm, const void *buff, int size
 
     GetOverlappedResult(PDATA(pgm)->usb_handle, &ovr, &bytesWritten, 0);
 
-    return bytesWritten > 0 ? bytesWritten : -1;
+    return bytesWritten > 0? (int) bytesWritten: -1;
 }
 
 static int pickit2_write_report(const PROGRAMMER *pgm, const unsigned char report[65]) {

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -84,9 +84,7 @@ static int pin_fill_old_pinno(const struct pindef_t * const pindef, unsigned int
  * @param[out] pinno old pin definition integer
  */
 static int pin_fill_old_pinlist(const struct pindef_t * const pindef, unsigned int * const pinno) {
-  int i;
-
-  for(i = 0; i < PIN_FIELD_SIZE; i++) {
+  for(size_t i = 0; i < PIN_FIELD_SIZE; i++) {
     if(i == 0) {
       if((pindef->mask[i] & ~PIN_MASK) != 0) {
         pmsg_error("pins of higher index than max field size for old pinno found\n");
@@ -229,7 +227,6 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     bool invalid = false;
     bool inverse = false;
     int index;
-    int segment;
     bool mandatory_used = false;
     pinmask_t invalid_used[PIN_FIELD_SIZE] = {0};
     pinmask_t inverse_used[PIN_FIELD_SIZE] = {0};
@@ -246,7 +243,7 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
       }
     }
 
-    for(segment = 0; segment < PIN_FIELD_SIZE; segment++) {
+    for(size_t segment = 0; segment < PIN_FIELD_SIZE; segment++) {
       // check if for mandatory any pin is defined
       invalid_used[segment] = pgm->pin[pinname].mask[segment] & ~valid_pins->mask[segment];
       if(is_mandatory && (0 != (pgm->pin[pinname].mask[segment] & valid_pins->mask[segment]))) {

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -705,11 +705,17 @@ static int serialupdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
                                  unsigned int page_size,
                                  unsigned int addr, unsigned int n_bytes)
 {
-  if (n_bytes > m->readsize) {
+  if(n_bytes > 65535) {
+    pmsg_error("%s() called with implausibly high n_bytes = %u\n", __func__, n_bytes);
+    return -1;
+  }
+
+  if ((int) n_bytes > m->readsize) {
     unsigned int read_offset = addr;
-    unsigned int remaining_bytes = n_bytes;
+    int remaining_bytes = n_bytes;
     int read_bytes = 0;
     int rc;
+
     while (remaining_bytes > 0) {
       rc = updi_read_data(pgm, m->offset + read_offset, m->buf + read_offset, 
                           remaining_bytes > m->readsize ? m->readsize : remaining_bytes);
@@ -733,10 +739,16 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
                                   unsigned int addr, unsigned int n_bytes)
 {
   int rc;
-  if (n_bytes > m->page_size) {
+
+  if(n_bytes > 65535) {
+    pmsg_error("%s() called with implausibly high n_bytes = %u\n", __func__, n_bytes);
+    return -1;
+  }
+  if ((int) n_bytes > m->page_size) {
     unsigned int write_offset = addr;
-    unsigned int remaining_bytes = n_bytes;
+    int remaining_bytes = n_bytes;
     int write_bytes = 0;
+
     while (remaining_bytes > 0) {
 
       if (strcmp(m->desc, "eeprom")==0) {

--- a/src/update.c
+++ b/src/update.c
@@ -560,8 +560,9 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, UPDATE *upd, enum updateflags
     pmsg_info("%d byte%s of %s%s written\n", fs.nbytes,
       update_plural(fs.nbytes), mem->desc, alias_mem_desc);
 
-    if (!(flags & UF_VERIFY))   // Fall through for auto verify unless -V was specified
+    if (!(flags & UF_VERIFY))   // Fall through for auto verify unless
       break;
+    // Fall through
 
   case DEVICE_VERIFY:
     // Verify that the in memory file is the same as what is on the chip

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -272,7 +272,9 @@ static int usbhid_recv(const union filedescriptor *fd, unsigned char *buf, size_
     return -1;
 
   rv = i = hid_read_timeout(udev, buf, nbytes, 10000);
-  if (i != nbytes)
+  if (i < 0)
+    pmsg_error("hid_read_timeout(usb, %lu, 10000) failed\n", (unsigned long) nbytes);
+  else if ((size_t) i != nbytes)
     pmsg_error("short read, read only %d out of %lu bytes\n", i, (unsigned long) nbytes);
 
   if (verbose > 4) {
@@ -291,6 +293,7 @@ static int usbhid_recv(const union filedescriptor *fd, unsigned char *buf, size_
     }
     msg_trace2("\n");
   }
+
   return rv;
 }
 

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -932,7 +932,7 @@ static int usbasp_spi_set_sck_period(const PROGRAMMER *pgm, double sckperiod) {
     pmsg_notice2("try to set SCK period to %g s (= %i Hz)\n", sckperiod, sckfreq);
 
     /* Check if programmer is capable of 3 MHz SCK, if not then ommit 3 MHz setting */
-    int i;
+    size_t i;
     if (PDATA(pgm)->sck_3mhz) {
       pmsg_notice2("connected USBasp is capable of 3 MHz SCK\n");
       i = 0;
@@ -1122,7 +1122,7 @@ static int usbasp_tpi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
   pr = addr + m->offset;
   readed = 0;
 
-  while(readed < n_bytes)
+  while(readed < (int) n_bytes)
   {
     clen = n_bytes - readed;
     if(clen > 32)
@@ -1187,7 +1187,7 @@ static int usbasp_tpi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
   usbasp_tpi_send_byte(pgm, TPI_OP_SSTPR(1));
   usbasp_tpi_send_byte(pgm, (pr >> 8) );
 
-  while(writed < n_bytes)
+  while(writed < (int) n_bytes)
   {
     clen = n_bytes - writed;
     if(clen > 32)

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -735,7 +735,7 @@ static int usbtiny_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     }
 
     // we can only write a page at a time anyways
-    if (m->paged && chunk > page_size)
+    if (m->paged && chunk > (int) page_size)
       chunk = page_size;
 
     if (usb_out(pgm,
@@ -752,8 +752,7 @@ static int usbtiny_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     }
 
     next = addr + chunk;       // Calculate what address we're at now
-    if (m->paged
-	&& ((next % page_size) == 0 || next == maxaddr) ) {
+    if (m->paged && (next % page_size == 0 || next == (int) maxaddr) ) {
       // If we're at a page boundary, send the SPI command to flush it.
       avr_write_page(pgm, p, m, (unsigned long) addr);
     }


### PR DESCRIPTION
This PR reviews all compiler warnings in gcc and silences them under Linux. This means that for new code development a higher warning level can be used without seeing legacy warnings that are inconsequential. En passant, this PR also fixes one minor fall through error.