### PR TITLE
Enable -c programmers to access -c string

### DIFF
--- a/src/avr910.c
+++ b/src/avr910.c
@@ -333,8 +333,7 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
     if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       msg_error("  -xdevcode=<arg> Override device code\n");
       msg_error("  -xno_blockmode  Disable default checking for block transfer capability\n");
       msg_error("  -xhelp          Show this help menu and exit\n");

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -37,7 +37,8 @@ extern char progbuf[];       // Spaces same length as progname
 extern int ovsigck;          // Override signature check (-F)
 extern int verbose;          // Verbosity level (-v, -vv, ...)
 extern int quell_progress;   // Quell progress report -q, reduce effective verbosity level (-qq, -qqq)
-extern const char *partdesc; // Part id
+extern const char *partdesc; // Part -p string
+extern const char *pgmid;    // Programmer -c string
 
 int avrdude_message(int msglvl, const char *format, ...);
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -378,8 +378,7 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 		}
 
 		if (str_eq(extended_param, "help")) {
-			char *prg = (char *)ldata(lfirst(pgm->id));
-			msg_error("%s -c %s extended options:\n", progname, prg);
+			msg_error("%s -c %s extended options:\n", progname, pgmid);
 			msg_error("  -xreset=cs,aux,aux2         Override default reset pin\n");
 			msg_error("  -xspifreq=<0..7>            Set binary SPI mode speed\n");
 			msg_error("  -xrawfreq=<0..3>            Set \"raw-wire\" SPI mode speed\n");

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -813,7 +813,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
         int haveinjct = 0;
         if(injct)
           for(size_t i=0; i<sizeof meminj/sizeof*meminj; i++)
-            if(meminj[i].mcu && str_match(meminj[i].mcu, p->desc) && str_match(meminj[i].mem, m->desc))
+            if(meminj[i].mcu && str_casematch(meminj[i].mcu, p->desc) && str_match(meminj[i].mem, m->desc))
               haveinjct = 1;
         if(!haveinjct)
           continue;
@@ -848,7 +848,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
     if(injct)
       for(size_t i=0; i<sizeof meminj/sizeof*meminj; i++)
         if(meminj[i].mcu)
-          if(str_match(meminj[i].mcu, p->desc) && str_match(meminj[i].mem, m->desc))
+          if(str_casematch(meminj[i].mcu, p->desc) && str_match(meminj[i].mem, m->desc))
             dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc,
               meminj[i].var, cfg_strdup("meminj", meminj[i].value), NULL);
 
@@ -882,7 +882,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
   if(injct)
     for(size_t i=0; i<sizeof ptinj/sizeof*ptinj; i++)
       if(ptinj[i].mcu)
-        if(str_match(ptinj[i].mcu, p->desc))
+        if(str_casematch(ptinj[i].mcu, p->desc))
           dev_part_strct_entry(tsv, ".pt", p->desc, NULL,
             ptinj[i].var, cfg_strdup("ptinj", ptinj[i].value), NULL);
 
@@ -1426,7 +1426,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
     for(size_t i=0; i<sizeof pgminj/sizeof*pgminj; i++)
       if(pgminj[i].pgmid)
         for(LNODEID *ln=lfirst(pgm->id); ln; ln=lnext(ln))
-          if(str_match(pgminj[i].pgmid, ldata(ln)))
+          if(str_casematch(pgminj[i].pgmid, ldata(ln)))
             dev_part_strct_entry(tsv, ".prog", ldata(ln), NULL,
               pgminj[i].var, cfg_strdup("pgminj", pgminj[i].value), NULL);
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1438,16 +1438,16 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
 
 
 // -c */[ASsrti]
