### PR TITLE
Add `-xvtarg`, `-xvaref` and `-xfosc` extended parameters

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1181,14 +1181,20 @@ bits before, and
 bits after the target AVR, respectively.
 Each AVR unit within the chain shifts by 4 bits.
 Other JTAG units might require a different bit shift count.
-.El
-.Pp
-The PICkit 4 and the Power Debugger also supports high-voltage UPDI programming.
-This is used to enable a UPDI pin that has previously been set to RESET or
-GPIO mode. High-voltage UPDI can be utilized by using an extended parameter:
-.Bl -tag -offset indent -width indent
 .It Ar hvupdi
-Enable high-voltage UPDI initialization for targets that supports this.
+.Nm Power Debugger and Pickit 4 only
+.sp 0.5
+High-voltage UPDI programming is used to enable a UPDI pin that has previously
+been set to RESET or GPIO mode. Use
+.Ar -xhvupdi
+to enable high-voltage UPDI initialization for targets that supports this.
+.It Ar vtarg=VALUE, vtarg
+.Nm Power Debugger only
+.sp 0.5
+The voltage generator can be enabled by setting a target voltage.
+The current set-voltage can be read by
+.Ar -xvtarg
+alone.
 .It Ar help
 Show help menu and exit.
 .El
@@ -1221,6 +1227,49 @@ a 0. The current state can be read by
 alone.
 Note that the target power switch will always be on after a power cycle.
 Also note that the smaller Xplained Nano boards does not have a target power switch.
+.It Ar help
+Show help menu and exit.
+.El
+.It Ar Curiosity Nano
+.Bl -tag -offset indent -width indent
+.It Ar vtarg=VALUE, vtarg
+The generated on-board target voltage can be changed by specifying a new voltage.
+The current set-voltage can be read by
+.Ar -xvtarg
+alone.
+.El
+.It Ar STK500
+.It Ar STK600
+.Bl -tag -offset indent -width indent
+.It Ar vtarg=VALUE, vtarg
+The generated on-board target voltage can be changed by specifying a new voltage.
+The current set-voltage can be read by
+.Ar -xvtarg
+alone.
+.It Ar fosc=VALUE[MHz|M|kHz|k|Hz], fosc
+Set the programmable oscillator frequency. The current frequency can be read by
+.Ar -xfosc
+alone.
+.It Ar varef=VALUE, varef
+The generated on-board analog reference voltage can be changed by specifying
+a new reference voltage. The current reference voltage can be read by
+.Ar -xvaref
+alone.
+.It Ar varef[0,1]=VALUE, varef[0,1]
+.Nm STK600 only
+.sp 0.5
+The generated on-board analog reference voltage for channel 0 or channel 1 can
+be changed by specifying a new reference voltage.
+The current reference voltage can be read by
+.Ar -xvaref0
+or
+.Ar -xvaref1
+alone.
+.It Ar attemps[=<1..99>]
+.Nm STK500V1 only
+.sp 0.5
+Specify how many connection retry attemps to perform before exiting.
+Defaults to 10 if not specified.
 .It Ar help
 Show help menu and exit.
 .El
@@ -1527,14 +1576,6 @@ XBee DOUT pin (pin 2) must be connected to the MCU's
 line, and the XBee DIN pin (pin 3) must be connected to the MCU's
 .Ql TXD
 line.
-.It Ar help
-Show help menu and exit.
-.El
-.It Ar STK500
-.Bl -tag -offset indent -width indent
-.It Ar attemps[=<1..99>]
-Specify how many connection retry attemps to perform before exiting.
-Defaults to 10 if not specified.
 .It Ar help
 Show help menu and exit.
 .El

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1237,6 +1237,8 @@ The generated on-board target voltage can be changed by specifying a new voltage
 The current set-voltage can be read by
 .Ar -xvtarg
 alone.
+.It Ar help
+Show help menu and exit.
 .El
 .It Ar STK500
 .It Ar STK600
@@ -1305,6 +1307,8 @@ Show help menu and exit.
 .It Ar attemps[=<1..99>]
 Specify how many connection retry attemps to perform before exiting.
 Defaults to 10 if not specified.
+.It Ar help
+Show help menu and exit.
 .El
 .It Ar Urclock
 .Bl -tag -offset indent -width indent

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1559,6 +1559,7 @@ the CS line being managed outside the application.
 .It Ar help
 Show help menu and exit.
 .El
+.El
 .Sh FILES
 .Bl -tag -offset indent -width /dev/ppi0XXX
 .It Pa /dev/ppi0

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1302,6 +1302,7 @@ programmer
     desc                   = "Atmel STK500 version 1.x firmware";
     type                   = "stk500";
     prog_modes             = PM_ISP;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
     connection_type        = serial;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1327,6 +1327,7 @@ programmer
     desc                   = "Atmel STK500 version 2.x firmware";
     type                   = "stk500v2";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1289,7 +1289,7 @@ programmer
     desc                   = "Atmel STK500";
     type                   = "stk500generic";
     prog_modes             = PM_ISP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1302,7 +1302,7 @@ programmer
     desc                   = "Atmel STK500 version 1.x firmware";
     type                   = "stk500";
     prog_modes             = PM_ISP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1339,7 +1339,7 @@ programmer
     desc                   = "Atmel STK500 v2 in parallel programming mode";
     type                   = "stk500pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1352,7 +1352,7 @@ programmer
     desc                   = "Atmel STK500 v2 in high-voltage serial programming mode";
     type                   = "stk500hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1365,7 +1365,7 @@ programmer
     desc                   = "Atmel STK600";
     type                   = "stk600";
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
 ;
 
@@ -1378,7 +1378,7 @@ programmer
     desc                   = "Atmel STK600 in parallel programming mode";
     type                   = "stk600pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
 ;
 
@@ -1391,7 +1391,7 @@ programmer
     desc                   = "Atmel STK600 in high-voltage serial programming mode";
     type                   = "stk600hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1289,7 +1289,7 @@ programmer
     desc                   = "Atmel STK500";
     type                   = "stk500generic";
     prog_modes             = PM_ISP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1338,7 +1338,7 @@ programmer
     desc                   = "Atmel STK500 v2 in parallel programming mode";
     type                   = "stk500pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1351,7 +1351,7 @@ programmer
     desc                   = "Atmel STK500 v2 in high-voltage serial programming mode";
     type                   = "stk500hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1364,7 +1364,7 @@ programmer
     desc                   = "Atmel STK600";
     type                   = "stk600";
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
     connection_type        = usb;
 ;
 
