### PR TITLE
Adds configuration for Kanda's AVRISP-U programmer.

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -915,6 +915,23 @@ programmer parent "ft2232h"
 ;
 
 #------------------------------------------------------------
+# avrisp-u
+#------------------------------------------------------------
+
+# Kanda's low cost FT2232H based programmer. Uses a different reset pin.
+# Adds a buffer and a LED indicating that the programming is in progress.
+# https://www.kanda.com/products/Kanda/AVRISP-U.html
+
+programmer parent "ft2232h"
+    id                     = "avrisp-u";
+    desc                   = "Kanda AVRISP-U";
+    usbsn                  = "AVR";
+    buff                   = ~5;
+    reset                  = 4;
+    pgmled                 = ~ 10;
+;
+
+#------------------------------------------------------------
 # ft4232h
 #------------------------------------------------------------
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -928,7 +928,7 @@ programmer parent "ft2232h"
     usbsn                  = "AVR";
     buff                   = ~5;
     reset                  = 4;
-    pgmled                 = ~ 10;
+    pgmled                 = ~10;
 ;
 
 #------------------------------------------------------------


### PR DESCRIPTION
At EPFL, as part of the _Microcontrollers and digital systems_ course ([EE-208](https://edu.epfl.ch/coursebook/en/microcontrollers-and-digital-systems-EE-208)), we are using Kanda's AVRISP-U programmer for a project. Unfortunately, this programmer is only supported by their in-house proprietary software.

This commit aims to add support for the AVRISP-U programmer in avrdude.
Credits to Kanda for the [initial configuration](https://www.kanda.com/blog/microcontrollers/avr-microcontrollers/avrdude-kanda-avrisp/). _Although we had to update the configuration by ourselves..._
Thanks to @danielpanero for the initial guidance.