### PR TITLE
Provide subshell command `!` in the terminal

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1162,6 +1162,9 @@ Leave terminal mode and thus
 .Nm avrdude .
 .It Ar q
 Can be used as an alias for quit.
+.It Ar !<line>
+Run the shell <line> in a subshell, eg, !ls *.hex. Subshell commands are
+always complete lines on their own.
 .El
 .Pp
 The terminal commands below may only be implemented on some specific programmers, and may therefore not be available in the help menu.

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1163,8 +1163,15 @@ Leave terminal mode and thus
 .It Ar q
 Can be used as an alias for quit.
 .It Ar !<line>
-Run the shell <line> in a subshell, eg, !ls *.hex. Subshell commands are
-always complete lines on their own.
+Run the shell <line> in a subshell, eg, !ls *.hex. Subshell commands take the
+rest of the line as their command. For security reasons, they must
+explictly be enabled by putting
+.Pa allow_subshells = yes;
+into your
+.Pa ${HOME}/.config/avrdude/avrdude.rc
+or
+.Pa ${HOME}/.avrduderc
+file.
 .El
 .Pp
 The terminal commands below may only be implemented on some specific programmers, and may therefore not be available in the help menu.

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -421,6 +421,7 @@ default_serial     = "@DEFAULT_SER_PORT@";
 default_spi        = "@DEFAULT_SPI_PORT@";
 # default_bitclock = 2.5;
 default_linuxgpio  = "@DEFAULT_LINUXGPIO_PORT@";
+allow_subshells    = no;
 
 @HAVE_PARPORT_BEGIN@
 

--- a/src/config.c
+++ b/src/config.c
@@ -41,6 +41,7 @@ const char *default_serial;
 const char *default_spi;
 double default_bitclock;
 char const *default_linuxgpio;
+int allow_subshells;
 
 LISTID       string_list;
 LISTID       number_list;

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -73,6 +73,7 @@ static int pin_name;
 %token K_PAGE_SIZE
 
 %token K_ALIAS
+%token K_ALLOW_SUBSHELLS
 %token K_BUFF
 %token K_CONNTYPE
 %token K_DEDICATED
@@ -230,6 +231,11 @@ def :
 
   K_DEFAULT_BITCLOCK TKN_EQUAL number_real TKN_SEMI {
     default_bitclock = $3->value.number_real;
+    free_token($3);
+  } |
+
+  K_ALLOW_SUBSHELLS TKN_EQUAL numexpr TKN_SEMI {
+    allow_subshells = $3->value.number;
     free_token($3);
   } |
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -905,6 +905,7 @@ void dev_output_pgm_part(int dev_opt_c, const char *programmer, int dev_opt_p, c
     dev_info("default_spi        = %s;\n", p = cfg_escape(default_spi)); free(p);
     dev_info("default_bitclock   = %7.5f;\n", default_bitclock);
     dev_info("default_linuxgpio  = %s;\n", p = cfg_escape(default_linuxgpio)); free(p);
+    dev_info("allow_subshells    = %s;\n", allow_subshells? "yes": "no");
 
     dev_info("\n#\n# PROGRAMMER DEFINITIONS\n#\n\n");
   }

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2283,8 +2283,10 @@ Can be used as an alias for @code{quit}.
 
 @item !@var{line}
 Run the shell @var{line} in a subshell, eg, @code{!ls *.hex}. Subshell
-commands are always complete lines on their own.
-
+commands take the rest of the line as their command. For security reasons,
+they must  be enabled explictly by putting @code{allow_subshells = yes;}
+into your @code{$@{HOME@}/.config/avrdude/avrdude.rc} or
+@code{$@{HOME@}/.avrduderc} file.
 
 @end table
 

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -3608,7 +3608,7 @@ compiler version that still supports MinGW builds, or use MinGW
 @noindent
 AVRDUDE on Windows looks for a system configuration file name of
 @code{avrdude.conf} and looks for a user override configuration file of
-@code{avrdude.rc}.
+@code{avrdude.rc} in the same directory where avrdude.exe is located.
 
 @c
 @c Node

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2281,6 +2281,11 @@ Leave terminal mode and thus AVRDUDE.
 @item q
 Can be used as an alias for @code{quit}.
 
+@item !@var{line}
+Run the shell @var{line} in a subshell, eg, @code{!ls *.hex}. Subshell
+commands are always complete lines on their own.
+
+
 @end table
 
 @noindent

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2701,6 +2701,15 @@ option.
 Assign the default bitclock value.  Can be overridden using the @option{-B}
 option.
 
