### PR TITLE
Define usersig memory for ATmega*RF[AR]* parts

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -12897,6 +12897,26 @@ part parent "m2561"
         delay              = 50;
         load_ext_addr      = NULL;
     ;
+
+    #####
+    # Three separate flash pages
+    #   - Offset 0x100 in signature row
+    #   - Only programmable with JTAG or HVPP
+    #   - Readable from an application
+    #   - Cannot be read using ISP
+    #   - Not erased by chip erase
+    #
+    memory "usersig"
+        paged              = yes;
+        size               = 768;
+        page_size          = 256;
+        num_pages          = 3;
+        offset             = 0x100;
+        mode               = 0x41;
+        delay              = 50;
+        blocksize          = 256;
+        readsize           = 256;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -12940,6 +12960,26 @@ part parent "m2561"
 
     memory "efuse"
         initval            = 0xfe;
+    ;
+
+    #####
+    # Three separate flash pages
+    #   - Offset 0x100 in signature row
+    #   - Only programmable with JTAG or HVPP
+    #   - Readable from an application
+    #   - Cannot be read using ISP
+    #   - Not erased by chip erase
+    #
+    memory "usersig"
+        paged              = yes;
+        size               = 768;
+        page_size          = 256;
+        num_pages          = 3;
+        offset             = 0x100;
+        mode               = 0x41;
+        delay              = 50;
+        blocksize          = 256;
+        readsize           = 256;
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -12941,6 +12941,8 @@ part parent "m2561"
         page_size          = 256;
         num_pages          = 3;
         offset             = 0x100;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         mode               = 0x41;
         delay              = 50;
         blocksize          = 256;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -4424,8 +4424,8 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
@@ -4433,8 +4433,8 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
@@ -4443,8 +4443,8 @@ part
         size               = 1;
         initval            = 0xfd;
         bitmask            = 0x03;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
     ;
@@ -4453,8 +4453,8 @@ part
         size               = 1;
         initval            = 0xff;
         bitmask            = 0x3f;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
@@ -4556,8 +4556,8 @@ part
     memory "eeprom"
         size               = 4096;
         page_size          = 8;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 10000;
+        max_write_delay    = 10000;
         readback           = 0xff 0xff;
         mode               = 0x04;
         delay              = 20;
@@ -4572,8 +4572,8 @@ part
         size               = 0x20000;
         page_size          = 256;
         num_pages          = 512;
-        min_write_delay    = 4500;
-        max_write_delay    = 4500;
+        min_write_delay    = 5000;
+        max_write_delay    = 5000;
         readback           = 0xff 0x00;
         mode               = 0x21;
         delay              = 10;
@@ -4589,8 +4589,8 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
@@ -4598,8 +4598,8 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
@@ -4608,8 +4608,8 @@ part
         size               = 1;
         initval            = 0xfd;
         bitmask            = 0x03;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.0000--0000.1000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.xxii";
     ;
@@ -4618,8 +4618,8 @@ part
         size               = 1;
         initval            = 0xff;
         bitmask            = 0x3f;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
@@ -5169,8 +5169,8 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
@@ -5178,8 +5178,8 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
@@ -5188,8 +5188,8 @@ part
         size               = 1;
         initval            = 0xff;
         bitmask            = 0x3f;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
@@ -7059,8 +7059,8 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        min_write_delay    = 2000;
-        max_write_delay    = 2000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
@@ -7068,8 +7068,8 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0x99;
-        min_write_delay    = 2000;
-        max_write_delay    = 2000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
@@ -7078,8 +7078,8 @@ part
         size               = 1;
         initval            = 0xff;
         bitmask            = 0x3f;
-        min_write_delay    = 2000;
-        max_write_delay    = 2000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
@@ -7321,8 +7321,8 @@ part
     memory "lfuse"
         size               = 1;
         initval            = 0xe1;
-        min_write_delay    = 2000;
-        max_write_delay    = 2000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.0000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.0000--xxxx.xxxx--iiii.iiii";
     ;