-void dev_output_pgm_defs(char *pgmid) {
+void dev_output_pgm_defs(char *pgmidcp) {
   bool astrc, strct, cmpst, raw, tsv, injct;
   char *flags;
   int nprinted;
   PROGRAMMER *nullpgm = pgm_new();
 
-  if((flags = strchr(pgmid, '/')))
+  if((flags = strchr(pgmidcp, '/')))
     *flags++ = 0;
 
-  if(!flags && str_eq(pgmid, "*")) // Treat -c * as if it was -c */s
+  if(!flags && str_eq(pgmidcp, "*")) // Treat -c * as if it was -c */s
     flags = "s";
 
   if(!*flags || !strchr("ASsrti", *flags)) {
@@ -1494,7 +1494,7 @@ void dev_output_pgm_defs(char *pgmid) {
     PROGRAMMER *pgm = ldata(ln1);
     int matched = 0;
     for(ln2=lfirst(pgm->id); ln2; ln2=lnext(ln2)) {
-      if(str_casematch(pgmid, ldata(ln2))) {
+      if(str_casematch(pgmidcp, ldata(ln2))) {
         matched = 1;
         break;
       }

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -164,11 +164,10 @@ static int dryrun_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   int pm = pgm->prog_modes & p->prog_modes;
 
   if(!pm)
-    Return("programmer %s and part %s have no common programming mode",
-      (char *) ldata(lfirst(pgm->id)), p->desc);
+    Return("programmer %s and part %s have no common programming mode", pgmid, p->desc);
    if(pm & (pm-1))
       Return("%s and %s share multiple programming modes (%s)",
-        (char *) ldata(lfirst(pgm->id)), p->desc, avr_prog_modes(pm));
+        pgmid, p->desc, avr_prog_modes(pm));
 */
 
   return pgm->program_enable(pgm, p);

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -879,7 +879,7 @@ int jtag3_getsync(const PROGRAMMER *pgm, int mode) {
   /* XplainedMini boards do not need this, and early revisions had a
    * firmware bug where they complained about it. */
   if ((pgm->flag & PGM_FL_IS_EDBG) &&
-      !str_starts(ldata(lfirst(pgm->id)), "xplainedmini")) {
+      !str_starts(pgmid, "xplainedmini")) {
     if (jtag3_edbg_prepare(pgm) < 0) {
       return -1;
     }
@@ -1583,13 +1583,12 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     else if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       if (str_eq(pgm->type, "JTAGICE3"))
         msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
-      if (str_eq(prg, "powerdebugger_updi") || str_eq(prg, "pickit4_updi"))
+      if (str_eq(pgmid, "powerdebugger_updi") || str_eq(pgmid, "pickit4_updi"))
         msg_error("  -xhvupdi                Enable high-voltage UPDI initialization\n");
-      if (str_starts(prg, "xplainedmini") && !str_eq(prg, "xplainedmini_tpi")) {
+      if (str_starts(pgmid, "xplainedmini") && !str_eq(pgmid, "xplainedmini_tpi")) {
         msg_error("  -xsuffer                Read SUFFER register value\n");
         msg_error("  -xsuffer=<arg>          Set SUFFER register value\n");
         msg_error("  -xvtarg_switch          Read on-board target voltage switch state\n");
@@ -1820,7 +1819,7 @@ void jtag3_close(PROGRAMMER * pgm) {
   /* XplainedMini boards do not need this, and early revisions had a
    * firmware bug where they complained about it. */
   if ((pgm->flag & PGM_FL_IS_EDBG) &&
-      !str_starts(ldata(lfirst(pgm->id)), "xplainedmini")) {
+      !str_starts(pgmid, "xplainedmini")) {
     jtag3_edbg_signoff(pgm);
   }
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1216,10 +1216,9 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   const char *ifname;
 
   /* Abort and print error if programmer does not support the target microcontroller */
-  if ((strncmp(pgm->type, "JTAGMKII_UPDI", strlen("JTAGMKII_UPDI")) == 0 && !(p->prog_modes & PM_UPDI)) ||
-      (strncmp(ldata(lfirst(pgm->id)), "jtagmkII", strlen("jtagmkII")) == 0 && (p->prog_modes & PM_UPDI))) {
-    msg_error("programmer %s does not support target %s\n\n",
-      (char *) ldata(lfirst(pgm->id)), p->desc);
+  if((str_starts(pgm->type, "JTAGMKII_UPDI") && !(p->prog_modes & PM_UPDI)) ||
+      (str_starts(pgmid, "jtagmkII") && (p->prog_modes & PM_UPDI))) {
+    msg_error("programmer %s does not support target %s\n\n", pgmid, p->desc);
     return -1;
   }
 
@@ -1289,9 +1288,8 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     AVRMEM *bootmem = avr_locate_mem(p, "boot");
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (bootmem == NULL || flashmem == NULL) {
-      if (strncmp(ldata(lfirst(pgm->id)), "jtagmkII", strlen("jtagmkII")) == 0) {
+      if(str_starts(pgmid, "jtagmkII"))
         pmsg_error("cannot locate flash or boot memories in description\n");
-      }
     } else {
       if (PDATA(pgm)->fwver < 0x700) {
         /* V7+ firmware does not need this anymore */
@@ -1401,8 +1399,7 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     }
 
     else if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       if (str_eq(pgm->type, "JTAGMKII") || str_eq(pgm->type, "DRAGON_JTAG"))
         msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
       msg_error(  "  -xhelp                  Show this help menu and exit\n");

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -864,6 +864,8 @@ void programmer_display(PROGRAMMER * pgm, const char * p);
 void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int show);
 void pgm_display_generic(const PROGRAMMER *pgm, const char *p);
 
+PROGRAMMER *locate_programmer_set(const LISTID programmers, const char *id, const char **setid);
+
 PROGRAMMER *locate_programmer(const LISTID programmers, const char *configid);
 
 typedef void (*walk_programmers_cb)(const char *name, const char *desc,

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -414,8 +414,7 @@ static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
       continue;
     }
     if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       msg_error("  -xdisable_no_cs Do not use the SPI_NO_CS bit for the SPI driver\n");
       msg_error("  -xhelp          Show this help menu and exit\n");
       exit(0);

--- a/src/main.c
+++ b/src/main.c
@@ -214,7 +214,7 @@ int verbose;                    // Verbose output
 int quell_progress;             // Quell progress report and un-verbose output
 int ovsigck;                    // 1 = override sig check, 0 = don't
 const char *partdesc;           // Part id
-
+const char *pgmid;              // Programmer id
 
 /*
  * usage message
@@ -511,7 +511,6 @@ int main(int argc, char * argv [])
   int     calibrate;   /* 1=calibrate RC oscillator, 0=don't */
   char  * port;        /* device port (/dev/xxx) */
   const char *exitspecs; /* exit specs string from command line */
-  const char *programmer; /* programmer id */
   int     explicit_c;  /* 1=explicit -c on command line, 0=not specified there */
   int     explicit_e;  /* 1=explicit -e on command line, 0=not specified there */
   char    sys_config[PATH_MAX]; /* system wide config file */
@@ -604,7 +603,7 @@ int main(int argc, char * argv [])
   quell_progress = 0;
   exitspecs     = NULL;
   pgm           = NULL;
-  programmer    = "";
+  pgmid         = "";
   explicit_c    = 0;
   explicit_e    = 0;
   verbose       = 0;
@@ -704,7 +703,7 @@ int main(int argc, char * argv [])
         break;
 
       case 'c': /* programmer id */
-        programmer = optarg;
+        pgmid = optarg;
         explicit_c = 1;
         break;
 
@@ -1003,15 +1002,15 @@ int main(int argc, char * argv [])
     bitclock = default_bitclock;
   }
 
-  if(!(programmer && *programmer) && *default_programmer)
-    programmer = cache_string(default_programmer);
+  if(!(pgmid && *pgmid) && *default_programmer)
+    pgmid = cache_string(default_programmer);
 
   // Developer options to print parts and/or programmer entries of avrdude.conf
-  int dev_opt_c = dev_opt(programmer); // -c <wildcard>/[sSArt]
-  int dev_opt_p = dev_opt(partdesc);   // -p <wildcard>/[dsSArcow*t]
+  int dev_opt_c = dev_opt(pgmid);    // -c <wildcard>/[sSArt]
+  int dev_opt_p = dev_opt(partdesc); // -p <wildcard>/[dsSArcow*t]
 
   if(dev_opt_c || dev_opt_p) {  // See -c/h and or -p/h
-    dev_output_pgm_part(dev_opt_c, programmer, dev_opt_p, partdesc);
+    dev_output_pgm_part(dev_opt_c, pgmid, dev_opt_p, partdesc);
     exit(0);
   }
 
@@ -1028,13 +1027,13 @@ int main(int argc, char * argv [])
 
   if (partdesc) {
     if (strcmp(partdesc, "?") == 0) {
-      if(programmer && *programmer && explicit_c) {
-        PROGRAMMER *pgm = locate_programmer(programmers, programmer);
+      if(pgmid && *pgmid && explicit_c) {
+        PROGRAMMER *pgm = locate_programmer(programmers, pgmid);
         if(!pgm) {
-          programmer_not_found(programmer);
+          programmer_not_found(pgmid);
           exit(1);
         }
-        msg_error("\nValid parts for programmer %s are:\n", programmer);
+        msg_error("\nValid parts for programmer %s are:\n", pgmid);
         list_parts(stderr, "  ", part_list, pgm->prog_modes);
       } else {
         msg_error("\nValid parts are:\n");
@@ -1045,8 +1044,8 @@ int main(int argc, char * argv [])
     }
   }
 
-  if (programmer) {
-    if (strcmp(programmer, "?") == 0) {
+  if(pgmid) {
+    if(strcmp(pgmid, "?") == 0) {
       if(partdesc && *partdesc) {
         AVRPART *p = locate_part(part_list, partdesc);
         if(!p) {
@@ -1063,7 +1062,7 @@ int main(int argc, char * argv [])
       exit(1);
     }
 
-    if (strcmp(programmer, "?type") == 0) {
+    if(strcmp(pgmid, "?type") == 0) {
       msg_error("\nValid programmer types are:\n");
       list_programmer_types(stderr, "  ");
       msg_error("\n");
@@ -1073,14 +1072,14 @@ int main(int argc, char * argv [])
 
   msg_notice("\n");
 
-  if (!programmer || !*programmer) {
+  if(!pgmid || !*pgmid) {
     programmer_not_found(NULL);
     exit(1);
   }
 
-  pgm = locate_programmer(programmers, programmer);
+  pgm = locate_programmer(programmers, pgmid);
   if (pgm == NULL) {
-    programmer_not_found(programmer);
+    programmer_not_found(pgmid);
     exit(1);
   }
 
@@ -1160,7 +1159,7 @@ int main(int argc, char * argv [])
 
   if (verbose > 0) {
     imsg_notice("Using Port                    : %s\n", port);
-    imsg_notice("Using Programmer              : %s\n", programmer);
+    imsg_notice("Using Programmer              : %s\n", pgmid);
   }
 
   if (baudrate != 0) {
@@ -1180,7 +1179,7 @@ int main(int argc, char * argv [])
 
   rc = pgm->open(pgm, port);
   if (rc < 0) {
-    pmsg_error("unable to open programmer %s on port %s\n", programmer, port);
+    pmsg_error("unable to open programmer %s on port %s\n", pgmid, port);
     exitrc = 1;
     pgm->ppidata = 0; /* clear all bits at exit */
     goto main_exit;

--- a/src/main.c
+++ b/src/main.c
@@ -213,8 +213,8 @@ static PROGRAMMER * pgm;
 int verbose;                    // Verbose output
 int quell_progress;             // Quell progress report and un-verbose output
 int ovsigck;                    // 1 = override sig check, 0 = don't
-const char *partdesc;           // Part id
-const char *pgmid;              // Programmer id
+const char *partdesc;           // Part -p string
+const char *pgmid;              // Programmer -c string
 
 /*
  * usage message
@@ -1103,8 +1103,7 @@ int main(int argc, char * argv [])
       for (LNODEID ln = lfirst(extended_params); ln; ln = lnext(ln)) {
         const char *extended_param = ldata(ln);
         if (str_eq(extended_param, "help")) {
-          char *prg = (char *)ldata(lfirst(pgm->id));
-          msg_error("%s -c %s extended options:\n", progname, prg);
+          msg_error("%s -c %s extended options:\n", progname, pgmid);
           msg_error("  -xhelp    Show this help menu and exit\n");
           exit(0);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -1028,7 +1028,7 @@ int main(int argc, char * argv [])
   if(partdesc) {
     if(str_eq(partdesc, "?")) {
       if(pgmid && *pgmid && explicit_c) {
-        PROGRAMMER *pgm = locate_programmer(programmers, pgmid);
+        PROGRAMMER *pgm = locate_programmer_set(programmers, pgmid, &pgmid);
         if(!pgm) {
           programmer_not_found(pgmid);
           exit(1);
@@ -1077,7 +1077,7 @@ int main(int argc, char * argv [])
     exit(1);
   }
 
-  pgm = locate_programmer(programmers, pgmid);
+  pgm = locate_programmer_set(programmers, pgmid, &pgmid);
   if (pgm == NULL) {
     programmer_not_found(pgmid);
     exit(1);

--- a/src/main.c
+++ b/src/main.c
@@ -280,7 +280,7 @@ static void pmshorten(char *desc, const char *modes) {
 
   for(size_t i=0; i<sizeof pairs/sizeof*pairs; i++) {
     size_t elen = strlen(pairs[i].end);
-    if(len > elen && strcasecmp(desc+len-elen, pairs[i].end) == 0 && strcmp(modes, pairs[i].mode) == 0) {
+    if(len > elen && str_caseeq(desc+len-elen, pairs[i].end) && str_eq(modes, pairs[i].mode)) {
       desc[len-elen] = 0;
       break;
     }
@@ -431,7 +431,7 @@ static void replace_backslashes(char *s)
 static int dev_opt(const char *str) {
   return
     !str? 0:
-    !strcmp(str, "*") || !strncmp(str, "*/", 2)? 2:
+    str_eq(str, "*") || str_starts(str, "*/")? 2:
     !!strchr(str, '/');
 }
 
@@ -559,7 +559,7 @@ int main(int argc, char * argv [])
     progname = argv[0];
 
   // Remove trailing .exe
-  if(strlen(progname) > 4 && strcmp(progname+strlen(progname)-4, ".exe") == 0) {
+  if(str_ends(progname, ".exe")) {
     progname = cfg_strdup("main()", progname); // Don't write to argv[0]
     progname[strlen(progname)-4] = 0;
   }
@@ -1025,8 +1025,8 @@ int main(int argc, char * argv [])
     }
   }
 
-  if (partdesc) {
-    if (strcmp(partdesc, "?") == 0) {
+  if(partdesc) {
+    if(str_eq(partdesc, "?")) {
       if(pgmid && *pgmid && explicit_c) {
         PROGRAMMER *pgm = locate_programmer(programmers, pgmid);
         if(!pgm) {
@@ -1045,7 +1045,7 @@ int main(int argc, char * argv [])
   }
 
   if(pgmid) {
-    if(strcmp(pgmid, "?") == 0) {
+    if(str_eq(pgmid, "?")) {
       if(partdesc && *partdesc) {
         AVRPART *p = locate_part(part_list, partdesc);
         if(!p) {
@@ -1062,7 +1062,7 @@ int main(int argc, char * argv [])
       exit(1);
     }
 
-    if(strcmp(pgmid, "?type") == 0) {
+    if(str_eq(pgmid, "?type")) {
       msg_error("\nValid programmer types are:\n");
       list_programmer_types(stderr, "  ");
       msg_error("\n");
@@ -1219,7 +1219,7 @@ int main(int argc, char * argv [])
   }
 
   if(verbose > 0) {
-    if ((strcmp(pgm->type, "avr910") == 0)) {
+    if((str_eq(pgm->type, "avr910"))) {
       imsg_notice("avr910_devcode (avrdude.conf) : ");
       if(p->avr910_devcode)
         msg_notice("0x%02x\n", (uint8_t) p->avr910_devcode);
@@ -1305,7 +1305,7 @@ int main(int argc, char * argv [])
     else
       imsg_error("- double check the connections and try again\n");
 
-    if (strcmp(pgm->type, "serialupdi") == 0 || strcmp(pgm->type, "SERBB") == 0)
+    if(str_eq(pgm->type, "serialupdi") || str_eq(pgm->type, "SERBB"))
       imsg_error("- use -b to set lower baud rate, e.g. -b %d\n", baudrate? baudrate/2: 57600);
     else
       imsg_error("- use -B to set lower the bit clock frequency, e.g. -B 125kHz\n");
@@ -1452,7 +1452,7 @@ int main(int argc, char * argv [])
         m = avr_locate_mem(p, upd->memtype);
         if (m == NULL)
           continue;
-        if ((strcmp(m->desc, memname) == 0) && (upd->op == DEVICE_WRITE)) {
+        if(str_eq(m->desc, memname) && upd->op == DEVICE_WRITE) {
           erase = 1;
           pmsg_info("Note: %s memory has been specified, an erase cycle will be performed.\n", memname);
           imsg_info("To disable this feature, specify the -D option.\n");

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -922,8 +922,7 @@ static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xpara
         }
         else if (str_eq(param, "help"))
         {
-            char *prg = (char *)ldata(lfirst(pgm->id));
-            msg_error("%s -c %s extended options:\n", progname, prg);
+            msg_error("%s -c %s extended options:\n", progname, pgmid);
             msg_error("  -xwait       Wait for the device to be plugged in if not connected\n");
             msg_error("  -xwait=<arg> Wait <arg> [s] for the device to be plugged in if not connected\n");
             msg_error("  -xhelp       Show this help menu and exit\n");

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -291,18 +291,24 @@ void pgm_display_generic(const PROGRAMMER *pgm, const char *p) {
   pgm_display_generic_mask(pgm, p, SHOW_ALL_PINS);
 }
 
-PROGRAMMER *locate_programmer(const LISTID programmers, const char *configid) {
-  PROGRAMMER *p = NULL;
-  int found = 0;
-
-  for(LNODEID ln1=lfirst(programmers); ln1 && !found; ln1=lnext(ln1)) {
-    p = ldata(ln1);
-    for(LNODEID ln2=lfirst(p->id); ln2 && !found; ln2=lnext(ln2))
-      if(strcasecmp(configid, (const char *) ldata(ln2)) == 0)
-        found = 1;
+PROGRAMMER *locate_programmer_set(const LISTID programmers, const char *configid, const char **setid) {
+  for(LNODEID ln1=lfirst(programmers); ln1; ln1=lnext(ln1)) {
+    PROGRAMMER *p = ldata(ln1);
+    for(LNODEID ln2=lfirst(p->id); ln2; ln2=lnext(ln2)) {
+      const char *id = (const char *) ldata(ln2);
+      if(str_caseeq(configid, id)) {
+        if(setid)
+          *setid = id;
+        return p;
+      }
+    }
   }
 
-  return found? p: NULL;
+  return NULL;
+}
+
+PROGRAMMER *locate_programmer(const LISTID programmers, const char *configid) {
+  return locate_programmer_set(programmers, configid, NULL);
 }
 
 /*

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1212,8 +1212,7 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             continue;
         }
         if (str_eq(extended_param, "help")) {
-            char *prg = (char *)ldata(lfirst(pgm->id));
-            msg_error("%s -c %s extended options:\n", progname, prg);
+            msg_error("%s -c %s extended options:\n", progname, pgmid);
             msg_error("  -xclockrate=<arg> Set the SPI clocking rate in <arg> [Hz]\n");
             msg_error("  -xtimeout=<arg>   Set the timeout for USB read/write to <arg> [ms]\n");
             msg_error("  -xhelp            Show this help menu and exit\n");

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -944,8 +944,7 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
       continue;
     }
     if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       msg_error("  -xrtsdtr=low,high Force RTS/DTR lines low or high state during programming\n");
       msg_error("  -xhelp            Show this help menu and exit\n");
       exit(0);

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -403,7 +403,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   stk500_getparm(pgm, Parm_STK_SW_MINOR, &min);
 
   // MIB510 does not need extparams
-  if (str_eq(ldata(lfirst(pgm->id)), "mib510"))
+  if (str_eq(pgmid, "mib510"))
     n_extparms = 0;
   else if ((maj > 1) || ((maj == 1) && (min > 10)))
     n_extparms = 4;
@@ -749,8 +749,7 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
     }
 
     else if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       msg_error("  -xattempts=<arg>      Specify no. connection retry attempts\n");
       if (pgm->extra_features & HAS_VTARG_ADJ) {
         msg_error("  -xvtarg               Read target supply voltage\n");
@@ -844,7 +843,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
   stk500_drain(pgm, 0);
 
   // MIB510 init
-  if (str_eq(ldata(lfirst(pgm->id)), "mib510") && mib510_isp(pgm, 1) != 0)
+  if (str_eq(pgmid, "mib510") && mib510_isp(pgm, 1) != 0)
     return -1;
 
   if (stk500_getsync(pgm) < 0)
@@ -857,7 +856,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
 static void stk500_close(PROGRAMMER * pgm)
 {
   // MIB510 close
-  if (str_eq(ldata(lfirst(pgm->id)), "mib510"))
+  if (str_eq(pgmid, "mib510"))
     (void)mib510_isp(pgm, 0);
 
   serial_close(&pgm->fd);
@@ -967,7 +966,7 @@ static int set_memtype_a_div(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   if(avr_mem_is_eeprom_type(m)) {
     *memtypep = 'E';
     // Word addr for bootloaders or Arduino as ISP if part is a "classic" part, byte addr otherwise
-    *a_divp = ((pgm->prog_modes & PM_SPM) || str_caseeq(ldata(lfirst(pgm->id)), "arduino_as_isp")) \
+    *a_divp = ((pgm->prog_modes & PM_SPM) || str_caseeq(pgmid, "arduino_as_isp")) \
        && !(p->prog_modes & (PM_UPDI | PM_PDI))? 2: 1;
     return 0;
   }
@@ -1003,7 +1002,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   for (; addr < n; addr += block_size) {
     // MIB510 uses fixed blocks size of 256 bytes
-    if (str_eq(ldata(lfirst(pgm->id)), "mib510")) {
+    if (str_eq(pgmid, "mib510")) {
       block_size = 256;
     } else {
       if (n - addr < page_size)
@@ -1075,7 +1074,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   n = addr + n_bytes;
   for (; addr < n; addr += block_size) {
     // MIB510 uses fixed blocks size of 256 bytes
-    if (str_eq(ldata(lfirst(pgm->id)), "mib510")) {
+    if(str_eq(pgmid, "mib510")) {
       block_size = 256;
     } else {
       if (n - addr < page_size)
@@ -1119,7 +1118,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if (stk500_recv(pgm, buf, 1) < 0)
       return -1;
 
-    if(str_eq(ldata(lfirst(pgm->id)), "mib510")) {
+    if(str_eq(pgmid, "mib510")) {
       if (buf[0] != Resp_STK_INSYNC) {
         msg_error("\n");
         pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1932,8 +1932,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     }
 
     else if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       if (pgm->extra_features & HAS_VTARG_ADJ) {
         msg_error("  -xvtarg               Read target supply voltage\n");
         msg_error("  -xvtarg=<arg>         Set target supply voltage\n");
@@ -2046,9 +2045,8 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
     }
 
     else if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
-      if (str_starts(prg, "xplainedmini")) {
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
+      if(str_starts(pgmid, "xplainedmini")) {
         msg_error("  -xsuffer              Read SUFFER register value\n");
         msg_error("  -xsuffer=<arg>        Set SUFFER register value\n");
         msg_error("  -xvtarg_switch        Read on-board target voltage switch state\n");

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -569,8 +569,7 @@ static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
         }
         else if (str_eq(param, "help"))
         {
-            char *prg = (char *)ldata(lfirst(pgm->id));
-            msg_error("%s -c %s extended options:\n", progname, prg);
+            msg_error("%s -c %s extended options:\n", progname, pgmid);
             msg_error("  -xwait       Wait for the device to be plugged in if not connected\n");
             msg_error("  -xwait=<arg> Wait <arg> [s] for the device to be plugged in if not connected\n");
             msg_error("  -xhelp       Show this help menu and exit\n");

--- a/src/term.c
+++ b/src/term.c
@@ -895,7 +895,7 @@ static int cmd_erase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   }
 
   if(rc) {
-    pmsg_error("(erase) programmer %s failed erasing the chip\n", (char *) ldata(lfirst(pgm->id)));
+    pmsg_error("(erase) programmer %s failed erasing the chip\n", pgmid);
     return -1;
   }
 
@@ -919,7 +919,7 @@ static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
     return -1;
   }
   if(!avr_has_paged_access(pgm, mem)) {
-    pmsg_error("(pgerase) %s memory cannot be paged addressed by %s\n", memtype, (char *) ldata(lfirst(pgm->id)));
+    pmsg_error("(pgerase) %s memory cannot be paged addressed by %s\n", memtype, pgmid);
     return -1;
   }
 

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1757,7 +1757,7 @@ static int ur_readEF(const PROGRAMMER *pgm, const AVRPART *p, uint8_t *buf, uint
   int classic = !(p->prog_modes & (PM_UPDI | PM_PDI | PM_aWire));
 
   pmsg_debug("ur_readEF(%s, %s, %s, %p, 0x%06x, %d, %c)\n",
-    (char *) ldata(lfirst(pgm->id)), p->desc, mchr=='F'? "flash": "eeprom", buf, badd, len, mchr);
+    pgmid, p->desc, mchr=='F'? "flash": "eeprom", buf, badd, len, mchr);
 
   if(mchr == 'F' && ur.urprotocol && !(ur.urfeatures & UB_READ_FLASH))
     Return("bootloader does not have flash read capability");
@@ -2498,7 +2498,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
   }
 
   if(help || rc < 0) {
-    msg_error("%s -c %s extended options:\n", progname, (char *) ldata(lfirst(pgm->id)));
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
     for(size_t i=0; i<sizeof options/sizeof*options; i++) {
       msg_error("  -x%s%s%*s%s\n", options[i].name, options[i].assign? "=<arg>": "",
         urmax(0, 16-(int) strlen(options[i].name)-(options[i].assign? 6: 0)), "", options[i].help);

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -290,8 +290,7 @@ static int usbasp_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
     if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       msg_error("  -xsection_config Erase configuration section only with -e (TPI only)\n");
       msg_error("  -xhelp           Show this help menu and exit\n");
       exit(0);
@@ -560,7 +559,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
   vid = pgm->usbvid? pgm->usbvid: USBASP_SHARED_VID;
   if (usbOpenDevice(&PDATA(pgm)->usbhandle, vid, pgm->usbvendor, pid, pgm->usbproduct) != 0) {
     /* try alternatives */
-    if(strcasecmp(ldata(lfirst(pgm->id)), "usbasp") == 0) {
+    if(str_eq(pgmid, "usbasp")) {
     /* for id usbasp autodetect some variants */
       if(strcasecmp(port, "nibobee") == 0) {
         pmsg_error("using -C usbasp -P nibobee is deprecated, use -C nibobee instead\n");

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -131,8 +131,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
     if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       msg_error("  -xsnooze=<arg> Wait <arg> [ms] before protocol sync after port open\n");
       msg_error("  -xhelp         Show this help menu and exit\n");
       exit(0);

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1652,8 +1652,7 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
     if (str_eq(extended_param, "help")) {
-      char *prg = (char *)ldata(lfirst(pgm->id));
-      msg_error("%s -c %s extended options:\n", progname, prg);
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
       msg_error("  -xxbeeresetpin=<1..7> Set XBee pin DIO<1..7> as reset pin\n");
       msg_error("  -xhelp                Show this help menu and exit\n");
       exit(0);


### PR DESCRIPTION
Enabling `-c` programmers to see the `-c` string chosen by the user is helpful to distinguish between different versions of (essentially) the same programmer.

The programmer id parameter is a list of programmer strings. Whenever code wants to refer to the name of the programmer selected by the user with `-c` it normally uses `(char *) ldata(lfirst(pgm->id))`. This is incorrect if the chosen programmer happens to be the *second* or later in a list of programmer ids. 

To reproduce, create the following two new programmers in `~/.avrduderc`
```
programmer parent "urclock"
    id                     = "urclock1", "urclock2";
;
```

Then execute
``` console
$ avrdude -c urclock2 -xhelp
avrdude -c urclock1 extended options:
  -xshowall         Show all info for connected part and exit
[...]
```

Notice the `urclock1` response whereas the user selected `urclock2`. 

This PR requires careful review as not all `(char *) ldata(lfirst(pgm->id))` can be replaced with `pgmid`. @MCUdude?