### PR TITLE
Support AT89S51, AT89S52, AT90S2323 and ATtiny22

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3070,7 +3070,74 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s1200
+# AT89S51
+#------------------------------------------------------------
+
+part
+    desc                   = "AT89S51";
+    id                     = "89S51";
+    prog_modes             = PM_ISP | PM_HVPP;
+    mcuid                  = 372;
+    stk500_devcode         = 0xe0;
+    chip_erase_delay       = 250000;
+    signature              = 0x1e 0x51 0x06;
+    timeout                = 200;
+    stabdelay              = 100;
+    cmdexedelay            = 25;
+    synchloops             = 32;
+    pollindex              = 4;
+    pollvalue              = 0x69;
+    predelay               = 1;
+    postdelay              = 1;
+    chiperasepulsewidth    = 15;
+    programfusepulsewidth  = 2;
+    programlockpolltimeout = 1;
+    chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
+    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
+
+    memory "flash"
+        size               = 4096;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        readback           = 0xff 0xff;
+        mode               = 0x02;
+        delay              = 10;
+        blocksize          = 256;
+        read               = "0010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
+        write              = "0100.0000--xxxa.aaaa--aaaa.aaaa--iiii.iiii";
+        # Nonstandard page mode is available but not implemented
+    ;
+
+    memory "lock"
+        size               = 1;
+        read               = "0010.0100--xxxx.xxxx--xxxx.xxxx--xxxo.ooxx";
+        # Nonstandard lock write is available but not implemented
+    ;
+
+    memory "signature"
+        size               = 3;
+        read               = "0 0 1 0 1 0 0 0  x x x x x x a1 a0  x x x x x x x 0  o o o o o o o o";
+    ;
+;
+
+#------------------------------------------------------------
+# AT89S52
+#------------------------------------------------------------
+
+part parent "89S51"
+    desc                   = "AT89S52";
+    id                     = "89S52";
+    mcuid                  = 373;
+    stk500_devcode         = 0xe1;
+    signature              = 0x1e 0x52 0x06;
+
+    memory "flash"
+        size               = 8192;
+    ;
+;
+
+#------------------------------------------------------------
+# AT90S1200
 #------------------------------------------------------------
 
 part
@@ -3152,7 +3219,7 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s4414
+# AT90S4414
 #------------------------------------------------------------
 
 part
@@ -3232,7 +3299,7 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s2313
+# AT90S2313
 #------------------------------------------------------------
 
 part
@@ -3312,7 +3379,7 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s2333
+# AT90S2333
 #------------------------------------------------------------
 
 part
@@ -3399,7 +3466,7 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s2343 (also AT90s2323 and ATtiny22)
+# AT90S2343 (also AT90S2323 and ATtiny22)
 #------------------------------------------------------------
 
 part
@@ -3489,93 +3556,60 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s4433
+# AT90S2323
 #------------------------------------------------------------
 
-part
+part parent "2343"
+    desc                   = "AT90S2323";
+    id                     = "2323";
+    mcuid                  = 187;
+    stk500_devcode         = 0x41;
+    avr910_devcode         = 0x48;
+    signature              = 0x1e 0x91 0x02;
+;
+
+#------------------------------------------------------------
+# ATtiny22
+#------------------------------------------------------------
+
+part parent "2343"
+    desc                   = "ATtiny22";
+    id                     = "t22";
+    mcuid                  = 13;
+    stk500_devcode         = 0x20;
+    avr910_devcode         = 0; # Unknown
+    signature              = 0x1e 0x91 0x06;
+;
+
+#------------------------------------------------------------
+# AT90S4433
+#------------------------------------------------------------
+
+part parent "2333"
     desc                   = "AT90S4433";
     id                     = "4433";
-    prog_modes             = PM_SPM | PM_ISP | PM_HVPP;
     mcuid                  = 191;
-    n_interrupts           = 14;
     stk500_devcode         = 0x51;
     avr910_devcode         = 0x30;
-    chip_erase_delay       = 20000;
     signature              = 0x1e 0x92 0x03;
-    timeout                = 200;
-    stabdelay              = 100;
-    cmdexedelay            = 25;
-    synchloops             = 32;
-    pollindex              = 3;
-    pollvalue              = 0x53;
-    predelay               = 1;
-    postdelay              = 1;
-    pp_controlstack        =
-        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
-        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
-        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
-        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    hventerstabdelay       = 100;
-    hvleavestabdelay       = 15;
-    chiperasepulsewidth    = 15;
-    programfusepulsewidth  = 2;
-    programlockpolltimeout = 1;
-    chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
-    pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
         size               = 256;
-        min_write_delay    = 9000;
-        max_write_delay    = 20000;
-        readback           = 0x00 0xff;
-        mode               = 0x04;
-        delay              = 12;
-        blocksize          = 128;
-        readsize           = 256;
         read               = "1010.0000--xxxx.xxxx--aaaa.aaaa--oooo.oooo";
         write              = "1100.0000--xxxx.xxxx--aaaa.aaaa--iiii.iiii";
     ;
 
     memory "flash"
         size               = 4096;
-        min_write_delay    = 9000;
-        max_write_delay    = 20000;
-        readback           = 0xff 0xff;
-        mode               = 0x04;
-        delay              = 12;
-        blocksize          = 128;
-        readsize           = 256;
         read_lo            = "0010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
         read_hi            = "0010.1000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
         write_lo           = "0100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
         write_hi           = "0100.1000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
     ;
-
-    memory "fuse"
-        size               = 1;
-        min_write_delay    = 9000;
-        max_write_delay    = 20000;
-        pwroff_after_write = yes;
-        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
-        write              = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
-    ;
-
-    memory "lock"
-        size               = 1;
-        min_write_delay    = 9000;
-        max_write_delay    = 20000;
-        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
-        write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
-    ;
-
-    memory "signature"
-        size               = 3;
-        read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
-    ;
 ;
 
 #------------------------------------------------------------
-# AT90s4434
+# AT90S4434
 #------------------------------------------------------------
 
 part
@@ -3635,7 +3669,7 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s8515
+# AT90S8515
 #------------------------------------------------------------
 
 part
@@ -3716,7 +3750,7 @@ part
 ;
 
 #------------------------------------------------------------
-# AT90s8535
+# AT90S8535
 #------------------------------------------------------------
 
 part

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3073,6 +3073,10 @@ part
 # AT89S51
 #------------------------------------------------------------
 
