### PR TITLE
Initialise unused bits of classic-part fuses with factory defaults

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -571,7 +571,7 @@ int avr_read_byte_silent(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *
   return ret;
 }
 
-
+// Initialise unused bits in fuses and lock bits from factory setting initval
 int avr_bitmask_data(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
   unsigned long addr, unsigned char data) {
 
@@ -841,7 +841,7 @@ int avr_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 {
 
   if(pgm->write_byte != avr_write_byte_default)
-    if(!(p->prog_modes & (PM_UPDI | PM_PDI | PM_aWire))) // Read-modify-write classic parts
+    if(!(p->prog_modes & (PM_UPDI | PM_aWire))) // Initialise unused bits in classic & XMEGA parts
       data = avr_bitmask_data(pgm, p, mem, addr, data);
 
   return pgm->write_byte(pgm, p, mem, addr, data);

--- a/src/avr.c
+++ b/src/avr.c
@@ -441,7 +441,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     /* else: fall back to byte-at-a-time read, for historical reasons */
   }
 
-  if (strcmp(mem->desc, "signature") == 0) {
+  if (str_eq(mem->desc, "signature")) {
     if (pgm->read_sig_bytes) {
       return pgm->read_sig_bytes(pgm, p, mem);
     }
@@ -465,7 +465,6 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
 
   return avr_mem_hiaddr(mem);
 }
-
 
 
 /*
@@ -589,7 +588,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
       return -1;
     }
 
-    if (strcmp(mem->desc, "flash") == 0) {
+    if (str_eq(mem->desc, "flash")) {
       pmsg_error("writing a byte to flash is not supported for %s\n", p->desc);
       return -1;
     } else if ((mem->offset + addr) & 1) {
@@ -600,7 +599,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     while (avr_tpi_poll_nvmbsy(pgm));
 
     /* must erase fuse first */
-    if (strcmp(mem->desc, "fuse") == 0) {
+    if (str_eq(mem->desc, "fuse")) {
       /* setup for SECTION_ERASE (high byte) */
       avr_tpi_setup_rw(pgm, mem, addr | 1, TPI_NVMCMD_SECTION_ERASE);
 
@@ -1109,7 +1108,6 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
 }
 
 
-
 /*
  * read the AVR device's signature bytes
  */
@@ -1359,7 +1357,7 @@ const char *avr_mem_order[100] = {
 
 void avr_add_mem_order(const char *str) {
   for(size_t i=0; i < sizeof avr_mem_order/sizeof *avr_mem_order; i++) {
-    if(avr_mem_order[i] && !strcmp(avr_mem_order[i], str))
+    if(avr_mem_order[i] && str_eq(avr_mem_order[i], str))
       return;
     if(!avr_mem_order[i]) {
       avr_mem_order[i] = cfg_strdup("avr_mem_order()", str);
@@ -1372,10 +1370,10 @@ void avr_add_mem_order(const char *str) {
 
 int avr_memtype_is_flash_type(const char *memtype) {
   return memtype && (
-     strcmp(memtype, "flash") == 0 ||
-     strcmp(memtype, "application") == 0 ||
-     strcmp(memtype, "apptable") == 0 ||
-     strcmp(memtype, "boot") == 0);
+     str_eq(memtype, "flash") ||
+     str_eq(memtype, "application") ||
+     str_eq(memtype, "apptable") ||
+     str_eq(memtype, "boot"));
 }
 
 int avr_mem_is_flash_type(const AVRMEM *mem) {
@@ -1383,7 +1381,7 @@ int avr_mem_is_flash_type(const AVRMEM *mem) {
 }
 
 int avr_memtype_is_eeprom_type(const char *memtype) {
-  return memtype && strcmp(memtype, "eeprom") == 0;
+  return memtype && str_eq(memtype, "eeprom");
 }
 
 int avr_mem_is_eeprom_type(const AVRMEM *mem) {
@@ -1393,7 +1391,7 @@ int avr_mem_is_eeprom_type(const AVRMEM *mem) {
 int avr_mem_is_known(const char *str) {
   if(str && *str)
     for(size_t i=0; i < sizeof avr_mem_order/sizeof *avr_mem_order; i++)
-      if(avr_mem_order[i] && !strcmp(avr_mem_order[i], str))
+      if(avr_mem_order[i] && str_eq(avr_mem_order[i], str))
         return 1;
   return 0;
 }
@@ -1401,7 +1399,7 @@ int avr_mem_is_known(const char *str) {
 int avr_mem_might_be_known(const char *str) {
   if(str && *str)
     for(size_t i=0; i < sizeof avr_mem_order/sizeof *avr_mem_order; i++)
-      if(avr_mem_order[i] && !strncmp(avr_mem_order[i], str, strlen(str)))
+      if(avr_mem_order[i] && str_starts(avr_mem_order[i], str))
         return 1;
   return 0;
 }

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -193,10 +193,10 @@
 #   ;
 #
 # If any of the above parameters are not specified, the default value
-# of 0 is used for numerics (except for mcuid, hvupdi_variant and
-# ocdrev, where the default value is -1, and for autobaud_sync which
-# defaults to 0x30), or the empty string "" for string values. If a
-# required parameter is left empty, AVRDUDE will complain. Almost all
+# of 0 is used for numerics (except for mcuid, hvupdi_variant, ocdrev
+# and bitmask, where the default value is -1, and for autobaud_sync
+# which defaults to 0x30), or the empty string "" for string values. If
+# a required parameter is left empty, AVRDUDE will complain. Almost all
 # occurrences of numbers (with the exception of pin numbers and where
 # they are separated by space, eg, in signature and readback) can also
 # be given as simple expressions involving arithemtic and bitwise

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -258,9 +258,12 @@
 #       'aN' = the bit is the Nth address bit, bit-number = N, i.e., a12
 #              is address bit 12 on input, a0 is address bit 0.
 #
-#       'i'  = the bit is an input data bit
+#       'i'  = the bit is an input data bit (can optionally be followed
+#              by a memory bit position between 0 and 7 if that differs
+#              from the bit-position in the SPI write command byte)
 #
-#       'o'  = the bit is an output data bit
+#       'o'  = the bit is an output data bit (can optionally be followed
+#              by a memory bit position between 0 and 7)
 #
 #    Each instruction must be composed of 32 bit specifiers. The
 #    instruction specification closely follows the instruction data
@@ -3843,7 +3846,7 @@ part
         bitmask            = 0x21;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
-        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxox.xxxo";
         write              = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
     ;
 
@@ -3853,7 +3856,7 @@ part
         bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
-        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
+        read               = "0 1 0 1 1 0 0 0  x x x x x x x x  x x x x x x x x  o1 o2 x x x x x x";
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
@@ -3994,8 +3997,8 @@ part
         bitmask            = 0x21;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
-        read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
-        write              = "1010.1100--101i.iiii--xxxx.xxxx--xxxx.xxxx";
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxox.xxxo";
+        write              = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
     ;
 
     memory "lock"
@@ -4004,7 +4007,7 @@ part
         bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
-        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
+        read               = "0 1 0 1 1 0 0 0  x x x x x x x x  x x x x x x x x  o1 o2 x x x x x x";
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
@@ -4177,7 +4180,7 @@ part
         bitmask            = 0x21;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxxo";
+        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxox.xxxo";
         write              = "1010.1100--1011.111i--xxxx.xxxx--xxxx.xxxx";
     ;
 
@@ -4187,7 +4190,7 @@ part
         bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
-        read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooxx.xxxx";
+        read               = "0 1 0 1 1 0 0 0  x x x x x x x x  x x x x x x x x  o1 o2 x x x x x x";
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
@@ -5476,6 +5479,7 @@ part parent "m324p"
     memory "efuse"
         initval            = 0x07;
         bitmask            = 0x0f;
+        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
     ;
 ;
 
@@ -6055,7 +6059,7 @@ part
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write              = "1010.1100--1010.0100--xxxx.xxxx--1111.1iii";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--111i.iii1";
     ;
 
     memory "lock"
@@ -7183,7 +7187,7 @@ part
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xoxo.oooo";
-        write              = "1010.1100--101x.xxxx--xxxx.xxxx--1i1i.iiii";
+        write              = "1010.1100--101x.xxxx--xxxx.xxxx--1i1i.1iii";
     ;
 
     memory "lock"
@@ -9200,7 +9204,7 @@ part
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
-        write              = "1010.1100--1010.0100--xxxx.xxxx--111i.iiii";
+        write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.1iii";
     ;
 
     memory "lock"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2967,7 +2967,6 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0x52;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.oooo";
@@ -3106,7 +3105,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x6a;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4401,7 +4399,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4411,7 +4408,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4568,7 +4564,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4578,7 +4573,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4729,7 +4723,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4739,7 +4732,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4868,7 +4860,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4878,7 +4869,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5007,7 +4997,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5017,7 +5006,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5156,7 +5144,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5166,7 +5153,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5317,7 +5303,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5327,7 +5312,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5626,7 +5610,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5636,7 +5619,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5848,7 +5830,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5858,7 +5839,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6035,7 +6015,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6045,7 +6024,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6306,7 +6284,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6316,7 +6293,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6561,7 +6537,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6571,7 +6546,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6834,7 +6808,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6844,7 +6817,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7062,7 +7034,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7072,7 +7043,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7326,7 +7296,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7336,7 +7305,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7478,7 +7446,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7488,7 +7455,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7608,7 +7574,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7618,7 +7583,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7735,7 +7699,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7869,7 +7832,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7879,7 +7841,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8039,7 +8000,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8049,7 +8009,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8205,7 +8164,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8215,7 +8173,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8445,7 +8402,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8455,7 +8411,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8691,7 +8646,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8701,7 +8655,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8941,7 +8894,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8951,7 +8903,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9190,7 +9141,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9339,7 +9289,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9349,7 +9298,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9489,7 +9437,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9499,7 +9446,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9637,7 +9583,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x6e;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9647,7 +9592,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9785,7 +9729,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x6e;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9795,7 +9738,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9932,7 +9874,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9942,7 +9883,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -10127,7 +10067,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -10137,7 +10076,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -10657,7 +10595,6 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -10800,7 +10737,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xdd;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -10986,7 +10922,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xd7;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11148,7 +11083,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x64;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11158,7 +11092,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11322,7 +11255,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11332,7 +11264,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11464,7 +11395,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11474,7 +11404,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11606,7 +11535,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11616,7 +11544,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11823,7 +11750,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11833,7 +11759,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11843,7 +11768,6 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xfd;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12076,7 +12000,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12086,7 +12009,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12237,7 +12159,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12247,7 +12168,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12395,7 +12315,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12405,7 +12324,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12539,7 +12457,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12549,7 +12466,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12682,7 +12598,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12692,7 +12607,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12849,7 +12763,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12859,7 +12772,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13219,7 +13131,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13229,7 +13140,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13400,7 +13310,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13410,7 +13319,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13473,6 +13381,7 @@ part parent "t44"
         "ATtiny44A-SSU:  SOIC14,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny44A-SSUR: SOIC14N, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = XVII + IV; # 21;
+
 
 
 ;
@@ -13582,7 +13491,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13592,7 +13500,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13836,7 +13743,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13846,7 +13752,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13977,7 +13882,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x52;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13987,7 +13891,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14120,7 +14023,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x52;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14130,7 +14032,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14261,7 +14162,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14271,7 +14171,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x9b;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14420,7 +14319,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14430,7 +14328,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14582,7 +14479,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14592,7 +14488,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14725,7 +14620,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14735,7 +14629,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14869,7 +14762,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14879,7 +14771,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -15013,7 +14904,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15023,7 +14913,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -15157,7 +15046,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15167,7 +15055,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -15305,7 +15192,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15315,7 +15201,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -15506,7 +15391,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--0000.0000--oooo.oooo";
@@ -15516,7 +15400,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--0000.0000--oooo.oooo";
@@ -15708,7 +15591,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--0000.0000--oooo.oooo";
@@ -15718,7 +15600,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--0000.0000--oooo.oooo";
@@ -16060,14 +15941,6 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -16079,10 +15952,6 @@ part parent ".xmega-a"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16231,14 +16100,6 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -16250,10 +16111,6 @@ part parent ".xmega-a"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16402,14 +16259,6 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -16421,10 +16270,6 @@ part parent ".xmega-a"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16781,10 +16626,6 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -16795,10 +16636,6 @@ part parent ".xmega"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16877,7 +16714,6 @@ part parent "x128c3"
     memory "fuse0"
         size               = 1;
         initval            = 0xff;
-        bitmask            = 0xff;
         offset             = 0x8f0020;
     ;
 
@@ -17087,14 +16923,6 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -17106,10 +16934,6 @@ part parent ".xmega-a"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17178,12 +17002,7 @@ part parent ".xmega"
     memory "fuse0"
         size               = 1;
         initval            = 0xff;
-        bitmask            = 0xff;
         offset             = 0x8f0020;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
     ;
 
     memory "fuse2"
@@ -17196,10 +17015,6 @@ part parent ".xmega"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17283,10 +17098,6 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -17297,10 +17108,6 @@ part parent ".xmega"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17371,7 +17178,6 @@ part parent "x192a1"
 
     memory "fuse0"
         initval            = 0xff;
-        bitmask            = 0xff;
     ;
 
     memory "fuse2"
@@ -17405,7 +17211,6 @@ part parent "x192a1"
 
     memory "fuse0"
         initval            = 0xff;
-        bitmask            = 0xff;
     ;
 
     memory "fuse4"
@@ -17469,10 +17274,6 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -17483,10 +17284,6 @@ part parent ".xmega"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17556,7 +17353,6 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
-        bitmask            = 0xff;
     ;
 
     memory "fuse2"
@@ -17590,7 +17386,6 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
-        bitmask            = 0xff;
     ;
 
     memory "fuse4"
@@ -17618,7 +17413,6 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
-        bitmask            = 0xff;
     ;
 
     memory "fuse2"
@@ -17649,7 +17443,6 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
-        bitmask            = 0xff;
     ;
 
     memory "fuse4"
@@ -17713,10 +17506,6 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x63;
     ;
@@ -17727,10 +17516,6 @@ part parent ".xmega"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17818,10 +17603,6 @@ part parent ".xmega-e"
         readsize           = 256;
     ;
 
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x43;
     ;
@@ -17832,14 +17613,6 @@ part parent ".xmega-e"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0xff;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17909,10 +17682,6 @@ part parent ".xmega-e"
         readsize           = 256;
     ;
 
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x43;
     ;
@@ -17923,14 +17692,6 @@ part parent ".xmega-e"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0xff;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -18000,10 +17761,6 @@ part parent ".xmega-e"
         readsize           = 256;
     ;
 
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x43;
     ;
@@ -18014,14 +17771,6 @@ part parent ".xmega-e"
 
     memory "fuse5"
         bitmask            = 0x3f;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0xff;
-    ;
-
-    memory "lock"
-        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -18180,7 +17929,6 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
-        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -18588,7 +18336,6 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xcd;
-        bitmask            = 0xff;
     ;
 
     memory "hfuse"
@@ -18850,14 +18597,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -18865,7 +18604,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18882,17 +18620,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -18926,14 +18655,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -18941,7 +18662,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18958,17 +18678,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19002,14 +18713,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19017,7 +18720,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19034,17 +18736,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19078,14 +18771,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19093,7 +18778,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19110,17 +18794,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19156,14 +18831,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19171,7 +18838,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19188,17 +18854,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19232,14 +18889,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19252,17 +18901,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19300,14 +18940,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19320,17 +18952,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19365,14 +18988,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19385,17 +19000,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19429,14 +19035,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19449,17 +19047,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19497,14 +19086,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19517,17 +19098,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19562,14 +19134,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19582,17 +19146,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19626,14 +19181,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19641,7 +19188,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19658,17 +19204,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19702,14 +19239,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19717,7 +19246,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19734,17 +19262,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19778,14 +19297,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19793,7 +19304,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19810,17 +19320,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19854,14 +19355,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19869,7 +19362,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19886,17 +19378,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -19932,14 +19415,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -19947,7 +19422,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19964,17 +19438,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20026,14 +19491,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20041,7 +19498,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20058,17 +19514,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20103,14 +19550,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20118,7 +19557,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20135,17 +19573,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20184,14 +19613,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20199,7 +19620,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20216,17 +19636,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20261,14 +19672,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20276,7 +19679,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20293,17 +19695,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20337,14 +19730,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20352,7 +19737,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20369,17 +19753,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20415,14 +19790,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20430,7 +19797,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20447,17 +19813,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20491,14 +19848,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20506,7 +19855,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20523,17 +19871,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20567,14 +19906,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20582,7 +19913,6 @@ part parent ".avr8x_tiny"
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
-        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -20599,17 +19929,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 
     memory "userrow"
@@ -20669,14 +19990,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20689,17 +20002,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20742,14 +20046,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20762,17 +20058,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20807,14 +20094,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20827,17 +20106,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20876,14 +20146,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20896,17 +20158,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -20949,14 +20202,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -20969,17 +20214,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21014,14 +20250,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21034,17 +20262,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21083,14 +20302,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21103,17 +20314,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21156,14 +20358,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21176,17 +20370,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21221,14 +20406,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21241,17 +20418,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21290,14 +20458,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21310,17 +20470,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21363,14 +20514,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21383,17 +20526,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21428,14 +20562,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21448,17 +20574,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21500,14 +20617,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21520,17 +20629,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21568,14 +20668,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21588,17 +20680,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21640,14 +20723,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21660,17 +20735,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21708,14 +20774,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21728,17 +20786,8 @@ part parent ".avr8x_tiny"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21780,14 +20829,6 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21800,17 +20841,8 @@ part parent ".avr8x_mega"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21848,14 +20880,6 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21868,17 +20892,8 @@ part parent ".avr8x_mega"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21920,14 +20935,6 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -21940,17 +20947,8 @@ part parent ".avr8x_mega"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -21989,14 +20987,6 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x83;
     ;
@@ -22009,17 +20999,8 @@ part parent ".avr8x_mega"
         bitmask            = 0x07;
     ;
 
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
-    ;
-
     memory "lock"
         initval            = 0xc5;
-        bitmask            = 0xff;
     ;
 ;
 
@@ -22216,14 +21197,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22235,14 +21208,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22285,14 +21250,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22304,14 +21261,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22354,14 +21303,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22373,14 +21314,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22425,14 +21358,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22444,14 +21369,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22494,14 +21411,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22513,14 +21422,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22563,14 +21464,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22582,14 +21475,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22632,14 +21517,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22651,14 +21528,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22703,14 +21572,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22722,14 +21583,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22772,14 +21625,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22791,14 +21636,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22841,14 +21678,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22860,14 +21689,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22910,14 +21731,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22929,14 +21742,6 @@ part parent ".avrdx"
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -22980,14 +21785,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -22998,14 +21795,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23047,14 +21836,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23065,14 +21846,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23114,14 +21887,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23132,14 +21897,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23183,14 +21940,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23201,14 +21950,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23250,14 +21991,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23268,14 +22001,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23317,14 +22042,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23335,14 +22052,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23384,14 +22093,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23402,14 +22103,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23453,14 +22146,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23471,14 +22156,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23520,14 +22197,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23538,14 +22207,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23587,14 +22248,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23605,14 +22258,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23654,14 +22299,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23672,14 +22309,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23715,14 +22344,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23734,14 +22355,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23778,14 +22391,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23797,14 +22402,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23843,14 +22440,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23862,14 +22451,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23906,14 +22487,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23925,14 +22498,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -23968,14 +22533,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -23987,14 +22544,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24031,14 +22580,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -24050,14 +22591,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24096,14 +22629,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -24115,14 +22640,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24159,14 +22676,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -24178,14 +22687,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24221,14 +22722,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -24240,14 +22733,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24283,14 +22768,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -24302,14 +22779,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24348,14 +22817,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -24367,14 +22828,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24411,14 +22864,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x07;
     ;
@@ -24430,14 +22875,6 @@ part parent ".avrdx"
 
     memory "fuse6"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24538,14 +22975,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24558,14 +22987,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24599,14 +23020,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24619,14 +23032,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24660,14 +23065,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24680,14 +23077,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24721,14 +23110,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24741,14 +23122,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24782,14 +23155,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24802,14 +23167,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24843,14 +23200,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24863,14 +23212,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24907,14 +23248,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24927,14 +23260,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -24971,14 +23296,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -24991,14 +23308,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -25035,14 +23344,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse0"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse1"
-        bitmask            = 0xff;
-    ;
-
     memory "fuse2"
         bitmask            = 0x08;
     ;
@@ -25055,14 +23356,6 @@ part parent ".avrex"
     memory "fuse6"
         initval            = 0x07;
         bitmask            = 0x07;
-    ;
-
-    memory "fuse7"
-        bitmask            = 0xff;
-    ;
-
-    memory "fuse8"
-        bitmask            = 0xff;
     ;
 
     memory "lock"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -193,8 +193,8 @@
 #   ;
 #
 # If any of the above parameters are not specified, the default value
-# of 0 is used for numerics (except for mcuid, hvupdi_variant, ocdrev
-# and bitmask, where the default value is -1, and for autobaud_sync
+# of 0 is used for numerics (except for mcuid, hvupdi_variant, ocdrev,
+# initval and bitmask, all of which default to -1, and for autobaud_sync
 # which defaults to 0x30), or the empty string "" for string values. If
 # a required parameter is left empty, AVRDUDE will complain. Almost all
 # occurrences of numbers (with the exception of pin numbers and where
@@ -13381,9 +13381,6 @@ part parent "t44"
         "ATtiny44A-SSU:  SOIC14,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny44A-SSUR: SOIC14N, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = XVII + IV; # 21;
-
-
-
 ;
 
 #------------------------------------------------------------
@@ -15810,18 +15807,21 @@ part
     memory "fuse2"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x63;
         offset             = 0x8f0022;
     ;
 
     memory "fuse4"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x1e;
         offset             = 0x8f0024;
     ;
 
     memory "fuse5"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         offset             = 0x8f0025;
     ;
 
@@ -15880,6 +15880,10 @@ part parent ".xmega"
         size               = 1;
         initval            = 0xff;
         offset             = 0x8f0020;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -15941,17 +15945,8 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
     memory "fuse4"
         initval            = 0xfe;
-        bitmask            = 0x1f;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -16100,17 +16095,8 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
     memory "fuse4"
         initval            = 0xfe;
-        bitmask            = 0x1f;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -16259,17 +16245,8 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
     memory "fuse4"
         initval            = 0xfe;
-        bitmask            = 0x1f;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -16518,6 +16495,33 @@ part parent "x64a1"
         "ATxmega64A4: N/A, Fmax=N/A, T=[N/A, N/A], Vcc=[1.6 V, 3.6 V]";
     mcuid                  = 251;
     signature              = 0x1e 0x96 0x46;
+
+    memory "fuse0"
+        initval            = -1;
+    ;
+
+    memory "fuse1"
+        initval            = -1;
+    ;
+
+    memory "fuse2"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse4"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse5"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "lock"
+        initval            = -1;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16624,18 +16628,6 @@ part parent ".xmega"
         page_size          = 512;
         offset             = 0x820000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
-    memory "fuse4"
-        bitmask            = 0x1e;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -16859,6 +16851,29 @@ part parent ".xmega"
         offset             = 0x8f0020;
     ;
 
+    memory "fuse1"
+        initval            = -1;
+    ;
+
+    memory "fuse2"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse4"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse5"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "lock"
+        initval            = -1;
+    ;
+
     memory "usersig"
         size               = 512;
         page_size          = 512;
@@ -16923,17 +16938,8 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
     memory "fuse4"
         initval            = 0xfe;
-        bitmask            = 0x1f;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -17005,16 +17011,8 @@ part parent ".xmega"
         offset             = 0x8f0020;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
     memory "fuse4"
         bitmask            = 0x1f;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -17098,18 +17096,6 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
-    memory "fuse4"
-        bitmask            = 0x1e;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
-    ;
-
     memory "usersig"
         size               = 512;
         page_size          = 512;
@@ -17156,13 +17142,36 @@ part parent "x192c3"
         size               = 1;
         offset             = 0x8f0020;
     ;
+
+    memory "fuse1"
+        initval            = -1;
+    ;
+
+    memory "fuse2"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse4"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse5"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "lock"
+        initval            = -1;
+    ;
 ;
 
 #------------------------------------------------------------
 # ATxmega192A3
 #------------------------------------------------------------
 
-part parent "x192a1"
+part parent "x192c3"
     desc                   = "ATxmega192A3";
     id                     = "x192a3";
     variants               =
@@ -17172,12 +17181,15 @@ part parent "x192a1"
         "ATxmega192A3-MH:  QFN64,  Fmax=32 MHz, T=[-40 C, 85 C], Vcc=[1.6 V, 3.6 V]",
         "ATxmega192A3-MHR: QFN64,  Fmax=32 MHz, T=[-40 C, 85 C], Vcc=[1.6 V, 3.6 V]",
         "ATxmega192A3-MU:  QFN64,  Fmax=32 MHz, T=[N/A,    N/A], Vcc=[1.6 V, 3.6 V]";
+    prog_modes             = PM_SPM | PM_PDI | PM_XMEGAJTAG;
     mcuid                  = 267;
     n_interrupts           = 122;
     signature              = 0x1e 0x97 0x44;
 
     memory "fuse0"
+        size               = 1;
         initval            = 0xff;
+        offset             = 0x8f0020;
     ;
 
     memory "fuse2"
@@ -17213,9 +17225,27 @@ part parent "x192a1"
         initval            = 0xff;
     ;
 
+    memory "fuse1"
+        initval            = 0x00;
+    ;
+
+    memory "fuse2"
+        initval            = 0xff;
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xfe;
         bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        initval            = 0xff;
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        initval            = 0xff;
     ;
 ;
 
@@ -17274,18 +17304,6 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
-    memory "fuse4"
-        bitmask            = 0x1e;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
-    ;
-
     memory "usersig"
         size               = 512;
         page_size          = 512;
@@ -17331,6 +17349,29 @@ part parent "x256c3"
         size               = 1;
         offset             = 0x8f0020;
     ;
+
+    memory "fuse1"
+        initval            = -1;
+    ;
+
+    memory "fuse2"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse4"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse5"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "lock"
+        initval            = -1;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17355,13 +17396,27 @@ part parent "x256a1"
         initval            = 0xff;
     ;
 
+    memory "fuse1"
+        initval            = 0x00;
+    ;
+
     memory "fuse2"
+        initval            = 0xff;
         bitmask            = 0x43;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
         bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        initval            = 0xff;
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        initval            = 0xff;
     ;
 ;
 
@@ -17388,9 +17443,27 @@ part parent "x256a1"
         initval            = 0xff;
     ;
 
+    memory "fuse1"
+        initval            = 0x00;
+    ;
+
+    memory "fuse2"
+        initval            = 0xff;
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xfe;
         bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        initval            = 0xff;
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        initval            = 0xff;
     ;
 ;
 
@@ -17415,13 +17488,27 @@ part parent "x256a1"
         initval            = 0xff;
     ;
 
+    memory "fuse1"
+        initval            = 0x00;
+    ;
+
     memory "fuse2"
+        initval            = 0xff;
         bitmask            = 0x43;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
         bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        initval            = 0xff;
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        initval            = 0xff;
     ;
 ;
 
@@ -17445,9 +17532,27 @@ part parent "x256a1"
         initval            = 0xff;
     ;
 
+    memory "fuse1"
+        initval            = 0x00;
+    ;
+
+    memory "fuse2"
+        initval            = 0xff;
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xfe;
         bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        initval            = 0xff;
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        initval            = 0xff;
     ;
 ;
 
@@ -17504,18 +17609,6 @@ part parent ".xmega"
         page_size          = 512;
         offset             = 0x860000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x63;
-    ;
-
-    memory "fuse4"
-        bitmask            = 0x1e;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -17607,14 +17700,6 @@ part parent ".xmega-e"
         bitmask            = 0x43;
     ;
 
-    memory "fuse4"
-        bitmask            = 0x1e;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
-    ;
-
     memory "usersig"
         size               = 128;
         page_size          = 128;
@@ -17686,14 +17771,6 @@ part parent ".xmega-e"
         bitmask            = 0x43;
     ;
 
-    memory "fuse4"
-        bitmask            = 0x1e;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
-    ;
-
     memory "usersig"
         size               = 128;
         page_size          = 128;
@@ -17763,14 +17840,6 @@ part parent ".xmega-e"
 
     memory "fuse2"
         bitmask            = 0x43;
-    ;
-
-    memory "fuse4"
-        bitmask            = 0x1e;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0x3f;
     ;
 
     memory "usersig"
@@ -17993,6 +18062,8 @@ part
     memory "fuse"
         size               = 1;
         page_size          = 16;
+        initval            = 0xff;
+        bitmask            = 0x07;
         offset             = 0x3f40;
         blocksize          = 4;
     ;
@@ -18000,6 +18071,8 @@ part
     memory "lockbits"
         size               = 1;
         page_size          = 16;
+        initval            = 0xff;
+        bitmask            = 0x03;
         offset             = 0x3f00;
     ;
 
@@ -18036,16 +18109,6 @@ part parent ".reduced_core_tiny"
         page_size          = 16;
         offset             = 0x4000;
         blocksize          = 128;
-    ;
-
-    memory "fuse"
-        initval            = 0xff;
-        bitmask            = 0x07;
-    ;
-
-    memory "lockbits"
-        initval            = 0xff;
-        bitmask            = 0x03;
     ;
 ;
 
@@ -18085,16 +18148,6 @@ part parent ".reduced_core_tiny"
         page_size          = 16;
         offset             = 0x4000;
         blocksize          = 128;
-    ;
-
-    memory "fuse"
-        initval            = 0xff;
-        bitmask            = 0x07;
-    ;
-
-    memory "lockbits"
-        initval            = 0xff;
-        bitmask            = 0x03;
     ;
 ;
 
@@ -18144,14 +18197,8 @@ part parent ".reduced_core_tiny"
     ;
 
     memory "fuse"
-        initval            = 0xff;
         bitmask            = 0x77;
         n_word_writes      = 2;
-    ;
-
-    memory "lockbits"
-        initval            = 0xff;
-        bitmask            = 0x03;
     ;
 ;
 
@@ -18182,14 +18229,8 @@ part parent ".reduced_core_tiny"
     ;
 
     memory "fuse"
-        initval            = 0xff;
         bitmask            = 0x77;
         n_word_writes      = 4;
-    ;
-
-    memory "lockbits"
-        initval            = 0xff;
-        bitmask            = 0x03;
     ;
 ;
 
@@ -18221,13 +18262,7 @@ part parent ".reduced_core_tiny"
     ;
 
     memory "fuse"
-        initval            = 0xff;
         bitmask            = 0x0f;
-    ;
-
-    memory "lockbits"
-        initval            = 0xff;
-        bitmask            = 0x03;
     ;
 
     memory "sigrow"
@@ -18261,13 +18296,7 @@ part parent ".reduced_core_tiny"
     ;
 
     memory "fuse"
-        initval            = 0xff;
         bitmask            = 0x0f;
-    ;
-
-    memory "lockbits"
-        initval            = 0xff;
-        bitmask            = 0x03;
     ;
 
     memory "sigrow"
@@ -18393,6 +18422,7 @@ part
     memory "fuse2"
         size               = 1;
         initval            = 0x7e;
+        bitmask            = 0x83;
         offset             = 0x1282;
         readsize           = 1;
     ;
@@ -18404,6 +18434,7 @@ part
     memory "fuse5"
         size               = 1;
         initval            = 0xf6;
+        bitmask            = 0xcd;
         offset             = 0x1285;
         readsize           = 1;
     ;
@@ -18415,6 +18446,7 @@ part
     memory "fuse6"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         offset             = 0x1286;
         readsize           = 1;
     ;
@@ -18555,6 +18587,10 @@ part parent ".avr8x"
     # Dedicated UPDI pin, no HV
     hvupdi_variant         = 1;
 
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
     memory "userrow"
         size               = 64;
         page_size          = 64;
@@ -18597,10 +18633,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -18610,14 +18642,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -18655,10 +18679,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -18668,14 +18688,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -18713,10 +18725,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -18726,14 +18734,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -18771,10 +18771,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -18784,14 +18780,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -18831,10 +18819,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -18844,14 +18828,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -18887,18 +18863,6 @@ part parent ".avr8x_tiny"
         page_size          = 64;
         offset             = 0x8000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -18940,18 +18904,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0xc5;
     ;
@@ -18988,18 +18940,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0xc5;
     ;
@@ -19033,18 +18973,6 @@ part parent ".avr8x_tiny"
         page_size          = 64;
         offset             = 0x8000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19086,18 +19014,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0xc5;
     ;
@@ -19132,18 +19048,6 @@ part parent ".avr8x_tiny"
         page_size          = 64;
         offset             = 0x8000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19181,10 +19085,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19194,14 +19094,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19239,10 +19131,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19252,14 +19140,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19297,10 +19177,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19310,14 +19186,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19355,10 +19223,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19368,14 +19232,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19415,10 +19271,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19428,14 +19280,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19491,10 +19335,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19504,14 +19344,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19550,10 +19382,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19563,14 +19391,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19613,10 +19433,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19626,14 +19442,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19672,10 +19480,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19685,14 +19489,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19730,10 +19526,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19743,14 +19535,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19790,10 +19574,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19803,14 +19583,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19848,10 +19620,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19861,14 +19629,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19906,10 +19666,6 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
@@ -19919,14 +19675,6 @@ part parent ".avr8x_tiny"
 
     memory "tcd0cfg"
         alias "fuse4";
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xcd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -19990,16 +19738,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20046,16 +19786,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20094,16 +19826,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20146,16 +19870,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20202,16 +19918,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20250,16 +19958,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20302,16 +20002,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20358,16 +20050,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20406,16 +20090,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20458,16 +20134,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20514,16 +20182,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20562,16 +20222,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xdd;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20617,16 +20269,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20668,16 +20312,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20723,16 +20359,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20774,16 +20402,8 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
     memory "fuse5"
         bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20829,18 +20449,6 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0xc5;
     ;
@@ -20878,18 +20486,6 @@ part parent ".avr8x_mega"
         page_size          = 128;
         offset             = 0x4000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -20935,18 +20531,6 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0xc5;
     ;
@@ -20985,18 +20569,6 @@ part parent ".avr8x_mega"
         page_size          = 128;
         offset             = 0x4000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x83;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -21045,6 +20617,7 @@ part
     memory "fuse2"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0x07;
         offset             = 0x1052;
         readsize           = 1;
     ;
@@ -21056,6 +20629,7 @@ part
     memory "fuse5"
         size               = 1;
         initval            = 0xc0;
+        bitmask            = 0xed;
         offset             = 0x1055;
         readsize           = 1;
     ;
@@ -21067,6 +20641,7 @@ part
     memory "fuse6"
         size               = 1;
         initval            = 0x08;
+        bitmask            = 0x1f;
         offset             = 0x1056;
         readsize           = 1;
     ;
@@ -21197,14 +20772,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
@@ -21250,14 +20817,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
@@ -21301,14 +20860,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
     ;
 
     memory "fuse6"
@@ -21358,14 +20909,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
@@ -21409,14 +20952,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
     ;
 
     memory "fuse6"
@@ -21464,14 +20999,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
@@ -21515,14 +21042,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
     ;
 
     memory "fuse6"
@@ -21572,14 +21091,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
@@ -21623,14 +21134,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
     ;
 
     memory "fuse6"
@@ -21678,14 +21181,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
     memory "fuse6"
         initval            = 0x00;
         bitmask            = 0x07;
@@ -21729,14 +21224,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
     ;
 
     memory "fuse6"
@@ -21785,18 +21272,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -21836,18 +21311,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -21885,18 +21348,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -21940,18 +21391,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -21989,18 +21428,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22042,18 +21469,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -22091,18 +21506,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22146,18 +21549,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -22195,18 +21586,6 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22248,18 +21627,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -22299,18 +21666,6 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
-    memory "fuse5"
-        bitmask            = 0xed;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -22344,17 +21699,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22391,17 +21738,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22440,17 +21779,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22487,17 +21818,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22533,17 +21856,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22580,17 +21895,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22629,17 +21936,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22676,17 +21975,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22722,17 +22013,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22768,17 +22051,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22817,17 +22092,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22864,17 +22131,9 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x07;
-    ;
-
     memory "fuse5"
         initval            = 0xd0;
         bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        bitmask            = 0x1f;
     ;
 
     memory "lock"
@@ -22891,6 +22150,20 @@ part parent ".avrdx"
     id                     = ".avrex";
     # Shared UPDI pin, HV on _RESET
     hvupdi_variant         = 2;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
+    memory "fuse5"
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        initval            = 0x07;
+        bitmask            = 0x07;
+    ;
 
     memory "userrow"
         size               = 64;
@@ -22922,6 +22195,37 @@ part parent ".avrex"
         offset             = 0x800000;
         readsize           = 256;
     ;
+
+    memory "fuse0"
+        initval            = -1;
+    ;
+
+    memory "fuse1"
+        initval            = -1;
+    ;
+
+    memory "fuse2"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse5"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse6"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse7"
+        initval            = -1;
+    ;
+
+    memory "fuse8"
+        initval            = -1;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22946,6 +22250,37 @@ part parent ".avrex"
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        initval            = -1;
+    ;
+
+    memory "fuse1"
+        initval            = -1;
+    ;
+
+    memory "fuse2"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse5"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse6"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "fuse7"
+        initval            = -1;
+    ;
+
+    memory "fuse8"
+        initval            = -1;
     ;
 ;
 
@@ -22973,20 +22308,6 @@ part parent ".avrex"
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -23020,20 +22341,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -23063,20 +22370,6 @@ part parent ".avrex"
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -23110,20 +22403,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -23155,20 +22434,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -23198,20 +22463,6 @@ part parent ".avrex"
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -23248,20 +22499,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -23294,20 +22531,6 @@ part parent ".avrex"
         page_size          = 128;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
     ;
 
     memory "lock"
@@ -23344,20 +22567,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "fuse2"
-        bitmask            = 0x08;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "fuse6"
-        initval            = 0x07;
-        bitmask            = 0x07;
-    ;
-
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -23373,6 +22582,24 @@ part parent "m88"
     mcuid                  = 227;
     signature              = 0x1e 0x93 0x0f;
     autobaud_sync          = 0x1c;
+
+    memory "lfuse"
+        initval            = -1;
+    ;
+
+    memory "hfuse"
+        initval            = -1;
+    ;
+
+    memory "efuse"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "lock"
+        initval            = -1;
+        bitmask            = -1;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -23385,6 +22612,24 @@ part parent "m168"
     mcuid                  = 228;
     signature              = 0x1e 0x94 0x0b;
     autobaud_sync          = 0x1c;
+
+    memory "lfuse"
+        initval            = -1;
+    ;
+
+    memory "hfuse"
+        initval            = -1;
+    ;
+
+    memory "efuse"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "lock"
+        initval            = -1;
+        bitmask            = -1;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -23397,4 +22642,22 @@ part parent "m328"
     mcuid                  = 229;
     signature              = 0x1e 0x95 0x0f;
     autobaud_sync          = 0x1c;
+
+    memory "lfuse"
+        initval            = -1;
+    ;
+
+    memory "hfuse"
+        initval            = -1;
+    ;
+
+    memory "efuse"
+        initval            = -1;
+        bitmask            = -1;
+    ;
+
+    memory "lock"
+        initval            = -1;
+        bitmask            = -1;
+    ;
 ;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -7183,7 +7183,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xda;
-        bitmask            = 0x3f;
+        bitmask            = 0x77;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xoxo.oooo";
@@ -13473,6 +13473,7 @@ part parent "t44"
         "ATtiny44A-SSU:  SOIC14,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny44A-SSUR: SOIC14N, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = XVII + IV; # 21;
+
 
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -168,6 +168,7 @@
 #           page_size       = <num> ;             # bytes
 #           num_pages       = <num> ;             # numeric
 #           initval         = <num> ;             # factory setting of fuses and lockbits
+#           bitmask         = <num> ;             # bits used (only in fuses and lockbits)
 #           n_word_writes   = <num> ;             # TPI only: if set, number of words to write
 #           min_write_delay = <num> ;             # micro-seconds
 #           max_write_delay = <num> ;             # micro-seconds
@@ -2864,11 +2865,13 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xf4;
+        bitmask            = 0x1f;
     ;
 
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
     ;
 
     memory "signature"
@@ -2961,6 +2964,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0x52;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.oooo";
@@ -2970,6 +2974,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
@@ -3098,6 +3103,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x6a;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -3107,6 +3113,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x1f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -3116,6 +3123,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -3245,6 +3253,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0x5c;
+        bitmask            = 0xf3;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--oooo.xxoo";
@@ -3254,6 +3263,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
@@ -3452,11 +3462,13 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0x21;
     ;
 
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
@@ -3547,11 +3559,13 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0x21;
     ;
 
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
@@ -3638,11 +3652,13 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0x21;
     ;
 
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         write              = "1010.1100--111x.xiix--xxxx.xxxx--xxxx.xxxx";
@@ -3725,6 +3741,7 @@ part
 
     memory "fuse"
         size               = 1;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         pwroff_after_write = yes;
@@ -3734,6 +3751,7 @@ part
 
     memory "lock"
         size               = 1;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
@@ -3822,6 +3840,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xde;
+        bitmask            = 0x21;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
@@ -3831,6 +3850,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooox.xxxo";
@@ -3971,6 +3991,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0x21;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxoo.oooo";
@@ -3980,6 +4001,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 20000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
@@ -4061,11 +4083,13 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0x21;
     ;
 
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
@@ -4150,6 +4174,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0x21;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxxo";
@@ -4159,6 +4184,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--ooxx.xxxx";
@@ -4248,6 +4274,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0x2b;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xxox.o1oo";
@@ -4257,6 +4284,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x06;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xoox";
@@ -4370,6 +4398,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4379,6 +4408,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4388,6 +4418,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xfd;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4397,6 +4428,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4533,6 +4565,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4542,6 +4575,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4551,6 +4585,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xfd;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4560,6 +4595,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4690,6 +4726,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4699,6 +4736,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4708,6 +4746,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4717,6 +4756,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4825,6 +4865,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4834,6 +4875,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4843,6 +4885,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4852,6 +4895,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4960,6 +5004,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -4969,6 +5014,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4978,6 +5024,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -4987,6 +5034,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5105,6 +5153,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5114,6 +5163,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5123,6 +5173,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5263,6 +5314,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5272,6 +5324,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5281,6 +5334,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5290,6 +5344,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5420,6 +5475,7 @@ part parent "m324p"
 
     memory "efuse"
         initval            = 0x07;
+        bitmask            = 0x0f;
     ;
 ;
 
@@ -5566,6 +5622,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5575,6 +5632,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5584,6 +5642,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5593,6 +5652,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5784,6 +5844,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5793,6 +5854,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5802,6 +5864,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5811,6 +5874,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5967,6 +6031,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -5976,6 +6041,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5985,6 +6051,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x1e;
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -5994,6 +6061,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 16000;
         max_write_delay    = 16000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6094,6 +6162,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xef;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--ooxx.oooo";
@@ -6103,6 +6172,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--xxxx.1ooo";
@@ -6112,6 +6182,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.0000--xxxx.0xxx--oooo.oooo";
@@ -6231,6 +6302,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6240,6 +6312,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6249,6 +6322,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x0f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6258,6 +6332,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6482,6 +6557,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6491,6 +6567,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6500,6 +6577,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6509,6 +6587,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6751,6 +6830,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6760,6 +6840,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6769,6 +6850,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6778,6 +6860,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6975,6 +7058,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -6984,6 +7068,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -6993,6 +7078,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7093,6 +7179,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xda;
+        bitmask            = 0x3f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--xxxx.xxxx--xxxx.xxxx--xoxo.oooo";
@@ -7102,6 +7189,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7234,6 +7322,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7243,6 +7332,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7252,6 +7342,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7383,6 +7474,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7392,6 +7484,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7401,6 +7494,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7510,6 +7604,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7519,6 +7614,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7528,6 +7624,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 2000;
         max_write_delay    = 2000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7634,6 +7731,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7643,6 +7741,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xf7;
+        bitmask            = 0x1f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7652,6 +7751,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
@@ -7765,6 +7865,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7774,6 +7875,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7783,6 +7885,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7792,6 +7895,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
@@ -7931,6 +8035,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -7940,6 +8045,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7949,6 +8055,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -7958,6 +8065,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
@@ -8093,6 +8201,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8102,6 +8211,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8111,6 +8221,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8120,6 +8231,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--xxxx.xxxx--xxxx.xxxx--xxxx.xxoo";
@@ -8205,11 +8317,13 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0x12;
+        bitmask            = 0x1f;
     ;
 
     memory "lock"
         size               = 1;
         initval            = 0x06;
+        bitmask            = 0x06;
     ;
 
     memory "signature"
@@ -8327,6 +8441,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8336,6 +8451,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8345,6 +8461,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8354,6 +8471,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8569,6 +8687,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8578,6 +8697,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8587,6 +8707,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf9;
+        bitmask            = 0x07;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8596,6 +8717,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8815,6 +8937,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -8824,6 +8947,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8833,6 +8957,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf9;
+        bitmask            = 0x07;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -8842,6 +8967,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9050,6 +9176,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x6e;
+        bitmask            = 0xf3;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9059,6 +9186,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9068,6 +9196,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0xf7;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9077,6 +9206,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9205,6 +9335,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9214,6 +9345,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9223,6 +9355,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9232,6 +9365,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -9351,6 +9485,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9360,6 +9495,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9369,6 +9505,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9378,6 +9515,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -9495,6 +9633,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x6e;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9504,6 +9643,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9513,6 +9653,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9522,6 +9663,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9639,6 +9781,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x6e;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9648,6 +9791,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9657,6 +9801,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9666,6 +9811,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9782,6 +9928,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9791,6 +9938,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9800,6 +9948,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9809,6 +9958,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9875,6 +10025,7 @@ part parent "m328"
 
     memory "efuse"
         initval            = 0xf7;
+        bitmask            = 0x0f;
         write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 ;
@@ -9972,6 +10123,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -9981,6 +10133,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -9990,6 +10143,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--11oo.oooo";
@@ -9999,6 +10153,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--11oo.oooo";
@@ -10498,6 +10653,7 @@ part
     memory "fuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -10507,6 +10663,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--1111.11oo";
@@ -10639,6 +10796,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xdd;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -10648,6 +10806,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xe9;
+        bitmask            = 0x1f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--111o.oooo";
@@ -10657,6 +10816,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--11oo.oooo";
@@ -10822,6 +10982,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xd7;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -10831,6 +10992,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xf9;
+        bitmask            = 0x0f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--1111.oooo";
@@ -10840,6 +11002,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--11oo.oooo";
@@ -10981,6 +11144,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x64;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -10990,6 +11154,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -10999,6 +11164,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11008,6 +11174,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11151,6 +11318,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11160,6 +11328,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11169,6 +11338,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11178,6 +11348,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11289,6 +11460,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11298,6 +11470,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11307,6 +11480,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf9;
+        bitmask            = 0xb7;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--o1oo.1ooo";
@@ -11316,6 +11490,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--11oo.oooo";
@@ -11427,6 +11602,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11436,6 +11612,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11445,6 +11622,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf9;
+        bitmask            = 0xf7;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11454,6 +11632,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11640,6 +11819,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11649,6 +11829,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11658,6 +11839,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xfd;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11667,6 +11849,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--11oo.oooo";
@@ -11889,6 +12072,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -11898,6 +12082,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11907,6 +12092,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -11916,6 +12102,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -12046,6 +12233,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12055,6 +12243,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12064,6 +12253,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12073,6 +12263,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -12200,6 +12391,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12209,6 +12401,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12218,6 +12411,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12227,6 +12421,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -12340,6 +12535,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12349,6 +12545,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12358,6 +12555,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12367,6 +12565,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12479,6 +12678,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12488,6 +12688,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12497,6 +12698,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12506,6 +12708,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12642,6 +12845,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -12651,6 +12855,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12660,6 +12865,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -12669,6 +12875,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13008,6 +13215,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13017,6 +13225,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13026,6 +13235,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13035,6 +13245,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -13185,6 +13396,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13194,6 +13406,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13203,6 +13416,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13212,6 +13426,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -13254,6 +13469,7 @@ part parent "t44"
         "ATtiny44A-SSU:  SOIC14,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny44A-SSUR: SOIC14N, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = XVII + IV; # 21;
+
 ;
 
 #------------------------------------------------------------
@@ -13361,6 +13577,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13370,6 +13587,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13379,6 +13597,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13388,6 +13607,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
@@ -13461,7 +13681,12 @@ part parent "t44"
         writepage          = "0100.1100--0000.0aaa--aaaa.axxx--xxxx.xxxx";
     ;
 
+    memory "lfuse"
+        bitmask            = 0xdf;
+    ;
+
     memory "efuse"
+        bitmask            = 0xff;
         write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 ;
@@ -13498,7 +13723,12 @@ part parent "t84"
         writepage          = "0100.1100--0000.aaaa--aaaa.axxx--xxxx.xxxx";
     ;
 
+    memory "lfuse"
+        bitmask            = 0xdf;
+    ;
+
     memory "efuse"
+        bitmask            = 0xff;
         write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 ;
@@ -13601,6 +13831,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13610,6 +13841,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13619,6 +13851,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x01;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13628,6 +13861,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13738,6 +13972,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x52;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13747,6 +13982,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13756,6 +13992,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xfb;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13765,6 +14002,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--00oo.oooo";
@@ -13877,6 +14115,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x52;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -13886,6 +14125,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13895,6 +14135,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xfb;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -13904,6 +14145,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14014,6 +14256,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14023,6 +14266,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x9b;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14032,6 +14276,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf3;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14041,6 +14286,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14169,6 +14415,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14178,6 +14425,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14187,6 +14435,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf3;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14196,6 +14445,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14327,6 +14577,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14336,6 +14587,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14345,6 +14597,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf4;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14354,6 +14607,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14466,6 +14720,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14475,6 +14730,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14484,6 +14740,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf4;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14493,6 +14750,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14606,6 +14864,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14615,6 +14874,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14624,6 +14884,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf4;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14633,6 +14894,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14746,6 +15008,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14755,6 +15018,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14764,6 +15028,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf4;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14773,6 +15038,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14886,6 +15152,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x5e;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -14895,6 +15162,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14904,6 +15172,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xf4;
+        bitmask            = 0x0f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -14913,6 +15182,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15030,6 +15300,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15039,6 +15310,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -15048,6 +15320,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x0f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -15057,6 +15330,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15227,6 +15501,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--0000.0000--oooo.oooo";
@@ -15236,6 +15511,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--0000.0000--oooo.oooo";
@@ -15245,6 +15521,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--0000.0000--oooo.oooo";
@@ -15254,6 +15531,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15425,6 +15703,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.0000--0000.0000--oooo.oooo";
@@ -15434,6 +15713,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
+        bitmask            = 0xff;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.1000--0000.0000--oooo.oooo";
@@ -15443,6 +15723,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x07;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.0000--0000.1000--0000.0000--oooo.oooo";
@@ -15452,6 +15733,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
         min_write_delay    = 9000;
         max_write_delay    = 9000;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -15773,8 +16055,29 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -15808,6 +16111,7 @@ part parent "x16a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -15836,6 +16140,7 @@ part parent "x16a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -15857,6 +16162,10 @@ part parent "x16a4u"
         "ATxmega16A4-MU:  VQFN44, Fmax=32 MHz, T=[N/A,    N/A], Vcc=[1.6 V, 3.6 V]";
     mcuid                  = 231;
     n_interrupts           = 94;
+
+    memory "fuse2"
+        bitmask            = 0x43;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -15917,8 +16226,29 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -15952,6 +16282,7 @@ part parent "x32a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -15981,6 +16312,7 @@ part parent "x32a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -16002,6 +16334,10 @@ part parent "x32a4u"
         "ATxmega32A4-MU:  VQFN44, Fmax=32 MHz, T=[N/A,    N/A], Vcc=[1.6 V, 3.6 V]";
     mcuid                  = 238;
     n_interrupts           = 94;
+
+    memory "fuse2"
+        bitmask            = 0x43;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16061,8 +16397,29 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16095,6 +16452,7 @@ part parent "x32a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -16121,6 +16479,7 @@ part parent "x32a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -16147,6 +16506,7 @@ part parent "x64a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -16174,6 +16534,7 @@ part parent "x64a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -16201,6 +16562,7 @@ part parent "x64a4u"
 
     memory "fuse4"
         initval            = 0xff;
+        bitmask            = 0x1e;
     ;
 ;
 
@@ -16223,6 +16585,10 @@ part parent "x64a4u"
     mcuid                  = 243;
     n_interrupts           = 125;
     signature              = 0x1e 0x96 0x4e;
+
+    memory "fuse2"
+        bitmask            = 0x43;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16243,6 +16609,10 @@ part parent "x64a1"
     mcuid                  = 244;
     n_interrupts           = 127;
     usbpid                 = 0x2fe8;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16281,6 +16651,10 @@ part parent "x64a1"
     mcuid                  = 247;
     n_interrupts           = 127;
     signature              = 0x1e 0x96 0x42;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16313,6 +16687,10 @@ part parent "x64a1"
     signature              = 0x1e 0x96 0x52;
     usbpid                 = 0x2fe1;
 
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xff;
     ;
@@ -16333,6 +16711,10 @@ part parent "x64a1"
     n_interrupts           = 54;
     signature              = 0x1e 0x96 0x51;
     usbpid                 = 0x2fdf;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
 
     memory "fuse4"
         initval            = 0xff;
@@ -16392,6 +16774,26 @@ part parent ".xmega"
         page_size          = 512;
         offset             = 0x820000;
         readsize           = 256;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1e;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16470,11 +16872,17 @@ part parent "x128c3"
     memory "fuse0"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0xff;
         offset             = 0x8f0020;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x43;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -16508,6 +16916,10 @@ part parent "x128a1"
     mcuid                  = 256;
     n_interrupts           = 127;
     usbpid                 = 0x2fed;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16547,6 +16959,10 @@ part parent "x128a1"
     n_interrupts           = 127;
     signature              = 0x1e 0x97 0x42;
     usbpid                 = 0x2fe6;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16666,8 +17082,29 @@ part parent ".xmega-a"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16736,7 +17173,28 @@ part parent ".xmega"
     memory "fuse0"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0xff;
         offset             = 0x8f0020;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -16820,6 +17278,26 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1e;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
+    ;
+
     memory "usersig"
         size               = 512;
         page_size          = 512;
@@ -16888,10 +17366,16 @@ part parent "x192a1"
 
     memory "fuse0"
         initval            = 0xff;
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x43;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -16916,10 +17400,12 @@ part parent "x192a1"
 
     memory "fuse0"
         initval            = 0xff;
+        bitmask            = 0xff;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -16976,6 +17462,26 @@ part parent ".xmega"
         page_size          = 512;
         offset             = 0x840000;
         readsize           = 256;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1e;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17045,10 +17551,16 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x43;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -17073,10 +17585,12 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
+        bitmask            = 0xff;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -17099,10 +17613,16 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x43;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -17124,10 +17644,12 @@ part parent "x256a1"
 
     memory "fuse0"
         initval            = 0xff;
+        bitmask            = 0xff;
     ;
 
     memory "fuse4"
         initval            = 0xfe;
+        bitmask            = 0x1f;
     ;
 ;
 
@@ -17184,6 +17706,26 @@ part parent ".xmega"
         page_size          = 512;
         offset             = 0x860000;
         readsize           = 256;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x63;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1e;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17271,6 +17813,30 @@ part parent ".xmega-e"
         readsize           = 256;
     ;
 
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x43;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1e;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
+    ;
+
     memory "usersig"
         size               = 128;
         page_size          = 128;
@@ -17338,6 +17904,30 @@ part parent ".xmega-e"
         readsize           = 256;
     ;
 
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x43;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1e;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
+    ;
+
     memory "usersig"
         size               = 128;
         page_size          = 128;
@@ -17403,6 +17993,30 @@ part parent ".xmega-e"
         page_size          = 128;
         offset             = 0x808000;
         readsize           = 256;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x43;
+    ;
+
+    memory "fuse4"
+        bitmask            = 0x1e;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0x3f;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        bitmask            = 0xff;
     ;
 
     memory "usersig"
@@ -17551,6 +18165,7 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0x62;
+        bitmask            = 0xdf;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -17560,6 +18175,7 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xdf;
+        bitmask            = 0xff;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -17569,6 +18185,7 @@ part
     memory "efuse"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x1f;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
@@ -17578,6 +18195,7 @@ part
     memory "lock"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x03;
         min_write_delay    = 4500;
         max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
@@ -17669,10 +18287,12 @@ part parent ".reduced_core_tiny"
 
     memory "fuse"
         initval            = 0xff;
+        bitmask            = 0x07;
     ;
 
     memory "lockbits"
         initval            = 0xff;
+        bitmask            = 0x03;
     ;
 ;
 
@@ -17716,10 +18336,12 @@ part parent ".reduced_core_tiny"
 
     memory "fuse"
         initval            = 0xff;
+        bitmask            = 0x07;
     ;
 
     memory "lockbits"
         initval            = 0xff;
+        bitmask            = 0x03;
     ;
 ;
 
@@ -17770,11 +18392,13 @@ part parent ".reduced_core_tiny"
 
     memory "fuse"
         initval            = 0xff;
+        bitmask            = 0x77;
         n_word_writes      = 2;
     ;
 
     memory "lockbits"
         initval            = 0xff;
+        bitmask            = 0x03;
     ;
 ;
 
@@ -17806,11 +18430,13 @@ part parent ".reduced_core_tiny"
 
     memory "fuse"
         initval            = 0xff;
+        bitmask            = 0x77;
         n_word_writes      = 4;
     ;
 
     memory "lockbits"
         initval            = 0xff;
+        bitmask            = 0x03;
     ;
 ;
 
@@ -17843,10 +18469,12 @@ part parent ".reduced_core_tiny"
 
     memory "fuse"
         initval            = 0xff;
+        bitmask            = 0x0f;
     ;
 
     memory "lockbits"
         initval            = 0xff;
+        bitmask            = 0x03;
     ;
 
     memory "sigrow"
@@ -17881,10 +18509,12 @@ part parent ".reduced_core_tiny"
 
     memory "fuse"
         initval            = 0xff;
+        bitmask            = 0x0f;
     ;
 
     memory "lockbits"
         initval            = 0xff;
+        bitmask            = 0x03;
     ;
 
     memory "sigrow"
@@ -17953,16 +18583,19 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xcd;
+        bitmask            = 0xff;
     ;
 
     memory "hfuse"
         size               = 1;
         initval            = 0xfe;
+        bitmask            = 0x03;
     ;
 
     memory "lockbits"
         size               = 1;
         initval            = 0xff;
+        bitmask            = 0x3f;
     ;
 
     memory "signature"
@@ -18212,9 +18845,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18223,8 +18869,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18258,9 +18921,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18269,8 +18945,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18304,9 +18997,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18315,8 +19021,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18350,9 +19073,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18361,8 +19097,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18398,9 +19151,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18409,8 +19175,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18444,8 +19227,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18483,8 +19295,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18519,8 +19360,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18554,8 +19424,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18593,8 +19492,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18629,8 +19557,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18664,9 +19621,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18675,8 +19645,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18710,9 +19697,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18721,8 +19721,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18756,9 +19773,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18767,8 +19797,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18802,9 +19849,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18813,8 +19873,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18850,9 +19927,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18861,8 +19951,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18914,9 +20021,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18925,8 +20045,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -18961,9 +20098,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -18972,8 +20122,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19012,9 +20179,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19023,8 +20203,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19059,9 +20256,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19070,8 +20280,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19105,9 +20332,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19116,8 +20356,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19153,9 +20410,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19164,8 +20434,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19199,9 +20486,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19210,8 +20510,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19245,9 +20562,22 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
     memory "fuse4"
         size               = 1;
         initval            = 0x00;
+        bitmask            = 0xff;
         offset             = 0x1284;
         readsize           = 1;
     ;
@@ -19256,8 +20586,25 @@ part parent ".avr8x_tiny"
         alias "fuse4";
     ;
 
+    memory "fuse5"
+        bitmask            = 0xcd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 
     memory "userrow"
@@ -19317,8 +20664,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19361,8 +20737,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19397,8 +20802,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19437,8 +20871,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19481,8 +20944,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19517,8 +21009,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19557,8 +21078,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19601,8 +21151,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19637,8 +21216,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19677,8 +21285,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19721,8 +21358,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19757,8 +21423,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xdd;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19800,8 +21495,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19839,8 +21563,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19882,8 +21635,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19921,8 +21703,37 @@ part parent ".avr8x_tiny"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -19964,8 +21775,37 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -20003,8 +21843,37 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -20046,8 +21915,37 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -20086,8 +21984,37 @@ part parent ".avr8x_mega"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x83;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xc9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0xc5;
+        bitmask            = 0xff;
     ;
 ;
 
@@ -20284,8 +22211,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20328,8 +22280,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20372,8 +22349,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20418,8 +22420,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20462,8 +22489,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20506,8 +22558,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20550,8 +22627,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20596,8 +22698,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20640,8 +22767,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20684,8 +22836,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20728,8 +22905,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
     memory "fuse6"
         initval            = 0x00;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20773,6 +22975,34 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -20812,6 +23042,34 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -20849,6 +23107,34 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20892,6 +23178,34 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -20929,6 +23243,34 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -20970,6 +23312,34 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -21007,6 +23377,34 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21050,6 +23448,34 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -21087,6 +23513,34 @@ part parent ".avrdx"
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21128,6 +23582,34 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -21167,6 +23649,34 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse5"
+        bitmask            = 0xed;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
@@ -21200,8 +23710,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21238,8 +23773,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21278,8 +23838,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21316,8 +23901,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21353,8 +23963,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21391,8 +24026,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21431,8 +24091,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21469,8 +24154,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21506,8 +24216,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21543,8 +24278,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21583,8 +24343,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21621,8 +24406,33 @@ part parent ".avrdx"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x07;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        bitmask            = 0x1f;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21722,6 +24532,40 @@ part parent ".avrex"
         offset             = 0x800000;
         readsize           = 256;
     ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
+    memory "fuse5"
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        initval            = 0x5cc5c55c;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21748,6 +24592,40 @@ part parent ".avrex"
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
+    memory "fuse5"
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        initval            = 0x5cc5c55c;
     ;
 ;
 
@@ -21776,6 +24654,40 @@ part parent ".avrex"
         offset             = 0x800000;
         readsize           = 256;
     ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
+    memory "fuse5"
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        initval            = 0x5cc5c55c;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21802,6 +24714,40 @@ part parent ".avrex"
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
+    memory "fuse5"
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        initval            = 0x5cc5c55c;
     ;
 ;
 
@@ -21830,6 +24776,40 @@ part parent ".avrex"
         offset             = 0x800000;
         readsize           = 256;
     ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
+    memory "fuse5"
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        initval            = 0x5cc5c55c;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21856,6 +24836,40 @@ part parent ".avrex"
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
+    ;
+
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
+    memory "fuse5"
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+    ;
+
+    memory "fuse6"
+        initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
+    ;
+
+    memory "lock"
+        initval            = 0x5cc5c55c;
     ;
 ;
 
@@ -21888,12 +24902,34 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
     ;
 
     memory "fuse6"
         initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21930,12 +24966,34 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
     ;
 
     memory "fuse6"
         initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"
@@ -21972,12 +25030,34 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
+    memory "fuse0"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse1"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse2"
+        bitmask            = 0x08;
+    ;
+
     memory "fuse5"
         initval            = 0xd0;
+        bitmask            = 0xf9;
     ;
 
     memory "fuse6"
         initval            = 0x07;
+        bitmask            = 0x07;
+    ;
+
+    memory "fuse7"
+        bitmask            = 0xff;
+    ;
+
+    memory "fuse8"
+        bitmask            = 0xff;
     ;
 
     memory "lock"

--- a/src/avrintel.c
+++ b/src/avrintel.c
@@ -9,7 +9,7 @@
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * v 1.3
- * 26.05.2023
+ * 27.05.2023
  *
  */
 
@@ -11621,9 +11621,9 @@ const Configitem_t cfgtab_atmega128rfr2[14] = {
 // ATmega161
 const Configitem_t cfgtab_atmega161[7] = {
   {"cksel", 8, _values_cksel_atmega161, "fuse", 0, 0x07, 0, 2, "clock source"},
-  {"sut", 2, _values_sut_atmega161, "fuse", 0, 0x08, 3, 1, "startup time"},
-  {"spien", 2, _values_spien_atmega328, "fuse", 0, 0x10, 4, 1, "serial programming"},
-  {"bootrst", 2, _values_bootrst_atmega328, "fuse", 0, 0x20, 5, 0, "reset address"},
+  {"sut", 2, _values_sut_atmega161, "fuse", 0, 0x10, 4, 1, "startup time"},
+  {"spien", 2, _values_spien_atmega328, "fuse", 0, 0x20, 5, 0, "serial programming"},
+  {"bootrst", 2, _values_bootrst_atmega328, "fuse", 0, 0x40, 6, 1, "reset address"},
   {"lb", 3, _values_lb_atmega328, "lock", 0, 0x03, 0, 3, "lock bits"},
   {"blb0", 4, _values_blb0_atmega328, "lock", 0, 0x0c, 2, 3, "boot lock bits: application section"},
   {"blb1", 4, _values_blb1_atmega328, "lock", 0, 0x30, 4, 3, "boot lock bits: boot section"},

--- a/src/avrintel.h
+++ b/src/avrintel.h
@@ -9,7 +9,7 @@
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * v 1.3
- * 26.05.2023
+ * 27.05.2023
  *
  */
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -331,6 +331,7 @@ AVRMEM *avr_new_memtype(void) {
   m->desc = cache_string("");
   m->page_size = 1;             // Ensure not 0
   m->initval = -1;              // Unknown value represented as -1
+  m->bitmask = -1;              // Default to -1
 
   return m;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -136,6 +136,7 @@ Component_t avr_comp[] = {
   mem_comp_desc(size, COMP_INT),
   mem_comp_desc(num_pages, COMP_INT),
   mem_comp_desc(initval, COMP_INT),
+  mem_comp_desc(bitmask, COMP_INT),
   mem_comp_desc(n_word_writes, COMP_INT),
   mem_comp_desc(offset, COMP_INT),
   mem_comp_desc(min_write_delay, COMP_INT),

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -813,7 +813,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
         int haveinjct = 0;
         if(injct)
           for(size_t i=0; i<sizeof meminj/sizeof*meminj; i++)
-            if(meminj[i].mcu && str_eq(meminj[i].mcu, p->desc) && str_eq(meminj[i].mem, m->desc))
+            if(meminj[i].mcu && str_match(meminj[i].mcu, p->desc) && str_match(meminj[i].mem, m->desc))
               haveinjct = 1;
         if(!haveinjct)
           continue;
@@ -848,7 +848,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
     if(injct)
       for(size_t i=0; i<sizeof meminj/sizeof*meminj; i++)
         if(meminj[i].mcu)
-          if(str_eq(meminj[i].mcu, p->desc) && str_eq(meminj[i].mem, m->desc))
+          if(str_match(meminj[i].mcu, p->desc) && str_match(meminj[i].mem, m->desc))
             dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc,
               meminj[i].var, cfg_strdup("meminj", meminj[i].value), NULL);
 
@@ -882,7 +882,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
   if(injct)
     for(size_t i=0; i<sizeof ptinj/sizeof*ptinj; i++)
       if(ptinj[i].mcu)
-        if(str_eq(ptinj[i].mcu, p->desc))
+        if(str_match(ptinj[i].mcu, p->desc))
           dev_part_strct_entry(tsv, ".pt", p->desc, NULL,
             ptinj[i].var, cfg_strdup("ptinj", ptinj[i].value), NULL);
 
@@ -1425,7 +1425,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
     for(size_t i=0; i<sizeof pgminj/sizeof*pgminj; i++)
       if(pgminj[i].pgmid)
         for(LNODEID *ln=lfirst(pgm->id); ln; ln=lnext(ln))
-          if(str_eq(pgminj[i].pgmid, ldata(ln)))
+          if(str_match(pgminj[i].pgmid, ldata(ln)))
             dev_part_strct_entry(tsv, ".prog", ldata(ln), NULL,
               pgminj[i].var, cfg_strdup("pgminj", pgminj[i].value), NULL);
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -828,6 +828,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
     _if_memout(intcmp, "%d", page_size);
     _if_memout(intcmp, "%d", num_pages);
     _if_memout(intcmp, m->initval == -1? "%d": "0x%02x", initval);
+    _if_memout(intcmp, m->bitmask == -1? "%d": "0x%02x", bitmask);
     _if_memout(intcmp, "%d", n_word_writes);
     _if_memout(intcmp, "0x%x", offset);
     _if_memout(intcmp, "%d", min_write_delay);

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2808,6 +2808,7 @@ part
         page_size       = <num> ;             # bytes
         num_pages       = <num> ;             # numeric
         initval         = <num> ;             # factory setting of fuses and lockbits
+        bitmask         = <num> ;             # bits used (only in fuses and lockbits)
         n_word_writes   = <num> ;             # TPI only: if set, number of words to write
         min_write_delay = <num> ;             # micro-seconds
         max_write_delay = <num> ;             # micro-seconds

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2896,24 +2896,30 @@ of the instruction.  Bit specifiers may be one of the following formats:
 The bit is always set on input as well as output
 
 @item 0
-the bit is always clear on input as well as output
+The bit is always clear on input as well as output
 
 @item x
-the bit is ignored on input and output
+The bit is ignored on input and output
 
 @item a
-the bit is an address bit, the bit-number matches this bit specifier's
+The bit is an address bit, the bit-number matches this bit specifier's
 position within the current instruction byte
 
 @item a@var{N}
-the bit is the @var{N}th address bit, bit-number = N, i.e., @code{a12}
+The bit is the @var{N}th address bit, bit-number = N, i.e., @code{a12}
 is address bit 12 on input, @code{a0} is address bit 0.
 
 @item i
-the bit is an input data bit
+The bit is an input data bit; as with @code{a} bits an input data bit can
+optionally be followed by a bit number, here between 0 and 7, if the bit
+needs to be moved to a different position in the SPI write command byte
+than it appears in memory.
 
 @item o
-the bit is an output data bit
+The bit is an output data bit; as with @code{i} bits an output data bit
+can optionally be followed by a bit number; this is useful in case the
+part's SPI read command places a particular bit into a different position
+than the write command put it, e.g., ATtiny22L or AT90S8535 lock bits.
 
 @end table
 

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2836,13 +2836,13 @@ part
 @noindent
 If any of the above parameters are not specified, the default value of 0
 is used for numerics (except for @code{mcuid}, @code{hvupdi_variant},
-@code{ocdrev} and @code{bitmask}, where the default value is -1, and for
-@code{autobaud_sync} which defaults to 0x30) or the empty string @code{""}
-for string values. If a required parameter is left empty, AVRDUDE will
-complain. Almost all occurrences of numbers (with the exception of pin
-numbers and where they are separated by space, e.g., in signature and
-readback) can also be given as simple expressions involving arithemtic and
-bitwise operators.
+@code{ocdrev}, @code{initval} and @code{bitmask}, all of which default to
+-1, and for @code{autobaud_sync} which defaults to 0x30) or the empty
+string @code{""} for string values. If a required parameter is left empty,
+AVRDUDE will complain. Almost all occurrences of numbers (with the
+exception of pin numbers and where they are separated by space, e.g., in
+signature and readback) can also be given as simple expressions involving
+arithemtic and bitwise operators.
 
 @menu
 * Parent Part::

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2835,13 +2835,14 @@ part
 
 @noindent
 If any of the above parameters are not specified, the default value of 0
-is used for numerics (except for @code{mcuid}, @code{hvupdi_variant} and
-@code{ocdrev}, where the default value is -1, and for @code{autobaud_sync}
-which defaults to 0x30) or the empty string @code{""} for string values.
-If a required parameter is left empty, AVRDUDE will complain. Almost all
-occurrences of numbers (with the exception of pin numbers and where they
-are separated by space, e.g., in signature and readback) can also be given
-as simple expressions involving arithemtic and bitwise operators.
+is used for numerics (except for @code{mcuid}, @code{hvupdi_variant},
+@code{ocdrev} and @code{bitmask}, where the default value is -1, and for
+@code{autobaud_sync} which defaults to 0x30) or the empty string @code{""}
+for string values. If a required parameter is left empty, AVRDUDE will
+complain. Almost all occurrences of numbers (with the exception of pin
+numbers and where they are separated by space, e.g., in signature and
+readback) can also be given as simple expressions involving arithemtic and
+bitwise operators.
 
 @menu
 * Parent Part::

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -291,7 +291,7 @@ int dryrun_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
     Return("cannot write byte to %s %s as address 0x%04lx outside range [0, 0x%04x]",
       dry.dp->desc, dmem->desc, addr, dmem->size-1);
 
-  if(!(p->prog_modes & (PM_UPDI | PM_PDI | PM_aWire))) { // Read-modify-write classic parts
+  if(!(p->prog_modes & (PM_UPDI | PM_aWire))) { // Initialise unused bits in classic & XMEGA parts
     int bitmask = avr_mem_bitmask(dry.dp, dmem, addr);
     // Read-modify-write for bitmasked memory
     data = (data & bitmask) | (dmem->buf[addr] & ~bitmask);

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -171,7 +171,7 @@ static void dryrun_disable(const PROGRAMMER *pgm) {
     avr_free_part(dry.dp);
     dry.dp = NULL;
   }
-    
+
   return;
 }
 
@@ -291,6 +291,12 @@ int dryrun_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
     Return("cannot write byte to %s %s as address 0x%04lx outside range [0, 0x%04x]",
       dry.dp->desc, dmem->desc, addr, dmem->size-1);
 
+  if(!(p->prog_modes & (PM_UPDI | PM_PDI | PM_aWire))) { // Read-modify-write classic parts
+    int bitmask = avr_mem_bitmask(dry.dp, dmem, addr);
+    // Read-modify-write for bitmasked memory
+    data = (data & bitmask) | (dmem->buf[addr] & ~bitmask);
+  }
+
   dmem->buf[addr] = data;
 
   if(str_eq(dmem->desc, "fuses") && addr < 10) { // Copy the byte to corresponding fuse[0-9]
@@ -298,7 +304,7 @@ int dryrun_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
     sprintf(memtype, "fuse%ld", addr);
     if((dfuse = avr_locate_mem(dry.dp, memtype)) && dfuse->size == 1)
       dfuse->buf[0] = data;
-  } else if(str_starts(m->desc, "fuse")) {
+  } else if(str_starts(m->desc, "fuse")) { // Copy fuseN byte into fuses memory
     int fno = m->desc[4]-'0';
     if(fno >= 0 && fno < 10)
       if((dfuse = avr_locate_mem(dry.dp, "fuses")) && dfuse->size > fno)

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -292,7 +292,7 @@ int flip1_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   if (dfu->dev_desc.bMaxPacketSize0 != 32)
     pmsg_warning("bMaxPacketSize0 (%d) != 32, things might go wrong\n", dfu->dev_desc.bMaxPacketSize0);
 
-  if (verbose)
+  if (verbose > 0)
     flip1_show_info(FLIP1(pgm));
 
   dfu_abort(dfu);

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -297,7 +297,7 @@ int flip2_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   if (result != 0)
     goto flip2_initialize_fail;
 
-  if (verbose)
+  if (verbose > 0)
     flip2_show_info(FLIP2(pgm));
 
   return 0;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1114,7 +1114,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       return -1;
   }
 
-  if (verbose && quell_progress < 2)
+  if (verbose > 0 && quell_progress < 2)
     jtag3_print_parms1(pgm, progbuf, stderr);
 
   // Read or write SUFFER register
@@ -2836,7 +2836,7 @@ static int jtag3_initialize_tpi(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
 
-  if (verbose && quell_progress < 2)
+  if (verbose > 0 && quell_progress < 2)
     jtag3_print_parms1(pgm, progbuf, stderr);
 
   pmsg_notice2("jtag3_initialize_tpi() start\n");

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -156,7 +156,7 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
   chiperasetime | (chiperase|program(fuse|lock))(polltimeout|pulsewidth) | synchcycles | hvspcmdexedelay |
   mcu_base | nvm_base | ocd_base | ocdrev |
   autobaud_sync | idr | rampz | spmcr | eecr | eind |
-  paged | size | num_pages | initval | n_word_writes | offset | min_write_delay | max_write_delay | pwroff_after_write |
+  paged | size | num_pages | initval | bitmask | n_word_writes | offset | min_write_delay | max_write_delay | pwroff_after_write |
   readback_p1 | readback_p2 | mode | delay | blocksize | readsize ) {
   /* struct components for PROGRAMMER, AVRPART and AVRMEM */
   Component_t *cp = cfg_comp_search(yytext, current_strct);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -328,6 +328,7 @@ typedef struct avrmem {
   int page_size;              /* size of memory page (if page addressed) */
   int num_pages;              /* number of pages (if page addressed) */
   int initval;                /* factory setting of fuses and lock bits */
+  int bitmask;                /* bits used in fuses and lock bits */
   int n_word_writes;          /* TPI only: number words to write at a time */
   unsigned int offset;        /* offset in IO memory (ATxmega) */
   int min_write_delay;        /* microseconds */

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -912,6 +912,12 @@ double avr_timestamp();
 int avr_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr, unsigned char data);
 
+int avr_read_byte_silent(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+  unsigned long addr, unsigned char *datap);
+
+int avr_bitmask_data(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
+  unsigned long addr, unsigned char data);
+
 int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
 			   unsigned long addr, unsigned char data);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -921,6 +921,8 @@ int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype, int 
 
 int avr_signature(const PROGRAMMER *pgm, const AVRPART *p);
 
+int avr_mem_bitmask(const AVRPART *p, const AVRMEM *mem, int addr);
+
 int avr_verify(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, const char *m, int size);
 
 int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles);

--- a/src/main.c
+++ b/src/main.c
@@ -321,7 +321,7 @@ static void list_programmers(FILE *f, const char *prefix, LISTID programmers, in
 
         if(*id == 0 || *id == '.')
           continue;
-        if(verbose)
+        if(verbose > 0)
           fprintf(f, "%s%-*s = %-30s [%s:%d]", prefix, maxlen, id, desc, pgm->config_file, pgm->lineno);
         else
           fprintf(f, "%s%-*s = %-s", prefix, maxlen, id, desc);
@@ -378,14 +378,14 @@ static void list_parts(FILE *f, const char *prefix, LISTID avrparts, int pm) {
     if(!pm || !p->prog_modes || (pm & p->prog_modes)) {
       if(verbose < 2 && p->id[0] == '.') // hide ids starting with '.'
         continue;
-      if(verbose)
+      if(verbose > 0)
         fprintf(f, "%s%-*s = %-18s [%s:%d]", prefix, maxlen, p->id, p->desc, p->config_file, p->lineno);
       else
         fprintf(f, "%s%-*s = %s", prefix, maxlen, p->id, p->desc);
       if(pm != ~0)
         fprintf(f, " via %s", avr_prog_modes(pm & p->prog_modes));
       fprintf(f, "\n");
-      if(verbose)
+      if(verbose > 0)
         for(LNODEID ln = lfirst(p->variants); ln; ln = lnext(ln))
           fprintf(f, "%s%s- %s\n", prefix, prefix, (char *) ldata(ln));
     }
@@ -1154,7 +1154,7 @@ int main(int argc, char * argv [])
     exit(1);
   }
 
-  if (verbose) {
+  if (verbose > 0) {
     imsg_notice("Using Port                    : %s\n", port);
     imsg_notice("Using Programmer              : %s\n", programmer);
   }
@@ -1215,7 +1215,7 @@ int main(int argc, char * argv [])
     goto main_exit;
   }
 
-  if(verbose) {
+  if(verbose > 0) {
     if ((strcmp(pgm->type, "avr910") == 0)) {
       imsg_notice("avr910_devcode (avrdude.conf) : ");
       if(p->avr910_devcode)
@@ -1269,7 +1269,7 @@ int main(int argc, char * argv [])
     goto main_exit;
   }
 
-  if (verbose && quell_progress < 2) {
+  if (verbose > 0 && quell_progress < 2) {
     avr_display(stderr, p, progbuf, verbose);
     msg_notice("\n");
     programmer_display(pgm, progbuf);


### PR DESCRIPTION
Fixes #1371
Fixes #1370
 - Fixes ATmega161's sut, spien and bootrst bit masks
 - Fixes several SPI fuse/lock read/write commands
      + AT90S2323   fuse    read
      + AT90S2323   lock    read
      + AT90S2343   fuse    read
      + AT90S2343   lock    read
      + AT90S4434   fuse    read
      + AT90S4434   fuse    write
      + AT90S4434   lock    read
      + AT90S8535   fuse    read
      + AT90S8535   lock    read
      + ATmega161   fuse    write
      + ATmega162   efuse   write
      + ATmega324PB efuse   write
      + ATtiny22    fuse    read
      + ATtiny22    lock    read
      + ATtiny828   efuse   write
      + ATtiny828R  efuse   write
