### PR TITLE
Suppress invalid compiler warning

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1180,7 +1180,7 @@ static void printproperty(Cfg_t *cc, int ii, Cfg_opts_t o) {
     vstr = buf;
   }
 
-  int lmin, lmax, llen;
+  size_t lmin, lmax, llen;
   lmin = lmax = strlen(vstr);
 
   if(o.verb > 0) {


### PR DESCRIPTION
A warning when building under NetBSD 9.3 (gcc 7.5.0) complains about a comparison of the form `lmax <= lmin+MAX_PAD`, which is mistaken to be of the type `(X + c) >= X` despite `lmin` and `lmax` not necessarily having the same value.

This PR tries to suppress the warning about potential signed overflow by making `lmin`, `lmax` and `llen` the type `size_t`.