### PR TITLE
Add more Avrdude CLI usage examples

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1157,8 +1157,9 @@ programmer
 
 programmer
     id                     = "digilent-hs2";
-    desc                   = "Digilient JTAG HS2 (MPSSE)";
+    desc                   = "Digilent JTAG HS2 (MPSSE)";
     type                   = "avrftdi";
+    prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6014;

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1487,6 +1487,11 @@ Show help menu and exit.
 @node Example Command Line Invocations,  , Programmers accepting extended parameters, Command Line Options
 @section Example Command Line Invocations
 
+AVRDUDE error messages, warnings and progress reports are generally written to
+stderr which can, in bash, be turned off by 2>/dev/null or using increasingly
+more -q options to suppress them. Terminal output of command or of the -U
+command with an output file - are written to stdout.
+
 @noindent
 Download the file @code{diag.hex} to the ATmega128 chip using the
 STK500 programmer connected to the default serial port:

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1514,7 +1514,7 @@ avrdude done.  Thank you.
 
 @page
 @noindent
-Upload the flash memory from the ATmega128 connected to the STK500
+Dump the flash memory from the ATmega128 connected to the STK500
 programmer and save it in raw binary format in the file named
 @code{c:/diag flash.bin}:
 
@@ -1569,6 +1569,31 @@ avrdude done.  Thank you.
 @end cartouche
 @end smallexample
 
+@noindent
+Read the low, high, and extended fuse and print their values in
+hexadecimal and binary formats:
+
+@smallexample
+@cartouche
+
+% avrdude -cusbasp -patmega128 -Ulfuse:r:-:h -Uhfuse:r:-:h -Uefuse:r:-:b
+avrdude: AVR device initialized and ready to accept instructions
+avrdude: device signature = 0x1e9702 (probably m128)
+avrdude: reading lfuse memory ...
+avrdude: writing output file <stdout>
+0xbf
+avrdude: reading hfuse memory ...
+avrdude: writing output file <stdout>
+0xc6
+avrdude: reading efuse memory ...
+avrdude: writing output file <stdout>
+0b11111111
+
+avrdude done.  Thank you.
+
+@end cartouche
+@end smallexample
+
 @page
 @noindent
 Connect to the JTAG ICE mkII which serial number ends up in 1C37 via
@@ -1592,7 +1617,7 @@ avrdude done.  Thank you.
 @noindent
 List the serial numbers of all JTAG ICEs attached to USB.  This is
 done by specifying an invalid serial number, and increasing the
-verbosity level.
+verbosity level:
 
 @smallexample
 @cartouche
@@ -1610,12 +1635,12 @@ avrdude: usbdev_open(): did not find any (matching) USB device "usb:xxx"
 @end smallexample
 
 @noindent
-Write data from stdin (standard input) to EEPROM.
+Write data from stdin (standard input) to EEPROM:
 
 @smallexample
 @cartouche
 
-% echo "The quick brown fox" | avrdude -cusbasp -pattiny13 -Ueeprom:w:-:r
+% echo 'The quick brown fox' | avrdude -cusbasp -pattiny13 -Ueeprom:w:-:r
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e9007 (probably t13)
 avrdude: reading input file <stdin> for eeprom
@@ -1634,7 +1659,29 @@ avrdude done.  Thank you.
 @end smallexample
 
 @noindent
-Read EEPROM and write content to stdout (standard output)
+Execute multiple terminal mode commands separated by semicolons:
+
+@smallexample
+@cartouche
+
+% echo 'write eeprom 0 "Bonjour le mode"; write eeprom 0x18 0x12345678; dump eeprom 0 0x20' | avrdude -cusbasp -patmega328p -t
+avrdude: AVR device initialized and ready to accept instructions
+avrdude: device signature = 0x1e950f (probably m328p)
+Caching | ################################################## | 100% 0.00 s
+Caching | ################################################## | 100% 0.00 s
+Reading | ################################################## | 100% 0.00 s
+0000  42 6f 6e 6a 6f 75 72 20  6c 65 20 6d 6f 64 65 00  |Bonjour le mode.|
+0010  ff ff ff ff ff ff ff ff  78 56 34 12 ff ff ff ff  |........xV4.....|
+avrdude> avrdude: synching cache to device ...
+Writing | ################################################## | 100% 0.25 s
+
+avrdude done.  Thank you.
+
+@end cartouche
+@end smallexample
+
+@noindent
+Read EEPROM and write content to stdout (standard output):
 
 @smallexample
 @cartouche
