### PR TITLE
extend max pin number to 1000

### DIFF
--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -428,7 +428,7 @@ enum {
 #ifdef HAVE_LINUXGPIO
 /* Embedded systems might have a lot more gpio than only 0-31 */
 #undef PIN_MAX
-#define PIN_MAX     400 /* largest allowed pin number */
+#define PIN_MAX     1000 /* largest allowed pin number */
 #endif
 
 /** Number of pins in each element of the bitfield */


### PR DESCRIPTION
Some embedded computers with GPIO are using very large pin numbers. For example, the pins on the LePotato SBC use numbers in the 400's.

Extending this max value makes is possible for users to make custom avrdude.conf additions that use this pins.

Le Potato board:

https://libre.computer/products/aml-s905x-cc/

Le Potato pin numbering reference:
https://docs.google.com/spreadsheets/d/1U3z0Gb8HUEfCIMkvqzmhMpJfzRqjPXq7mFLC-hvbKlE

This change was verified to work using the following avrdude.conf entry:
```
#------------------------------------------------------------
# potato_pidog_gpio
#------------------------------------------------------------

programmer
    id                     = "potato_pidog_gpio";
    desc                   = "Program a PiDog from the LePotato GPIO lines";
    type                   = "linuxgpio";
    reset                  = ~495;
    sck                    = 491;
    sdo                    = 488;
    sdi                    = 489;
;
```