@@ -7330,8 +7330,8 @@ part
     memory "hfuse"
         size               = 1;
         initval            = 0xd9;
-        min_write_delay    = 2000;
-        max_write_delay    = 2000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.1000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--1010.1000--xxxx.xxxx--iiii.iiii";
     ;
@@ -7340,8 +7340,8 @@ part
         size               = 1;
         initval            = 0xff;
         bitmask            = 0x3f;
-        min_write_delay    = 2000;
-        max_write_delay    = 2000;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
@@ -12886,18 +12886,37 @@ part parent "m2561"
     ocdrev                 = 3;
 
     memory "eeprom"
+        min_write_delay    = 13000;
+        max_write_delay    = 13000;
         delay              = 50;
     ;
 
     memory "flash"
         size               = 0x20000;
         num_pages          = 512;
-        min_write_delay    = 50000;
-        max_write_delay    = 50000;
         delay              = 50;
         load_ext_addr      = NULL;
     ;
 
+    memory "lfuse"
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+    ;
+
+    memory "hfuse"
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+    ;
+
+    memory "efuse"
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+    ;
+
+    memory "lock"
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+    ;
     #####
     # Three separate flash pages
     #   - Offset 0x100 in signature row
@@ -12940,8 +12959,6 @@ part parent "m128rfa1"
 
     memory "eeprom"
         size               = 8192;
-        min_write_delay    = 13000;
-        max_write_delay    = 13000;
         read               = "1010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
         write              = "1100.0000--xxxa.aaaa--aaaa.aaaa--iiii.iiii";
         writepage          = "1100.0010--00xa.aaaa--aaaa.a000--xxxx.xxxx";
@@ -12950,8 +12967,6 @@ part parent "m128rfa1"
     memory "flash"
         size               = 0x40000;
         num_pages          = 1024;
-        min_write_delay    = 4500;
-        max_write_delay    = 4500;
         load_ext_addr      = "0100.1101--0000.0000--0000.000a--0000.0000";
     ;
 
@@ -13001,8 +13016,6 @@ part parent "m128rfa1"
 
     memory "eeprom"
         size               = 2048;
-        min_write_delay    = 13000;
-        max_write_delay    = 13000;
         read               = "1010.0000--xxxx.xaaa--aaaa.aaaa--oooo.oooo";
         write              = "1100.0000--xxxx.xaaa--aaaa.aaaa--iiii.iiii";
         writepage          = "1100.0010--00xx.xaaa--aaaa.a000--xxxx.xxxx";

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -12923,7 +12923,7 @@ part parent "m2561"
 # ATmega256RFR2
 #------------------------------------------------------------
 
-part parent "m2561"
+part parent "m128rfa1"
     desc                   = "ATmega256RFR2";
     id                     = "m256rfr2";
     variants               =
@@ -12934,52 +12934,29 @@ part parent "m2561"
     mcuid                  = 108;
     n_interrupts           = 77;
     chip_erase_delay       = 18500;
-    bs2                    = 0xe2;
     signature              = 0x1e 0xa8 0x02;
-    pp_controlstack        =
-        0x0e, 0x1e, 0x0f, 0x1f, 0x2e, 0x3e, 0x2f, 0x3f,
-        0x4e, 0x5e, 0x4f, 0x5f, 0x6e, 0x7e, 0x6f, 0x7f,
-        0x66, 0x76, 0x67, 0x77, 0x6a, 0x7a, 0x6b, 0x7b,
-        0xbe, 0xfd, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00;
-    latchcycles            = 5;
     chiperasepolltimeout   = 20;
+    ocdrev                 = 4;
 
     memory "eeprom"
         size               = 8192;
         min_write_delay    = 13000;
         max_write_delay    = 13000;
-        delay              = 50;
         read               = "1010.0000--xxxa.aaaa--aaaa.aaaa--oooo.oooo";
         write              = "1100.0000--xxxa.aaaa--aaaa.aaaa--iiii.iiii";
         writepage          = "1100.0010--00xa.aaaa--aaaa.a000--xxxx.xxxx";
     ;
 
     memory "flash"