@@ -1377,7 +1377,7 @@ programmer
     desc                   = "Atmel STK600 in parallel programming mode";
     type                   = "stk600pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
     connection_type        = usb;
 ;
 
@@ -1390,7 +1390,7 @@ programmer
     desc                   = "Atmel STK600 in high-voltage serial programming mode";
     type                   = "stk600hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_AREF_ADJ;
     connection_type        = usb;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -71,6 +71,10 @@
 #   #  - HAS_VTARG_SWITCH: Programer has a programmable target power switch
 #   #  - HAS_VTARG_ADJ: Programmer has an adjustable target power source that can
 #   #    be controlled with Avrdude
+#   #  - HAS_FOSC_ADJ: Programmer has a programable frequency generator that
+#   #    can clock an AVR directly through its XTAL1 pin
+#   #  - HAS_VAREF_ADJ: Programmer has an adjustable analog reference voltage that
+#   #    can be controlled with Avrdude
 #   #
 #   # (3) Not all programmer types can process a list of PIDs
 #
@@ -1285,6 +1289,7 @@ programmer
     desc                   = "Atmel STK500";
     type                   = "stk500generic";
     prog_modes             = PM_ISP;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1333,6 +1338,7 @@ programmer
     desc                   = "Atmel STK500 v2 in parallel programming mode";
     type                   = "stk500pp";
     prog_modes             = PM_HVPP;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1345,6 +1351,7 @@ programmer
     desc                   = "Atmel STK500 v2 in high-voltage serial programming mode";
     type                   = "stk500hvsp";
     prog_modes             = PM_HVSP;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = serial;
 ;
 
@@ -1357,7 +1364,7 @@ programmer
     desc                   = "Atmel STK600";
     type                   = "stk600";
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
 ;
 
@@ -1370,7 +1377,7 @@ programmer
     desc                   = "Atmel STK600 in parallel programming mode";
     type                   = "stk600pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
 ;
 
@@ -1383,7 +1390,7 @@ programmer
     desc                   = "Atmel STK600 in high-voltage serial programming mode";
     type                   = "stk600hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
 ;
 

