### PR TITLE
Provide programmer arduino_as_isp

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1340,6 +1340,21 @@ programmer
 ;
 
 #------------------------------------------------------------
+# arduino_as_isp
+#------------------------------------------------------------
+
+# Not to be confused with arduinoISP, this is the same as `-c stk500v1`
+# but treats EEPROM r/w correctly for arduino_as_isp programmers
+
+programmer
+    id                     = "arduino_as_isp";
+    desc                   = "Arduino board as programmer using arduino as ISP firmware";
+    type                   = "stk500";
+    prog_modes             = PM_ISP;
+    connection_type        = serial;
+;
+
+#------------------------------------------------------------
 # mib510
 #------------------------------------------------------------
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -966,8 +966,9 @@ static int set_memtype_a_div(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
   if(avr_mem_is_eeprom_type(m)) {
     *memtypep = 'E';
-    // Word addr for bootloaders where part is a "classic" part (eg, optiboot, arduinoisp, ...), byte addr otherwise
-    *a_divp = (pgm->prog_modes & PM_SPM) && !(p->prog_modes & (PM_UPDI | PM_PDI))? 2: 1;
+    // Word addr for bootloaders or Arduino as ISP if part is a "classic" part, byte addr otherwise
+    *a_divp = ((pgm->prog_modes & PM_SPM) || str_caseeq(ldata(lfirst(pgm->id)), "arduino_as_isp")) \
+       && !(p->prog_modes & (PM_UPDI | PM_PDI))? 2: 1;
     return 0;
   }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -108,7 +108,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
 
   for (attempt = 0; attempt < max_sync_attempts; attempt++) {
     // Restart Arduino bootloader for every sync attempt
-    if (strcmp(pgm->type, "Arduino") == 0 && attempt > 0) {
+    if (str_eq(pgm->type, "Arduino") && attempt > 0) {
       // This code assumes a negative-logic USB to TTL serial adapter
       // Pull the RTS/DTR line low to reset AVR: it is still high from open()/last attempt
       serial_set_dtr_rts(&pgm->fd, 1);
@@ -403,7 +403,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   stk500_getparm(pgm, Parm_STK_SW_MINOR, &min);
 
   // MIB510 does not need extparams
-  if (strcmp(ldata(lfirst(pgm->id)), "mib510") == 0)
+  if (str_eq(ldata(lfirst(pgm->id)), "mib510"))
     n_extparms = 0;
   else if ((maj > 1) || ((maj == 1) && (min > 10)))
     n_extparms = 4;
@@ -844,8 +844,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
   stk500_drain(pgm, 0);
 
   // MIB510 init
-  if (strcmp(ldata(lfirst(pgm->id)), "mib510") == 0 &&
-      mib510_isp(pgm, 1) != 0)
+  if (str_eq(ldata(lfirst(pgm->id)), "mib510") && mib510_isp(pgm, 1) != 0)
     return -1;
 
   if (stk500_getsync(pgm) < 0)
@@ -858,7 +857,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
 static void stk500_close(PROGRAMMER * pgm)
 {
   // MIB510 close
-  if (strcmp(ldata(lfirst(pgm->id)), "mib510") == 0)
+  if (str_eq(ldata(lfirst(pgm->id)), "mib510"))
     (void)mib510_isp(pgm, 0);
 
   serial_close(&pgm->fd);
@@ -1003,7 +1002,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   for (; addr < n; addr += block_size) {
     // MIB510 uses fixed blocks size of 256 bytes
-    if (strcmp(ldata(lfirst(pgm->id)), "mib510") == 0) {
+    if (str_eq(ldata(lfirst(pgm->id)), "mib510")) {
       block_size = 256;
     } else {
       if (n - addr < page_size)
@@ -1075,7 +1074,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   n = addr + n_bytes;
   for (; addr < n; addr += block_size) {
     // MIB510 uses fixed blocks size of 256 bytes
-    if (strcmp(ldata(lfirst(pgm->id)), "mib510") == 0) {
+    if (str_eq(ldata(lfirst(pgm->id)), "mib510")) {
       block_size = 256;
     } else {
       if (n - addr < page_size)
@@ -1119,7 +1118,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if (stk500_recv(pgm, buf, 1) < 0)
       return -1;
 
-    if(strcmp(ldata(lfirst(pgm->id)), "mib510") == 0) {
+    if(str_eq(ldata(lfirst(pgm->id)), "mib510")) {
       if (buf[0] != Resp_STK_INSYNC) {
         msg_error("\n");
         pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
@@ -1385,7 +1384,7 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
     }
     msg_info("%sTopcard         : %s\n", p, n);
   }
-  if(strcmp(pgm->type, "Arduino") != 0)
+  if(!str_eq(pgm->type, "Arduino"))
     stk500_print_parms1(pgm, p, stderr);
 
   return;


### PR DESCRIPTION
`-c arduinoAsISP` should be used instead of `-c stk500v1` to correctly treat EEPROM r/w. See #1337, in particular this [comment](https://github.com/avrdudes/avrdude/issues/1337#issuecomment-1575575131).

PS: Also raises the question whether the current git main correctly treats EEPROM with `-c avrisp` or with `-c mib510`. Can somebody test? If the same problems occur with both of these (which I *suspect* they might) then this PR should further change `str_caseeq(ldata(lfirst(pgm->id)), "arduinoAsISP")` with`!str_caseeq(ldata(lfirst(pgm->id)), "stk500v1")`