@@ -1650,6 +1697,102 @@ avrdude: writing output file <stdout>
 :00000001FF
 
 avrdude done.  Thank you.
+
+@end cartouche
+@end smallexample
+
+@noindent
+Using && and quell-output-option -qq to confirm that AVRDUDE command went OK:
+
+@smallexample
+@cartouche
+
+% avrdude -qq -cusbasp -pattiny13 -Uflash:w:diag.hex:i && echo OK
+OK
+
+@end cartouche
+@end smallexample
+
+@noindent
+Factory fuse setting of a device:
+
+@smallexample
+@cartouche
+
+% avrdude -patmega328p/St | grep initval
+.ptmm	ATmega328P	lfuse	initval	0x62
+.ptmm	ATmega328P	hfuse	initval	0xd9
+.ptmm	ATmega328P	efuse	initval	0xff
+.ptmm	ATmega328P	lock	initval	0xff
+
+@end cartouche
+@end smallexample
+
+@noindent
+List of all parts known to AVRDUDE:
+
+@smallexample
+@cartouche
+
+% avrdude -p*/d | grep = | cut -f2 -d"'"
+ATtiny11
+ATtiny12
+ATtiny13
+ATtiny13A
+ATtiny15
+AT89S51
+[...]
+AVR64EA48
+LGT8F88P
+LGT8F168P
+LGT8F328P
+
+@end cartouche
+@end smallexample
+
+@noindent
+Create a simple bash shell script to create terminal scripts that will reset a
+part to factory settings:
+@smallexample
+@cartouche
+
+mkdir /tmp/factory
+for part in $(avrdude -p*/d | grep = | cut -f2 -d"'"); do
+  echo $part
+  avrdude -p$part/St | grep initval | cut -f3,5 | grep -ve-1 | sed "s/.*/write &/" >/tmp/factory/$part.ini
+done
+
+$ cat /tmp/factory/ATmega328P.ini
+write lfuse	0x62
+write hfuse	0xd9
+write efuse	0xff
+write lock	0xff
+
+$ avrdude -qq -cusbasp -pATmega328P -t < /tmp/factory/ATmega328P.ini && echo OK
+OK
+
+@end cartouche
+@end smallexample
+
+@noindent
+Output a list of non-bootloader programmers that can be used for a part.
+Note that |& folds stderr into stdout in a bash shell:
+@smallexample
+@cartouche
+
+$ avrdude -c? -pavr32ea32 |& grep -v bootloader
+Valid programmers for part AVR32EA32 are:
+  atmelice_updi      = Atmel-ICE (ARM/AVR) via UPDI
+  dryrun             = Emulates programming without a programmer via UPDI
+  jtag2updi          = JTAGv2 to UPDI bridge via UPDI
+  jtag3updi          = Atmel AVR JTAGICE3 via UPDI
+  pickit4_updi       = MPLAB(R) PICkit 4 via UPDI
+  pkobn_updi         = Curiosity nano (nEDBG) via UPDI
+  powerdebugger_updi = Atmel PowerDebugger (ARM/AVR) via UPDI
+  serialupdi         = SerialUPDI via UPDI
+  snap_updi          = MPLAB(R) SNAP via UPDI
+  xplainedmini_updi  = Atmel AVR XplainedMini via UPDI
+  xplainedpro_updi   = Atmel AVR XplainedPro via UPDI
 
 @end cartouche
 @end smallexample
@@ -2196,7 +2339,7 @@ Dump the first 64 bytes of the EEPROM using a "terminal mode one-liner".
 @smallexample
 @cartouche
 