+# Nonstandard part
+#   - Tested with -c avrisp
+#   - USBASP programmers may require different firmware
+
 part
     desc                   = "AT89S51";
     id                     = "89S51";
@@ -3111,12 +3115,12 @@ part
     memory "lock"
         size               = 1;
         read               = "0010.0100--xxxx.xxxx--xxxx.xxxx--xxxo.ooxx";
-        # Nonstandard write
+        # Nonstandard write: expect verification errors
         # See datasheet Page 20, Note 1 https://ww1.microchip.com/downloads/en/DeviceDoc/doc2487.pdf
-        # Activating lock mode 0: -U lock:w:0:m
-        # Activating lock mode 1: -U lock:w:0:m -U lock:w:1:m
-        # Activating lock mode 2: -U lock:w:0:m -U lock:w:1:m -U lock:w:2:m
-        # Activating lock mode 3: -U lock:w:0:m -U lock:w:1:m -U lock:w:2:m -U lock:w:3:m
+        # Activate lock mode 0 through chip erase: avrdude -e
+        # Activate lock mode 1: avrdude -e -V -U lock:w:1:m
+        # Activate lock mode 2: avrdude -e -V -U lock:w:1:m -U lock:w:2:m
+        # Activate lock mode 3: avrdude -e -V -U lock:w:1:m -U lock:w:2:m -U lock:w:3:m
         write              = "1010.1100--1110.00ii--xxxx.xxxx--xxxx.xxxx";
     ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3111,7 +3111,13 @@ part
     memory "lock"
         size               = 1;
         read               = "0010.0100--xxxx.xxxx--xxxx.xxxx--xxxo.ooxx";
-        # Nonstandard lock write is available but not implemented
+        # Nonstandard write
+        # See datasheet Page 20, Note 1 https://ww1.microchip.com/downloads/en/DeviceDoc/doc2487.pdf
+        # Activating lock mode 0: -U lock:w:0:m
+        # Activating lock mode 1: -U lock:w:0:m -U lock:w:1:m
+        # Activating lock mode 2: -U lock:w:0:m -U lock:w:1:m -U lock:w:2:m
+        # Activating lock mode 3: -U lock:w:0:m -U lock:w:1:m -U lock:w:2:m -U lock:w:3:m
+        write              = "1010.1100--1110.00ii--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "signature"

--- a/src/avrintel.c
+++ b/src/avrintel.c
@@ -3,13 +3,13 @@
  *
  * avrintel.c
  *
- * Atmel AVR8L, AVR8, XMEGA and AVR8X family description of interrupts and more
+ * Microchip AVR8L, AVR8, XMEGA and AVR8X family description of interrupts and more
  *
- * published under GNU General Public License, version 3 (GPL-3.0)
- * meta-author Stefan Rueger <stefan.rueger@urclocks.com>
+ * Published under GNU General Public License, version 3 (GPL-3.0)
+ * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * v 1.1
- * 02.01.2023
+ * 04.03.2023
  *
  */
 
@@ -42,7 +42,7 @@ const uPcore_t uP_table[] = {   // Value of -1 typically means unknown
   {"ATtiny13",          10,  F_AVR8, {0x1E, 0x90, 0x07},       0, 0x00400, 0x020,  0,      0,       0, 0x0040,  4, 0x0060, 0x0040,  2,  1,  10,  vtab_attiny13a}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATtiny13A",         11,  F_AVR8, {0x1E, 0x90, 0x07},       0, 0x00400, 0x020,  0,      0,       0, 0x0040,  4, 0x0060, 0x0040,  2,  1,  10,  vtab_attiny13a}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATtiny15",          12,  F_AVR8, {0x1E, 0x90, 0x06},       0, 0x00400, 0x001,  0,      0,       0, 0x0040,  2, 0x0060, 0x0020,  1,  1,   9,   vtab_attiny15}, // atdf, avr-gcc 12.2.0, avrdude
-  {"ATtiny22",          13,  F_AVR8, {0x1E, 0x91, 0x06},       0, 0x00800,    -1,  0,      0,      -1,     -1, -1, 0x0060, 0x0080,  1,  1,   3,   vtab_attiny22}, // avr-gcc 12.2.0, boot size (manual)
+  {"ATtiny22",          13,  F_AVR8, {0x1E, 0x91, 0x06},       0, 0x00800, 0x001,  0,      0,       0, 0x0080,  1, 0x0060, 0x0080,  1,  1,   3,   vtab_attiny22}, // avr-gcc 12.2.0, avrdude, boot size (manual)
   {"ATtiny24",          14,  F_AVR8, {0x1E, 0x91, 0x0B},       0, 0x00800, 0x020,  0,      0,       0, 0x0080,  4, 0x0060, 0x0080,  3,  1,  17,  vtab_attiny84a}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATtiny24A",         15,  F_AVR8, {0x1E, 0x91, 0x0B},       0, 0x00800, 0x020,  0,      0,       0, 0x0080,  4, 0x0060, 0x0080,  3,  1,  17,  vtab_attiny84a}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATtiny25",          16,  F_AVR8, {0x1E, 0x91, 0x08},       0, 0x00800, 0x020,  0,      0,       0, 0x0080,  4, 0x0060, 0x0080,  3,  1,  15,   vtab_attiny85}, // atdf, avr-gcc 12.2.0, avrdude
@@ -155,7 +155,7 @@ const uPcore_t uP_table[] = {   // Value of -1 typically means unknown
   {"ATmega329P",       123,  F_AVR8, {0x1E, 0x95, 0x0B},       0, 0x08000, 0x080,  4, 0x0200,       0, 0x0400,  4, 0x0100, 0x0800,  3,  1,  23, vtab_atmega649p}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega329PA",      124,  F_AVR8, {0x1E, 0x95, 0x0B},       0, 0x08000, 0x080,  4, 0x0200,       0, 0x0400,  4, 0x0100, 0x0800,  3,  1,  23, vtab_atmega649p}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega406",        125,  F_AVR8, {0x1E, 0x95, 0x07},       0, 0x0a000, 0x080,  4, 0x0200,       0, 0x0200,  4, 0x0100, 0x0800,  2,  1,  23,  vtab_atmega406}, // atdf, avr-gcc 12.2.0, avrdude
