### PR TITLE
build.sh: For compatibility with old CMake versions, use old syntax to generate build system

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,9 +74,11 @@ case "${ostype}" in
 	;;
 esac
 
-cmake ${build_flags} ${extra_enable} -D CMAKE_BUILD_TYPE=${build_type} -B build_${ostype} ||\
+mkdir -p build_${ostype}
+cd build_${ostype}
+cmake ${build_flags} ${extra_enable} -D CMAKE_BUILD_TYPE=${build_type} .. ||\
     { echo "CMake failed."; exit 1; }
-cmake --build build_${ostype} ||\
+cmake --build . ||\
     { echo "Build failed."; exit 1; }
 
 cat <<EOF


### PR DESCRIPTION
Fixes #1300 