### PR TITLE
Remove pgm->page_erase() function when unable to erase page

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1054,7 +1054,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
 
       if (need_write) {
         rc = 0;
-        if (auto_erase)
+        if (auto_erase && pgm->page_erase)
           rc = pgm->page_erase(pgm, p, cm, pageaddr);
         if (rc >= 0)
           rc = pgm->paged_write(pgm, p, cm, cm->page_size, pageaddr, cm->page_size);

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -549,7 +549,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
 
       for(int iwr = 0, pgno = 0, n = 0; n < cp->size; pgno++, n += cp->page_size) {
         if(cp->iscached[pgno] && memcmp(cp->copy + n, cp->cont + n, cp->page_size)) {
-          if(!chiperase && mems[i].pgerase)
+          if(!chiperase && mems[i].pgerase && pgm->page_erase)
             pgm->page_erase(pgm, p, mem, n);
           if(writeCachePage(cp, pgm, p, mem, n, 1) < 0)
             return LIBAVRDUDE_GENERAL_FAILURE;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1474,6 +1474,9 @@ static void jtag3_disable(const PROGRAMMER *pgm) {
 }
 
 static void jtag3_enable(PROGRAMMER *pgm, const AVRPART *p) {
+  if(!(p->prog_modes & (PM_PDI | PM_UPDI)))
+    pgm->page_erase = NULL;
+
   return;
 }
 
@@ -3207,6 +3210,7 @@ void jtag3_dw_initpgm(PROGRAMMER *pgm) {
    */
   pgm->paged_write    = jtag3_paged_write;
   pgm->paged_load     = jtag3_paged_load;
+  pgm->page_erase     = NULL;
   pgm->print_parms    = jtag3_print_parms;
   pgm->parseextparams = jtag3_parseextparms;
   pgm->setup          = jtag3_setup;
@@ -3327,6 +3331,7 @@ void jtag3_tpi_initpgm(PROGRAMMER *pgm) {
    */
   pgm->paged_write    = jtag3_paged_write_tpi;
   pgm->paged_load     = jtag3_paged_load_tpi;
+  pgm->page_erase     = NULL;
   pgm->print_parms    = jtag3_print_parms;
   pgm->parseextparams = jtag3_parseextparms;
   pgm->setup          = jtag3_setup;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1364,7 +1364,13 @@ static void jtagmkII_disable(const PROGRAMMER *pgm) {
   (void)jtagmkII_program_disable(pgm);
 }
 
-static void jtagmkII_enable(PROGRAMMER *pgm_unused, const AVRPART *p_unused) {
+static void jtagmkII_enable(PROGRAMMER *pgm, const AVRPART *p) {
+  // Unset page_erase when part or programmer not capable of it
+  if(!(p->prog_modes & (PM_PDI | PM_UPDI)))
+    pgm->page_erase = NULL;
+  if(pgm->flag & PGM_FL_IS_DW)
+    pgm->page_erase = NULL;
+
   return;
 }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3134,13 +3134,6 @@ static int stk500hvsp_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 }
 
 
-static int stk500v2_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
-                               unsigned int addr)
-{
-  pmsg_error("this function must never be called\n");
-  return -1;
-}
-
 static int stk500v2_set_vtarget(const PROGRAMMER *pgm, double v) {
   unsigned char uaref, utarg;
 
@@ -4696,7 +4689,7 @@ static void stk600_setup_isp(PROGRAMMER * pgm)
   pgm->write_byte = stk500isp_write_byte;
   pgm->paged_load = stk500v2_paged_load;
   pgm->paged_write = stk500v2_paged_write;
-  pgm->page_erase = stk500v2_page_erase;
+  pgm->page_erase = NULL;
   pgm->chip_erase = stk500v2_chip_erase;
 }
 
@@ -4725,7 +4718,7 @@ void stk500v2_initpgm(PROGRAMMER *pgm) {
    */
   pgm->paged_write    = stk500v2_paged_write;
   pgm->paged_load     = stk500v2_paged_load;
-  pgm->page_erase     = stk500v2_page_erase;
+  pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_set_sck_period;
   pgm->perform_osccal = stk500v2_perform_osccal;
@@ -4854,7 +4847,7 @@ void stk500v2_jtagmkII_initpgm(PROGRAMMER *pgm) {
    */
   pgm->paged_write    = stk500v2_paged_write;
   pgm->paged_load     = stk500v2_paged_load;
-  pgm->page_erase     = stk500v2_page_erase;
+  pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
   pgm->perform_osccal = stk500v2_perform_osccal;
@@ -4888,7 +4881,7 @@ void stk500v2_dragon_isp_initpgm(PROGRAMMER *pgm) {
    */
   pgm->paged_write    = stk500v2_paged_write;
   pgm->paged_load     = stk500v2_paged_load;
-  pgm->page_erase     = stk500v2_page_erase;
+  pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
   pgm->setup          = stk500v2_jtagmkII_setup;
@@ -4983,7 +4976,7 @@ void stk600_initpgm(PROGRAMMER *pgm) {
    */
   pgm->paged_write    = stk500v2_paged_write;
   pgm->paged_load     = stk500v2_paged_load;
-  pgm->page_erase     = stk500v2_page_erase;
+  pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_vtarget    = stk600_set_vtarget;
   pgm->set_varef      = stk600_set_varef;
@@ -5091,7 +5084,7 @@ void stk500v2_jtag3_initpgm(PROGRAMMER *pgm) {
    */
   pgm->paged_write    = stk500v2_paged_write;
   pgm->paged_load     = stk500v2_paged_load;
-  pgm->page_erase     = stk500v2_page_erase;
+  pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_jtag3_set_sck_period;
   pgm->perform_osccal = stk500v2_perform_osccal;


### PR DESCRIPTION
Fixes #1267 

AVRDUDE treats `pgm->page_erase()` as an optional function that should *only* be set if the programmer/part actually can erase pages. jtagmkII, jtag3 and stk500v2 programmers offer page_erase() functions that, in some circumstances, cannot erase pages. This PR attempts to correct this behaviour.