-  {"ATmega640",        126,  F_AVR8, {0x1E, 0x96, 0x08},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2561}, // atdf, avr-gcc 12.2.0, avrdude
+  {"ATmega640",        126,  F_AVR8, {0x1E, 0x96, 0x08},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2560}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega644",        127,  F_AVR8, {0x1E, 0x96, 0x09},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x0800,  8, 0x0100, 0x1000,  3,  1,  28,  vtab_atmega644}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega644A",       128,  F_AVR8, {0x1E, 0x96, 0x09},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x0800,  8, 0x0100, 0x1000,  3,  1,  31, vtab_atmega644pa}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega644P",       129,  F_AVR8, {0x1E, 0x96, 0x0A},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x0800,  8, 0x0100, 0x1000,  3,  1,  31, vtab_atmega644pa}, // atdf, avr-gcc 12.2.0, avrdude
@@ -167,12 +167,12 @@ const uPcore_t uP_table[] = {   // Value of -1 typically means unknown
   {"ATmega649",        135,  F_AVR8, {0x1E, 0x96, 0x03},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x0800,  8, 0x0100, 0x1000,  3,  1,  23, vtab_atmega649p}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega649A",       136,  F_AVR8, {0x1E, 0x96, 0x03},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x0800,  8, 0x0100, 0x1000,  3,  1,  23, vtab_atmega649p}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega649P",       137,  F_AVR8, {0x1E, 0x96, 0x0B},       0, 0x10000, 0x100,  4, 0x0400,       0, 0x0800,  8, 0x0100, 0x1000,  3,  1,  23, vtab_atmega649p}, // atdf, avr-gcc 12.2.0, avrdude
