### PR TITLE
Update configure.ac for MinGW build

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -78,6 +78,9 @@ dnl Makefile.am:77: compiling `config_gram.c' with per-target flags requires `AM
 AM_PROG_CC_C_O
 
 # Checks for libraries.
++# For MinGW.
++AC_CHECK_LIB([ws2_32], [WSAStartup])
++
 AC_CHECK_LIB([termcap], [tputs])
 AC_CHECK_LIB([ncurses], [tputs])
 AC_CHECK_LIB([readline], [readline])


### PR DESCRIPTION
Fix #957.

Even though we are only supporting CMake build now, the fix is simple enough and not affecting CMake.