### PR TITLE
Document terminal comments

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1185,6 +1185,8 @@ into your
 or
 .Pa ${HOME}/.avrduderc
 file.
+.It Ar # <comment>
+Place comments onto the terminal line (useful for scripts).
 .El
 .Pp
 The terminal commands below may only be implemented on some specific programmers, and may therefore not be available in the help menu.

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2299,6 +2299,9 @@ they must  be enabled explictly by putting @code{allow_subshells = yes;}
 into your @code{$@{HOME@}/.config/avrdude/avrdude.rc} or
 @code{$@{HOME@}/.avrduderc} file.
 
+@item # @var{comment}
+Place comments onto the terminal line (useful for scripts).
+
 @end table
 
 @noindent

--- a/src/term.c
+++ b/src/term.c
@@ -1783,8 +1783,11 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
     term_out(cmd[i].desc, cmd[i].name);
     term_out("\n");
   }
-  term_out("  !<line> : run the shell <line> in a subshell, eg, !ls *.hex\n\n"
-    "For more details about a terminal command cmd type cmd -?\n\n"
+  term_out(
+    "\nFor more details about a terminal command cmd type cmd -?\n\n"
+    "Other:\n"
+    "  !<line> : run the shell <line> in a subshell, eg, !ls *.hex\n"
+    "  # ...   : ignore rest of line (eg, used as comments in scripts)\n\n"
     "Note that not all programmer derivatives support all commands. Flash and\n"
     "EEPROM type memories are normally read and written using a cache via paged\n"
     "read and write access; the cache is synchronised on quit or flush commands.\n"


### PR DESCRIPTION
New help message in the terminal

```
$ avrdude -qqT help
Valid commands:
  dump    : display a memory section as hex dump
  read    : alias for dump
  write   : write data to memory; flash and EEPROM are cached
  save    : save memory data to file
  flush   : synchronise flash and EEPROM cache with the device
  abort   : abort flash and EEPROM writes, ie, reset the r/w cache
  erase   : perform a chip or memory erase
  config  : change or show configuration properties of the part
  sig     : display device signature bytes
  part    : display the current part information
  send    : send a raw command to the programmer
  verbose : display or set -v verbosity level
  quell   : display or set -q quell level for progress bars
  help    : show help message
  ?       : same as help
  quit    : synchronise flash/EEPROM cache with device and quit
  q       : abbreviation for quit

For more details about a terminal command cmd type cmd -?

Other:
  !<line> : run the shell <line> in a subshell, eg, !ls *.hex
  # ...   : ignore rest of line (eg, used as comments in scripts)

Note that not all programmer derivatives support all commands. Flash and
EEPROM type memories are normally read and written using a cache via paged
read and write access; the cache is synchronised on quit or flush commands.
The part command displays valid memory types for use with dump and write.
```