### PR TITLE
Utilize `HAS_VTARG_READ` defined in avrdude.conf

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -69,6 +69,7 @@
 #   #    the behavior of the mEDBG programmer/debugger chip. See the Xplained Mini/Nano
 #   #    documentation for more information
 #   #  - HAS_VTARG_SWITCH: Programer has a programmable target power switch
+#   #  - HAS_VTARG_READ: Programmer can read the target voltage
 #   #  - HAS_VTARG_ADJ: Programmer has an adjustable target power source that can
 #   #    be controlled with Avrdude
 #   #  - HAS_FOSC_ADJ: Programmer has a programable frequency generator that
@@ -2246,6 +2247,7 @@ programmer
     desc                   = "Atmel AVR XplainedPro in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
+    extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     usbpid                 = 0x2111;
 ;
@@ -2259,6 +2261,7 @@ programmer
     desc                   = "Atmel AVR XplainedPro in PDI mode";
     type                   = "jtagice3_pdi";
     prog_modes             = PM_PDI;
+    extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     usbpid                 = 0x2111;
     hvupdi_support         = 1;
@@ -2273,6 +2276,7 @@ programmer
     desc                   = "Atmel AVR XplainedPro in UPDI mode";
     type                   = "jtagice3_updi";
     prog_modes             = PM_UPDI;
+    extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     usbpid                 = 0x2111;
     hvupdi_support         = 1;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2621,7 +2621,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sVout measured   : %.02f V\n", p, (float) analog_raw_data / -200.0);
+        fmsg_out(fp, "%sVout measured   : %.02f V\n", p, analog_raw_data / -200.0);
       }
 
       // Read channel A voltage
@@ -2633,7 +2633,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh A voltage    : %.03f V\n", p, (float) analog_raw_data / -200.0);
+        fmsg_out(fp, "%sCh A voltage    : %.03f V\n", p, analog_raw_data / -200.0);
       }
 
       // Read channel A current
@@ -2643,7 +2643,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       if (buf[0] != 0x90)
         pmsg_error("invalid PARM3_ANALOG_A_CURRENT data packet format\n");
       else
-        fmsg_out(fp, "%sCh A current    : %.3f mA\n", p, (float) analog_raw_data * 0.003472);
+        fmsg_out(fp, "%sCh A current    : %.3f mA\n", p, analog_raw_data * 0.003472);
 
       // Read channel B voltage
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_B_VOLTAGE, buf, 2) < 0)
@@ -2654,7 +2654,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh B voltage    : %.03f V\n", p, (float) analog_raw_data / -200.0);
+        fmsg_out(fp, "%sCh B voltage    : %.03f V\n", p, analog_raw_data / -200.0);
       }
 
       // Read channel B current
@@ -2666,7 +2666,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh B current    : %.3f mA\n", p, (float) analog_raw_data * 0.555556);
+        fmsg_out(fp, "%sCh B current    : %.3f mA\n", p, analog_raw_data * 0.555556);
       }
       break;
     }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2562,11 +2562,13 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
   unsigned char prog_mode[2];
   unsigned char buf[3];
 
-  if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
-    return;
-  msg_info("%sVtarget         : %.2f V\n", p, b2_to_u16(buf)/1000.0);
+  if (pgm->extra_features & HAS_VTARG_READ) {
+    if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
+      return;
+    msg_info("%sVtarget         : %.2f V\n", p, b2_to_u16(buf)/1000.0);
+  }
 
-  // Print clocks if programmer typ is not TPI
+  // Print clocks if programmer type is not TPI
   if (!str_eq(pgm->type, "JTAGICE3_TPI")) {
     // Get current programming mode and target type from to determine what data to print
     if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, prog_mode, 1) < 0)

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -1179,8 +1179,7 @@ static void jtagmkI_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp)
   const char *clkstr;
   double clk;
 
-  if (jtagmkI_getparm(pgm, PARM_OCD_VTARGET, &vtarget) < 0 ||
-      jtagmkI_getparm(pgm, PARM_CLOCK, &jtag_clock) < 0)
+  if (jtagmkI_getparm(pgm, PARM_CLOCK, &jtag_clock) < 0)
     return;
 
   switch ((unsigned)jtag_clock) {
@@ -1209,7 +1208,11 @@ static void jtagmkI_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp)
     clk = 1e6;
   }
 