+@item allow_subshells = @var{no};
+Whether or not AVRDUDE's interactive terminal is allowed to use subshell
+@code{!} commands. This defaults to no for security reasons, eg, in the
+rare case @code{avrdude -t} is set up with attached hardware to provide a
+web service, remote ssh or a login on a PC instead of a shell, say, for
+demo or training purposes. In almost all other cases this can be
+overridden in the personal @code{avrddude.rc} or @code{.avrduderc}
+configuration file with @var{yes}.
+
 @end table
 
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -179,6 +179,7 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
 }
 
 alias            { yylval=NULL; return K_ALIAS; }
+allow_subshells  { yylval=NULL; return K_ALLOW_SUBSHELLS; }
 allowfullpagebitstream { yylval=NULL; ccap(); return K_ALLOWFULLPAGEBITSTREAM; }
 buff             { yylval=NULL; ccap(); return K_BUFF; }
 chip_erase       { yylval=new_token(K_CHIP_ERASE); ccap(); return K_CHIP_ERASE; }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1136,14 +1136,15 @@ void walk_programmer_types(/*LISTID programmer_types,*/ walk_programmer_types_cb
 
 /* formerly config.h */
 
-extern LISTID       part_list;
-extern LISTID       programmers;
+extern LISTID      part_list;
+extern LISTID      programmers;
 extern const char *default_programmer;
 extern const char *default_parallel;
 extern const char *default_serial;
 extern const char *default_spi;
-extern double       default_bitclock;
-extern char const * default_linuxgpio;
+extern double      default_bitclock;
+extern char const *default_linuxgpio;
+extern int         allow_subshells;
 
 /* This name is fixed, it's only here for symmetry with
  * default_parallel and default_serial. */

--- a/src/main.c
+++ b/src/main.c
@@ -573,6 +573,7 @@ int main(int argc, char * argv [])
   default_spi        = "";
   default_bitclock   = 0.0;
   default_linuxgpio  = "";
+  allow_subshells    = 0;
 
   init_config();
 

--- a/src/term.c
+++ b/src/term.c
@@ -1785,8 +1785,8 @@ static int cmd_quell(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
 /*
  * Simplified shell-like tokenising of a command line, which is broken up
  * into an (argc, argv) style pointer array until
- *   - A token ends with a semicolon, which is set to nul
- *   - A token starts with a comment character #
+ *   - A not end-of-line token ends with a semicolon, which is set to nul
+ *   - A token starts with a comment character # or subshell character !
  *   - The end of the string is encountered
  *
  * Tokenisation takes single and double quoted strings into consideration. In
@@ -1820,16 +1820,23 @@ static char *tokenize(char *s, int *argcp, char ***argvp) {
   buf  = (char *) (argv+nargs+1);
 
   for(n=0, r=s; *r; ) {
-    q = str_nexttok(r, " \t\n\r\v\f", &r);
-    if(*q == '#') {             // Inline comment: ignore rest of line
+    if(n == 0 && *r == '!') {   // Subshell command ! takes rest of line
+      q = r;
       r = q+strlen(q);
-      break;
+    } else {
+      q = str_nexttok(r, " \t\n\r\v\f", &r);
+      if(*q == '#') {           // Inline comment: ignore rest of line
+        r = q+strlen(q);
+        break;
+      }
     }
     strcpy(buf, q);
     if(*buf && !str_eq(buf, ";")) // Don't record empty arguments
       argv[n++] = buf;
-    buf += strlen(q) + 1;
-    if(buf[-2] == ';') {        // Command separator
+
+    size_t len = strlen(q);
+    buf += len + 1;
+    if(n && **argv != '!' && len > 1 && buf[-2] == ';') { // End command
       buf[-2] = 0;
       break;
     }
@@ -1896,29 +1903,32 @@ static int process_line(char *q, const PROGRAMMER *pgm, const AVRPART *p) {
   if (!*q || (*q == '#'))
     return 0;
 
-  if(*q == '!') {
-    if(allow_subshells) {
-      while(*++q && isspace((unsigned char) *q))
-        continue;
-      errno = 0;
-      int shret = *q? system(q): 0;
-      if(errno)
-        pmsg_warning("system() call returned %d: %s\n", shret, strerror(errno));
-    } else {
-      pmsg_warning("subshell commands are by default not allowed in the terminal\n");
-      imsg_warning("allow_subshells = yes; in avrdude.rc or ~/.avrduderc changes this\n");
-    }
-    return 0;
-  }
-
-  // Tokenize command line
+  // Tokenise command line
   do {
     argc = 0; argv = NULL;
     q = tokenize(q, &argc, &argv);
     if(!q)
       return -1;
+
     if(argc <= 0 || !argv)
       continue;
+
+    if(argc == 1 && **argv == '!') {
+      if(allow_subshells) {
+        for(q=argv[0]+1; *q && isspace((unsigned char) *q); q++)
+          continue;
+        errno = 0;
+        int shret = *q? system(q): 0;
+        if(errno)
+          pmsg_warning("system() call returned %d: %s\n", shret, strerror(errno));
+      } else {
+        pmsg_warning("subshell commands are by default not allowed in the terminal\n");
+        imsg_warning("allow_subshells = yes; in avrdude.rc or ~/.avrduderc changes this\n");
+      }
+      free(argv);
+      return 0;
+    }
+
     // Run the command
     rc = do_cmd(pgm, p, argc, argv);
     free(argv);

--- a/src/term.c
+++ b/src/term.c
@@ -1924,7 +1924,7 @@ static int process_line(char *q, const PROGRAMMER *pgm, const AVRPART *p) {
       } else {
         pmsg_info("by default subshell commands are not allowed in the terminal; to change put\n");
 #if defined(WIN32)
-        imsg_info("allow_subshells = yes; into " USER_CONF_FILE "\n");
+        imsg_info("allow_subshells = yes; into " USER_CONF_FILE " in the avrdude.exe directory\n");
 #else
         imsg_info("allow_subshells = yes; into ~/.config/avrdude/avrdude.rc or ~/.avrduderc\n");
 #endif

--- a/src/term.c
+++ b/src/term.c
@@ -1675,7 +1675,7 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
     term_out(cmd[i].desc, cmd[i].name);
     term_out("\n");
   }
-  term_out("\n"
+  term_out("  !<scmd> : run the command <scmd> in a subshell, eg, !ls\n\n"
     "For more details about a terminal command cmd type cmd -?\n\n"
     "Note that not all programmer derivatives support all commands. Flash and\n"
     "EEPROM type memories are normally read and written using a cache via paged\n"
@@ -1895,6 +1895,21 @@ static int process_line(char *q, const PROGRAMMER *pgm, const AVRPART *p) {
   // Skip blank lines and comments
   if (!*q || (*q == '#'))
     return 0;
+
+  if(*q == '!') {
+    if(allow_subshells) {
+      while(*++q && isspace((unsigned char) *q))
+        continue;
+      errno = 0;
+      int shret = *q? system(q): 0;
+      if(errno)
+        pmsg_warning("system() call returned %d: %s\n", shret, strerror(errno));
+    } else {
+      pmsg_warning("subshell commands are by default not allowed in the terminal\n");
+      imsg_warning("allow_subshells = yes; in avrdude.rc or ~/.avrduderc changes this\n");
+    }
+    return 0;
+  }
 
   // Tokenize command line
   do {

--- a/src/term.c
+++ b/src/term.c
@@ -1922,8 +1922,12 @@ static int process_line(char *q, const PROGRAMMER *pgm, const AVRPART *p) {
         if(errno)
           pmsg_warning("system() call returned %d: %s\n", shret, strerror(errno));
       } else {
-        pmsg_warning("subshell commands are by default not allowed in the terminal\n");
-        imsg_warning("allow_subshells = yes; in avrdude.rc or ~/.avrduderc changes this\n");
+        pmsg_info("by default subshell commands are not allowed in the terminal; to change put\n");
+#if defined(WIN32)
+        imsg_info("allow_subshells = yes; into " USER_CONF_FILE "\n");
+#else
+        imsg_info("allow_subshells = yes; into ~/.config/avrdude/avrdude.rc or ~/.avrduderc\n");
+#endif
       }
       free(argv);
       return 0;

--- a/src/term.c
+++ b/src/term.c
@@ -1675,7 +1675,7 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
     term_out(cmd[i].desc, cmd[i].name);
     term_out("\n");
   }
-  term_out("  !<scmd> : run the command <scmd> in a subshell, eg, !ls\n\n"
+  term_out("  !<line> : run the shell <line> in a subshell, eg, !ls *.hex\n\n"
     "For more details about a terminal command cmd type cmd -?\n\n"
     "Note that not all programmer derivatives support all commands. Flash and\n"
     "EEPROM type memories are normally read and written using a cache via paged\n"


### PR DESCRIPTION
Needs to have `allow_subshells = yes;` in `~/.avrduderc` so subshell commands can be executed, eg,

```
$ avrdude -t

avrdude> !ls
myapplication.hex    myapplication.eep

avrdude> !avrdude -pm328p/St | grep efuse.initval
.ptmm   ATmega328P      efuse   initval 0xff
```
