### PR TITLE
Provide terminal include command

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1150,6 +1150,11 @@ can be uniquely resolved.
 It is quite possible, as is with direct writing to the underlying fuses
 and lock bits, to brick a part, i.e., make it unresponsive to further
 programming with the chosen programmer: here be dragons.
+.It Ar include [<opts>] <file>
+Include contents of the named file as if it was typed. This is useful for
+batch scripts, eg, recurring initialisation code for fuses. The include
+option -e prints the lines of the file as comments before processing them;
+on a non-zero verbosity level the line numbers are printed, too.
 .It Ar sig
 Display the device signature bytes.
 .It Ar part

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2267,6 +2267,13 @@ It is quite possible, as is with direct writing to the underlying fuses
 and lock bits, to brick a part, i.e., make it unresponsive to further
 programming with the chosen programmer: here be dragons.
 
+@item include [@var{opts}] @var{file}
+Include contents of the named file @var{file} as if it was typed. This is
+useful for batch scripts, eg, recurring initialisation code for fuses. The
+include option @code{-e} prints the lines of the file as comments before
+processing them; on a non-zero verbosity level the line numbers are
+printed, too.
+
 @item sig
 Display the device signature bytes.
 

--- a/src/term.c
+++ b/src/term.c
@@ -73,6 +73,7 @@ static int cmd_abort  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
 static int cmd_erase  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_config (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
+static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_sig    (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_part   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_help   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
@@ -100,6 +101,7 @@ struct command cmd[] = {
   { "erase", cmd_erase, _fo(chip_erase_cached), "perform a chip or memory erase" },
   { "pgerase", cmd_pgerase, _fo(page_erase),    "erase one page of flash or EEPROM memory" },
   { "config", cmd_config, _fo(open),            "change or show configuration properties of the part" },
+  { "include", cmd_include, _fo(open),          "include contents of named file as if it was typed" },
   { "sig",   cmd_sig,   _fo(open),              "display device signature bytes" },
   { "part",  cmd_part,  _fo(open),              "display the current part information" },
   { "send",  cmd_send,  _fo(cmd),               "send a raw command to the programmer" },
@@ -2206,6 +2208,75 @@ int terminal_mode(const PROGRAMMER *pgm, const AVRPART *p) {
 #endif
   return terminal_mode_noninteractive(pgm, p);
 }
+
+
+static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+  int help = 0, invalid = 0, echo = 0, itemac=1;
+
+  for(int ai = 0; --argc > 0; ) { // Simple option parsing
+    const char *q;
+    if(*(q=argv[++ai]) != '-' || !q[1])
+      argv[itemac++] = argv[ai];
+    else {
+      while(*++q) {
+        switch(*q) {
+        case '?':
+        case 'h':
+          help++;
+          break;
+        case 'e':
+          echo++;
+          break;
+        default:
+          if(!invalid++)
+            pmsg_error("(config) invalid option %c, see usage:\n", *q);
+          q = "x";
+        }
+      }
+    }
+  }
+  argc = itemac;                // (arg,c argv) still valid but options have been removed
+
+  if(argc != 2 || help || invalid) {
+    msg_error(
+      "Syntax: include [opts] <file>\n"
+      "Function: include contents of named file as if it was typed\n"
+      "Option:\n"
+      "    -e echo lines as they are processed\n"
+    );
+    return !help || invalid? -1: 0;
+  }
+
+  int lineno = 0, rc = 0;
+  const char *errstr;
+  FILE *fp = fopen(argv[1], "r");
+  if(fp == NULL) {
+    pmsg_ext_error("(include) cannot open file %s: %s\n", argv[1], strerror(errno));
+    return -1;
+  }
+
+  for(char *buffer; (buffer = str_fgets(fp, &errstr)); free(buffer)) {
+    lineno++;
+    if(echo) {
+      term_out("# ");
+      if(verbose > 0)
+       term_out("%d: ", lineno);
+      term_out("%s", buffer);
+      term_out("\v");
+    }
+    if(process_line(buffer, pgm, p) < 0)
+      rc = -1;
+    term_out("\v");
+  }
+  if(errstr) {
+    pmsg_error("(include) read error in file %s: %s\n", argv[1], errstr);
+    return -1;
+  }
+
+  fclose(fp);
+  return rc;
+}
+
 
 static void update_progress_tty(int percent, double etime, const char *hdr, int finish) {
   static char *header;


### PR DESCRIPTION
Example
-------

Initialise a config file for ATmega328P with factory settings and edit it:
```
$ avrdude -qqTconfig -c dryrun -p m328p >config-m328p.txt
$ vi config-m328p.txt
```

The new include command allows this file to be applied before opening a terminal:
```
$ avrdude -qq -T"include config-m328p.txt" -t -c dryrun -p m328p
avrdude> quit
```

The include option `-e` prints the lines as comments before processing them:
```
$ avrdude -qq -T"include -e config-m328p.txt" -c dryrun -p m328p
# config sut_cksel=intrcosc_8mhz_6ck_14ck_65ms # 34
# config ckout=co_disabled # 1
# config ckdiv8=by_8 # 0
# config bootrst=application # 1
# config bootsz=bs_2048w # 0
# config eesave=ee_erased # 1
# config wdton=wdt_programmable # 1
# config spien=isp_enabled # 0
# config dwen=dw_off # 1
# config rstdisbl=external_reset # 1
# config bodlevel=bod_disabled # 7
# config lb=no_lock # 3
# config blb0=no_lock_in_app # 3
# config blb1=no_lock_in_boot # 3
```

On non-zero verbosity level the include option `-e` also prints line numbers:
```
$ avrdude -vqqq -T"include -e config-m328p.txt" -c dryrun -p m328p
# 1: config sut_cksel=intrcosc_8mhz_6ck_14ck_65ms # 34
# 2: config ckout=co_disabled # 1
# 3: config ckdiv8=by_8 # 0
# 4: config bootrst=application # 1
# 5: config bootsz=bs_2048w # 0
# 6: config eesave=ee_erased # 1
# 7: config wdton=wdt_programmable # 1
# 8: config spien=isp_enabled # 0
# 9: config dwen=dw_off # 1
# 10: config rstdisbl=external_reset # 1
# 11: config bodlevel=bod_disabled # 7
# 12: config lb=no_lock # 3
# 13: config blb0=no_lock_in_app # 3
# 14: config blb1=no_lock_in_boot # 3
```

