### PR TITLE
Rewrite fileio functions to cater for a list of memory segments

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -72,6 +72,8 @@ char *fileio_fmtstr(FILEFMT format) {
     return "ELF";
   case FMT_IMM:
     return "in-place immediate";
+  case FMT_EEGG:
+    return "R-number list";
   case FMT_BIN:
     return "0b-binary byte list";
   case FMT_DEC:
@@ -101,6 +103,8 @@ int fileio_fmtchr(FILEFMT format) {
     return 'e';
   case FMT_IMM:
     return 'm';
+  case FMT_EEGG:
+    return 'R';
   case FMT_BIN:
     return 'b';
   case FMT_DEC:
@@ -113,7 +117,6 @@ int fileio_fmtchr(FILEFMT format) {
     return '?';
   }
 }
-
 
 FILEFMT fileio_format(char c) {
   switch (c) {
@@ -131,6 +134,8 @@ FILEFMT fileio_format(char c) {
     return FMT_ELF;
   case 'm':
     return FMT_IMM;
+  case 'R':
+    return FMT_EEGG;
   case 'b':
     return FMT_BIN;
   case 'd':
@@ -148,6 +153,7 @@ typedef enum {
   FIRST_SEG = 1,
   LAST_SEG  = 2,
 } Segorder_t;
+
 
 static void print_ihex_extended_addr(int n_64k, FILE *outf) {
   unsigned char hi = (n_64k >> 8);
@@ -1199,10 +1205,15 @@ static int b2num(const char *filename, FILE *f, const AVRMEM *mem, Segment_t *se
       prefix = "0b";
       base = 2;
       break;
+
+    case FMT_EEGG:
+      prefix = "";
+      base = 'r';
+      break;
   }
 
   for (int i = segp->addr; i < segp->addr + segp->len; i++) {
-    char cbuf[20];
+    char cbuf[81];
 
     if (i > 0) {
       if (putc(',', f) == EOF)
@@ -1218,7 +1229,7 @@ static int b2num(const char *filename, FILE *f, const AVRMEM *mem, Segment_t *se
       if (fputs(prefix, f) == EOF)
         goto writeerr;
     }
-   str_utoa(num, cbuf, base);
+    str_utoa(num, cbuf, base);
     if (fputs(cbuf, f) == EOF)
       goto writeerr;
   }
@@ -1601,6 +1612,7 @@ int fileio_segments(int oprwv, const char *filename, FILEFMT format,
     case FMT_DEC:
     case FMT_OCT:
     case FMT_BIN:
+    case FMT_EEGG:
       thisrc = fileio_num(&fio, fname, f, mem, seglist+i, format);
       break;
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -46,16 +46,14 @@
 #include "libavrdude.h"
 
 
-#define IHEX_MAXDATA 256
-
 #define MAX_LINE_LEN 256  /* max line length for ASCII format input files */
 
-
-struct ihexrec {
+// Common internal record structure for ihex and srec files
+struct ihexsrec {
   unsigned char    reclen;
   unsigned int     loadofs;
   unsigned char    rectyp;
-  unsigned char    data[IHEX_MAXDATA];
+  unsigned char    data[256];
   unsigned char    cksum;
 };
 
@@ -75,9 +73,9 @@ static int b2srec(const unsigned char *inbuf, int bufsize,
 static int srec2b(const char *infile, FILE *inf,
              const AVRMEM *mem, int bufsize, unsigned int fileoffset);
 
-static int ihex_readrec(struct ihexrec *ihex, char *rec);
+static int ihex_readrec(struct ihexsrec *ihex, char *rec);
 
-static int srec_readrec(struct ihexrec *srec, char *rec);
+static int srec_readrec(struct ihexsrec *srec, char *rec);
 
 static int fileio_rbin(struct fioparms *fio,
              const char *filename, FILE *f, const AVRMEM *mem, int size);
@@ -281,8 +279,7 @@ static int b2ihex(const unsigned char *inbuf, int bufsize, int recsize,
 }
 
 
-static int ihex_readrec(struct ihexrec * ihex, char * rec)
-{
+static int ihex_readrec(struct ihexsrec *ihex, char *rec) {
   int i, j;
   char buf[8];
   int offset, len;
@@ -378,7 +375,7 @@ static int ihex2b(const char *infile, FILE *inf,
   int i;
   int lineno;
   int len;
-  struct ihexrec ihex;
+  struct ihexsrec ihex;
   int rc;
 
   lineno   = 0;
@@ -573,8 +570,7 @@ static int b2srec(const unsigned char *inbuf, int bufsize, int recsize,
 }
 
 
-static int srec_readrec(struct ihexrec * srec, char * rec)
-{
+static int srec_readrec(struct ihexsrec* srec, char *rec) {
   int i, j;
   char buf[8];
   int offset, len, addr_width;
@@ -657,7 +653,7 @@ static int srec2b(const char *infile, FILE * inf,
   int i;
   int lineno;
   int len;
-  struct ihexrec srec;
+  struct ihexsrec srec;
   int rc;
   unsigned int reccount;
   unsigned char datarec;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1449,7 +1449,7 @@ int fileio(int op, const char *filename, FILEFMT format,
 
 
 // Normalise segment address and length to be non-negative
-int segmemt_normalise(AVRMEM *mem, Segment_t *segp) {
+int segmemt_normalise(const AVRMEM *mem, Segment_t *segp) {
   int addr = segp->addr, len = segp->len, maxsize = mem->size;
   int digits = maxsize > 0x10000? 5: 4;
 
@@ -1479,7 +1479,7 @@ int segmemt_normalise(AVRMEM *mem, Segment_t *segp) {
 
 
 static int fileio_segments_normalise(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, AVRMEM *mem, int n, Segment_t *seglist) {
+  const AVRPART *p, const AVRMEM *mem, int n, Segment_t *seglist) {
 
   int op, rc;
   FILE * f;
@@ -1630,7 +1630,7 @@ static int fileio_segments_normalise(int oprwv, const char *filename, FILEFMT fo
 }
 
 int fileio_segments(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, AVRMEM *mem, int n, const Segment_t *list) {
+  const AVRPART *p, const AVRMEM *mem, int n, const Segment_t *list) {
 
   Segment_t *seglist = cfg_malloc(__func__, n*sizeof*seglist);
   memcpy(seglist, list, n*sizeof*seglist);

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1,6 +1,7 @@
 /*
  * avrdude - A Downloader/Uploader for AVR device programmers
  * Copyright (C) 2000-2004  Brian S. Dean <bsd@bsdhome.com>
+ * Copyright (C) 2023 Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1287,7 +1287,7 @@ static int fileio_num(struct fioparms *fio,
 }
 
 
-int fileio_setparms(int op, struct fioparms *fp, const AVRPART *p, const AVRMEM * m) {
+static int fileio_setparms(int op, struct fioparms *fp, const AVRPART *p, const AVRMEM *m) {
   fp->op = op;
 
   switch (op) {

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -176,7 +176,7 @@ static void print_ihex_extended_addr(int n_64k, FILE *outf) {
  * Return the maximum memory address within mem->buf that was read from
  * plus one. If an error occurs, return -1.
  */
-static int b2ihex(const unsigned char *buf, Segment_t *segp, Segorder_t where,
+static int b2ihex(const unsigned char *buf, const Segment_t *segp, Segorder_t where,
   int recsize, int startaddr, const char *outfile_unused, FILE *outf,
   FILEFMT ffmt) {
 
@@ -339,7 +339,7 @@ static int ihex_readrec(struct ihexsrec *ihex, char * rec) {
  * plus one. If an error occurs, return -1.
  */
 static int ihex2b(const char *infile, FILE *inf, const AVRMEM *mem,
-  Segment_t *segp, unsigned int fileoffset, FILEFMT ffmt) {
+  const Segment_t *segp, unsigned int fileoffset, FILEFMT ffmt) {
 
   const char *errstr;
   unsigned int nextaddr, baseaddr, maxaddr;
@@ -458,7 +458,7 @@ static unsigned int cksum_srec(const unsigned char *buf, int n, unsigned addr, i
 
 
 // Binary to Motorola S-Record, see https://en.wikipedia.org/wiki/SREC_(file_format)
-static int b2srec(const AVRMEM *mem, Segment_t *segp, Segorder_t where,
+static int b2srec(const AVRMEM *mem, const Segment_t *segp, Segorder_t where,
   int recsize, int startaddr, const char *outfile_unused, FILE *outf) {
 
   const unsigned char *buf;
@@ -609,7 +609,7 @@ static int srec_readrec(struct ihexsrec *srec, char *rec) {
 
 // Motorola S-Record to binary
 static int srec2b(const char *infile, FILE * inf,
-  const AVRMEM *mem, Segment_t *segp, unsigned int fileoffset) {
+  const AVRMEM *mem, const Segment_t *segp, unsigned int fileoffset) {
 
   const char *errstr;
   unsigned int nextaddr, maxaddr;
@@ -823,7 +823,7 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
 
 // ELF format to binary (the memory segment to read into is ignored)
 static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
-  const AVRPART *p, Segment_t *segp_unused, unsigned int fileoffset_unused) {
+  const AVRPART *p, const Segment_t *segp_unused, unsigned int fileoffset_unused) {
 
   Elf *e;
   int rv = 0, size = 0;
@@ -1033,7 +1033,7 @@ done:
 
 // Read/write binary files and return highest memory addr set + 1
 static int fileio_rbin(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, Segment_t *segp) {
+  const AVRMEM *mem, const Segment_t *segp) {
 
   int rc;
   switch (fio->op) {
@@ -1061,7 +1061,7 @@ static int fileio_rbin(struct fioparms *fio, const char *filename, FILE *f,
 
 
 static int fileio_imm(struct fioparms *fio, const char *fname, FILE *f_unused,
- const AVRMEM *mem, Segment_t *segp) {
+ const AVRMEM *mem, const Segment_t *segp) {
 
   char *tok, *p, *line;
   const char *errstr;
@@ -1100,7 +1100,7 @@ static int fileio_imm(struct fioparms *fio, const char *fname, FILE *f_unused,
 
 
 static int fileio_ihex(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, Segment_t *segp, FILEFMT ffmt, Segorder_t where) {
+  const AVRMEM *mem, const Segment_t *segp, FILEFMT ffmt, Segorder_t where) {
 
   int rc;
 
@@ -1123,7 +1123,7 @@ static int fileio_ihex(struct fioparms *fio, const char *filename, FILE *f,
 
 
 static int fileio_srec(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, Segment_t *segp, Segorder_t where) {
+  const AVRMEM *mem, const Segment_t *segp, Segorder_t where) {
 
   int rc;
 
@@ -1147,7 +1147,7 @@ static int fileio_srec(struct fioparms *fio, const char *filename, FILE *f,
 
 #ifdef HAVE_LIBELF
 static int fileio_elf(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const AVRPART *p, Segment_t *segp) {
+  const AVRMEM *mem, const AVRPART *p, const Segment_t *segp) {
 
   int rc;
 
@@ -1171,7 +1171,7 @@ static int fileio_elf(struct fioparms *fio, const char *filename, FILE *f,
 #endif
 
 
-static int b2num(const char *filename, FILE *f, const AVRMEM *mem, Segment_t *segp, FILEFMT fmt) {
+static int b2num(const char *filename, FILE *f, const AVRMEM *mem, const Segment_t *segp, FILEFMT fmt) {
   const char *prefix;
   int base;
 
@@ -1235,7 +1235,7 @@ static int b2num(const char *filename, FILE *f, const AVRMEM *mem, Segment_t *se
 }
 
 
-static int num2b(const char *filename, FILE *f, const AVRMEM *mem, Segment_t *segp) {
+static int num2b(const char *filename, FILE *f, const AVRMEM *mem, const Segment_t *segp) {
   const char *geterr = NULL;
   char *line;
   int n = segp->addr, end = segp->addr + segp->len;
@@ -1271,7 +1271,7 @@ static int num2b(const char *filename, FILE *f, const AVRMEM *mem, Segment_t *se
 
 
 static int fileio_num(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, Segment_t *segp, FILEFMT fmt) {
+  const AVRMEM *mem, const Segment_t *segp, FILEFMT fmt) {
 
   switch (fio->op) {
     case FIO_WRITE:
@@ -1443,7 +1443,7 @@ int fileio(int op, const char *filename, FILEFMT format,
   if(size < 0 || op == FIO_READ || FIO_READ_FOR_VERIFY)
     size = mem->size;
 
-  Segment_t seg = {0, size};
+  const Segment_t seg = {0, size};
   return fileio_segments(op, filename, format, p, mem, 1, &seg);
 }
 
@@ -1478,7 +1478,7 @@ int segmemt_normalise(AVRMEM *mem, Segment_t *segp) {
 }
 
 
-int fileio_segments(int oprwv, const char *filename, FILEFMT format,
+static int fileio_segments_normalise(int oprwv, const char *filename, FILEFMT format,
   const AVRPART *p, AVRMEM *mem, int n, Segment_t *seglist) {
 
   int op, rc;
@@ -1628,3 +1628,15 @@ int fileio_segments(int oprwv, const char *filename, FILEFMT format,
 
   return rc;
 }
+
+int fileio_segments(int oprwv, const char *filename, FILEFMT format,
+  const AVRPART *p, AVRMEM *mem, int n, const Segment_t *list) {
+
+  Segment_t *seglist = cfg_malloc(__func__, n*sizeof*seglist);
+  memcpy(seglist, list, n*sizeof*seglist);
+  int ret = fileio_segments_normalise(oprwv, filename, format, p, mem, n, seglist);
+  free(seglist);
+
+  return ret;
+}
+

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -58,50 +58,6 @@ struct ihexsrec {
 };
 
 
-static int b2ihex(const unsigned char *inbuf, int bufsize,
-             int recsize, int startaddr,
-             const char *outfile, FILE *outf, FILEFMT ffmt);
-
-static int ihex2b(const char *infile, FILE *inf,
-             const AVRMEM *mem, int bufsize, unsigned int fileoffset,
-             FILEFMT ffmt);
-
-static int b2srec(const unsigned char *inbuf, int bufsize,
-             int recsize, int startaddr,
-             const char *outfile, FILE *outf);
-
-static int srec2b(const char *infile, FILE *inf,
-             const AVRMEM *mem, int bufsize, unsigned int fileoffset);
-
-static int ihex_readrec(struct ihexsrec *ihex, char *rec);
-
-static int srec_readrec(struct ihexsrec *srec, char *rec);
-
-static int fileio_rbin(struct fioparms *fio,
-             const char *filename, FILE *f, const AVRMEM *mem, int size);
-
-static int fileio_ihex(struct fioparms *fio,
-             const char *filename, FILE *f, const AVRMEM *mem, int size,
-             FILEFMT ffmt);
-
-static int fileio_srec(struct fioparms *fio,
-             const char *filename, FILE *f, const AVRMEM *mem, int size);
-
-#ifdef HAVE_LIBELF
-static int elf2b(const char *infile, FILE *inf,
-                 const AVRMEM *mem, const AVRPART *p,
-                 int bufsize, unsigned int fileoffset);
-
-static int fileio_elf(struct fioparms *fio,
-             const char *filename, FILE *f, const AVRMEM *mem,
-             const AVRPART *p, int size);
-#endif
-
-static int fileio_num(struct fioparms *fio,
-             const char *filename, FILE *f, const AVRMEM *mem, int size,
-             FILEFMT fmt);
-
-
 char *fileio_fmtstr(FILEFMT format) {
   switch (format) {
   case FMT_AUTO:
@@ -1705,4 +1661,3 @@ int fileio_segments(int oprwv, const char *filename, FILEFMT format,
 
   return rc;
 }
-

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -814,8 +814,9 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
 }
 
 
+// ELF format to binary (the memory segment to read into is ignored)
 static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
-  const AVRPART *p, int bufsize_unused, unsigned int fileoffset_unused) {
+  const AVRPART *p, Segment_t *segp_unused, unsigned int fileoffset_unused) {
 
   Elf *e;
   int rv = 0, size = 0;
@@ -1148,10 +1149,9 @@ static int fileio_srec(struct fioparms *fio, const char *filename, FILE *f,
 
 
 #ifdef HAVE_LIBELF
-static int fileio_elf(struct fioparms *fio,
-             const char *filename, FILE *f, const AVRMEM *mem,
-             const AVRPART *p, int size)
-{
+static int fileio_elf(struct fioparms *fio, const char *filename, FILE *f,
+  const AVRMEM *mem, const AVRPART *p, Segment_t *segp) {
+
   int rc;
 
   switch (fio->op) {
@@ -1161,7 +1161,7 @@ static int fileio_elf(struct fioparms *fio,
       break;
 
     case FIO_READ:
-      rc = elf2b(filename, f, mem, p, size, fio->fileoffset);
+      rc = elf2b(filename, f, mem, p, segp, fio->fileoffset);
       return rc;
 
     default:
@@ -1586,7 +1586,7 @@ int fileio_segments(int oprwv, const char *filename, FILEFMT format,
 
     case FMT_ELF:
 #ifdef HAVE_LIBELF
-      thisrc = fileio_elf(&fio, fname, f, mem, p, size);
+      thisrc = fileio_elf(&fio, fname, f, mem, p, seglist+i);
       break;
 #else
       pmsg_error("cannot handle ELF file %s, ELF file support was not compiled in\n", fname);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1227,6 +1227,7 @@ int str_caseeq(const char *str1, const char *str2);
 int str_match(const char *pattern, const char *string);
 int str_casematch(const char *pattern, const char *string);
 char *str_sprintf(const char *fmt, ...);
+char *str_fgets(FILE *fp, const char **errpp);
 char *str_lc(char *s);
 char *str_uc(char *s);
 char *str_lcfirst(char *s);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1039,7 +1039,7 @@ int fileio(int oprwv, const char *filename, FILEFMT format,
 int segmemt_normalise(AVRMEM *mem, Segment_t *segp);
 
 int fileio_segments(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, AVRMEM *mem, int n, Segment_t *seglist);
+  const AVRPART *p, AVRMEM *mem, int n, const Segment_t *seglist);
 
 #ifdef __cplusplus
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -989,6 +989,7 @@ typedef enum {
   FMT_IHEX,
   FMT_RBIN,
   FMT_IMM,
+  FMT_EEGG,
   FMT_HEX,
   FMT_DEC,
   FMT_OCT,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1036,10 +1036,10 @@ int fileio_fmt_autodetect(const char *fname);
 int fileio(int oprwv, const char *filename, FILEFMT format,
   const AVRPART *p, const char *memtype, int size);
 
-int segmemt_normalise(AVRMEM *mem, Segment_t *segp);
+int segmemt_normalise(const AVRMEM *mem, Segment_t *segp);
 
 int fileio_segments(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, AVRMEM *mem, int n, const Segment_t *seglist);
+  const AVRPART *p, const AVRMEM *mem, int n, const Segment_t *seglist);
 
 #ifdef __cplusplus
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1006,6 +1006,10 @@ struct fioparms {
   unsigned int fileoffset;
 };
 
+typedef struct {
+  int addr, len;
+} Segment_t;
+
 enum {
   FIO_READ,
   FIO_WRITE,
@@ -1029,7 +1033,12 @@ int fileio_fmt_autodetect_fp(FILE *f);
 int fileio_fmt_autodetect(const char *fname);
 
 int fileio(int oprwv, const char *filename, FILEFMT format,
-      const AVRPART *p, const char *memtype, int size);
+  const AVRPART *p, const char *memtype, int size);
+
+int segmemt_normalise(AVRMEM *mem, Segment_t *segp);
+
+int fileio_segments(int oprwv, const char *filename, FILEFMT format,
+  const AVRPART *p, AVRMEM *mem, int n, Segment_t *seglist);
 
 #ifdef __cplusplus
 }

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -24,6 +24,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <ctype.h>
+
 #include "libavrdude.h"
 
 // Return 1 if str starts with starts, 0 otherwise
@@ -233,6 +234,47 @@ char *str_sprintf(const char *fmt, ...) {
     *p = 0;
 
   return p;
+}
+
+
+// Reads a potentially long line and returns it in a malloc'd buffer
+char *str_fgets(FILE *fp, const char **errpp) {
+  int bs = 1023;                // Must be 2^n - 1
+  char *ret = (char *) cfg_malloc(__func__, bs);
+
+  ret[bs-2] = 0;
+  if(!fgets(ret, bs, fp)) {
+    free(ret);
+    if(errpp)
+      *errpp = ferror(fp) && !feof(fp)? "I/O error": NULL;
+    return NULL;
+  }
+
+  while(ret[bs-2] != 0 && ret[bs-2] != '\n' && ret[bs-2] != '\r') {
+    if(bs >= INT_MAX/2) {
+      free(ret);
+      if(errpp)
+        *errpp = "cannot cope with lines longer than INT_MAX/2 bytes";
+      return NULL;
+    }
+    int was = bs;
+    bs = 2*bs+1;
+    ret = cfg_realloc(__func__, ret, bs);
+    ret[was-1] = ret[bs-2] = 0;
+    if(!fgets(ret+was-1, bs-(was-1), fp)) { // EOF? Error?
+      if(ferror(fp)) {
+        free(ret);
+        if(errpp)
+          *errpp = "I/O error";
+        return NULL;
+      }
+      break;
+    }
+  }
+
+  if(errpp)
+    *errpp = NULL;
+  return ret;
 }
 
 

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -310,6 +310,30 @@ char *str_utoa(unsigned n, char *buf, int base) {
   unsigned q;
   char *cp;
 
+  if(base == 'r') {
+    const char *units = "IVXLCDMFTYHSNabcdefghijkl";
+    const char *rep[10] = {"", "a", "aa", "aaa", "ab", "b", "ba", "baa", "baaa", "ac"};
+
+    if(n == 0) {
+      strcpy(buf, "0");
+      return buf;
+    }
+
+    int i = 0;
+    for(unsigned u = n; u; u /= 10)
+      i++;
+    for(*buf = 0; i > 0; i--) {
+      unsigned u = n;
+      for(int j=1; j<i; j++)
+        u /= 10;
+      char *q = buf+strlen(buf);
+      for(const char *p = rep[u%10], *d = units + (i-1)*2; *p; p++)
+        *q++ = d[*p-'a'];
+      *q = 0;
+    }
+    return buf;
+  }
+
   if(base < 2 || base > 36) {
     *buf = 0;
     return buf;


### PR DESCRIPTION
The `fileio.c` functions all have a granularity of the complete AVR memory, which matches what is needed in `-U`. In order to enable writing of memory intervals in the terminal this PR updates the I/O functions in `fileio.c` for later use.

Also fixes Issues #1390 and #1391.