### PR TITLE
Write empty flash memory to file in correct format

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -521,7 +521,7 @@ static int b2srec(const AVRMEM *mem, const Segment_t *segp, Segorder_t where,
 
   // Add S5/6 record count record and S7/8/9 end of data record
   if(where & LAST_SEG) {
-    if(reccount > 0 && reccount <= 0xffffff) {
+    if(reccount >= 0 && reccount <= 0xffffff) {
       int wd = reccount <= 0xffff? 2: 3;
       fprintf(outf, "S%c%02X%0*X%02X\n", '5' + (wd == 3), wd + 1, 2*wd, reccount,
         cksum_srec(NULL, 0, reccount, wd));

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1457,8 +1457,8 @@ int segment_normalise(const AVRMEM *mem, Segment_t *segp) {
     addr = maxsize + addr;
 
   if(addr < 0 || addr >= maxsize) {
-    pmsg_error("%s address %s is out of range [-0x%0*x, 0x%0*x]\n",
-      mem->desc, segp->addr, digits, maxsize, digits, maxsize-1);
+    pmsg_error("%s address 0x%0*x is out of range [-0x%0*x, 0x%0*x]\n",
+      mem->desc, digits, segp->addr, digits, maxsize, digits, maxsize-1);
     return -1;
   }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1227,7 +1227,7 @@ static int b2num(const char *filename, FILE *f, const AVRMEM *mem, const Segment
   if (putc('\n', f) == EOF)
     goto writeerr;
 
-  return segp->addr + segp->len-1;
+  return segp->addr + segp->len;
 
  writeerr:
   pmsg_ext_error("unable to write to %s: %s\n", filename, strerror(errno));
@@ -1555,7 +1555,7 @@ static int fileio_segments_normalise(int oprwv, const char *filename, FILEFMT fo
   for(int i=0; i<n; i++) {
     int addr = seglist[i].addr, len = seglist[i].len;
 
-    if(len == 0)
+    if(len == 0 && fio.op != FIO_WRITE)
       continue;
 
     if(fio.op == FIO_READ) // Fill unspecified memory in segment


### PR DESCRIPTION
`-U flash:r:<file>:<fmt>` produces an empty file if flash memory is empty (unless `-A` has switched off the trailing 0xff removal). However, an empty file is not a correct Intel Hex file as it misses the EOF marker:
```
$ avrdude -qq -c dryrun -p m328p -U flash:r:empty-flash.hex:i
$ avrdude -qq -c dryrun -p m328p -U flash:w:empty-flash.hex:i
avrdude error: no valid record found in Intel Hex file empty-flash.hex
avrdude error: read from file empty-flash.hex failed
srueger@medlar avrdude-main 2005$ (main 5U) ls -l empty-flash.hex 
-rw------- 1 srueger srueger 0 Jun 24 12:58 empty-flash.hex
```

This PR creates empty files with the correct format
 - Intel Hex (EOF record)
 - Motorola S-Record (Start record, EOF record)
 - Number lists (one empty line, ie, one character `\n`)
 - Raw binary (empty file, ie, zero characters)