-        delay              = 50;
+        size               = 0x40000;
+        num_pages          = 1024;
+        min_write_delay    = 4500;
+        max_write_delay    = 4500;
+        load_ext_addr      = "0100.1101--0000.0000--0000.000a--0000.0000";
     ;
 
     memory "efuse"
         initval            = 0xfe;
-    ;
-
-    #####
-    # Three separate flash pages
-    #   - Offset 0x100 in signature row
-    #   - Only programmable with JTAG or HVPP
-    #   - Readable from an application
-    #   - Cannot be read using ISP
-    #   - Not erased by chip erase
-    #
-    memory "usersig"
-        paged              = yes;
-        size               = 768;
-        page_size          = 256;
-        num_pages          = 3;
-        offset             = 0x100;
-        mode               = 0x41;
-        delay              = 50;
-        blocksize          = 256;
-        readsize           = 256;
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -9348,7 +9348,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
-#   ATtiny87 has Signature Bytes: 0x1E 0x93 0x87.
+
+    # ATtiny87 has signature bytes 0x1E 0x93 0x87
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -9496,7 +9497,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
-#   ATtiny167 has Signature Bytes: 0x1E 0x94 0x87.
+
+    # ATtiny167 has signature bytes 0x1E 0x94 0x87
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -11142,11 +11144,13 @@ part
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
-#   ATtiny2313 has Signature Bytes: 0x1E 0x91 0x0A.
+
+    # ATtiny2313 has signature bytes 0x1E 0x91 0x0A
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
     ;
+
 # The Tiny2313 has calibration data for both 4 MHz and 8 MHz.
 # The information in the data sheet of April/2004 is wrong, this works:
 
@@ -11314,7 +11318,8 @@ part
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
-#   ATtiny4313 has Signature Bytes: 0x1E 0x92 0x0D.
+
+    # ATtiny4313 has signature bytes 0x1E 0x92 0x0D
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -11594,7 +11599,8 @@ part
         read               = "0101.1000--0000.0000--xxxx.xxxx--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
-#   AT90PWM2 has Signature Bytes: 0x1E 0x93 0x81.
+
+    # AT90PWM2 has signature bytes 0x1E 0x93 0x81
     memory "signature"
         size               = 3;
         read               = "0011.0000--00xx.xxxx--xxxx.xxaa--oooo.oooo";
@@ -12059,7 +12065,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
-#   ATtiny25 has Signature Bytes: 0x1E 0x91 0x08.
+
+    # ATtiny25 has signature bytes 0x1E 0x91 0x08
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -12218,7 +12225,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
-#   ATtiny45 has Signature Bytes: 0x1E 0x92 0x08. (Data sheet 2586C-AVR-06/05 (doc2586.pdf) indicates otherwise!)
+
+    # ATtiny45 has signature bytes 0x1E 0x92 0x08 (data sheet 2586C-AVR-06/05 doc2586.pdf indicates otherwise)
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -12374,7 +12382,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--11ii.iiii";
     ;
-#   ATtiny85 has Signature Bytes: 0x1E 0x93 0x08.
+
+    # ATtiny85 has signature bytes 0x1E 0x93 0x08
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -12917,6 +12926,7 @@ part parent "m2561"
         min_write_delay    = 4500;
         max_write_delay    = 4500;
     ;
+
     #####
     # Three separate flash pages
     #   - Offset 0x100 in signature row
@@ -13219,7 +13229,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
-#   ATtiny24 has Signature Bytes: 0x1E 0x91 0x0B.
+
+    # ATtiny24 has signature bytes 0x1E 0x91 0x0B
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -13398,7 +13409,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
-#   ATtiny44 has Signature Bytes: 0x1E 0x92 0x07.
+
+    # ATtiny44 has signature bytes 0x1E 0x92 0x07
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -13576,7 +13588,8 @@ part
         read               = "0101.1000--0000.0000--0000.0000--oooo.oooo";
         write              = "1010.1100--111x.xxxx--xxxx.xxxx--xxxx.xxii";
     ;