-% echo "dump eeprom 0 0x40" | avrdude -cusbasp -patmega328p -t
+% echo 'dump eeprom 0 0x40' | avrdude -cusbasp -patmega328p -t
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e950f (probably m328p)
 Reading | ################################################## | 100% 0.02 s

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1609,6 +1609,51 @@ avrdude: usbdev_open(): did not find any (matching) USB device "usb:xxx"
 @end cartouche
 @end smallexample
 
+@noindent
+Write data from stdin (standard input) to EEPROM.
+
+@smallexample
+@cartouche
+
+% echo "The quick brown fox" | avrdude -cusbasp -pattiny13 -Ueeprom:w:-:r
+avrdude: AVR device initialized and ready to accept instructions
+avrdude: device signature = 0x1e9007 (probably t13)
+avrdude: reading input file <stdin> for eeprom
+         with 20 bytes in 1 section within [0, 0x13]
+         using 5 pages and 0 pad bytes
+avrdude: writing 20 bytes eeprom ...
+Writing | ################################################## | 100% 0.21 s
+avrdude: 20 bytes of eeprom written
+avrdude: verifying eeprom memory against <stdin>
+Reading | ################################################## | 100% 0.01 s
+avrdude: 20 bytes of eeprom verified
+
+avrdude done.  Thank you.
+
+@end cartouche
+@end smallexample
+
+@noindent
+Read EEPROM and write content to stdout (standard output)
+
+@smallexample
+@cartouche
+
+% avrdude -cusbasp -pattiny13 -Ueeprom:r:-:I
+avrdude: AVR device initialized and ready to accept instructions
+avrdude: device signature = 0x1e9007 (probably t13)
+avrdude: reading eeprom memory ...
+Reading | ################################################## | 100% 0.02 s
+avrdude: writing output file <stdout>
+:2000000054686520717569636B2062726F776E20666F780AFFFFFFFFFFFFFFFFFFFFFFFFCF // 00000> The_quick_brown_fox.............
+:20002000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 // 00020> ................................
+:00000001FF
+
+avrdude done.  Thank you.
+
+@end cartouche
+@end smallexample
+
 
 @c
 @c Node
@@ -2144,6 +2189,27 @@ avrdude done.  Thank you.
 
 @end cartouche
 @end smallexample
+
+@noindent
+Dump the first 64 bytes of the EEPROM using a "terminal mode one-liner".
+
+@smallexample
+@cartouche
+
+% echo "dump eeprom 0 0x40" | avrdude -cusbasp -patmega328p -t
+avrdude: AVR device initialized and ready to accept instructions
+avrdude: device signature = 0x1e950f (probably m328p)
+Reading | ################################################## | 100% 0.02 s
+0000  48 65 6c 6c 6f 20 57 6f  72 6c 64 21 00 ff ff ff  |Hello World!....|
+0010  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
+0020  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
+0030  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
+
+avrdude done.  Thank you.
+
+@end cartouche
+@end smallexample
+
 
 @c
 @c Node

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2077,12 +2077,12 @@ avrdude> dump eeprom 0 16
 Reading | ################################################## | 100% 0.01 s
 0000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
 
-avrdude> write eeprom 0 1 2 3 4 0xcafe "Avrdude"
+avrdude> write eeprom 0 1 2 3 4 0xcafe "Avrdude" 0b10101010
 Caching | ################################################## | 100% 0.00 s
 
 avrdude> dump eeprom 0 16
 Reading | ################################################## | 100% 0.00 s
-0000  01 02 03 04 fe ca 41 76  72 64 75 64 65 00 ff ff  |......Avrdude...|
+0000  01 02 03 04 fe ca 41 76  72 64 75 64 65 00 55 ff  |......Avrdude.U.|
 
 avrdude> flush
 avrdude: synching cache to device ...
@@ -2166,7 +2166,7 @@ Reading | ################################################## | 100% 0.00 s
 avrdude> write flash -64 1234567890 'A' 'V' 'R' 2.718282 0xaa 0xbb 0xcc "Hello World!"
 Caching | ################################################## | 100% 0.00 s
 
-avrdude> write flash -32 -1 0x01 0x02 0x03 0x04 0x05 ...
+avrdude> write flash -32 -1 0x01 0b00000010 0b11 0x04 0x05 ...
 Caching | ################################################## | 100% 0.00 s
 
 avrdude> read flash -64 -33

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1489,7 +1489,7 @@ Show help menu and exit.
 
 AVRDUDE error messages, warnings and progress reports are generally written to
 stderr which can, in bash, be turned off by 2>/dev/null or using increasingly
