### PR TITLE
Change Arduino auto-reset via RTS to allow direct RTS-reset connection

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -88,7 +88,13 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
   // This code assumes a negative-logic USB to TTL serial adapter
   // Set RTS/DTR high to discharge the series-capacitor, if present
   serial_set_dtr_rts(&pgm->fd, 0);
-  usleep(50 * 1000);
+  /*
+   * Long wait needed for optiboot: otherwise the second of two bootloader
+   * calls in quick succession fails:
+   *
+   * avrdude -c arduino -qqp m328p -U x.hex; avrdude -c arduino -qqp m328p -U x.hex
+   */
+  usleep(250 * 1000);
   // Pull the RTS/DTR line low to reset AVR
   serial_set_dtr_rts(&pgm->fd, 1);
   usleep(50 * 1000);

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -85,13 +85,16 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
-  /* Clear DTR and RTS to unload the RESET capacitor 
-   * (for example in Arduino) */
+  // This code assumes a negative-logic USB to TTL serial adapter
+  // Set RTS/DTR high to discharge the series-capacitor, if present
   serial_set_dtr_rts(&pgm->fd, 0);
-  usleep(250*1000);
-  /* Set DTR and RTS back to high */
+  usleep(50 * 1000);
+  // Pull the RTS/DTR line low to reset AVR
   serial_set_dtr_rts(&pgm->fd, 1);
-  usleep(50*1000);
+  usleep(50 * 1000);
+  // Set the RTS/DTR line back to high
+  serial_set_dtr_rts(&pgm->fd, 0);
+  usleep(50 * 1000);
 
   /*
    * drain any extraneous input
@@ -106,7 +109,6 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
 
 static void arduino_close(PROGRAMMER * pgm)
 {
-  serial_set_dtr_rts(&pgm->fd, 0);
   serial_close(&pgm->fd);
   pgm->fd.ifd = -1;
 }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -98,15 +98,11 @@ int stk500_getsync(const PROGRAMMER *pgm) {
     // Restart Arduino bootloader for every sync attempt
     if (strcmp(pgm->type, "Arduino") == 0 && attempt > 0) {
       // This code assumes a negative-logic USB to TTL serial adapter
-      // Set RTS/DTR high to discharge the series-capacitor, if present
-      serial_set_dtr_rts(&pgm->fd, 0);
-      usleep(50 * 1000);
-      // Pull the RTS/DTR line low to reset AVR
+      // Pull the RTS/DTR line low to reset AVR: it is still high from open()/last attempt
       serial_set_dtr_rts(&pgm->fd, 1);
-      usleep(50 * 1000);
+      usleep(20*1000);
       // Set the RTS/DTR line back to high
       serial_set_dtr_rts(&pgm->fd, 0);
-      usleep(50 * 1000);
       stk500_drain(pgm, 0);
     }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -97,10 +97,16 @@ int stk500_getsync(const PROGRAMMER *pgm) {
   for (attempt = 0; attempt < max_sync_attempts; attempt++) {
     // Restart Arduino bootloader for every sync attempt
     if (strcmp(pgm->type, "Arduino") == 0 && attempt > 0) {
-      serial_set_dtr_rts(&pgm->fd, 0); // Set DTR and RTS low
-      usleep(250*1000);
-      serial_set_dtr_rts(&pgm->fd, 1); // Set DTR and RTS back to high
-      usleep(50*1000);
+      // This code assumes a negative-logic USB to TTL serial adapter
+      // Set RTS/DTR high to discharge the series-capacitor, if present
+      serial_set_dtr_rts(&pgm->fd, 0);
+      usleep(50 * 1000);
+      // Pull the RTS/DTR line low to reset AVR
+      serial_set_dtr_rts(&pgm->fd, 1);
+      usleep(50 * 1000);
+      // Set the RTS/DTR line back to high
+      serial_set_dtr_rts(&pgm->fd, 0);
+      usleep(50 * 1000);
       stk500_drain(pgm, 0);
     }
 

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2240,16 +2240,15 @@ static int urclock_open(PROGRAMMER *pgm, const char *port) {
   // This code assumes a negative-logic USB to TTL serial adapter
   // Set RTS/DTR high to discharge the series-capacitor, if present
   serial_set_dtr_rts(&pgm->fd, 0);
-  usleep(50 * 1000);
+  usleep(20*1000);
   // Pull the RTS/DTR line low to reset AVR
   serial_set_dtr_rts(&pgm->fd, 1);
-  usleep(50 * 1000);
+  usleep(20*1000);
   // Set the RTS/DTR line back to high
   serial_set_dtr_rts(&pgm->fd, 0);
-  usleep(50 * 1000);
 
-  if((70+ur.delay) > 0)
-    usleep((70+ur.delay)*1000); // Wait until board comes out of reset
+  if((100+ur.delay) > 0)
+    usleep((100+ur.delay)*1000); // Wait until board comes out of reset
 
   pmsg_debug("%4ld ms: enter urclock_getsync()\n", avr_mstimestamp());
   if(urclock_getsync(pgm) < 0)

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -175,6 +175,9 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
 
     serial_set_dtr_rts(&pgm->fd, 1);
     usleep(50*1000);
+
+    /* Set high, so a direct connection to reset works. */
+    serial_set_dtr_rts(&pgm->fd, 0);
   }
 
   /* drain any extraneous input */
@@ -188,7 +191,6 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
 
 static void wiring_close(PROGRAMMER * pgm)
 {
-  serial_set_dtr_rts(&pgm->fd, 0);
   serial_close(&pgm->fd);
   pgm->fd.ifd = -1;
 }


### PR DESCRIPTION
Closes #1262

@stefanrueger Here is something to look at. I have not grasped the timing logic in urclock, but assuming the magic starts with releasing the reset line in [line 2247](https://github.com/mariusgreuel/avrdude-fork/blob/pr-auto-reset/src/urclock.c#L2247), I figured 120 minus 50 for the extra wait?