-  {"ATmega1280",       138,  F_AVR8, {0x1E, 0x97, 0x03},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2561}, // atdf, avr-gcc 12.2.0, avrdude
+  {"ATmega1280",       138,  F_AVR8, {0x1E, 0x97, 0x03},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2560}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega1281",       139,  F_AVR8, {0x1E, 0x97, 0x04},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2561}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega1284",       140,  F_AVR8, {0x1E, 0x97, 0x06},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0100, 0x4000,  3,  1,  35, vtab_atmega1284p}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega1284P",      141,  F_AVR8, {0x1E, 0x97, 0x05},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0100, 0x4000,  3,  1,  35, vtab_atmega1284p}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega1284RFR2",   142,  F_AVR8, {0x1E, 0xA7, 0x03},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x4000,  3,  1,  77, vtab_atmega2564rfr2}, // atdf, avr-gcc 12.2.0, avrdude
-  {"ATmega2560",       143,  F_AVR8, {0x1E, 0x98, 0x01},       0, 0x40000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2561}, // atdf, avr-gcc 12.2.0, avrdude
+  {"ATmega2560",       143,  F_AVR8, {0x1E, 0x98, 0x01},       0, 0x40000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2560}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega2561",       144,  F_AVR8, {0x1E, 0x98, 0x02},       0, 0x40000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0200, 0x2000,  3,  1,  57, vtab_atmega2561}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega2564RFR2",   145,  F_AVR8, {0x1E, 0xA8, 0x03},       0, 0x40000, 0x100,  4, 0x0400,       0, 0x2000,  8, 0x0200, 0x8000,  3,  1,  77, vtab_atmega2564rfr2}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATmega3250",       146,  F_AVR8, {0x1E, 0x95, 0x06},       0, 0x08000, 0x080,  4, 0x0200,       0, 0x0400,  4, 0x0100, 0x0800,  3,  1,  25, vtab_atmega6450p}, // atdf, avr-gcc 12.2.0, avrdude
@@ -195,7 +195,9 @@ const uPcore_t uP_table[] = {   // Value of -1 typically means unknown
   {"AT43USB355",       163,  F_AVR8, {0xff,   -1,   -1},       0, 0x06000,    -1, -1,     -1,      -1,     -1, -1, 0x0060, 0x0400, -1, -1,   0,            NULL}, // avr-gcc 12.2.0
   {"AT76C711",         164,  F_AVR8, {0xff,   -1,   -1},       0, 0x04000,    -1, -1,     -1,      -1,     -1, -1, 0x0060, 0x07a0, -1, -1,   0,            NULL}, // avr-gcc 12.2.0
   {"AT86RF401",        165,  F_AVR8, {0x1E, 0x91, 0x81},       0, 0x00800,    -1, -1,     -1,      -1,     -1, -1, 0x0060, 0x0080,  0,  1,   3,  vtab_at86rf401}, // avr-gcc 12.2.0
-  {"AT90PWM1",         166,  F_AVR8, {0x1E, 0x93, 0x83},       0, 0x02000, 0x040,  4, 0x0100,       0, 0x0200,  4, 0x0100, 0x0200,  3,  1,  32, vtab_at90pwm316}, // atdf, avr-gcc 12.2.0
+  {"AT89S51",          372,  F_AVR8, {0x1E, 0x51, 0x06},       0, 0x01000, 0x001, -1,     -1,       0,      0,  0,     -1,     -1, -1, -1,   0,            NULL}, // avrdude
+  {"AT89S52",          373,  F_AVR8, {0x1E, 0x52, 0x06},       0, 0x02000, 0x001, -1,     -1,       0,      0,  0,     -1,     -1, -1, -1,   0,            NULL}, // avrdude
+  {"AT90PWM1",         166,  F_AVR8, {0x1E, 0x93, 0x83},       0, 0x02000, 0x040,  4, 0x0100,       0, 0x0200,  4, 0x0100, 0x0200,  3,  1,  32,   vtab_at90pwm1}, // atdf, avr-gcc 12.2.0
   {"AT90PWM2",         167,  F_AVR8, {0x1E, 0x93, 0x81},       0, 0x02000, 0x040,  4, 0x0100,       0, 0x0200,  4, 0x0100, 0x0200,  3,  1,  32,   vtab_at90pwm2}, // avr-gcc 12.2.0, avrdude, boot size (manual)
   {"AT90PWM2B",        168,  F_AVR8, {0x1E, 0x93, 0x83},       0, 0x02000, 0x040,  4, 0x0100,       0, 0x0200,  4, 0x0100, 0x0200,  3,  1,  32,  vtab_at90pwm3b}, // atdf, avr-gcc 12.2.0, avrdude
   {"AT90PWM3",         169,  F_AVR8, {0x1E, 0x93, 0x81},       0, 0x02000, 0x040,  4, 0x0100,       0, 0x0200,  4, 0x0100, 0x0200,  3,  1,  32,  vtab_at90pwm3b}, // atdf, avr-gcc 12.2.0, avrdude
@@ -216,7 +218,7 @@ const uPcore_t uP_table[] = {   // Value of -1 typically means unknown
   {"AT90USB1286",      184,  F_AVR8, {0x1E, 0x97, 0x82},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0100, 0x2000,  3,  1,  38, vtab_atmega32u6}, // atdf, avr-gcc 12.2.0, avrdude
   {"AT90USB1287",      185,  F_AVR8, {0x1E, 0x97, 0x82},       0, 0x20000, 0x100,  4, 0x0400,       0, 0x1000,  8, 0x0100, 0x2000,  3,  1,  38, vtab_atmega32u6}, // atdf, avr-gcc 12.2.0, avrdude
   {"AT90S2313",        186,  F_AVR8, {0x1E, 0x91, 0x01},       0, 0x00800, 0x001,  0,      0,       0, 0x0080,  1, 0x0060, 0x0080,  1,  1,  11,  vtab_at90s2313}, // avr-gcc 12.2.0, avrdude, boot size (manual)
-  {"AT90S2323",        187,  F_AVR8, {0x1E, 0x91, 0x02},       0, 0x00800,    -1,  0,      0,      -1,     -1, -1, 0x0060, 0x0080,  1,  1,   3,   vtab_attiny22}, // avr-gcc 12.2.0, boot size (manual)
+  {"AT90S2323",        187,  F_AVR8, {0x1E, 0x91, 0x02},       0, 0x00800, 0x001,  0,      0,       0, 0x0080,  1, 0x0060, 0x0080,  1,  1,   3,   vtab_attiny22}, // avr-gcc 12.2.0, avrdude, boot size (manual)
   {"AT90S2333",        188,  F_AVR8, {0x1E, 0x91, 0x05},       0, 0x00800, 0x001,  0,      0,       0, 0x0080,  1, 0x0060, 0x0080, -1, -1,  14,  vtab_at90s4433}, // avr-gcc 12.2.0, avrdude, boot size (manual)
   {"AT90S2343",        189,  F_AVR8, {0x1E, 0x91, 0x03},       0, 0x00800, 0x001,  0,      0,       0, 0x0080,  1, 0x0060, 0x0080,  1,  1,   3,   vtab_attiny22}, // avr-gcc 12.2.0, avrdude, boot size (manual)
   {"AT90S4414",        190,  F_AVR8, {0x1E, 0x92, 0x01},       0, 0x01000, 0x001,  0,      0,       0, 0x0100,  1, 0x0060, 0x0100,  1,  1,  13,  vtab_at90s8515}, // avr-gcc 12.2.0, avrdude, boot size (manual)
@@ -285,7 +287,7 @@ const uPcore_t uP_table[] = {   // Value of -1 typically means unknown
   {"ATxmega64A4U",     252, F_XMEGA, {0x1E, 0x96, 0x46},       0, 0x11000, 0x100,  1, 0x1000,       0, 0x0800, 32, 0x2000, 0x1000,  6,  1, 127, vtab_atxmega128a4u}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATxmega64D4",      253, F_XMEGA, {0x1E, 0x96, 0x47},       0, 0x11000, 0x100,  1, 0x1000,       0, 0x0800, 32, 0x2000, 0x1000,  6,  1,  91, vtab_atxmega128d4}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATxmega128A1",     254, F_XMEGA, {0x1E, 0x97, 0x4C},       0, 0x22000, 0x200,  1, 0x2000,       0, 0x0800, 32, 0x2000, 0x2000,  6,  1, 125, vtab_atxmega128a1}, // atdf, avr-gcc 12.2.0, avrdude
-  {"ATxmega128A1revD", 255, F_XMEGA, {0x1E, 0x97, 0x41},       0, 0x22000, 0x200, -1,     -1,       0, 0x0800, 32,     -1,     -1, -1, -1,   0,            NULL}, // avrdude
+  {"ATxmega128A1revD", 255, F_XMEGA, {0x1E, 0x97, 0x41},       0, 0x22000, 0x200,  1, 0x2000,       0, 0x0800, 32, 0x2000, 0x2000,  6,  1, 125, vtab_atxmega128a1}, // avrdude, from ATxmega128A1
   {"ATxmega128A1U",    256, F_XMEGA, {0x1E, 0x97, 0x4C},       0, 0x22000, 0x200,  1, 0x2000,       0, 0x0800, 32, 0x2000, 0x2000,  6,  1, 127, vtab_atxmega128a1u}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATxmega128B1",     257, F_XMEGA, {0x1E, 0x97, 0x4D},       0, 0x22000, 0x100,  1, 0x2000,       0, 0x0800, 32, 0x2000, 0x2000,  6,  1,  81, vtab_atxmega128b1}, // atdf, avr-gcc 12.2.0, avrdude
   {"ATxmega128A3",     258, F_XMEGA, {0x1E, 0x97, 0x42},       0, 0x22000, 0x200,  1, 0x2000,       0, 0x0800, 32, 0x2000, 0x2000,  6,  1, 122, vtab_atxmega256a3}, // atdf, avr-gcc 12.2.0, avrdude
@@ -1123,8 +1125,8 @@ const char * const vtab_atmega64hve2[vts_atmega64hve2] = { // ATmega64HVE2, ATme
   "TIMER0_COMPA",               //  11: Timer 0 Compare Match A
   "TIMER0_COMPB",               //  12: Timer 0 Compare Match B
   "TIMER0_OVF",                 //  13: Timer 0 Overflow
-  "LIN_STATUS",                 //  14: Local Interconnect Network Status
-  "LIN_ERROR",                  //  15: Local Interconnect Network Error
+  "LIN_STATUS",                 //  14: LIN Status Change
+  "LIN_ERROR",                  //  15: LIN Error
   "SPI_STC",                    //  16: SPI Serial Transfer Complete
   "VADC_CONV",                  //  17: Versatile Analog to Digital Conversion
   "VADC_ACC",                   //  18: Versatile Analog to Digital Compare or Capture
@@ -1253,12 +1255,12 @@ const char * const vtab_atmega128rfa1[vts_atmega128rfa1] = { // ATmega128RFA1
   "TIMER5_COMPB",               //  48: Timer 5 Compare Match B
   "TIMER5_COMPC",               //  49: Timer 5 Compare Match C
   "TIMER5_OVF",                 //  50: Timer 5 Overflow
-  "USART2_RX",                  //  51: USART 2 Receive Complete
-  "USART2_UDRE",                //  52: USART 2 Data Register Empty
-  "USART2_TX",                  //  53: USART 2 Transmit Complete
-  "USART3_RX",                  //  54: USART 3 Receive Complete
-  "USART3_UDRE",                //  55: USART 3 Data Register Empty
-  "USART3_TX",                  //  56: USART 3 Transmit Complete
+  "UNUSED",                     //  51: not useful owing to limited pin count
+  "UNUSED",                     //  52: not useful owing to limited pin count
+  "UNUSED",                     //  53: not useful owing to limited pin count
+  "UNUSED",                     //  54: not useful owing to limited pin count
+  "UNUSED",                     //  55: not useful owing to limited pin count
+  "UNUSED",                     //  56: not useful owing to limited pin count
   "TRX24_PLL_LOCK",             //  57: TRX24 PLL Lock
   "TRX24_PLL_UNLOCK",           //  58: TRX24 PLL Unlock
   "TRX24_RX_START",             //  59: TRX24 Receive Start
@@ -1746,7 +1748,7 @@ const char * const vtab_atmega1284p[vts_atmega1284p] = { // ATmega1284P, ATmega1
   "TIMER3_OVF",                 //  34: Timer 3 Overflow
 };
 
-const char * const vtab_atmega2561[vts_atmega2561] = { // ATmega2561, ATmega2560, ATmega1281, ATmega1280, ATmega640
+const char * const vtab_atmega2560[vts_atmega2560] = { // ATmega2560, ATmega1280, ATmega640
   "RESET",                      //   0: Reset (various reasons)
   "INT0",                       //   1: External Interrupt 0
   "INT1",                       //   2: External Interrupt 1
@@ -1804,6 +1806,66 @@ const char * const vtab_atmega2561[vts_atmega2561] = { // ATmega2561, ATmega2560
   "USART3_RX",                  //  54: USART 3 Receive Complete
   "USART3_UDRE",                //  55: USART 3 Data Register Empty
   "USART3_TX",                  //  56: USART 3 Transmit Complete
+};
+
+const char * const vtab_atmega2561[vts_atmega2561] = { // ATmega2561, ATmega1281
+  "RESET",                      //   0: Reset (various reasons)
+  "INT0",                       //   1: External Interrupt 0
+  "INT1",                       //   2: External Interrupt 1
+  "INT2",                       //   3: External Interrupt 2
+  "INT3",                       //   4: External Interrupt 3
+  "INT4",                       //   5: External Interrupt 4
+  "INT5",                       //   6: External Interrupt 5
+  "INT6",                       //   7: External Interrupt 6
+  "INT7",                       //   8: External Interrupt 7
+  "PCINT0",                     //   9: Pin Change Interrupt 0
+  "PCINT1",                     //  10: Pin Change Interrupt 1
+  "PCINT2",                     //  11: Pin Change Interrupt 2
+  "WDT",                        //  12: Watchdog Time-out
+  "TIMER2_COMPA",               //  13: Timer 2 Compare Match A
+  "TIMER2_COMPB",               //  14: Timer 2 Compare Match B
+  "TIMER2_OVF",                 //  15: Timer 2 Overflow
+  "TIMER1_CAPT",                //  16: Timer 1 Capture Event
+  "TIMER1_COMPA",               //  17: Timer 1 Compare Match A
+  "TIMER1_COMPB",               //  18: Timer 1 Compare Match B
+  "TIMER1_COMPC",               //  19: Timer 1 Compare Match C
+  "TIMER1_OVF",                 //  20: Timer 1 Overflow
+  "TIMER0_COMPA",               //  21: Timer 0 Compare Match A
+  "TIMER0_COMPB",               //  22: Timer 0 Compare Match B
+  "TIMER0_OVF",                 //  23: Timer 0 Overflow
+  "SPI_STC",                    //  24: SPI Serial Transfer Complete
+  "USART0_RX",                  //  25: USART 0 Receive Complete
+  "USART0_UDRE",                //  26: USART 0 Data Register Empty
+  "USART0_TX",                  //  27: USART 0 Transmit Complete
+  "ANALOG_COMP",                //  28: Analog Comparator
+  "ADC",                        //  29: ADC Conversion Complete
+  "EE_READY",                   //  30: EEPROM Ready
+  "TIMER3_CAPT",                //  31: Timer 3 Capture Event
+  "TIMER3_COMPA",               //  32: Timer 3 Compare Match A
+  "TIMER3_COMPB",               //  33: Timer 3 Compare Match B
+  "TIMER3_COMPC",               //  34: Timer 3 Compare Match C
+  "TIMER3_OVF",                 //  35: Timer 3 Overflow
+  "USART1_RX",                  //  36: USART 1 Receive Complete
+  "USART1_UDRE",                //  37: USART 1 Data Register Empty
+  "USART1_TX",                  //  38: USART 1 Transmit Complete
+  "TWI",                        //  39: 2-Wire Interface
+  "SPM_READY",                  //  40: Store Program Memory Ready
+  "TIMER4_CAPT",                //  41: Timer 4 Capture Event
+  "TIMER4_COMPA",               //  42: Timer 4 Compare Match A
+  "TIMER4_COMPB",               //  43: Timer 4 Compare Match B
+  "TIMER4_COMPC",               //  44: Timer 4 Compare Match C
+  "TIMER4_OVF",                 //  45: Timer 4 Overflow
+  "TIMER5_CAPT",                //  46: Timer 5 Capture Event
+  "TIMER5_COMPA",               //  47: Timer 5 Compare Match A
+  "TIMER5_COMPB",               //  48: Timer 5 Compare Match B
+  "TIMER5_COMPC",               //  49: Timer 5 Compare Match C
+  "TIMER5_OVF",                 //  50: Timer 5 Overflow
+  "UNUSED",                     //  51: not useful owing to limited pin count
+  "UNUSED",                     //  52: not useful owing to limited pin count
+  "UNUSED",                     //  53: not useful owing to limited pin count
+  "UNUSED",                     //  54: not useful owing to limited pin count
+  "UNUSED",                     //  55: not useful owing to limited pin count
+  "UNUSED",                     //  56: not useful owing to limited pin count
 };
 
 const char * const vtab_atmega2564rfr2[vts_atmega2564rfr2] = { // ATmega2564RFR2, ATmega1284RFR2, ATmega644RFR2, ATmega256RFR2, ATmega128RFR2, ATmega64RFR2
@@ -1992,6 +2054,41 @@ const char * const vtab_at86rf401[vts_at86rf401] = { // AT86RF401
   "TXEMPTY",                    //   2: Transmit Register Empty
 };
 
+const char * const vtab_at90pwm1[vts_at90pwm1] = { // AT90PWM1
+  "RESET",                      //   0: Reset (various reasons)
+  "PSC2_CAPT",                  //   1: PSC 2 Capture Event
+  "PSC2_EC",                    //   2: PSC 2 End Cycle
+  "PSC1_CAPT",                  //   3: PSC 1 Capture Event
+  "PSC1_EC",                    //   4: PSC 1 End Cycle
+  "PSC0_CAPT",                  //   5: PSC 0 Capture Event
+  "PSC0_EC",                    //   6: PSC 0 End Cycle
+  "ANALOG_COMP_0",              //   7: Analog Comparator 0
+  "ANALOG_COMP_1",              //   8: Analog Comparator 1
+  "ANALOG_COMP_2",              //   9: Analog Comparator 2
+  "INT0",                       //  10: External Interrupt 0
+  "TIMER1_CAPT",                //  11: Timer 1 Capture Event
+  "TIMER1_COMPA",               //  12: Timer 1 Compare Match A
+  "TIMER1_COMPB",               //  13: Timer 1 Compare Match B
+  "RESERVED15",                 //  14: Reserved 15
+  "TIMER1_OVF",                 //  15: Timer 1 Overflow
+  "TIMER0_COMP_A",              //  16: Timer 0 Compare Match A
+  "TIMER0_OVF",                 //  17: Timer 0 Overflow
+  "ADC",                        //  18: ADC Conversion Complete
+  "INT1",                       //  19: External Interrupt 1
+  "SPI_STC",                    //  20: SPI Serial Transfer Complete
+  "RESERVED21",                 //  21: Reserved 21
+  "RESERVED22",                 //  22: Reserved 22
+  "RESERVED23",                 //  23: Reserved 23
+  "INT2",                       //  24: External Interrupt 2
+  "WDT",                        //  25: Watchdog Time-out
+  "EE_READY",                   //  26: EEPROM Ready
+  "TIMER0_COMPB",               //  27: Timer 0 Compare Match B
+  "INT3",                       //  28: External Interrupt 3
+  "RESERVED30",                 //  29: Reserved 30
+  "RESERVED31",                 //  30: Reserved 31
+  "SPM_READY",                  //  31: Store Program Memory Ready
+};
+
 const char * const vtab_at90pwm2[vts_at90pwm2] = { // AT90PWM2
   "RESET",                      //   0: Reset (various reasons)
   "PSC2_CAPT",                  //   1: PSC 2 Capture Event
@@ -2166,7 +2263,7 @@ const char * const vtab_at90pwm161[vts_at90pwm161] = { // AT90PWM161, AT90PWM81
   "SPM_READY",                  //  19: Store Program Memory Ready
 };
 
-const char * const vtab_at90pwm316[vts_at90pwm316] = { // AT90PWM316, AT90PWM216, AT90PWM1
+const char * const vtab_at90pwm316[vts_at90pwm316] = { // AT90PWM316, AT90PWM216
   "RESET",                      //   0: Reset (various reasons)
   "PSC2_CAPT",                  //   1: PSC 2 Capture Event
   "PSC2_EC",                    //   2: PSC 2 End Cycle
@@ -3539,9 +3636,9 @@ const char * const vtab_atxmega128d4[vts_atxmega128d4] = { // ATxmega128D4, ATxm
   "UNUSED",                     //  55: not implemented on this device
   "UNUSED",                     //  56: not implemented on this device
   "UNUSED",                     //  57: not implemented on this device
-  "USARTE0_RXC",                //  58: USARTE 0 Reception Complete
-  "USARTE0_DRE",                //  59: USARTE 0 Data Register Empty
-  "USARTE0_TXC",                //  60: USARTE 0 Transmission Complete
+  "UNUSED",                     //  58: not implemented on this device
+  "UNUSED",                     //  59: not implemented on this device
+  "UNUSED",                     //  60: not implemented on this device
   "UNUSED",                     //  61: not implemented on this device
   "UNUSED",                     //  62: not implemented on this device
   "UNUSED",                     //  63: not implemented on this device
@@ -4243,9 +4340,9 @@ const char * const vtab_atxmega384c3[vts_atxmega384c3] = { // ATxmega384C3
   "USARTC0_RXC",                //  25: USARTC 0 Reception Complete
   "USARTC0_DRE",                //  26: USARTC 0 Data Register Empty
   "USARTC0_TXC",                //  27: USARTC 0 Transmission Complete
-  "USARTC1_RXC",                //  28: USARTC 1 Reception Complete
-  "USARTC1_DRE",                //  29: USARTC 1 Data Register Empty
-  "USARTC1_TXC",                //  30: USARTC 1 Transmission Complete
+  "UNUSED",                     //  28: not implemented on this device
+  "UNUSED",                     //  29: not implemented on this device
+  "UNUSED",                     //  30: not implemented on this device
   "AES_INT",                    //  31: AES Interrupt
   "NVM_EE",                     //  32: NVM EEPROM
   "NVM_SPM",                    //  33: NVM SPM

--- a/src/avrintel.h
+++ b/src/avrintel.h
@@ -3,13 +3,13 @@
  *
  * avrintel.h
  *
- * Atmel AVR8L, AVR8, XMEGA and AVR8X family description of interrupts and more
+ * Microchip AVR8L, AVR8, XMEGA and AVR8X family description of interrupts and more
  *
- * published under GNU General Public License, version 3 (GPL-3.0)
- * meta-author Stefan Rueger <stefan.rueger@urclocks.com>
+ * Published under GNU General Public License, version 3 (GPL-3.0)
+ * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * v 1.1
- * 02.01.2023
+ * 04.03.2023
  *
  */
 
@@ -213,6 +213,8 @@ typedef struct {                // Value of -1 typically means unknown
 #define id_at43usb355      163u
 #define id_at76c711        164u
 #define id_at86rf401       165u
+#define id_at89s51         372u
+#define id_at89s52         373u
 #define id_at90pwm1        166u
 #define id_at90pwm2        167u
 #define id_at90pwm2b       168u
@@ -826,7 +828,7 @@ typedef struct {                // Value of -1 typically means unknown
 #define vbu_atmega16m1       31
 #define vbu_atmega16hva2     22
 #define vbu_atmega16u2       29
-#define vbu_atmega16u4       43
+#define vbu_atmega16u4        5
 #define vbu_atmega32         21
 #define vbu_atmega32a        21
 #define vbu_atmega32hvb      29
@@ -834,7 +836,7 @@ typedef struct {                // Value of -1 typically means unknown
 #define vbu_atmega32c1       31
 #define vbu_atmega32m1       31
 #define vbu_atmega32u2       29
-#define vbu_atmega32u4       43
+#define vbu_atmega32u4        5
 #define vbu_atmega32u6       38
 #define vbu_atmega48         26
 #define vbu_atmega48a        26
@@ -847,7 +849,7 @@ typedef struct {                // Value of -1 typically means unknown
 #define vbu_atmega64c1       31
 #define vbu_atmega64m1       31
 #define vbu_atmega64hve2     25
-#define vbu_atmega64rfr2     77
+#define vbu_atmega64rfr2     51
 #define vbu_atmega88         26
 #define vbu_atmega88a        26
 #define vbu_atmega88p        26
@@ -856,8 +858,8 @@ typedef struct {                // Value of -1 typically means unknown
 #define vbu_atmega103        24
 #define vbu_atmega128        35
 #define vbu_atmega128a       35
-#define vbu_atmega128rfa1    72
-#define vbu_atmega128rfr2    77
+#define vbu_atmega128rfa1    51
+#define vbu_atmega128rfr2    51
 #define vbu_atmega161        21
 #define vbu_atmega162        28
 #define vbu_atmega163        18
@@ -877,7 +879,7 @@ typedef struct {                // Value of -1 typically means unknown
 #define vbu_atmega169a       23
 #define vbu_atmega169p       23
 #define vbu_atmega169pa      23
-#define vbu_atmega256rfr2    77
+#define vbu_atmega256rfr2    51
 #define vbu_atmega323        21
 #define vbu_atmega324a       31
 #define vbu_atmega324p       31
@@ -900,7 +902,7 @@ typedef struct {                // Value of -1 typically means unknown
 #define vbu_atmega644a       31
 #define vbu_atmega644p       31
 #define vbu_atmega644pa      31
-#define vbu_atmega644rfr2    77
+#define vbu_atmega644rfr2    51
 #define vbu_atmega645        22
 #define vbu_atmega645a       22
 #define vbu_atmega645p       22
@@ -908,45 +910,45 @@ typedef struct {                // Value of -1 typically means unknown
 #define vbu_atmega649a       23
 #define vbu_atmega649p       23
 #define vbu_atmega1280       57
-#define vbu_atmega1281       57
+#define vbu_atmega1281       51
 #define vbu_atmega1284       35
 #define vbu_atmega1284p      35
-#define vbu_atmega1284rfr2   77
+#define vbu_atmega1284rfr2   51
 #define vbu_atmega2560       57
-#define vbu_atmega2561       57
-#define vbu_atmega2564rfr2   77
-#define vbu_atmega3250       25
-#define vbu_atmega3250a      25
-#define vbu_atmega3250p      25
-#define vbu_atmega3250pa     25
+#define vbu_atmega2561       51
+#define vbu_atmega2564rfr2   51
+#define vbu_atmega3250       22
+#define vbu_atmega3250a      22
+#define vbu_atmega3250p      22
+#define vbu_atmega3250pa     22
 #define vbu_atmega3290       25
 #define vbu_atmega3290a      25
 #define vbu_atmega3290p      25
 #define vbu_atmega3290pa     25
-#define vbu_atmega6450       25
-#define vbu_atmega6450a      25
-#define vbu_atmega6450p      25
+#define vbu_atmega6450       22
+#define vbu_atmega6450a      22
+#define vbu_atmega6450p      22
 #define vbu_atmega6490       25
 #define vbu_atmega6490a      25
 #define vbu_atmega6490p      25
 #define vbu_atmega8515       17
 #define vbu_atmega8535       21
 #define vbu_at86rf401         3
-#define vbu_at90pwm1         32
+#define vbu_at90pwm1         14
 #define vbu_at90pwm2         14
-#define vbu_at90pwm2b        32
-#define vbu_at90pwm3         32
-#define vbu_at90pwm3b        32
+#define vbu_at90pwm2b        14
+#define vbu_at90pwm3         14
+#define vbu_at90pwm3b        14
 #define vbu_at90can32        37
 #define vbu_at90can64        37
 #define vbu_at90pwm81        20
 #define vbu_at90usb82        29
-#define vbu_at90scr100       38
+#define vbu_at90scr100       24
 #define vbu_at90can128       37
 #define vbu_at90pwm161       20
 #define vbu_at90usb162       29
-#define vbu_at90pwm216       32
-#define vbu_at90pwm316       32
+#define vbu_at90pwm216       14
+#define vbu_at90pwm316       14
 #define vbu_at90usb646       38
 #define vbu_at90usb647       38
 #define vbu_at90s1200         4
@@ -1199,7 +1201,7 @@ typedef struct {                // Value of -1 typically means unknown
 #define vtab_atmega329a      vtab_atmega649p
 #define vtab_atmega329p      vtab_atmega649p
 #define vtab_atmega329pa     vtab_atmega649p
-#define vtab_atmega640       vtab_atmega2561
+#define vtab_atmega640       vtab_atmega2560
 #define vtab_atmega644a      vtab_atmega644pa
 #define vtab_atmega644p      vtab_atmega644pa
 #define vtab_atmega644rfr2   vtab_atmega2564rfr2
@@ -1207,11 +1209,10 @@ typedef struct {                // Value of -1 typically means unknown
 #define vtab_atmega645a      vtab_atmega645p
 #define vtab_atmega649       vtab_atmega649p
 #define vtab_atmega649a      vtab_atmega649p
-#define vtab_atmega1280      vtab_atmega2561
+#define vtab_atmega1280      vtab_atmega2560
 #define vtab_atmega1281      vtab_atmega2561
 #define vtab_atmega1284      vtab_atmega1284p
 #define vtab_atmega1284rfr2  vtab_atmega2564rfr2
-#define vtab_atmega2560      vtab_atmega2561
 #define vtab_atmega3250      vtab_atmega6450p
 #define vtab_atmega3250a     vtab_atmega6450p
 #define vtab_atmega3250p     vtab_atmega6450p
@@ -1224,7 +1225,6 @@ typedef struct {                // Value of -1 typically means unknown
 #define vtab_atmega6450a     vtab_atmega6450p
 #define vtab_atmega6490      vtab_atmega6490p
 #define vtab_atmega6490a     vtab_atmega6490p
-#define vtab_at90pwm1        vtab_at90pwm316
 #define vtab_at90pwm2b       vtab_at90pwm3b
 #define vtab_at90pwm3        vtab_at90pwm3b
 #define vtab_at90can32       vtab_at90can128
@@ -1404,19 +1404,21 @@ extern const char * const vtab_atmega644pa[31];   // ATmega644PA, ATmega644P, AT
 extern const char * const vtab_atmega645p[22];    // ATmega645P, ATmega645A, ATmega645, ATmega325PA, ATmega325P, ATmega325A, ATmega325, ATmega165PA, ATmega165P, ATmega165A, ATmega165
 extern const char * const vtab_atmega649p[23];    // ATmega649P, ATmega649A, ATmega649, ATmega329PA, ATmega329P, ATmega329A, ATmega329, ATmega169PA, ATmega169P, ATmega169A, ATmega169
 extern const char * const vtab_atmega1284p[35];   // ATmega1284P, ATmega1284
-extern const char * const vtab_atmega2561[57];    // ATmega2561, ATmega2560, ATmega1281, ATmega1280, ATmega640
+extern const char * const vtab_atmega2560[57];    // ATmega2560, ATmega1280, ATmega640
+extern const char * const vtab_atmega2561[57];    // ATmega2561, ATmega1281
 extern const char * const vtab_atmega2564rfr2[77]; // ATmega2564RFR2, ATmega1284RFR2, ATmega644RFR2, ATmega256RFR2, ATmega128RFR2, ATmega64RFR2
 extern const char * const vtab_atmega6450p[25];   // ATmega6450P, ATmega6450A, ATmega6450, ATmega3250PA, ATmega3250P, ATmega3250A, ATmega3250
 extern const char * const vtab_atmega6490p[25];   // ATmega6490P, ATmega6490A, ATmega6490, ATmega3290PA, ATmega3290P, ATmega3290A, ATmega3290
 extern const char * const vtab_atmega8515[17];    // ATmega8515
 extern const char * const vtab_atmega8535[21];    // ATmega8535
 extern const char * const vtab_at86rf401[3];      // AT86RF401
+extern const char * const vtab_at90pwm1[32];      // AT90PWM1
 extern const char * const vtab_at90pwm2[32];      // AT90PWM2
 extern const char * const vtab_at90pwm3b[32];     // AT90PWM3B, AT90PWM3, AT90PWM2B
 extern const char * const vtab_at90scr100[38];    // AT90SCR100
 extern const char * const vtab_at90can128[37];    // AT90CAN128, AT90CAN64, AT90CAN32
 extern const char * const vtab_at90pwm161[20];    // AT90PWM161, AT90PWM81
-extern const char * const vtab_at90pwm316[32];    // AT90PWM316, AT90PWM216, AT90PWM1
+extern const char * const vtab_at90pwm316[32];    // AT90PWM316, AT90PWM216
 extern const char * const vtab_at90s1200[4];      // AT90S1200
 extern const char * const vtab_at90s2313[11];     // AT90S2313
 extern const char * const vtab_at90s4433[14];     // AT90S4433, AT90S2333
@@ -1472,6 +1474,6 @@ extern const char * const vtab_avr128db48[61];    // AVR128DB48, AVR64DB48, AVR3
 extern const char * const vtab_avr128da64[64];    // AVR128DA64, AVR64DA64
 extern const char * const vtab_avr128db64[65];    // AVR128DB64, AVR64DB64
 
-extern const uPcore_t uP_table[372];
+extern const uPcore_t uP_table[374];
 
 #endif

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1311,9 +1311,10 @@ static int parse_cmdbits(OPCODE * op, int opnum)
           sb = opnum == AVR_OP_LOAD_EXT_ADDR? bitno+8: bitno-8; // should be this number
           if(bitno < 8 || bitno > 23)
             yywarning("address bits don't normally appear in Bytes 0 or 3 of SPI commands");
-          else if((bn & 31) != sb)
-            yywarning("a%d would normally be expected to be a%d", bn, sb);
-          else if(bn < 0 || bn > 31)
+          else if((bn & 31) != sb) {
+            if(strncasecmp(current_part->desc, "AT89S5", 6)) // Exempt AT89S5x from warning
+              yywarning("a%d would normally be expected to be a%d", bn, sb);
+          } else if(bn < 0 || bn > 31)
             yywarning("invalid address bit a%d, using a%d", bn, bn & 31);
 
           op->bit[bitno].bitno = bn & 31;

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1099,7 +1099,7 @@ void dev_output_part_defs(char *partdesc) {
       if(descs) {
         int len = 16-strlen(p->desc);
         dev_info("%s '%s' =>%*s [0x%02X, 0x%02X, 0x%02X, 0x%08x, 0x%05x, 0x%03x, 0x%06x, 0x%04x, 0x%03x, %d, 0x%03x, 0x%04x, '%s'], # %s %d\n",
-          tsv || all? ".desc": " ",
+          tsv || all? ".desc": "   ",
           p->desc, len > 0? len: 0, "",
           p->signature[0], p->signature[1], p->signature[2],
           flashoffset, flashsize, flashpagesize,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -176,7 +176,7 @@ enum ctl_stack_t {
 typedef struct cmdbit {
   int          type;  /* AVR_CMDBIT_* */
   int          bitno; /* which input bit to use for this command bit */
-  int          value; /* bit value if type == AVR_CMDBIT_VALUD */
+  int          value; /* bit value if type == AVR_CMDBIT_VALUE */
 } CMDBIT;
 
 typedef struct opcode {


### PR DESCRIPTION
Fixes #1304

In `avrdude.conf.in` this PR
  - Adds AT89S51 and AT89S52
  - Adds AT90S2323 and ATtiny22 by inheritance from AT902343
  - Changes AT90S4433 to inherit from AT90S2333 (same datasheet)

Changes in `avrintel.[ch]` are needed to add the two new `mucid`s for AT89S51/52; as a "bycatch" a new version of avrintel.c is deployed with corrections to UART interrupts

`config_gram.y` needed changing to suppress false warnings for the odd address bit positions for AT89S51/52 SPI read signature commands.