-more -q options to suppress them. Terminal output of command or of the -U
+more -q options to suppress them. Terminal output of commands or of the -U
 command with an output file - are written to stdout.
 
 @noindent

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1512,7 +1512,6 @@ avrdude done.  Thank you.
 @end cartouche
 @end smallexample
 
-@page
 @noindent
 Dump the flash memory from the ATmega128 connected to the STK500
 programmer and save it in raw binary format in the file named
@@ -1658,22 +1657,24 @@ avrdude done.  Thank you.
 @end cartouche
 @end smallexample
 
+@page
 @noindent
 Execute multiple terminal mode commands separated by semicolons:
 
 @smallexample
 @cartouche
 
-% echo 'write eeprom 0 "Bonjour le mode"; write eeprom 0x18 0x12345678; dump eeprom 0 0x20' | avrdude -cusbasp -patmega328p -t
+% echo 'write eeprom 0 "Bonjour"; write ee 0x18 0x12345678; dump eeprom 0 0x20' |
+> ./avrdude -cusbasp -patmega328p -t
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e950f (probably m328p)
+Caching | ################################################## | 100% 0.01 s
 Caching | ################################################## | 100% 0.00 s
-Caching | ################################################## | 100% 0.00 s
-Reading | ################################################## | 100% 0.00 s
-0000  42 6f 6e 6a 6f 75 72 20  6c 65 20 6d 6f 64 65 00  |Bonjour le mode.|
+Reading | ################################################## | 100% 0.01 s
+0000  42 6f 6e 6a 6f 75 72 00  ff ff ff ff ff ff ff ff  |Bonjour.........|
 0010  ff ff ff ff ff ff ff ff  78 56 34 12 ff ff ff ff  |........xV4.....|
 avrdude> avrdude: synching cache to device ...
-Writing | ################################################## | 100% 0.25 s
+Writing | ################################################## | 100% 0.13 s
 
 avrdude done.  Thank you.
 
@@ -1686,14 +1687,14 @@ Read EEPROM and write content to stdout (standard output):
 @smallexample
 @cartouche
 
-% avrdude -cusbasp -pattiny13 -Ueeprom:r:-:I
+% avrdude -cusbasp -pattiny13 -Ueeprom:r:-:i
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e9007 (probably t13)
 avrdude: reading eeprom memory ...
 Reading | ################################################## | 100% 0.02 s
 avrdude: writing output file <stdout>
-:2000000054686520717569636B2062726F776E20666F780AFFFFFFFFFFFFFFFFFFFFFFFFCF // 00000> The_quick_brown_fox.............
-:20002000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0 // 00020> ................................
+:20000000E2809954686520717569636B2062726F776E20666F78E280990AFFFFFFFFFFFFD3
+:20002000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0
 :00000001FF
 
 avrdude done.  Thank you.
@@ -1728,6 +1729,7 @@ Factory fuse setting of a device:
 @end cartouche
 @end smallexample
 
+@page
 @noindent
 List of all parts known to AVRDUDE:
 
@@ -1759,7 +1761,8 @@ part to factory settings:
 mkdir /tmp/factory
 for part in $(avrdude -p*/d | grep = | cut -f2 -d"'"); do
   echo $part
-  avrdude -p$part/St | grep initval | cut -f3,5 | grep -ve-1 | sed "s/.*/write &/" >/tmp/factory/$part.ini
+  avrdude -p$part/St | grep initval | cut -f3,5 | grep -ve-1 |
+  sed "s/.*/write &/" >/tmp/factory/$part.ini
 done
 
 $ cat /tmp/factory/ATmega328P.ini
@@ -1797,6 +1800,7 @@ Valid programmers for part AVR32EA32 are:
 @end cartouche
 @end smallexample
 
+@page
 @noindent
 Print all metadata stored in flash using the Urboot bootloader and
 the Urclock programmer option:
