### PR TITLE
Remove PM_PDI flag for avrispv2 programmer

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1169,7 +1169,7 @@ programmer
     id                     = "avrispv2";
     desc                   = "Atmel AVR ISP v2";
     type                   = "stk500v2";
-    prog_modes             = PM_TPI | PM_ISP | PM_PDI;
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = serial;
 ;
 


### PR DESCRIPTION
Fixes #1313 

In `avrdude.conf.in`, this PR removes PM_PDI flags for avrispv2 which does not support PDI protocol.