--- a/src/config.c
+++ b/src/config.c
@@ -564,7 +564,7 @@ void capture_comment_str(const char *com, int lineno) {
 
 // Capture assignments (keywords left of =) and associate comments to them
 void capture_lvalue_kw(const char *kw, int lineno) {
-  if(str_eq(kw, "memory")) {   // Push part comments and start memory comments
+  if(str_eq(kw, "memory")) {    // Push part comments and start memory comments
     if(!cfg_pushed) {           // config_gram.y pops the part comments
       cfg_pushed = 1;
       cfg_pushedcomms = cfg_strctcomms;

--- a/src/config.c
+++ b/src/config.c
@@ -352,6 +352,7 @@ TOKEN *new_constant(const char *con) {
     !strcmp("HAS_VTARG_SWITCH", con)? HAS_VTARG_SWITCH:
     !strcmp("HAS_VTARG_ADJ", con)? HAS_VTARG_ADJ:
     !strcmp("HAS_VTARG_READ", con)? HAS_VTARG_READ:
+    !strcmp("HAS_FOSC_ADJ", con)? HAS_FOSC_ADJ:
     !strcmp("pseudo", con)? 2:
     !strcmp("yes", con) || !strcmp("true", con)? 1:
     !strcmp("no", con) || !strcmp("false", con)? 0:

--- a/src/config.c
+++ b/src/config.c
@@ -335,28 +335,28 @@ TOKEN *new_constant(const char *con) {
 
   tkn->value.type = V_NUM;
   tkn->value.number =
-    !strcmp("PM_SPM", con)? PM_SPM:
-    !strcmp("PM_TPI", con)? PM_TPI:
-    !strcmp("PM_ISP", con)? PM_ISP:
-    !strcmp("PM_PDI", con)? PM_PDI:
-    !strcmp("PM_UPDI", con)? PM_UPDI:
-    !strcmp("PM_HVSP", con)? PM_HVSP:
-    !strcmp("PM_HVPP", con)? PM_HVPP:
-    !strcmp("PM_debugWIRE", con)? PM_debugWIRE:
-    !strcmp("PM_JTAG", con)? PM_JTAG:
-    !strcmp("PM_JTAGmkI", con)? PM_JTAGmkI:
-    !strcmp("PM_XMEGAJTAG", con)? PM_XMEGAJTAG:
-    !strcmp("PM_AVR32JTAG", con)? PM_AVR32JTAG:
-    !strcmp("PM_aWire", con)? PM_aWire:
-    !strcmp("HAS_SUFFER", con)? HAS_SUFFER:
-    !strcmp("HAS_VTARG_SWITCH", con)? HAS_VTARG_SWITCH:
-    !strcmp("HAS_VTARG_ADJ", con)? HAS_VTARG_ADJ:
-    !strcmp("HAS_VTARG_READ", con)? HAS_VTARG_READ:
-    !strcmp("HAS_FOSC_ADJ", con)? HAS_FOSC_ADJ:
-    !strcmp("HAS_VAREF_ADJ", con)? HAS_VAREF_ADJ:
-    !strcmp("pseudo", con)? 2:
-    !strcmp("yes", con) || !strcmp("true", con)? 1:
-    !strcmp("no", con) || !strcmp("false", con)? 0:
+    str_eq(con, "PM_SPM")? PM_SPM:
+    str_eq(con, "PM_TPI")? PM_TPI:
+    str_eq(con, "PM_ISP")? PM_ISP:
+    str_eq(con, "PM_PDI")? PM_PDI:
+    str_eq(con, "PM_UPDI")? PM_UPDI:
+    str_eq(con, "PM_HVSP")? PM_HVSP:
+    str_eq(con, "PM_HVPP")? PM_HVPP:
+    str_eq(con, "PM_debugWIRE")? PM_debugWIRE:
+    str_eq(con, "PM_JTAG")? PM_JTAG:
+    str_eq(con, "PM_JTAGmkI")? PM_JTAGmkI:
+    str_eq(con, "PM_XMEGAJTAG")? PM_XMEGAJTAG:
+    str_eq(con, "PM_AVR32JTAG")? PM_AVR32JTAG:
+    str_eq(con, "PM_aWire")? PM_aWire:
+    str_eq(con, "HAS_SUFFER")? HAS_SUFFER:
+    str_eq(con, "HAS_VTARG_SWITCH")? HAS_VTARG_SWITCH:
+    str_eq(con, "HAS_VTARG_ADJ")? HAS_VTARG_ADJ:
+    str_eq(con, "HAS_VTARG_READ")? HAS_VTARG_READ:
+    str_eq(con, "HAS_FOSC_ADJ")? HAS_FOSC_ADJ:
+    str_eq(con, "HAS_VAREF_ADJ")? HAS_VAREF_ADJ:
+    str_eq(con, "pseudo")? 2:
+    str_eq(con, "yes") || str_eq(con, "true")? 1:
+    str_eq(con, "no") || str_eq(con, "false")? 0:
     (assigned = 0);
 
   if(!assigned) {
@@ -496,7 +496,7 @@ const char *cache_string(const char *p) {
     hs = hstrings[h] = (char **) cfg_realloc("cache_string()", NULL, (16+1)*sizeof**hstrings);
 
   for(k=0; hs[k]; k++)
-    if(*p == *hs[k] && !strcmp(p, hs[k]))
+    if(*p == *hs[k] && str_eq(p, hs[k]))
       return hs[k];
 
   if(k && k%16 == 0)
@@ -521,7 +521,7 @@ COMMENT *locate_comment(const LISTID comments, const char *where, int rhs) {
   if(comments)
     for(LNODEID ln=lfirst(comments); ln; ln=lnext(ln)) {
       COMMENT *n = ldata(ln);
-      if(n && rhs == n->rhs && n->kw && strcmp(where, n->kw) == 0)
+      if(n && rhs == n->rhs && n->kw && str_eq(where, n->kw))
         return n;
     }
 
@@ -564,7 +564,7 @@ void capture_comment_str(const char *com, int lineno) {
 
 // Capture assignments (keywords left of =) and associate comments to them
 void capture_lvalue_kw(const char *kw, int lineno) {
-  if(!strcmp(kw, "memory")) {   // Push part comments and start memory comments
+  if(str_eq(kw, "memory")) {   // Push part comments and start memory comments
     if(!cfg_pushed) {           // config_gram.y pops the part comments
       cfg_pushed = 1;
       cfg_pushedcomms = cfg_strctcomms;
@@ -572,7 +572,7 @@ void capture_lvalue_kw(const char *kw, int lineno) {
     }
   }
 
-  if(!strcmp(kw, "programmer") || !strcmp(kw, "part") || !strcmp(kw, "memory"))
+  if(str_eq(kw, "programmer") || str_eq(kw, "part") || str_eq(kw, "memory"))
     kw = "*";                   // Show comment before programmer/part/memory
 
   if(lkw)
@@ -832,9 +832,9 @@ char *cfg_escape(const char *s) {
 
 static int cmp_comp(const void *v1, const void *v2) {
   const Component_t *c1 = v1, *c2 = v2;
-  int ret = strcmp(c1->name, c2->name);
+  int ret = str_eq(c1->name, c2->name);
 
-  return ret? ret: c1->strct - c2->strct;
+  return ret? c1->strct - c2->strct: ret;
 }
 
 Component_t *cfg_comp_search(const char *name, int strct) {

--- a/src/config.c
+++ b/src/config.c
@@ -353,6 +353,7 @@ TOKEN *new_constant(const char *con) {
     !strcmp("HAS_VTARG_ADJ", con)? HAS_VTARG_ADJ:
     !strcmp("HAS_VTARG_READ", con)? HAS_VTARG_READ:
     !strcmp("HAS_FOSC_ADJ", con)? HAS_FOSC_ADJ:
+    !strcmp("HAS_AREF_ADJ", con)? HAS_AREF_ADJ:
     !strcmp("pseudo", con)? 2:
     !strcmp("yes", con) || !strcmp("true", con)? 1:
     !strcmp("no", con) || !strcmp("false", con)? 0:

--- a/src/config.c
+++ b/src/config.c
@@ -353,7 +353,7 @@ TOKEN *new_constant(const char *con) {
     !strcmp("HAS_VTARG_ADJ", con)? HAS_VTARG_ADJ:
     !strcmp("HAS_VTARG_READ", con)? HAS_VTARG_READ:
     !strcmp("HAS_FOSC_ADJ", con)? HAS_FOSC_ADJ:
-    !strcmp("HAS_AREF_ADJ", con)? HAS_AREF_ADJ:
+    !strcmp("HAS_VAREF_ADJ", con)? HAS_VAREF_ADJ:
     !strcmp("pseudo", con)? 2:
     !strcmp("yes", con) || !strcmp("true", con)? 1:
     !strcmp("no", con) || !strcmp("false", con)? 0:

--- a/src/config.c
+++ b/src/config.c
@@ -832,9 +832,9 @@ char *cfg_escape(const char *s) {
 
 static int cmp_comp(const void *v1, const void *v2) {
   const Component_t *c1 = v1, *c2 = v2;
-  int ret = str_eq(c1->name, c2->name);
+  int ret = strcmp(c1->name, c2->name);
 
-  return ret? c1->strct - c2->strct: ret;
+  return ret? ret: c1->strct - c2->strct;
 }
 
 Component_t *cfg_comp_search(const char *name, int strct) {

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -258,8 +258,8 @@ static char *extra_features_str(int m) {
     strcat(mode, " | HAS_VTARG_READ");
   if(m & HAS_FOSC_ADJ)
     strcat(mode, " | HAS_FOSC_ADJ");
-  if(m & HAS_AREF_ADJ)
-    strcat(mode, " | HAS_AREF_ADJ");
+  if(m & HAS_VAREF_ADJ)
+    strcat(mode, " | HAS_VAREF_ADJ");
 
   return mode + (mode[1] == 0? 0: 4);
 }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -258,6 +258,8 @@ static char *extra_features_str(int m) {
     strcat(mode, " | HAS_VTARG_READ");
   if(m & HAS_FOSC_ADJ)
     strcat(mode, " | HAS_FOSC_ADJ");
+  if(m & HAS_AREF_ADJ)
+    strcat(mode, " | HAS_AREF_ADJ");
 
   return mode + (mode[1] == 0? 0: 4);
 }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -256,6 +256,8 @@ static char *extra_features_str(int m) {
     strcat(mode, " | HAS_VTARG_ADJ");
   if(m & HAS_VTARG_READ)
     strcat(mode, " | HAS_VTARG_READ");
+  if(m & HAS_FOSC_ADJ)
+    strcat(mode, " | HAS_FOSC_ADJ");
 
   return mode + (mode[1] == 0? 0: 4);
 }

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -937,14 +937,19 @@ after, @var{BB} bits before, and @var{BA} bits after the target AVR,
 respectively.
 Each AVR unit within the chain shifts by 4 bits.
 Other JTAG units might require a different bit shift count.
-@end table
 
-The PICkit 4 and the Power Debugger also supports high-voltage UPDI programming.
-This is used to enable a UPDI pin that has previously been set to RESET or
-GPIO mode. High-voltage UPDI can be utilized by using an extended parameter:
-@table @code
 @item @samp{hvupdi}
-Enable high-voltage UPDI initialization for targets that supports this.
+@var{Power Debugger and Pickit 4 only}
+@*
+High-voltage UPDI programming is used to enable a UPDI pin that has previously
+been set to RESET or GPIO mode. Use @samp{-xhvupdi} to enable high-voltage UPDI
+initialization for supported targets.
+
+@item @samp{vtarg=VALUE, vtarg}
+@var{Power Debugger only}
+@*
+The voltage generator can be enabled by setting a target voltage.
+The current set-voltage can be read by @samp{-xvtarg} alone.
 
 @item @samp{help}
 Show help menu and exit.
@@ -981,6 +986,51 @@ a 0. The current state can be read by @samp{-xvtarg_switch} alone.
 Note that the target power switch will always be on after a power cycle.
 Also note that the smaller Xplained Nano boards does not have a target power switch.
 
+@item @samp{help}
+Show help menu and exit.
+@end table
+
+@cindex @code{-x} Curiosity Nano
+@item Curiosity Nano
+
+The Curiosity Nano board accepts the following extended parameter:
+@table @code
+@item @samp{vtarg=VALUE, vtarg}
+The generated on-board target voltage can be changed by specifying a new voltage.
+The current set-voltage can be read by @samp{-xvtarg} alone.
+@item @samp{help}
+Show help menu and exit.
+@end table
+
+@cindex @code{-x} STK500
+@cindex @code{-x} STK600
+@item STK500
+@item STK600
+
+The STK500 and STK600 boards accepts the following extended parameters:
+@table @code
+@item @samp{vtarg=VALUE, vtarg}
+The generated on-board target voltage can be changed by specifying a new voltage.
+The current set-voltage can be read by @samp{-xvtarg} alone.
+@item @samp{fosc=VALUE[MHz|M|kHz|k|Hz], fosc}
+Set the programmable oscillator frequency in MHz, kHz or Hz.
+The current frequency can be read by @samp{-xfosc} alone.
+@item @samp{varef=VALUE, varef}
+The generated on-board analog reference voltage can be changed by specifying
+a new reference voltage. The current reference voltage can be read by
+@samp{-xvaref} alone.
+@item @samp{varef[0,1]=VALUE, varef[0,1]}
+@var{STK600 only}
+@*
+The generated on-board analog reference voltage for channel 0 or channel 1 can
+be changed by specifying a new reference voltage.
+The current reference voltage can be read by @samp{-xvaref0} or
+@samp{-xvaref1} alone.
+@item @samp{attemps[=<1..99>]}
+@var{STK500V1 only}
+@*
+Specify how many connection retry attemps to perform before exiting.
+Defaults to 10 if not specified.
 @item @samp{help}
 Show help menu and exit.
 @end table

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1007,7 +1007,7 @@ Show help menu and exit.
 @item STK500
 @item STK600
 
-The STK500 and STK600 boards accepts the following extended parameters:
+The STK500 and STK600 boards accept the following extended parameters:
 @table @code
 @item @samp{vtarg=VALUE, vtarg}
 The generated on-board target voltage can be changed by specifying a new voltage.

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1569,13 +1569,13 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
             break;
           }
           PDATA(pgm)->vtarg_set = true;
+          continue;
         }
         // Get target voltage
-        else if(str_eq(extended_param, "vtarg"))
+        else if(str_eq(extended_param, "vtarg")) {
           PDATA(pgm)->vtarg_get = true;
-        else
-          break;
-        continue;
+          continue;
+        }
       }
     }
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1104,7 +1104,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if (PDATA(pgm)->set_sck(pgm, parm) < 0)
       return -1;
   }
-  jtag3_print_parms1(pgm, progbuf, stderr);
+
   if (conn == PARM3_CONN_JTAG) {
     pmsg_notice2("jtag3_initialize(): "
       "trying to set JTAG daisy-chain info to %d,%d,%d,%d\n",
@@ -2544,7 +2544,8 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
   msg_info("%sICE HW version  : %d\n", p, parms[0]);
   msg_info("%sICE FW version  : %d.%02d (rel. %d)\n", p, parms[1], parms[2],
            (parms[3] | (parms[4] << 8)));
-  msg_info("%sSerial number   : %s", p, sn);
+  msg_info("%sSerial number   : %s\n", p, sn);
+  jtag3_print_parms1(pgm, progbuf, stderr);
   free(resp);
 }
 
@@ -2832,8 +2833,6 @@ static int jtag3_initialize_tpi(const PROGRAMMER *pgm, const AVRPART *p) {
   if ((status = jtag3_command_tpi(pgm, cmd, 3, &resp, "Set NVMCSR")) < 0)
     return -1;
   free(resp);
-
-  jtag3_print_parms1(pgm, progbuf, stderr);
 
   return 0;
 }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2556,8 +2556,12 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
   unsigned char prog_mode[2];
   unsigned char buf[3];
 
+  if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
+    return;
+  msg_info("%sVtarget         : %.2f V\n", p, b2_to_u16(buf)/1000.0);
+
   // Print clocks if programmer typ is not TPI
-  if (strcmp(pgm->type, "JTAGICE3_TPI")) {
+  if (!str_eq(pgm->type, "JTAGICE3_TPI")) {
     // Get current programming mode and target type from to determine what data to print
     if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, prog_mode, 1) < 0)
       return;
@@ -2588,10 +2592,6 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
         fmsg_out(fp, "%sPDI/UPDI clk    : %u kHz\n", p, b2_to_u16(buf));
     }
   }
-
-  if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
-    return;
-  msg_info("%sVtarget         : %.2f V\n", p, b2_to_u16(buf)/1000.0);
 
   // Print features unique to the Power Debugger
   for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln)) {
@@ -2663,7 +2663,6 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       break;
     }
   }
-
   fmsg_out(fp, "\n");
 }
 
@@ -2812,6 +2811,9 @@ static int jtag3_initialize_tpi(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char cmd[3];
   unsigned char* resp;
   int status;
+
+  if (verbose && quell_progress < 2)
+    jtag3_print_parms1(pgm, progbuf, stderr);
 
   pmsg_notice2("jtag3_initialize_tpi() start\n");
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -3180,6 +3180,7 @@ void jtag3_dw_initpgm(PROGRAMMER *pgm) {
   pgm->paged_write    = jtag3_paged_write;
   pgm->paged_load     = jtag3_paged_load;
   pgm->print_parms    = jtag3_print_parms;
+  pgm->parseextparams = jtag3_parseextparms;
   pgm->setup          = jtag3_setup;
   pgm->teardown       = jtag3_teardown;
   pgm->page_size      = 256;
@@ -3219,6 +3220,7 @@ void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
   pgm->page_erase     = jtag3_page_erase;
   pgm->print_parms    = jtag3_print_parms;
   pgm->set_sck_period = jtag3_set_sck_period;
+  pgm->parseextparams = jtag3_parseextparms;
   pgm->setup          = jtag3_setup;
   pgm->teardown       = jtag3_teardown;
   pgm->page_size      = 256;
@@ -3240,7 +3242,6 @@ void jtag3_updi_initpgm(PROGRAMMER *pgm) {
    * mandatory functions
    */
   pgm->initialize     = jtag3_initialize;
-  pgm->parseextparams = jtag3_parseextparms;
   pgm->display        = jtag3_display;
   pgm->enable         = jtag3_enable;
   pgm->disable        = jtag3_disable;
@@ -3259,6 +3260,7 @@ void jtag3_updi_initpgm(PROGRAMMER *pgm) {
   pgm->page_erase     = jtag3_page_erase;
   pgm->print_parms    = jtag3_print_parms;
   pgm->set_sck_period = jtag3_set_sck_period;
+  pgm->parseextparams = jtag3_parseextparms;
   pgm->setup          = jtag3_setup;
   pgm->teardown       = jtag3_teardown;
   pgm->page_size      = 256;
@@ -3298,6 +3300,7 @@ void jtag3_tpi_initpgm(PROGRAMMER *pgm) {
   pgm->paged_write    = jtag3_paged_write_tpi;
   pgm->paged_load     = jtag3_paged_load_tpi;
   pgm->print_parms    = jtag3_print_parms;
+  pgm->parseextparams = jtag3_parseextparms;
   pgm->setup          = jtag3_setup;
   pgm->teardown       = jtag3_teardown;
   pgm->page_size      = 256;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1592,6 +1592,10 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
         msg_error("  -xvtarg_switch          Read on-board target voltage switch state\n");
         msg_error("  -xvtarg_switch=<0..1>   Set on-board target voltage switch state\n");
       }
+      if (pgm->extra_features & HAS_VTARG_ADJ) {
+        msg_error("  -xvtarg                 Read on-board target supply voltage\n");
+        msg_error("  -xvtarg=<arg>           Set on-board target supply voltage\n");
+      }
       msg_error  ("  -xhelp                  Show this help menu and exit\n");
       exit(0);
     }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -3100,6 +3100,9 @@ void jtag3_initpgm(PROGRAMMER *pgm) {
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_JTAG;
 
+  /*
+   * hardware dependent functions
+   */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }
@@ -3134,6 +3137,9 @@ void jtag3_dw_initpgm(PROGRAMMER *pgm) {
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_DW;
 
+  /*
+   * hardware dependent functions
+   */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }
@@ -3170,6 +3176,9 @@ void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_PDI;
 
+  /*
+   * hardware dependent functions
+   */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }
@@ -3209,6 +3218,9 @@ void jtag3_updi_initpgm(PROGRAMMER *pgm) {
   pgm->unlock         = jtag3_unlock_erase_key;
   pgm->read_sib       = jtag3_read_sib;
 
+  /*
+   * hardware dependent functions
+   */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -145,7 +145,7 @@ SIGN     [+-]
 
 
 (?x: PM_(SPM|TPI|ISP|PDI|UPDI|HVSP|HVPP|debugWIRE|JTAG|JTAGmkI|XMEGAJTAG|AVR32JTAG|aWire) |
- HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ|FOSC_ADJ|AREF_ADJ) |
+ HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ|FOSC_ADJ|VAREF_ADJ) |
  yes|no|pseudo | true|false ) { /* Constants */
   yylval = new_constant(yytext);
   return TKN_NUMBER;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -145,7 +145,7 @@ SIGN     [+-]
 
 
 (?x: PM_(SPM|TPI|ISP|PDI|UPDI|HVSP|HVPP|debugWIRE|JTAG|JTAGmkI|XMEGAJTAG|AVR32JTAG|aWire) |
- HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ|FOSC_ADJ) |
+ HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ|FOSC_ADJ|AREF_ADJ) |
  yes|no|pseudo | true|false ) { /* Constants */
   yylval = new_constant(yytext);
   return TKN_NUMBER;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -145,7 +145,7 @@ SIGN     [+-]
 
 
 (?x: PM_(SPM|TPI|ISP|PDI|UPDI|HVSP|HVPP|debugWIRE|JTAG|JTAGmkI|XMEGAJTAG|AVR32JTAG|aWire) |
- HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ) |
+ HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ|FOSC_ADJ) |
  yes|no|pseudo | true|false ) { /* Constants */
   yylval = new_constant(yytext);
   return TKN_NUMBER;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -216,6 +216,7 @@ typedef struct opcode {
 #define HAS_VTARG_ADJ          4
 #define HAS_VTARG_READ         8
 #define HAS_FOSC_ADJ          16
+#define HAS_AREF_ADJ          32
 
 #define AVR_FAMILYIDLEN 7
 #define AVR_SIBLEN 16

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -216,7 +216,7 @@ typedef struct opcode {
 #define HAS_VTARG_ADJ          4
 #define HAS_VTARG_READ         8
 #define HAS_FOSC_ADJ          16
-#define HAS_AREF_ADJ          32
+#define HAS_VAREF_ADJ         32
 
 #define AVR_FAMILYIDLEN 7
 #define AVR_SIBLEN 16

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -215,6 +215,7 @@ typedef struct opcode {
 #define HAS_VTARG_SWITCH       2
 #define HAS_VTARG_ADJ          4
 #define HAS_VTARG_READ         8
+#define HAS_FOSC_ADJ          16
 
 #define AVR_FAMILYIDLEN 7
 #define AVR_SIBLEN 16

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -680,7 +680,7 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 
     else if (str_starts(extended_param, "varef")) {
       if (pgm->extra_features & HAS_VAREF_ADJ) {
-        int sscanf_success;
+        int sscanf_success = 0;
         double varef_set_val = 0;
         // Get new analog reference voltage for channel 0
         if (str_starts(extended_param, "varef=")) {

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -606,7 +606,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     unsigned int osc_pscale;
     unsigned int osc_cmatch;
     const char *unit_get = {"Hz"};
-    double f_get;
+    double f_get = 0.0;
     stk500_getparm(pgm, Parm_STK_OSC_PSCALE, &osc_pscale);
     stk500_getparm(pgm, Parm_STK_OSC_CMATCH, &osc_cmatch);
     if(osc_pscale) {

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1300,11 +1300,18 @@ void stk500_initpgm(PROGRAMMER *pgm) {
   pgm->paged_write    = stk500_paged_write;
   pgm->paged_load     = stk500_paged_load;
   pgm->print_parms    = stk500_print_parms;
-  pgm->set_vtarget    = stk500_set_vtarget;
-  pgm->set_varef      = stk500_set_varef;
-  pgm->set_fosc       = stk500_set_fosc;
   pgm->set_sck_period = stk500_set_sck_period;
   pgm->setup          = stk500_setup;
   pgm->teardown       = stk500_teardown;
   pgm->page_size      = 256;
+
+  /*
+   * hardware dependent functions
+   */
+  if (pgm->extra_features & HAS_VTARG_ADJ)
+    pgm->set_vtarget    = stk500_set_vtarget;
+  if (pgm->extra_features & HAS_AREF_ADJ)
+    pgm->set_varef      = stk500_set_varef;
+  if (pgm->extra_features & HAS_FOSC_ADJ)
+    pgm->set_fosc       = stk500_set_fosc;
 }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1348,7 +1348,7 @@ void stk500_initpgm(PROGRAMMER *pgm) {
    */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget    = stk500_set_vtarget;
-  if (pgm->extra_features & HAS_AREF_ADJ)
+  if (pgm->extra_features & HAS_VAREF_ADJ)
     pgm->set_varef      = stk500_set_varef;
   if (pgm->extra_features & HAS_FOSC_ADJ)
     pgm->set_fosc       = stk500_set_fosc;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -557,6 +557,21 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
 
+  // Read or write target voltage
+  if (PDATA(pgm)->vtarg_get || PDATA(pgm)->vtarg_set) {
+    // Read current target voltage set value
+    unsigned int vtarg_read;
+    stk500_getparm(pgm, Parm_STK_VTARGET, &vtarg_read);
+    if (PDATA(pgm)->vtarg_get)
+      msg_info("Target voltage value read as %.2fV\n", (vtarg_read / 10.0));
+    // Write target voltage value
+    else {
+      msg_info("Changing target voltage from %.2f to %.2fV\n", (vtarg_read / 10.0), PDATA(pgm)->vtarg_data);
+      if(pgm->set_vtarget(pgm, PDATA(pgm)->vtarg_data) < 0)
+        return -1;
+    }
+  }
+
   return pgm->program_enable(pgm, p);
 }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -604,13 +604,13 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
             break;
           }
           PDATA(pgm)->vtarg_set = true;
+          continue;
         }
         // Get target voltage
-        else if(str_eq(extended_param, "vtarg"))
+        else if(str_eq(extended_param, "vtarg")) {
           PDATA(pgm)->vtarg_get = true;
-        else
-          break;
-        continue;
+          continue;
+        }
       }
     }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -751,8 +751,20 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
     else if (str_eq(extended_param, "help")) {
       char *prg = (char *)ldata(lfirst(pgm->id));
       msg_error("%s -c %s extended options:\n", progname, prg);
-      msg_error("  -xattempts=<arg> Specify no. connection retry attempts\n");
-      msg_error("  -xhelp           Show this help menu and exit\n");
+      msg_error("  -xattempts=<arg>      Specify no. connection retry attempts\n");
+      if (pgm->extra_features & HAS_VTARG_ADJ) {
+        msg_error("  -xvtarg               Read target supply voltage\n");
+        msg_error("  -xvtarg=<arg>         Set target supply voltage\n");
+      }
+      if (pgm->extra_features & HAS_VAREF_ADJ) {
+        msg_error("  -xvaref               Read analog reference voltage\n");
+        msg_error("  -xvaref=<arg>         Set analog reference voltage\n");
+      }
+      if (pgm->extra_features & HAS_FOSC_ADJ) {
+        msg_error("  -xfosc                Read oscillator clock frequency\n");
+        msg_error("  -xfosc=<arg>[M|k]|off Set oscillator clock frequency\n");
+      }
+      msg_error("  -xhelp                Show this help menu and exit\n");
       exit(0);
     }
 

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -52,6 +52,11 @@ struct pdata {
   bool varef_get;
   bool varef_set;
   double varef_data;
+
+  // Get/set flags for programmable clock generator
+  bool fosc_get;
+  bool fosc_set;
+  double fosc_data;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -47,6 +47,11 @@ struct pdata {
   bool vtarg_get;
   bool vtarg_set;
   double vtarg_data;
+
+  // Get/set flags for adjustable analog reference voltage
+  bool varef_get;
+  bool varef_set;
+  double varef_data;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -42,6 +42,11 @@ struct pdata {
   unsigned char ext_addr_byte;  // Record ext-addr byte set in the target device (if used)
   int retry_attempts;           // Number of connection attempts provided by the user
   int xbeeResetPin;             // Piggy back variable used by xbee programmmer
+
+  // Get/set flags for adjustable target voltage
+  bool vtarg_get;
+  bool vtarg_set;
+  double vtarg_data;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -4444,7 +4444,7 @@ void stk500v2_initpgm(PROGRAMMER *pgm) {
    */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = stk500v2_set_vtarget;
-  if (pgm->extra_features & HAS_AREF_ADJ)
+  if (pgm->extra_features & HAS_VAREF_ADJ)
     pgm->set_varef    = stk500v2_set_varef;
   if (pgm->extra_features & HAS_FOSC_ADJ)
     pgm->set_fosc     = stk500v2_set_fosc;
@@ -4486,7 +4486,7 @@ void stk500pp_initpgm(PROGRAMMER *pgm) {
    */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = stk500v2_set_vtarget;
-  if (pgm->extra_features & HAS_AREF_ADJ)
+  if (pgm->extra_features & HAS_VAREF_ADJ)
     pgm->set_varef    = stk500v2_set_varef;
   if (pgm->extra_features & HAS_FOSC_ADJ)
     pgm->set_fosc     = stk500v2_set_fosc;
@@ -4528,7 +4528,7 @@ void stk500hvsp_initpgm(PROGRAMMER *pgm) {
    */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = stk500v2_set_vtarget;
-  if (pgm->extra_features & HAS_AREF_ADJ)
+  if (pgm->extra_features & HAS_VAREF_ADJ)
     pgm->set_varef    = stk500v2_set_varef;
   if (pgm->extra_features & HAS_FOSC_ADJ)
     pgm->set_fosc     = stk500v2_set_fosc;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -4684,6 +4684,9 @@ void stk500v2_jtag3_initpgm(PROGRAMMER *pgm) {
   pgm->teardown       = stk500v2_jtag3_teardown;
   pgm->page_size      = 256;
 
+  /*
+   * hardware dependent functions
+   */
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -4508,9 +4508,6 @@ void stk500v2_dragon_pp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_write    = stk500pp_paged_write;
   pgm->paged_load     = stk500pp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
-  pgm->set_vtarget    = stk500v2_set_vtarget;
-  pgm->set_varef      = stk500v2_set_varef;
-  pgm->set_fosc       = stk500v2_set_fosc;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
   pgm->setup          = stk500v2_jtagmkII_setup;
   pgm->teardown       = stk500v2_jtagmkII_teardown;
@@ -4542,9 +4539,6 @@ void stk500v2_dragon_hvsp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_write    = stk500hvsp_paged_write;
   pgm->paged_load     = stk500hvsp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
-  pgm->set_vtarget    = stk500v2_set_vtarget;
-  pgm->set_varef      = stk500v2_set_varef;
-  pgm->set_fosc       = stk500v2_set_fosc;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
   pgm->setup          = stk500v2_jtagmkII_setup;
   pgm->teardown       = stk500v2_jtagmkII_teardown;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1298,7 +1298,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       unsigned char osc_pscale;
       unsigned char osc_cmatch;
       const char *unit_get = {"Hz"};
-      double f_get;
+      double f_get = 0.0;
       stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
       stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
       if(osc_pscale) {
@@ -1613,7 +1613,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       unsigned char osc_pscale;
       unsigned char osc_cmatch;
       const char *unit_get = {"Hz"};
-      double f_get;
+      double f_get = 0.0;
       stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
       stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
       if(osc_pscale) {

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1844,7 +1844,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
 
     else if (str_starts(extended_param, "varef")) {
       if (pgm->extra_features & HAS_VAREF_ADJ) {
-        int sscanf_success;
+        int sscanf_success = 0;
         double varef_set_val = 0;
         // Get new analog reference voltage for channel 0
         if (str_starts(extended_param, "varef=")) {

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1641,13 +1641,13 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
             break;
           }
           PDATA(pgm)->vtarg_set = true;
+          continue;
         }
         // Get target voltage
-        else if(str_eq(extended_param, "vtarg"))
+        else if(str_eq(extended_param, "vtarg")) {
           PDATA(pgm)->vtarg_get = true;
-        else
-          break;
-        continue;
+          continue;
+        }
       }
     }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -4280,14 +4280,14 @@ static void stk600_setup_xprog(PROGRAMMER * pgm)
  */
 static void stk600_setup_isp(PROGRAMMER * pgm)
 {
-    pgm->program_enable = stk500v2_program_enable;
-    pgm->disable = stk500v2_disable;
-    pgm->read_byte = stk500isp_read_byte;
-    pgm->write_byte = stk500isp_write_byte;
-    pgm->paged_load = stk500v2_paged_load;
-    pgm->paged_write = stk500v2_paged_write;
-    pgm->page_erase = stk500v2_page_erase;
-    pgm->chip_erase = stk500v2_chip_erase;
+  pgm->program_enable = stk500v2_program_enable;
+  pgm->disable = stk500v2_disable;
+  pgm->read_byte = stk500isp_read_byte;
+  pgm->write_byte = stk500isp_write_byte;
+  pgm->paged_load = stk500v2_paged_load;
+  pgm->paged_write = stk500v2_paged_write;
+  pgm->page_erase = stk500v2_page_erase;
+  pgm->chip_erase = stk500v2_chip_erase;
 }
 
 const char stk500v2_desc[] = "Atmel STK500 Version 2.x firmware";

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -4317,14 +4317,21 @@ void stk500v2_initpgm(PROGRAMMER *pgm) {
   pgm->paged_load     = stk500v2_paged_load;
   pgm->page_erase     = stk500v2_page_erase;
   pgm->print_parms    = stk500v2_print_parms;
-  pgm->set_vtarget    = stk500v2_set_vtarget;
-  pgm->set_varef      = stk500v2_set_varef;
-  pgm->set_fosc       = stk500v2_set_fosc;
   pgm->set_sck_period = stk500v2_set_sck_period;
   pgm->perform_osccal = stk500v2_perform_osccal;
   pgm->setup          = stk500v2_setup;
   pgm->teardown       = stk500v2_teardown;
   pgm->page_size      = 256;
+
+  /*
+   * hardware dependent functions
+   */
+  if (pgm->extra_features & HAS_VTARG_ADJ)
+    pgm->set_vtarget  = stk500v2_set_vtarget;
+  if (pgm->extra_features & HAS_AREF_ADJ)
+    pgm->set_varef    = stk500v2_set_varef;
+  if (pgm->extra_features & HAS_FOSC_ADJ)
+    pgm->set_fosc     = stk500v2_set_fosc;
 }
 
 const char stk500pp_desc[] = "Atmel STK500 V2 in parallel programming mode";
@@ -4352,13 +4359,20 @@ void stk500pp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_write    = stk500pp_paged_write;
   pgm->paged_load     = stk500pp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
-  pgm->set_vtarget    = stk500v2_set_vtarget;
-  pgm->set_varef      = stk500v2_set_varef;
-  pgm->set_fosc       = stk500v2_set_fosc;
   pgm->set_sck_period = stk500v2_set_sck_period;
   pgm->setup          = stk500v2_setup;
   pgm->teardown       = stk500v2_teardown;
   pgm->page_size      = 256;
+
+  /*
+   * hardware dependent functions
+   */
+  if (pgm->extra_features & HAS_VTARG_ADJ)
+    pgm->set_vtarget  = stk500v2_set_vtarget;
+  if (pgm->extra_features & HAS_AREF_ADJ)
+    pgm->set_varef    = stk500v2_set_varef;
+  if (pgm->extra_features & HAS_FOSC_ADJ)
+    pgm->set_fosc     = stk500v2_set_fosc;
 }
 
 const char stk500hvsp_desc[] = "Atmel STK500 V2 in high-voltage serial programming mode";
@@ -4386,13 +4400,20 @@ void stk500hvsp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_write    = stk500hvsp_paged_write;
   pgm->paged_load     = stk500hvsp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
-  pgm->set_vtarget    = stk500v2_set_vtarget;
-  pgm->set_varef      = stk500v2_set_varef;
-  pgm->set_fosc       = stk500v2_set_fosc;
   pgm->set_sck_period = stk500v2_set_sck_period;
   pgm->setup          = stk500v2_setup;
   pgm->teardown       = stk500v2_teardown;
   pgm->page_size      = 256;
+
+  /*
+   * hardware dependent functions
+   */
+  if (pgm->extra_features & HAS_VTARG_ADJ)
+    pgm->set_vtarget  = stk500v2_set_vtarget;
+  if (pgm->extra_features & HAS_AREF_ADJ)
+    pgm->set_varef    = stk500v2_set_varef;
+  if (pgm->extra_features & HAS_FOSC_ADJ)
+    pgm->set_fosc     = stk500v2_set_fosc;
 }
 
 const char stk500v2_jtagmkII_desc[] = "Atmel JTAG ICE mkII in ISP mode";

--- a/src/stk500v2_private.h
+++ b/src/stk500v2_private.h
@@ -285,6 +285,12 @@ struct pdata
   bool vtarg_set;
   double vtarg_data;
 
+  /* Get/set flags for adjustable analog reference voltage */
+  bool varef_get;
+  bool varef_set;
+  int varef_channel;
+  double varef_data;
+
   const AVRPART *lastpart;
 
   /* Start address of Xmega boot area */

--- a/src/stk500v2_private.h
+++ b/src/stk500v2_private.h
@@ -280,6 +280,11 @@ struct pdata
   bool vtarg_switch_set;
   unsigned char vtarg_switch_data[2];
 
+  /* Get/set flags for adjustable target voltage */
+  bool vtarg_get;
+  bool vtarg_set;
+  double vtarg_data;
+
   const AVRPART *lastpart;
 
   /* Start address of Xmega boot area */

--- a/src/stk500v2_private.h
+++ b/src/stk500v2_private.h
@@ -291,6 +291,11 @@ struct pdata
   int varef_channel;
   double varef_data;
 
+  /* Get/set flags for programmable clock generator */
+  bool fosc_get;
+  bool fosc_set;
+  double fosc_data;
+
   const AVRPART *lastpart;
 
   /* Start address of Xmega boot area */


### PR DESCRIPTION
This PR adresses issue #1340, and provides `-xvtarg`, `-xvaref` and `-xfosc` to programmer hardware that supports this. I'll provide updated documentation when the code has been approved.

**Supported hardware:**
* STK500 development board (stk500v1 and stk500v2)
* STK600
* Power Debugger (`-xvtarg` only)
* Curiosity Nano (`-xvtarg` only)

Please review and test! I'm happy to receive feedback, feature suggestions or suggestion on how the code can be improved further. 

```
$ ./avrdude -patmega2560 -cstk600 -xhelp
avrdude -c stk600 extended options:
  -xvtarg               Read target supply voltage
  -xvtarg=<arg>         Set target supply voltage
  -xvaref               Read channel 0 analog reference voltage
  -xvaref0              Alias for -xvaref
  -xvaref1              Read channel 1 analog reference voltage
  -xvaref=<arg>         Set channel 0 analog reference voltage
  -xvaref0=<arg>        Alias for -xvaref=<arg>
  -xvaref1=<arg>        Set channel 1 analog reference voltage
  -xfosc                Read oscillator clock frequency
  -xfosc=<arg>[M|k]|off Set oscillator clock frequency
  -xhelp                Show this help menu and exit

$ ./avrdude -patmega2560 -cstk600 -xvtarg
Target voltage value read as 5.50V
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9801 (probably m2560)

avrdude done.  Thank you.

$ ./avrdude -patmega2560 -cstk600 -xvtarg=3.3
Changing target voltage from 5.50 to 3.30V
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9801 (probably m2560)

avrdude done.  Thank you.

$ ./avrdude -patmega2560 -cstk600 -xvaref0
Analog reference channel 0 voltage read as 1.87V
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9801 (probably m2560)

avrdude done.  Thank you.

$ ./avrdude -patmega2560 -cstk600 -xvaref0=2.5
Changing analog reference channel 0 voltage from 1.87 to 2.50V
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9801 (probably m2560)

avrdude done.  Thank you.

$ ./avrdude -patmega2560 -cstk600 -xfosc
Oscillator currently set to 7.996 MHz
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9801 (probably m2560)

avrdude done.  Thank you.

$ ./avrdude -patmega2560 -cstk600 -xfosc=16MHz
Changing oscillator frequency from 7.996 MHz to 16.000 MHz
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9801 (probably m2560)

avrdude done.  Thank you.

$ ./avrdude -patmega2560 -cstk600 -xfosc=off
Changing oscillator frequency from 15.992 MHz to 0.000 Hz
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9801 (probably m2560)

avrdude done.  Thank you.
```