-#   ATtiny84 has Signature Bytes: 0x1E 0x93 0x0C.
+
+    # ATtiny84 has signature bytes 0x1E 0x93 0x0C
     memory "signature"
         size               = 3;
         read               = "0011.0000--000x.xxxx--xxxx.xxaa--oooo.oooo";
@@ -17113,6 +17126,7 @@ part parent ".xmega"
     n_interrupts           = 127;
     boot_section_size      = 8192;
     signature              = 0x1e 0x97 0x51;
+
 #   usbpid                 = 0x2f??;
 
     memory "eeprom"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -4519,7 +4519,7 @@ part
     boot_section_size      = 1024;
     stk500_devcode         = 0xb2;
     avr910_devcode         = 0x43;
-    chip_erase_delay       = 9000;
+    chip_erase_delay       = 10000;
     pagel                  = 0xd7;
     bs2                    = 0xa0;
     signature              = 0x1e 0x97 0x02;
@@ -7254,7 +7254,7 @@ part
     boot_section_size      = 256;
     stk500_devcode         = 0x70;
     avr910_devcode         = 0x76;
-    chip_erase_delay       = 10000;
+    chip_erase_delay       = 9000;
     pagel                  = 0xd7;
     bs2                    = 0xc2;
     signature              = 0x1e 0x93 0x07;
@@ -12874,7 +12874,7 @@ part parent "m2561"
         "ATmega128RFA1-ZUR00:     VFQFN64, Fmax=N/A, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]";
     mcuid                  = 87;
     n_interrupts           = 72;
-    chip_erase_delay       = 55000;
+    chip_erase_delay       = 18500;
     bs2                    = 0xe2;
     signature              = 0x1e 0xa7 0x01;
     pp_controlstack        =
@@ -12952,7 +12952,6 @@ part parent "m128rfa1"
         "ATmega256RFR2-ZUR: VFQFN64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]";
     mcuid                  = 108;
     n_interrupts           = 77;
-    chip_erase_delay       = 18500;
     signature              = 0x1e 0xa8 0x02;
     chiperasepolltimeout   = 20;
     ocdrev                 = 4;

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -361,9 +361,11 @@ void dev_print_comment(const LISTID comms) {
 static void dev_cout(const LISTID comms, const char *name, int rhs, int elself) {
   COMMENT *cp;
 
+  if(elself == 2)
+    dev_info("\n");
   if((cp = locate_comment(comms, name, rhs)))
     dev_print_comment(cp->comms);
-  else if(elself)
+  else if(elself == 1)
     dev_info("\n");
 }
 
@@ -819,7 +821,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
           continue;
       }
 
-      dev_cout(m->comments, "*", 0, 1);
+      dev_cout(m->comments, "*", 0, 2);
       dev_info("    memory \"%s\"\n", m->desc);
     }
 


### PR DESCRIPTION
With a bit of fair wind the following memory definition for `ATmega128RFA1` `ATmega256RFR2` `ATmega128RFR2` `ATmega64RFR2` `ATmega2564RFR2` `ATmega1284RFR2` `ATmega644RFR2` could be sufficient to  solve Issue #379. Only tests will tell whether JTAG or HVPP programmers "do the right thing" with this special memory of these special parts. If anything, perhaps the `offset` might be problematic but let's see who can help testing.

```
   #####
    # Three separate flash pages
    #   - Offset 0x100 in signature row
    #   - Only programmable with JTAG or HVPP
    #   - Readable from an application
    #   - Cannot be read using ISP
    #   - Not erased by chip erase
    #
    memory "usersig"
        paged              = yes;
        size               = 768;
        page_size          = 256;
        num_pages          = 3;
        offset             = 0x100;
        mode               = 0x41;
        delay              = 50;
        blocksize          = 256;
        readsize           = 256;
    ;
```