### PR TITLE
Remove comment and URL for arduino-ft232r programmer

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1546,6 +1546,13 @@ programmer
 # arduino-ft232r
 #------------------------------------------------------------
 
+# This programmer helps programming the Arduino Diecimila, NG and
+# Duemilanove (but not the Uno) without bootloader or external
+# programmer using the on-board FT232RL chip. Instructions here:
+# https://make.kosakalab.com/arduino/bootloader/index_en.html
+# Note that the -c diecimila avrdude.conf entry mentioned in above post
+# is the same as the -c arduino-ft232r entry here.
+
 programmer
     id                     = "arduino-ft232r";
     desc                   = "Arduino: FT232R connected to ISP";

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1546,9 +1546,6 @@ programmer
 # arduino-ft232r
 #------------------------------------------------------------
 
-# see http://www.geocities.jp/arduino_diecimila/bootloader/index_en.html
-# Note: pins are numbered from 1!
-
 programmer
     id                     = "arduino-ft232r";
     desc                   = "Arduino: FT232R connected to ISP";


### PR DESCRIPTION
Normally I would want to *add* comments and URLs to programmer definitions, but in this case the URL is not accessible in EEA and the UK (and the bootloader path element makes me doubt it is on topic). Anyone know better URLs for this?

![Screenshot from 2023-06-21 16-21-09](https://github.com/avrdudes/avrdude/assets/14282046/88a14bc8-5c50-4e9d-a1a8-e08c219f7dce)