@@ -1805,7 +1809,8 @@ the Urclock programmer option:
 
 % avrdude -curclock -P/dev/ttyUSB0 -pattiny13 -xshowall
 avrdude: AVR device initialized and ready to accept instructions
-0 2023-05-22 22.03 Blink.ino.hex 78 store 665 meta 25 boot 256 u7.7 w-u-jPr-- vector 4 (EE_RDY) ATtiny13A
+0 2023-05-22 22.03 Blink.ino.hex 78 store 665 meta 25 boot 256 u7.7 w-u-jPr--
+vector 4 (EE_RDY) ATtiny13A
 
 @end cartouche
 @end smallexample
@@ -1833,49 +1838,38 @@ avrdude -cusbasp -pattiny13 -U{eeprom,flash,{l,h}fuse,lock}:w:"$1":e "${@:2}"
 }
 @end verbatim
 
-# Run function where -B8 is appended to the Avrdude command
-$ avrdude-elf program.elf -B8
+# Run function where -B8 and -V is appended to the Avrdude command
+$ avrdude-elf program.elf -B8 -v
 avrdude: set SCK frequency to 93750 Hz
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e9007 (probably t13)
 avrdude: Note: flash memory has been specified, an erase cycle will be performed.
          To disable this feature, specify the -D option.
 avrdude: erasing chip
-avrdude: reading input file program.elf for eeprom
+avrdude: reading input file Blink.elf for eeprom
          with 0 bytes in 0 sections within [0, -1]
          using 0 pages and 0 pad bytes
 avrdude: writing 0 bytes eeprom ...
 Writing | ################################################## | 100% 0.00 s
 avrdude: 0 bytes of eeprom written
-avrdude: verifying eeprom memory against program.elf
-Reading | ###########################
-avrdude: reading input file program.elf for flash
+avrdude: reading input file Blink.elf for flash
          with 78 bytes in 1 section within [0, 0x4d]
          using 3 pages and 18 pad bytes
 avrdude: writing 78 bytes flash ...
-Writing | ################################################## | 100% 0.10 s
+Writing | ################################################## | 100% 0.09 s
 avrdude: 78 bytes of flash written
-avrdude: verifying flash memory against program.elf
-Reading | ################################################## | 100% 0.05 s
-avrdude: 78 bytes of flash verified
-avrdude: reading input file program.elf for lfuse
+avrdude: reading input file Blink.elf for lfuse
          with 1 byte in 1 section within [0, 0]
 avrdude: writing 1 byte lfuse ...
 avrdude: 1 byte of lfuse written
-avrdude: verifying lfuse memory against program.elf
-avrdude: 1 byte of lfuse verified
-avrdude: reading input file program.elf for hfuse
+avrdude: reading input file Blink.elf for hfuse
          with 1 byte in 1 section within [0, 0]
 avrdude: writing 1 byte hfuse ...
 avrdude: 1 byte of hfuse written
-avrdude: verifying hfuse memory against program.elf
-avrdude: 1 byte of hfuse verified
-avrdude: reading input file program.elf for lock
+avrdude: reading input file Blink.elf for lock
          with 1 byte in 1 section within [0, 0]
 avrdude: writing 1 byte lock ...
 avrdude: 1 byte of lock written
-avrdude: verifying lock memory against program.elf
-avrdude: 1 byte of lock verified
 
 avrdude done.  Thank you.
 

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2269,6 +2269,8 @@ Display programmer specific parameters.
 
 @end table
 
+@page
+
 @c
 @c Node
 @c
@@ -2383,6 +2385,8 @@ avrdude done.  Thank you.
 
 @end cartouche
 @end smallexample
+
+@page
 
 The following example demonstrates negative address and length bytes, and the
 second form of the @code{write} command where the last data value provided

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1665,7 +1665,7 @@ Execute multiple terminal mode commands separated by semicolons:
 @cartouche
 
 % echo 'write eeprom 0 "Bonjour"; write ee 0x18 0x12345678; dump eeprom 0 0x20' |
-> ./avrdude -cusbasp -patmega328p -t
+> avrdude -cusbasp -patmega328p -t
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e950f (probably m328p)
 Caching | ################################################## | 100% 0.01 s
