### PR TITLE
Run -t interactive terminals when it is their turn wrt -t/-T/-U options

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -698,7 +698,7 @@ is no longer present. They are silently ignored for backwards compatibility.
 .It Fl T Ar cmd
 Run terminal line
 .Ar cmd
-when it is its turn in relation to other -t interactive terminal shells,
+when it is its turn in relation to other -t interactive terminals
 -T terminal commands and -U memory operations. Except for the simplest
 of terminal commands the argument
 .Ar cmd
@@ -707,8 +707,8 @@ details. See below for a detailed description of all terminal commands.
 .It Fl t
 Tells
 .Nm
-to run an interactive terminal shell when it is its turn in relation to
-other -t interactive terminal shells, -T terminal commands and -U memory
+to run an interactive terminal when it is its turn in relation to
+other -t interactive terminals, -T terminal commands and -U memory
 operations.
 .It Xo Fl U Ar memory Ns
 .Ar \&: Ns Ar op Ns
@@ -716,7 +716,7 @@ operations.
 .Op \&: Ns Ar format
 .Xc
 Perform a memory operation as indicated  when it is its turn in relation to
-other -t interactive terminal shells, -T terminal commands and -U memory
+other -t interactive terminals, -T terminal commands and -U memory
 operations. The
 .Ar memory
 field specifies the memory to operate on. The available memory types are

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -696,31 +696,31 @@ to the device.  Specify it more often for even quieter operations.
 These options used to control the obsolete "safemode" feature which
 is no longer present. They are silently ignored for backwards compatibility.
 .It Fl T Ar cmd
-Slots a terminal command line
+Run terminal line
 .Ar cmd
-into the intermixed list of -T terminal commands and -U memory operations.
-The terminal command line is executed when it is its turn in the mixed list.
-Except for the simplest of terminal commands the argument
+when it is its turn in relation to other -t interactive terminal shells,
+-T terminal commands and -U memory operations. Except for the simplest
+of terminal commands the argument
 .Ar cmd
 will most likely need to be set in quotes, see your OS shell manual for
-details.
+details. See below for a detailed description of all terminal commands.
 .It Fl t
 Tells
 .Nm
-to enter the interactive terminal shell before up- or downloading files
-via the -U option or processing other -T terminal commands, if any. See
-below for a detailed description of the terminal mode.
+to run an interactive terminal shell when it is its turn in relation to
+other -t interactive terminal shells, -T terminal commands and -U memory
+operations.
 .It Xo Fl U Ar memory Ns
 .Ar \&: Ns Ar op Ns
 .Ar \&: Ns Ar filename Ns
 .Op \&: Ns Ar format
 .Xc
-Perform a memory operation as indicated. Multiple -U operations are
-allowed. The
+Perform a memory operation as indicated  when it is its turn in relation to
+other -t interactive terminal shells, -T terminal commands and -U memory
+operations. The
 .Ar memory
-field specifies the memory to operate on.
-The available memory types are device-dependent, the actual
-configuration can be viewed with the
+field specifies the memory to operate on. The available memory types are
+device-dependent, the actual configuration can be viewed with the
 .Cm part
 command in terminal mode.
 Typically, a device's memory configuration at least contains

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -759,20 +759,20 @@ is no longer present. They are silently ignored for backwards compatibility.
 
 @item -T @var{cmd}
 Run terminal line @var{cmd} when it is its turn in relation to other
-@code{-t} interactive terminal shells, @code{-T} terminal commands and
+@code{-t} interactive terminals, @code{-T} terminal commands and
 @code{-U} memory operations. Except for the simplest of terminal commands
 the argument @var{cmd} will most likely need to be set in quotes, see your
 OS shell manual for details. See below for a detailed description of all
 terminal commands.
 
 @item -t
-Tells AVRDUDE to run an interactive terminal shell when it is its turn in
-relation to other @code{-t} interactive terminal shells, @code{-T}
+Tells AVRDUDE to run an interactive terminal when it is its turn in
+relation to other @code{-t} interactive terminals, @code{-T}
 terminal commands and @code{-U} memory operations.
 
 @item -U @var{memory}:@var{op}:@var{filename}[:@var{format}]
 Perform a memory operation when it is its turn in relation to other
-@code{-t} interactive terminal shells, @code{-T} terminal commands and
+@code{-t} interactive terminals, @code{-T} terminal commands and
 @code{-U} memory operations. The @var{memory} field specifies the memory
 type to operate on. Use the @option{-T part} option on the command line or
 the @code{part} command in the interactive terminal to display all the

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -758,26 +758,25 @@ These options used to control the obsolete "safemode" feature which
 is no longer present. They are silently ignored for backwards compatibility.
 
 @item -T @var{cmd}
-Slots a terminal command line @var{cmd} into the intermixed list of
-@code{-T} terminal commands and @code{-U} memory operations. The terminal
-command line is executed when it is its turn in the mixed list. Except for
-the simplest of terminal commands the argument @var{cmd} will most likely
-need to be set in quotes, see your OS shell manual for details.
+Run terminal line @var{cmd} when it is its turn in relation to other
+@code{-t} interactive terminal shells, @code{-T} terminal commands and
+@code{-U} memory operations. Except for the simplest of terminal commands
+the argument @var{cmd} will most likely need to be set in quotes, see your
+OS shell manual for details. See below for a detailed description of all
+terminal commands.
 
 @item -t
-Tells AVRDUDE to enter the interactive terminal shell before uploading or
-downloading files via the @code{-U} option or processing other @code{-T}
-terminal commands, if any.  See below for a detailed description of the
-terminal mode.
+Tells AVRDUDE to run an interactive terminal shell when it is its turn in
+relation to other @code{-t} interactive terminal shells, @code{-T}
+terminal commands and @code{-U} memory operations.
 
 @item -U @var{memory}:@var{op}:@var{filename}[:@var{format}]
-Perform a memory operation.
-Multiple @option{-U} options can be specified in order to operate on
-multiple memories on the same command-line invocation.  The
-@var{memory} field specifies the memory type to operate on. Use
-the @option{-v} option on the command line or the @code{part} command from
-terminal mode to display all the memory types supported by a particular
-device.
+Perform a memory operation when it is its turn in relation to other
+@code{-t} interactive terminal shells, @code{-T} terminal commands and
+@code{-U} memory operations. The @var{memory} field specifies the memory
+type to operate on. Use the @option{-T part} option on the command line or
+the @code{part} command in the interactive terminal to display all the
+memory types supported by a particular device.
 
 Typically, a device's memory configuration at least contains the memory
 types @code{flash}, @code{eeprom}, @code{signature} and @code{lock}, which


### PR DESCRIPTION
Think breakpoints for a series of memory operations. In this example
```
$ avrdude -t -U eeprom:r:dopp.eep:i -t -U eeprom:w:dopp.eep
```
the first `-U` makes a backup of the EEPROM that the second terminal can then arbitrarily change because the second `-U` restores the EEPROM content.