### PR TITLE
Suppress overzealous compiler warnings

### DIFF
--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2725,7 +2725,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   // determine which command is to be used
   if (strcmp(m->desc, "flash") == 0) {
     addrshift = 1;
-    PDATA(pgm)->flash_pageaddr = -1UL; // Invalidate cache
+    PDATA(pgm)->flash_pageaddr = ~0UL; // Invalidate cache
     commandbuf[0] = CMD_PROGRAM_FLASH_ISP;
     /*
      * If bit 31 is set, this indicates that the following read/write
@@ -2737,7 +2737,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
       use_ext_addr = (1U << 31);
     }
   } else if (strcmp(m->desc, "eeprom") == 0) {
-    PDATA(pgm)->eeprom_pageaddr = -1UL; // Invalidate cache
+    PDATA(pgm)->eeprom_pageaddr = ~0UL; // Invalidate cache
     commandbuf[0] = CMD_PROGRAM_EEPROM_ISP;
   }
   commandbuf[4] = m->delay;


### PR DESCRIPTION
This PR replaces `-1UL` with `~0UL` (and my heart bleeds a little).

Some compilers are overzealous when the unary minus operates on an unsigned number, and issue a warning. In fact, `-u` is a perfectly valid unsigned for any unsigned `u`, and always has been from K&R C to C++20. `-u` is the same as `~u + 1`. C/C++ unsigned numbers form a group, where `-u` is the unique unsigned number that when added to `u` results in `0`. Neither `u` nor `-u` can be negative because no unsigned number is.