@@ -1710,6 +1710,20 @@ Using && and quell-output-option -qq to confirm that AVRDUDE command went OK:
 
 % avrdude -qq -cusbasp -pattiny13 -Uflash:w:diag.hex:i && echo OK
 OK
+
+@end cartouche
+@end smallexample
+
+@noindent
+Using the Avrdude output to print strings present in flash memory:
+
+@smallexample
+@cartouche
+
+% avrdude -pattiny13 -qq -U flash:r:-:r | strings
+Main menu
+Distance: %dcm
+Exit
 
 @end cartouche
 @end smallexample
@@ -1824,7 +1838,7 @@ EEPROM data:
 @cartouche
 
 # Show all memories present for the ATtiny13
-$ ./avrdude -pattiny13/ot | grep write | cut -f3 | uniq
+$ avrdude -pattiny13/ot | grep write | cut -f3 | uniq
 eeprom
 flash
 lfuse

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1669,8 +1669,8 @@ Execute multiple terminal mode commands separated by semicolons:
 @smallexample
 @cartouche
 
-% echo 'write eeprom 0 "Bonjour"; write ee 0x18 0x12345678; dump eeprom 0 0x20' |
-> avrdude -cusbasp -patmega328p -t
+% echo 'write eeprom 0 "Bonjour"; write ee 0x18 0x12345678; dump eeprom 0 0x20' \
+> | avrdude -cusbasp -patmega328p -t
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e950f (probably m328p)
 Caching | ################################################## | 100% 0.01 s
@@ -1780,8 +1780,8 @@ part to factory settings:
 mkdir /tmp/factory
 for part in $(avrdude -p*/d | grep = | cut -f2 -d"'"); do
   echo $part
-  avrdude -p$part/St | grep initval | cut -f3,5 | grep -ve-1 |
-  sed "s/.*/write &/" >/tmp/factory/$part.ini
+  avrdude -p$part/St | grep initval | cut -f3,5 | grep -ve-1 \
+  | sed "s/.*/write &/" >/tmp/factory/$part.ini
 done
 
 $ cat /tmp/factory/ATmega328P.ini

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1733,6 +1733,7 @@ Exit
 @end cartouche
 @end smallexample
 
+@page
 @noindent
 Factory fuse setting of a device:
 
@@ -1748,7 +1749,6 @@ Factory fuse setting of a device:
 @end cartouche
 @end smallexample
 
-@page
 @noindent
 List of all parts known to AVRDUDE:
 
@@ -1796,6 +1796,7 @@ OK
 @end cartouche
 @end smallexample
 
+@page
 @noindent
 Output a list of non-bootloader programmers that can be used for a part.
 Note that |& folds stderr into stdout in a bash shell:
@@ -1819,7 +1820,6 @@ Valid programmers for part AVR32EA32 are:
 @end cartouche
 @end smallexample
 
-@page
 @noindent
 Print all metadata stored in flash using the Urboot bootloader and
 the Urclock programmer option:
@@ -1834,6 +1834,7 @@ vector 4 (EE_RDY) ATtiny13A
 @end cartouche
 @end smallexample
 
+@page
 @noindent
 Create a bash function, @code{avrdude-elf}, that takes an elf file as input,
 with support for optional Avrdude flags at the end, and writes to the memories
@@ -1858,7 +1859,7 @@ avrdude -cusbasp -pattiny13 -U{eeprom,flash,{l,h}fuse,lock}:w:"$1":e "${@:2}"
 @end verbatim
 
 # Run function where -B8 and -V is appended to the Avrdude command
-$ avrdude-elf program.elf -B8 -v
+$ avrdude-elf program.elf -B8 -V
 avrdude: set SCK frequency to 93750 Hz
 avrdude: AVR device initialized and ready to accept instructions
 avrdude: device signature = 0x1e9007 (probably t13)

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1797,6 +1797,19 @@ Valid programmers for part AVR32EA32 are:
 @end cartouche
 @end smallexample
 