-  fmsg_out(fp, "%sVtarget       : %.1f V\n", p, 6.25 * (unsigned)vtarget / 255.0);
+  if (pgm->extra_features & HAS_VTARG_READ) {
+    if (jtagmkI_getparm(pgm, PARM_OCD_VTARGET, &vtarget) < 0)
+      return;
+    fmsg_out(fp, "%sVtarget       : %.1f V\n", p, 6.25 * (unsigned)vtarget / 255.0);
+  }
   fmsg_out(fp, "%sJTAG clock    : %s (%.1f us)\n", p, clkstr, 1.0e6 / clk);
 
   return;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2574,10 +2574,11 @@ static void jtagmkII_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
   char clkbuf[20];
   double clk;
 
-  if (jtagmkII_getparm(pgm, PAR_OCD_VTARGET, vtarget) < 0)
-    return;
-
-  fmsg_out(fp, "%sVtarget         : %.1f V\n", p, b2_to_u16(vtarget) / 1000.0);
+  if (pgm->extra_features & HAS_VTARG_READ) {
+    if (jtagmkII_getparm(pgm, PAR_OCD_VTARGET, vtarget) < 0)
+      return;
+    fmsg_out(fp, "%sVtarget         : %.1f V\n", p, b2_to_u16(vtarget) / 1000.0);
+  }
 
   if ((pgm->flag & PGM_FL_IS_JTAG)) {
     if (jtagmkII_getparm(pgm, PAR_OCD_JTAG_CLK, jtag_clock) < 0)

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1394,42 +1394,48 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
 static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
   unsigned vtarget, vadjust, osc_pscale, osc_cmatch, sck_duration;
 
-  stk500_getparm(pgm, Parm_STK_VTARGET, &vtarget);
-  stk500_getparm(pgm, Parm_STK_VADJUST, &vadjust);
-  stk500_getparm(pgm, Parm_STK_OSC_PSCALE, &osc_pscale);
-  stk500_getparm(pgm, Parm_STK_OSC_CMATCH, &osc_cmatch);
-  stk500_getparm(pgm, Parm_STK_SCK_DURATION, &sck_duration);
-
-  fmsg_out(fp, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
-  fmsg_out(fp, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
-  fmsg_out(fp, "%sOscillator      : ", p);
-  if (osc_pscale == 0)
-    fmsg_out(fp, "Off\n");
-  else {
-    int prescale = 1;
-    double f = STK500_XTAL / 2;
-    const char *unit;
-
-    switch (osc_pscale) {
-      case 2: prescale = 8; break;
-      case 3: prescale = 32; break;
-      case 4: prescale = 64; break;
-      case 5: prescale = 128; break;
-      case 6: prescale = 256; break;
-      case 7: prescale = 1024; break;
-    }
-    f /= prescale;
-    f /= (osc_cmatch + 1);
-    if (f > 1e6) {
-      f /= 1e6;
-      unit = "MHz";
-    } else if (f > 1e3) {
-      f /= 1000;
-      unit = "kHz";
-    } else
-      unit = "Hz";
-    fmsg_out(fp, "%.3f %s\n", f, unit);
+  if (pgm->extra_features & HAS_VTARG_READ) {
+    stk500_getparm(pgm, Parm_STK_VTARGET, &vtarget);
+    fmsg_out(fp, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
   }
+  if (pgm->extra_features & HAS_VAREF_ADJ) {
+    stk500_getparm(pgm, Parm_STK_VADJUST, &vadjust);
+    fmsg_out(fp, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
+  }
+  if (pgm->extra_features & HAS_FOSC_ADJ) {
+    stk500_getparm(pgm, Parm_STK_OSC_PSCALE, &osc_pscale);
+    stk500_getparm(pgm, Parm_STK_OSC_CMATCH, &osc_cmatch);
+    fmsg_out(fp, "%sOscillator      : ", p);
+    if (osc_pscale == 0)
+      fmsg_out(fp, "Off\n");
+    else {
+      int prescale = 1;
+      double f = STK500_XTAL / 2;
+      const char *unit;
+
+      switch (osc_pscale) {
+        case 2: prescale = 8; break;
+        case 3: prescale = 32; break;
+        case 4: prescale = 64; break;
+        case 5: prescale = 128; break;
+        case 6: prescale = 256; break;
+        case 7: prescale = 1024; break;
+      }
+      f /= prescale;
+      f /= (osc_cmatch + 1);
+      if (f > 1e6) {
+        f /= 1e6;
+        unit = "MHz";
+      } else if (f > 1e3) {
+        f /= 1000;
+        unit = "kHz";
+      } else
+        unit = "Hz";
+      fmsg_out(fp, "%.3f %s\n", f, unit);
+    }
+  }
+
+  stk500_getparm(pgm, Parm_STK_SCK_DURATION, &sck_duration);
   fmsg_out(fp, "%sSCK period      : %.1f us\n", p, sck_duration * 8.0e6 / STK500_XTAL + 0.05);
 
   return;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3701,7 +3701,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
   case PGMTYPE_JTAGICE_MKII:
     stk500v2_getparm(pgm, PARAM_SCK_DURATION, &sck_duration);
     fmsg_out(fp, "%sSCK period      : %.2f us\n", p,
-	    (float) 1000000 / avrispmkIIfreqs[sck_duration]);
+	    1000000 / avrispmkIIfreqs[sck_duration]);
     break;
 
   case PGMTYPE_JTAGICE3:
@@ -3731,7 +3731,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
       fmsg_out(fp, "%sVaref 1         : %.2f V\n", p, varef / 100.0);
     }
     stk500v2_getparm2(pgm, PARAM2_SCK_DURATION, &sck_stk600);
-    fmsg_out(fp, "%sSCK period      : %.2f us\n", p, (float) (sck_stk600 + 1) / 8.0);
+    fmsg_out(fp, "%sSCK period      : %.2f us\n", p, (sck_stk600 + 1) / 8.0);
     if (pgm->extra_features & HAS_FOSC_ADJ) {
       stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf);
       oct = (clock_conf & 0xf000) >> 12u;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3649,45 +3649,51 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
 
   memset(vtarget_jtag, 0, sizeof vtarget_jtag);
 
-  if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE_MKII) {
-    PROGRAMMER *pgmcp = pgm_dup(pgm);
-    pgmcp->cookie = PDATA(pgm)->chained_pdata;
-    jtagmkII_getparm(pgmcp, PAR_OCD_VTARGET, vtarget_jtag);
-    pgm_free(pgmcp);
-    fmsg_out(fp, "%sVtarget         : %.1f V\n", p, b2_to_u16(vtarget_jtag) / 1000.0);
-  } else if (PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE3) {
-    stk500v2_getparm(pgm, PARAM_VTARGET, &vtarget);
-    fmsg_out(fp, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
+  if (pgm->extra_features & HAS_VTARG_READ) {
+    if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE_MKII) {
+      PROGRAMMER *pgmcp = pgm_dup(pgm);
+      pgmcp->cookie = PDATA(pgm)->chained_pdata;
+      jtagmkII_getparm(pgmcp, PAR_OCD_VTARGET, vtarget_jtag);
+      pgm_free(pgmcp);
+      fmsg_out(fp, "%sVtarget         : %.1f V\n", p, b2_to_u16(vtarget_jtag) / 1000.0);
+    } else if (PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE3) {
+      stk500v2_getparm(pgm, PARAM_VTARGET, &vtarget);
+      fmsg_out(fp, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
+    }
   }
 
   switch (PDATA(pgm)->pgmtype) {
   case PGMTYPE_STK500:
     stk500v2_getparm(pgm, PARAM_SCK_DURATION, &sck_duration);
-    stk500v2_getparm(pgm, PARAM_VADJUST, &vadjust);
-    stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
-    stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
     fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
 	    stk500v2_sck_to_us(pgm, sck_duration));
-    fmsg_out(fp, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
-    fmsg_out(fp, "%sOscillator      : ", p);
-    if (osc_pscale == 0)
-      fmsg_out(fp, "Off\n");
-    else {
-      prescale = 1;
-      f = STK500V2_XTAL / 2;
+    if (pgm->extra_features & HAS_VAREF_ADJ) {
+      stk500v2_getparm(pgm, PARAM_VADJUST, &vadjust);
+      fmsg_out(fp, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
+    }
+    if (pgm->extra_features & HAS_FOSC_ADJ) {
+      stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
+      stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
+      fmsg_out(fp, "%sOscillator      : ", p);
+      if (osc_pscale == 0)
+        fmsg_out(fp, "Off\n");
+      else {
+        prescale = 1;
+        f = STK500V2_XTAL / 2;
 
-      switch (osc_pscale) {
-        case 2: prescale = 8; break;
-        case 3: prescale = 32; break;
-        case 4: prescale = 64; break;
-        case 5: prescale = 128; break;
-        case 6: prescale = 256; break;
-        case 7: prescale = 1024; break;
+        switch (osc_pscale) {
+          case 2: prescale = 8; break;
+          case 3: prescale = 32; break;
+          case 4: prescale = 64; break;
+          case 5: prescale = 128; break;
+          case 6: prescale = 256; break;
+          case 7: prescale = 1024; break;
+        }
+        f /= prescale;
+        f /= (osc_cmatch + 1);
+        f = f_to_kHz_MHz(f, &unit);
+        fmsg_out(fp, "%.3f %s\n", f, unit);
       }
-      f /= prescale;
-      f /= (osc_cmatch + 1);
-      f = f_to_kHz_MHz(f, &unit);
-      fmsg_out(fp, "%.3f %s\n", f, unit);
     }
     break;
 
@@ -3718,20 +3724,22 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
     break;
 
   case PGMTYPE_STK600:
-    stk500v2_getparm2(pgm, PARAM2_AREF0, &varef);
-    fmsg_out(fp, "%sVaref 0         : %.2f V\n", p, varef / 100.0);
-    stk500v2_getparm2(pgm, PARAM2_AREF1, &varef);
-    fmsg_out(fp, "%sVaref 1         : %.2f V\n", p, varef / 100.0);
+    if (pgm->extra_features & HAS_VAREF_ADJ) {
+      stk500v2_getparm2(pgm, PARAM2_AREF0, &varef);
+      fmsg_out(fp, "%sVaref 0         : %.2f V\n", p, varef / 100.0);
+      stk500v2_getparm2(pgm, PARAM2_AREF1, &varef);
+      fmsg_out(fp, "%sVaref 1         : %.2f V\n", p, varef / 100.0);
+    }
     stk500v2_getparm2(pgm, PARAM2_SCK_DURATION, &sck_stk600);
-    fmsg_out(fp, "%sSCK period      : %.2f us\n", p,
-	    (float) (sck_stk600 + 1) / 8.0);
-    stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf);
-    oct = (clock_conf & 0xf000) >> 12u;
-    dac = (clock_conf & 0x0ffc) >> 2u;
-    f = pow(2, (double)oct) * 2078.0 / (2 - (double)dac / 1024.0);
-    f = f_to_kHz_MHz(f, &unit);
-    fmsg_out(fp, "%sOscillator      : %.3f %s\n",
-            p, f, unit);
+    fmsg_out(fp, "%sSCK period      : %.2f us\n", p, (float) (sck_stk600 + 1) / 8.0);
+    if (pgm->extra_features & HAS_FOSC_ADJ) {
+      stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf);
+      oct = (clock_conf & 0xf000) >> 12u;
+      dac = (clock_conf & 0x0ffc) >> 2u;
+      f = pow(2, (double)oct) * 2078.0 / (2 - (double)dac / 1024.0);
+      f = f_to_kHz_MHz(f, &unit);
+      fmsg_out(fp, "%sOscillator      : %.3f %s\n", p, f, unit);
+    }
     break;
 
   default:

--- a/src/term.c
+++ b/src/term.c
@@ -105,7 +105,7 @@ struct command cmd[] = {
   { "sig",   cmd_sig,   _fo(open),              "display device signature bytes" },
   { "part",  cmd_part,  _fo(open),              "display the current part information" },
   { "send",  cmd_send,  _fo(cmd),               "send a raw command to the programmer" },
-  { "parms", cmd_parms, _fo(print_parms),       "display adjustable parameters" },
+  { "parms", cmd_parms, _fo(print_parms),       "display useful parameters" },
   { "vtarg", cmd_vtarg, _fo(set_vtarget),       "set the target voltage" },
   { "varef", cmd_varef, _fo(set_varef),         "set the analog reference voltage" },
   { "fosc",  cmd_fosc,  _fo(set_fosc),          "set the oscillator frequency" },
@@ -1631,7 +1631,7 @@ static int cmd_parms(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   if(argc > 1) {
     msg_error(
       "Syntax: parms\n"
-      "Function: display adjustable parameters\n"
+      "Function: display useful parameters\n"
     );
     return -1;
   }


### PR DESCRIPTION
Resolves issue #1469.

Tested with the following programmers, where I've tried with and without `HAS_VTARG_READ` in avrdude.conf.

* `xplainedpro`
* `xplainedpro_pdi`
* `xplainedpro_updi`
* `powerdebugger_jtag`
* `powerdebugger_isp`
* `powerdebugger_pdi`
* `powerdebugger_updi`
* `dragon_isp`
* `dragon_pp`
* `avrispmkii`
* `xplainedmini_updi`
* `xplainedmini_isp`