+@noindent
+Print all metadata stored in flash using the Urboot bootloader and
+the Urclock programmer option:
+@smallexample
+@cartouche
+
+% avrdude -curclock -P/dev/ttyUSB0 -pattiny13 -xshowall
+avrdude: AVR device initialized and ready to accept instructions
+0 2023-05-22 22.03 Blink.ino.hex 78 store 665 meta 25 boot 256 u7.7 w-u-jPr-- vector 4 (EE_RDY) ATtiny13A
+
+@end cartouche
+@end smallexample
+
 
 @c
 @c Node

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1810,6 +1810,78 @@ avrdude: AVR device initialized and ready to accept instructions
 @end cartouche
 @end smallexample
 
+@noindent
+Create a bash function, @code{avrdude-elf}, that takes an elf file as input,
+with support for optional Avrdude flags at the end, and writes to the memories
+specified in the elf file. In this example, the elf file did not contain any
+EEPROM data:
+@smallexample
+@cartouche
+
+# Show all memories present for the ATtiny13
+$ ./avrdude -pattiny13/ot | grep write | cut -f3 | uniq
+eeprom
+flash
+lfuse
+hfuse
+lock
+
+# Function that writes to all memories present in the elf file
+@verbatim
+avrdude-elf() {
+avrdude -cusbasp -pattiny13 -U{eeprom,flash,{l,h}fuse,lock}:w:"$1":e "${@:2}"
+}
+@end verbatim
+
+# Run function where -B8 is appended to the Avrdude command
+$ avrdude-elf program.elf -B8
+avrdude: set SCK frequency to 93750 Hz
+avrdude: AVR device initialized and ready to accept instructions
+avrdude: device signature = 0x1e9007 (probably t13)
+avrdude: Note: flash memory has been specified, an erase cycle will be performed.
+         To disable this feature, specify the -D option.
+avrdude: erasing chip
+avrdude: reading input file program.elf for eeprom
+         with 0 bytes in 0 sections within [0, -1]
+         using 0 pages and 0 pad bytes
+avrdude: writing 0 bytes eeprom ...
+Writing | ################################################## | 100% 0.00 s
+avrdude: 0 bytes of eeprom written
+avrdude: verifying eeprom memory against program.elf
+Reading | ###########################
+avrdude: reading input file program.elf for flash
+         with 78 bytes in 1 section within [0, 0x4d]
+         using 3 pages and 18 pad bytes
+avrdude: writing 78 bytes flash ...
+Writing | ################################################## | 100% 0.10 s
+avrdude: 78 bytes of flash written
+avrdude: verifying flash memory against program.elf
+Reading | ################################################## | 100% 0.05 s
+avrdude: 78 bytes of flash verified
+avrdude: reading input file program.elf for lfuse
+         with 1 byte in 1 section within [0, 0]
+avrdude: writing 1 byte lfuse ...
+avrdude: 1 byte of lfuse written
+avrdude: verifying lfuse memory against program.elf
+avrdude: 1 byte of lfuse verified
+avrdude: reading input file program.elf for hfuse
+         with 1 byte in 1 section within [0, 0]
+avrdude: writing 1 byte hfuse ...
+avrdude: 1 byte of hfuse written
+avrdude: verifying hfuse memory against program.elf
+avrdude: 1 byte of hfuse verified
+avrdude: reading input file program.elf for lock
+         with 1 byte in 1 section within [0, 0]
+avrdude: writing 1 byte lock ...
+avrdude: 1 byte of lock written
+avrdude: verifying lock memory against program.elf
+avrdude: 1 byte of lock verified
+
+avrdude done.  Thank you.
+
+@end cartouche
+@end smallexample
+
 
 @c
 @c Node


### PR DESCRIPTION
Resolves issue #1362 

@stefanrueger In the Urboot/Urclock -xshowall example it would be great if we could mention what each data field represents. Have you written this down somewhere, or do I have to read through the urclock source code?

I've also not added [this ELF example](https://github.com/avrdudes/avrdude/issues/1354#issuecomment-1525791333), because I'm not sure how to get it working.

The previous CLI examples in avrdude.texi had their own `@page`. Is this necessary to have for each example?
It would be great if someone could export the texi file to PDF and look at the formatting. For some reason, I can't get the tools necessary to export as PDF to work on my computer.

