### PR TITLE
Replace string comparison functions

### DIFF
--- a/src/avr910.c
+++ b/src/avr910.c
@@ -403,7 +403,7 @@ static int avr910_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 {
   char cmd[2];
 
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     if (addr & 0x01) {
       cmd[0] = 'C';             /* Write Program Mem high byte */
     }
@@ -413,7 +413,7 @@ static int avr910_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
     addr >>= 1;
   }
-  else if (strcmp(m->desc, "eeprom") == 0) {
+  else if (str_eq(m->desc, "eeprom")) {
     cmd[0] = 'D';
   }
   else {
@@ -468,11 +468,11 @@ static int avr910_read_byte_eeprom(const PROGRAMMER *pgm, const AVRPART *p, cons
 static int avr910_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                             unsigned long addr, unsigned char * value)
 {
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     return avr910_read_byte_flash(pgm, p, m, addr, value);
   }
 
-  if (strcmp(m->desc, "eeprom") == 0) {
+  if (str_eq(m->desc, "eeprom")) {
     return avr910_read_byte_eeprom(pgm, p, m, addr, value);
   }
 
@@ -574,9 +574,9 @@ static int avr910_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 {
   int rval = 0;
   if (PDATA(pgm)->use_blockmode == 0) {
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       rval = avr910_paged_write_flash(pgm, p, m, page_size, addr, n_bytes);
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       rval = avr910_paged_write_eeprom(pgm, p, m, page_size, addr, n_bytes);
     } else {
       rval = -2;
@@ -589,7 +589,7 @@ static int avr910_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     unsigned int blocksize = PDATA(pgm)->buffersize;
     int wr_size;
 
-    if (strcmp(m->desc, "flash") && strcmp(m->desc, "eeprom"))
+    if (!str_eq(m->desc, "flash") && !str_eq(m->desc, "eeprom"))
       return -2;
 
     if (m->desc[0] == 'e') {
@@ -640,10 +640,10 @@ static int avr910_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
   max_addr = addr + n_bytes;
 
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     cmd[0] = 'R';
     rd_size = 2;                /* read two bytes per addr */
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     cmd[0] = 'd';
     rd_size = 1;
   } else {

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1253,9 +1253,9 @@ static int avrftdi_flash_read(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 static int avrftdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
 		unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
-	if (strcmp(m->desc, "flash") == 0)
+	if (str_eq(m->desc, "flash"))
 		return avrftdi_flash_write(pgm, p, m, page_size, addr, n_bytes);
-	else if (strcmp(m->desc, "eeprom") == 0)
+	else if (str_eq(m->desc, "eeprom"))
 		return avrftdi_eeprom_write(pgm, p, m, page_size, addr, n_bytes);
 	else
 		return -2;
@@ -1264,9 +1264,9 @@ static int avrftdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
 static int avrftdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
 		unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
-	if (strcmp(m->desc, "flash") == 0)
+	if (str_eq(m->desc, "flash"))
 		return avrftdi_flash_read(pgm, p, m, page_size, addr, n_bytes);
-	else if(strcmp(m->desc, "eeprom") == 0)
+	else if(str_eq(m->desc, "eeprom"))
 		return avrftdi_eeprom_read(pgm, p, m, page_size, addr, n_bytes);
 	else
 		return -2;
@@ -1541,7 +1541,7 @@ static int avrftdi_jtag_chip_erase(const PROGRAMMER *pgm, const AVRPART *p)
 static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		const AVRMEM *m, unsigned long addr, unsigned char *value)
 {
-	if (strcmp(m->desc, "lfuse") == 0) {
+	if (str_eq(m->desc, "lfuse")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1549,7 +1549,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3200, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3300, 15) & 0xff;
 
-	} else if (strcmp(m->desc, "hfuse") == 0) {
+	} else if (str_eq(m->desc, "hfuse")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1557,7 +1557,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3e00, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3f00, 15) & 0xff;
 
-	} else if (strcmp(m->desc, "efuse") == 0) {
+	} else if (str_eq(m->desc, "efuse")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1565,7 +1565,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3a00, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3b00, 15) & 0xff;
 
-	} else if (strcmp(m->desc, "lock") == 0) {
+	} else if (str_eq(m->desc, "lock")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1573,7 +1573,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3600, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0xff;
 
-	} else if (strcmp(m->desc, "signature") == 0) {
+	} else if (str_eq(m->desc, "signature")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_SIGCAL_READ, 15);
 		avrftdi_jtag_dr_out(pgm, 0x0300 | (addr & 0xff), 15);
@@ -1582,7 +1582,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3200, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3300, 15) & 0xff;
 
-	} else if (strcmp(m->desc, "calibration") == 0) {
+	} else if (str_eq(m->desc, "calibration")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_SIGCAL_READ, 15);
 		avrftdi_jtag_dr_out(pgm, 0x0300 | (addr & 0xff), 15);
@@ -1601,7 +1601,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		const AVRMEM *m, unsigned long addr, unsigned char value)
 {
-	if (strcmp(m->desc, "lfuse") == 0) {
+	if (str_eq(m->desc, "lfuse")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_WRITE, 15);
 
@@ -1618,7 +1618,7 @@ static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3300, 15) & 0x0200))
 			;
 
-	} else if (strcmp(m->desc, "hfuse") == 0) {
+	} else if (str_eq(m->desc, "hfuse")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_WRITE, 15);
 
@@ -1635,7 +1635,7 @@ static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0x0200))
 			;
 
-	} else if (strcmp(m->desc, "efuse") == 0) {
+	} else if (str_eq(m->desc, "efuse")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_WRITE, 15);
 
@@ -1652,7 +1652,7 @@ static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3b00, 15) & 0x0200))
 			;
 
-	} else if (strcmp(m->desc, "lock") == 0) {
+	} else if (str_eq(m->desc, "lock")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_LOCK_WRITE, 15);
 
@@ -1683,7 +1683,7 @@ static int avrftdi_jtag_paged_write(const PROGRAMMER *pgm, const AVRPART *p,
 	unsigned int maxaddr = addr + n_bytes;
 	unsigned char byte;
 
-	if (strcmp(m->desc, "flash") == 0) {
+	if (str_eq(m->desc, "flash")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FLASH_WRITE, 15);
 
@@ -1710,7 +1710,7 @@ static int avrftdi_jtag_paged_write(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0x0200))
 			;
 
-	} else if (strcmp(m->desc, "eeprom") == 0) {
+	} else if (str_eq(m->desc, "eeprom")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_EEPROM_WRITE, 15);
 
@@ -1758,7 +1758,7 @@ static int avrftdi_jtag_paged_read(const PROGRAMMER *pgm, const AVRPART *p,
     buf = alloca(n_bytes * 8 + 1);
     ptr = buf;
 
-	if (strcmp(m->desc, "flash") == 0) {
+	if (str_eq(m->desc, "flash")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FLASH_READ, 15);
 
@@ -1798,7 +1798,7 @@ static int avrftdi_jtag_paged_read(const PROGRAMMER *pgm, const AVRPART *p,
 			m->buf[addr + i] = (buf[i * 2] >> 1) | (buf[(i * 2) + 1] << 2);
 		}
 
-	} else if (strcmp(m->desc, "eeprom") == 0) {
+	} else if (str_eq(m->desc, "eeprom")) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_EEPROM_READ, 15);
 

--- a/src/avrintel.c
+++ b/src/avrintel.c
@@ -47,7 +47,7 @@ int upidxsig(const uint8_t *sigs) {
 // Given the long name of a part return index in uP table or -1 if not found
 int upidxname(const char *name) {
   for(size_t i=0; i < sizeof uP_table/sizeof *uP_table; i++)
-    if(str_caseeq(name, uP_table[i].name))
+    if(0 == strcasecmp(name, uP_table[i].name))
       return i;
 
   return -1;

--- a/src/avrintel.c
+++ b/src/avrintel.c
@@ -47,7 +47,7 @@ int upidxsig(const uint8_t *sigs) {
 // Given the long name of a part return index in uP table or -1 if not found
 int upidxname(const char *name) {
   for(size_t i=0; i < sizeof uP_table/sizeof *uP_table; i++)
-    if(0 == strcasecmp(name, uP_table[i].name))
+    if(str_caseeq(name, uP_table[i].name))
       return i;
 
   return -1;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -137,7 +137,7 @@ int avr_set_addr_mem(const AVRMEM *mem, int opnum, unsigned char *cmd, unsigned 
   if(!(op = mem->op[opnum]))
     return -1;
 
-  isflash = !strcmp(mem->desc, "flash"); // ISP parts have only one flash-like memory
+  isflash = str_eq(mem->desc, "flash"); // ISP parts have only one flash-like memory
   memsize = mem->size >> isflash;        // word addresses for flash
   pagesize = mem->page_size >> isflash;
 
@@ -434,7 +434,7 @@ AVRMEM_ALIAS *avr_locate_memalias(const AVRPART *p, const char *desc) {
   match = NULL;
   for (ln=lfirst(p->mem_alias); ln; ln=lnext(ln)) {
     m = ldata(ln);
-    if(l && strncmp(m->desc, desc, l) == 0) { // Partial initial match
+    if(l && str_starts(m->desc, desc)) { // Partial initial match
       match = m;
       matches++;
       if(m->desc[l] == 0)       // Exact match; return straight away
@@ -459,7 +459,7 @@ AVRMEM *avr_locate_mem_noalias(const AVRPART *p, const char *desc) {
   match = NULL;
   for (ln=lfirst(p->mem); ln; ln=lnext(ln)) {
     m = ldata(ln);
-    if(l && strncmp(m->desc, desc, l) == 0) { // Partial initial match
+    if(l && str_starts(m->desc, desc)) { // Partial initial match
       match = m;
       matches++;
       if(m->desc[l] == 0)       // Exact match; return straight away
@@ -511,7 +511,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
 
   if (m != NULL) {
     // Only print memory section if the previous section printed isn't identical
-    if(prev_mem_offset != m->offset || prev_mem_size != m->size || (strcmp(p->family_id, "") == 0)) {
+    if(prev_mem_offset != m->offset || prev_mem_size != m->size || str_eq(p->family_id, "")) {
       prev_mem_offset = m->offset;
       prev_mem_size = m->size;
       AVRMEM_ALIAS *ap = avr_find_memalias(p, m);

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -342,11 +342,11 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 			char *resetpin;
 			while ((resetpin = strtok(preset, ","))) {
 				preset = NULL; /* for subsequent strtok() calls */
-				if (strcasecmp(resetpin, "cs") == 0)
+				if (str_caseeq(resetpin, "cs"))
 					PDATA(pgm)->reset |= BP_RESET_CS;
-				else if (strcasecmp(resetpin, "aux") == 0 || strcasecmp(reset, "aux1") == 0)
+				else if (str_caseeq(resetpin, "aux") || str_caseeq(reset, "aux1"))
 					PDATA(pgm)->reset |= BP_RESET_AUX;
-				else if (strcasecmp(resetpin, "aux2") == 0)
+				else if (str_caseeq(resetpin, "aux2"))
 					PDATA(pgm)->reset |= BP_RESET_AUX2;
 				else {
 					pmsg_error("reset must be either CS or AUX\n");

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -669,7 +669,7 @@ static int buspirate_start_spi_mode_ascii(const PROGRAMMER *pgm) {
 		if (rcvd == NULL) {
 			return -1;
 		}
-		if (strstr(rcvd, "Normal (H=3.3V, L=GND)")) {
+		if (str_contains(rcvd, "Normal (H=3.3V, L=GND)")) {
 			/* BP firmware 2.1 defaults to Open-drain output.
 			 * That doesn't work on my board, even with pull-up
 			 * resistors. Select 3.3V output mode instead. */

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -456,7 +456,7 @@ static int butterfly_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   int size;
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
 
-  if ((strcmp(m->desc, "flash") == 0) || (strcmp(m->desc, "eeprom") == 0))
+  if (str_eq(m->desc, "flash") || str_eq(m->desc, "eeprom"))
   {
     cmd[0] = 'B';
     cmd[1] = 0;
@@ -476,7 +476,7 @@ static int butterfly_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
       butterfly_set_addr(pgm, addr);
     }
   }
-  else if (strcmp(m->desc, "lock") == 0)
+  else if (str_eq(m->desc, "lock"))
   {
     cmd[0] = 'l';
     cmd[1] = value;
@@ -515,9 +515,9 @@ static int butterfly_read_byte_flash(const PROGRAMMER *pgm, const AVRPART *p, co
     }
     // Defaults to flash read ('F')
     char msg[4] = {'g', 0x00, 0x02, 'F'};
-    if (strcmp(m->desc, "prodsig") == 0)
+    if (str_eq(m->desc, "prodsig"))
       msg[3] = 'P';
-    else if (strcmp(m->desc, "usersig") == 0)
+    else if (str_eq(m->desc, "usersig"))
       msg[3] = 'U';
     butterfly_send(pgm, msg, 4);
     /* Read back the program mem word (MSB first) */
@@ -552,26 +552,26 @@ static int butterfly_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
 {
   char cmd;
 
-  if (strcmp(m->desc, "flash")   == 0 ||
-      strcmp(m->desc, "prodsig") == 0 ||
-      strcmp(m->desc, "usersig") == 0) {
+  if (str_eq(m->desc, "flash")   ||
+      str_eq(m->desc, "prodsig") ||
+      str_eq(m->desc, "usersig")) {
     return butterfly_read_byte_flash(pgm, p, m, addr, value);
   }
 
-  if (strcmp(m->desc, "eeprom") == 0) {
+  if (str_eq(m->desc, "eeprom")) {
     return butterfly_read_byte_eeprom(pgm, p, m, addr, value);
   }
 
-  if (strcmp(m->desc, "lfuse") == 0) {
+  if (str_eq(m->desc, "lfuse")) {
     cmd = 'F';
   }
-  else if (strcmp(m->desc, "hfuse") == 0) {
+  else if (str_eq(m->desc, "hfuse")) {
     cmd = 'N';
   }
-  else if (strcmp(m->desc, "efuse") == 0) {
+  else if (str_eq(m->desc, "efuse")) {
     cmd = 'Q';
   }
-  else if (strcmp(m->desc, "lock") == 0) {
+  else if (str_eq(m->desc, "lock")) {
     cmd = 'r';
   }
   else
@@ -595,9 +595,9 @@ static int butterfly_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const 
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
   unsigned int wr_size = 2;
 
-  if (strcmp(m->desc, "flash")  &&
-      strcmp(m->desc, "eeprom") &&
-      strcmp(m->desc, "usersig"))
+  if (!str_eq(m->desc, "flash")  &&
+      !str_eq(m->desc, "eeprom") &&
+      !str_eq(m->desc, "usersig"))
     return -2;
 
   if (m->desc[0] == 'e')
@@ -652,9 +652,9 @@ static int butterfly_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
 
   /* check parameter syntax: only "flash", "eeprom" or "usersig" is allowed */
-  if (strcmp(m->desc, "flash")  &&
-      strcmp(m->desc, "eeprom") &&
-      strcmp(m->desc, "usersig"))
+  if (!str_eq(m->desc, "flash")  &&
+      !str_eq(m->desc, "eeprom") &&
+      !str_eq(m->desc, "usersig"))
     return -2;
 
   if (m->desc[0] == 'e')

--- a/src/config.c
+++ b/src/config.c
@@ -939,7 +939,7 @@ void cfg_update_mcuid(AVRPART *part) {
 
   // Find an entry that shares the same name, overwrite mcuid with known, existing mcuid
   for(size_t i=0; i < sizeof uP_table/sizeof *uP_table; i++) {
-    if(strcasecmp(part->desc, uP_table[i].name) == 0) {
+    if(str_caseeq(part->desc, uP_table[i].name)) {
       if(part->mcuid != (int) uP_table[i].mcuid) {
         if(part->mcuid >= 0 && verbose >= MSG_DEBUG)
           yywarning("overwriting mcuid of part %s to be %d", part->desc, uP_table[i].mcuid);

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -630,7 +630,7 @@ part_parm :
         TOKEN *t = lrmv_n(string_list, 1);
         int found = 0;
         for(LNODEID ln = lfirst(current_part->variants); ln; ln = lnext(ln)) {
-          if(!strcmp((char *) ldata(ln), t->value.string)) {
+          if(str_eq((char *) ldata(ln), t->value.string)) {
             found = 1;
             break;
           }
@@ -1358,7 +1358,7 @@ static int parse_cmdbits(OPCODE * op, int opnum)
           if(bitno < 8 || bitno > 23)
             yywarning("address bits don't normally appear in Bytes 0 or 3 of SPI commands");
           else if((bn & 31) != sb) {
-            if(strncasecmp(current_part->desc, "AT89S5", 6)) // Exempt AT89S5x from warning
+            if(!str_casestarts(current_part->desc, "AT89S5")) // Exempt AT89S5x from warning
               yywarning("a%d would normally be expected to be a%d", bn, sb);
           } else if(bn < 0 || bn > 31)
             yywarning("invalid address bit a%d, using a%d", bn, bn & 31);

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -345,7 +345,7 @@ int dev_message(int msglvl, const char *fmt, ...) {
 int dev_has_subsstr_comms(const LISTID comms, const char *subs) {
   if(comms)
     for(LNODEID ln=lfirst(comms); ln; ln=lnext(ln))
-       if(strstr((char *) ldata(ln), subs))
+       if(str_contains((char *) ldata(ln), subs))
          return 1;
   return 0;
 }

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -109,7 +109,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
    * function, where we actually open the device.
    */
 
-  if (strncmp(port_spec, "usb", 3) != 0) {
+  if (!str_starts(port_spec, "usb")) {
     pmsg_error("invalid port specification %s for USB device\n", port_spec);
     return NULL;
   }
@@ -184,10 +184,10 @@ int dfu_init(struct dfu_dev *dfu, unsigned short vid, unsigned short pid)
 
   for (bus = usb_busses; !found && bus != NULL; bus = bus->next) {
     for (dev = bus->devices; !found && dev != NULL; dev = dev->next) {
-      if (dfu->bus_name != NULL && strcmp(bus->dirname, dfu->bus_name))
+      if (dfu->bus_name != NULL && !str_eq(bus->dirname, dfu->bus_name))
          continue;
       if (dfu->dev_name != NULL) {
-        if (strcmp(dev->filename, dfu->dev_name))
+        if (!str_eq(dev->filename, dfu->dev_name))
           continue;
       } else if (vid != dev->descriptor.idVendor)
         continue;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -759,7 +759,7 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
   int rv = 0;
 
   if (p->prog_modes & PM_aWire) { // AVR32
-    if (strcmp(mem->desc, "flash") == 0) {
+    if (str_eq(mem->desc, "flash")) {
       *lowbound = 0x80000000;
       *highbound = 0xffffffff;
       *fileoff = 0;
@@ -767,48 +767,48 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       rv = -1;
     }
   } else {
-    if (strcmp(mem->desc, "flash") == 0 ||
-        strcmp(mem->desc, "boot") == 0 ||
-        strcmp(mem->desc, "application") == 0 ||
-        strcmp(mem->desc, "apptable") == 0) {
+    if (str_eq(mem->desc, "flash") ||
+        str_eq(mem->desc, "boot") ||
+        str_eq(mem->desc, "application") ||
+        str_eq(mem->desc, "apptable")) {
       *lowbound = 0;
       *highbound = 0x7Fffff;    // Max 8 MiB
       *fileoff = 0;
-    } else if (strcmp(mem->desc, "data") == 0) { // SRAM for XMEGAs
+    } else if (str_eq(mem->desc, "data")) { // SRAM for XMEGAs
       *lowbound = 0x802000;
       *highbound = 0x80ffff;
       *fileoff = 0;
-    } else if (strcmp(mem->desc, "eeprom") == 0) {
+    } else if (str_eq(mem->desc, "eeprom")) {
       *lowbound = 0x810000;
       *highbound = 0x81ffff;    // Max 64 KiB
       *fileoff = 0;
-    } else if (strcmp(mem->desc, "lfuse") == 0 || strcmp(mem->desc, "fuses") == 0) {
+    } else if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuses")) {
       *lowbound = 0x820000;
       *highbound = 0x82ffff;
       *fileoff = 0;
-    } else if (strcmp(mem->desc, "hfuse") == 0) {
+    } else if (str_eq(mem->desc, "hfuse")) {
       *lowbound = 0x820000;
       *highbound = 0x82ffff;
       *fileoff = 1;
-    } else if (strcmp(mem->desc, "efuse") == 0) {
+    } else if (str_eq(mem->desc, "efuse")) {
       *lowbound = 0x820000;
       *highbound = 0x82ffff;
       *fileoff = 2;
-    } else if (strncmp(mem->desc, "fuse", 4) == 0 &&
+    } else if (str_starts(mem->desc, "fuse") &&
                (mem->desc[4] >= '0' && mem->desc[4] <= '9')) {
       /* Xmega fuseN */
       *lowbound = 0x820000;
       *highbound = 0x82ffff;
       *fileoff = mem->desc[4] - '0';
-    } else if (strncmp(mem->desc, "lock", 4) == 0) { // Lock or lockbits
+    } else if (str_starts(mem->desc, "lock")) { // Lock or lockbits
       *lowbound = 0x830000;
       *highbound = 0x83ffff;
       *fileoff = 0;
-    } else if (strcmp(mem->desc, "signature") == 0) { // Read only
+    } else if (str_eq(mem->desc, "signature")) { // Read only
       *lowbound = 0x840000;
       *highbound = 0x84ffff;
       *fileoff = 0;
-    } else if (strncmp(mem->desc, "user", 4) == 0) { // Usersig or userrow
+    } else if (str_starts(mem->desc, "user")) { // Usersig or userrow
       *lowbound = 0x850000;
       *highbound = 0x85ffff;
       *fileoff = 0;
@@ -842,9 +842,9 @@ static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
    * than one sub-segment.
    */
   if ((p->prog_modes & PM_PDI) != 0 &&
-      (strcmp(mem->desc, "boot") == 0 ||
-       strcmp(mem->desc, "application") == 0 ||
-       strcmp(mem->desc, "apptable") == 0)) {
+      (str_eq(mem->desc, "boot") ||
+       str_eq(mem->desc, "application") ||
+       str_eq(mem->desc, "apptable"))) {
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (flashmem == NULL) {
       pmsg_error("no flash memory region found, cannot compute bounds of %s sub-region\n", mem->desc);

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -371,7 +371,7 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   if (FLIP1(pgm)->dfu == NULL)
     return -1;
 
-  if (strcmp(mem->desc, "signature") == 0) {
+  if (str_eq(mem->desc, "signature")) {
     if (flip1_read_sig_bytes(pgm, part, mem) < 0)
       return -1;
     if (addr >= (unsigned long) mem->size) {
@@ -808,9 +808,9 @@ const char * flip1_mem_unit_str(enum flip1_mem_unit mem_unit)
 }
 
 enum flip1_mem_unit flip1_mem_unit(const char *name) {
-  if (strcmp(name, "flash") == 0)
+  if (str_eq(name, "flash"))
     return FLIP1_MEM_UNIT_FLASH;
-  if (strcmp(name, "eeprom") == 0)
+  if (str_eq(name, "eeprom"))
     return FLIP1_MEM_UNIT_EEPROM;
   return FLIP1_MEM_UNIT_UNKNOWN;
 }

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -401,7 +401,7 @@ int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (strcmp(mem->desc, "flash") == 0)
+    if (str_eq(mem->desc, "flash"))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;
@@ -422,7 +422,7 @@ int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (strcmp(mem->desc, "flash") == 0)
+    if (str_eq(mem->desc, "flash"))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;
@@ -444,7 +444,7 @@ int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (strcmp(mem->desc, "flash") == 0)
+    if (str_eq(mem->desc, "flash"))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;
@@ -475,7 +475,7 @@ int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (strcmp(mem->desc, "flash") == 0)
+    if (str_eq(mem->desc, "flash"))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;
@@ -500,11 +500,11 @@ int flip2_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
   s = str;
   while ((cp = strtok(s, ","))) {
     s = NULL;
-    if (!strcmp(cp, "reset")) {
+    if (str_eq(cp, "reset")) {
       pgm->exit_reset = EXIT_RESET_ENABLED;
       continue;
     }
-    if (!strcmp(cp, "noreset")) {
+    if (str_eq(cp, "noreset")) {
       pgm->exit_reset = EXIT_RESET_DISABLED;
       continue;
     }
@@ -900,11 +900,11 @@ const char * flip2_mem_unit_str(enum flip2_mem_unit mem_unit)
 }
 
 enum flip2_mem_unit flip2_mem_unit(const char *name) {
-  if (strcmp(name, "application") == 0)
+  if (str_eq(name, "application"))
     return FLIP2_MEM_UNIT_FLASH;
-  if (strcmp(name, "eeprom") == 0)
+  if (str_eq(name, "eeprom"))
     return FLIP2_MEM_UNIT_EEPROM;
-  if (strcmp(name, "signature") == 0)
+  if (str_eq(name, "signature"))
     return FLIP2_MEM_UNIT_SIGNATURE;
   return FLIP2_MEM_UNIT_UNKNOWN;
 }

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -1101,10 +1101,10 @@ static int ft245r_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if(!n_bytes)
         return 0;
 
-    if(strcmp(m->desc, "flash") == 0)
+    if(str_eq(m->desc, "flash"))
         return ft245r_paged_write_flash(pgm, p, m, page_size, addr, n_bytes);
 
-    if(strcmp(m->desc, "eeprom") == 0)
+    if(str_eq(m->desc, "eeprom"))
         return ft245r_paged_write_gen(pgm, p, m, page_size, addr, n_bytes);
 
     return -2;
@@ -1199,10 +1199,10 @@ static int ft245r_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if(!n_bytes)
         return 0;
 
-    if(strcmp(m->desc, "flash") == 0)
+    if(str_eq(m->desc, "flash"))
         return ft245r_paged_load_flash(pgm, p, m, page_size, addr, n_bytes);
 
-   if(strcmp(m->desc, "eeprom") == 0)
+    if(str_eq(m->desc, "eeprom"))
         return ft245r_paged_load_gen(pgm, p, m, page_size, addr, n_bytes);
 
    return -2;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2135,29 +2135,22 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_eq(mem->desc, "lfuse")) {
+  } else if (str_contains(mem->desc, "fuse")) {
     cmd[3] = MTYPE_FUSE_BITS;
-    addr = 0;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    cmd[3] = MTYPE_FUSE_BITS;
-    addr = 1;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    cmd[3] = MTYPE_FUSE_BITS;
-    addr = 2;
+    if (str_eq(mem->desc, "lfuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
+    else if (str_starts(mem->desc, "fuse") && !(p->prog_modes & PM_UPDI))
+      addr = mem->offset & 7;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
   } else if (str_starts(mem->desc, "lock")) {
     cmd[3] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (str_starts(mem->desc, "fuse")) {
-    cmd[3] = MTYPE_FUSE_BITS;
-    if (!(p->prog_modes & PM_UPDI))
-      addr = mem->offset & 7;
   } else if (str_eq(mem->desc, "usersig") ||
              str_eq(mem->desc, "userrow")) {
     cmd[3] = MTYPE_USERSIG;
@@ -2321,32 +2314,25 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
       pagesize = PDATA(pgm)->eeprom_pagesize;
     }
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (str_eq(mem->desc, "lfuse")) {
+  } else if (str_contains(mem->desc, "fuse")) {
     cmd[3] = MTYPE_FUSE_BITS;
-    addr = 0;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    cmd[3] = MTYPE_FUSE_BITS;
-    addr = 1;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    cmd[3] = MTYPE_FUSE_BITS;
-    addr = 2;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_starts(mem->desc, "fuse")) {
-    cmd[3] = MTYPE_FUSE_BITS;
-    if (!(p->prog_modes & PM_UPDI))
+    if (str_eq(mem->desc, "lfuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
+    else if (str_starts(mem->desc, "fuse") && !(p->prog_modes & PM_UPDI))
       addr = mem->offset & 7;
-  } else if (str_eq(mem->desc, "usersig") ||
-             str_eq(mem->desc, "userrow")) {
-    cmd[3] = MTYPE_USERSIG;
+    if (pgm->flag & PGM_FL_IS_DW)
+      unsupp = 1;
   } else if (str_starts(mem->desc, "lock")) {
     cmd[3] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
+  } else if (str_eq(mem->desc, "usersig") ||
+             str_eq(mem->desc, "userrow")) {
+    cmd[3] = MTYPE_USERSIG;
   } else if (str_eq(mem->desc, "io"))
     cmd[3] = MTYPE_SRAM;
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1186,33 +1186,33 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
       m = ldata(ln);
-      if (strcmp(m->desc, "flash") == 0) {
+      if (str_eq(m->desc, "flash")) {
         if (m->readsize != 0 && m->readsize < m->page_size)
           PDATA(pgm)->flash_pagesize = m->readsize;
         else
           PDATA(pgm)->flash_pagesize = m->page_size;
         u16_to_b2(xd.flash_page_size, m->page_size);
-      } else if (strcmp(m->desc, "eeprom") == 0) {
+      } else if (str_eq(m->desc, "eeprom")) {
         PDATA(pgm)->eeprom_pagesize = m->page_size;
         xd.eeprom_page_size = m->page_size;
         u16_to_b2(xd.eeprom_size, m->size);
         u32_to_b4(xd.nvm_eeprom_offset, m->offset);
-      } else if (strcmp(m->desc, "application") == 0) {
+      } else if (str_eq(m->desc, "application")) {
         u32_to_b4(xd.app_size, m->size);
         u32_to_b4(xd.nvm_app_offset, m->offset);
-      } else if (strcmp(m->desc, "boot") == 0) {
+      } else if (str_eq(m->desc, "boot")) {
         u16_to_b2(xd.boot_size, m->size);
         u32_to_b4(xd.nvm_boot_offset, m->offset);
-      } else if (strcmp(m->desc, "fuse1") == 0) {
+      } else if (str_eq(m->desc, "fuse1")) {
         u32_to_b4(xd.nvm_fuse_offset, m->offset & ~7);
       } else if (str_starts(m->desc, "lock")) {
         u32_to_b4(xd.nvm_lock_offset, m->offset);
-      } else if (strcmp(m->desc, "usersig") == 0 ||
-                 strcmp(m->desc, "userrow") == 0) {
+      } else if (str_eq(m->desc, "usersig") ||
+                 str_eq(m->desc, "userrow")) {
         u32_to_b4(xd.nvm_user_sig_offset, m->offset);
-      } else if (strcmp(m->desc, "prodsig") == 0) {
+      } else if (str_eq(m->desc, "prodsig")) {
         u32_to_b4(xd.nvm_prod_sig_offset, m->offset);
-      } else if (strcmp(m->desc, "data") == 0) {
+      } else if (str_eq(m->desc, "data")) {
         u32_to_b4(xd.nvm_data_offset, m->offset);
       }
     }
@@ -1231,7 +1231,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
       m = ldata(ln);
-      if (strcmp(m->desc, "flash") == 0) {
+      if (str_eq(m->desc, "flash")) {
         u16_to_b2(xd.prog_base, m->offset&0xFFFF);
         xd.prog_base_msb = m->offset>>16;
 
@@ -1249,28 +1249,28 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         else
           xd.address_mode = UPDI_ADDRESS_MODE_16BIT;
       }
-      else if (strcmp(m->desc, "eeprom") == 0) {
+      else if (str_eq(m->desc, "eeprom")) {
         PDATA(pgm)->eeprom_pagesize = m->page_size;
         xd.eeprom_page_size = m->page_size;
 
         u16_to_b2(xd.eeprom_bytes, m->size);
         u16_to_b2(xd.eeprom_base, m->offset);
       }
-      else if (strcmp(m->desc, "usersig") == 0 ||
-               strcmp(m->desc, "userrow") == 0) {
+      else if (str_eq(m->desc, "usersig") ||
+               str_eq(m->desc, "userrow")) {
         u16_to_b2(xd.user_sig_bytes, m->size);
         u16_to_b2(xd.user_sig_base, m->offset);
       }
-      else if (strcmp(m->desc, "signature") == 0) {
+      else if (str_eq(m->desc, "signature")) {
         u16_to_b2(xd.signature_base, m->offset);
         xd.device_id[0] = p->signature[1];
         xd.device_id[1] = p->signature[2];
       }
-      else if (strcmp(m->desc, "fuses") == 0) {
+      else if (str_eq(m->desc, "fuses")) {
         xd.fuses_bytes = m->size;
         u16_to_b2(xd.fuses_base, m->offset);
       }
-      else if (strcmp(m->desc, "lock") == 0) {
+      else if (str_eq(m->desc, "lock")) {
         u16_to_b2(xd.lockbits_base, m->offset);
       }
     }
@@ -1338,7 +1338,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
     for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
       m = ldata(ln);
-      if (strcmp(m->desc, "flash") == 0) {
+      if (str_eq(m->desc, "flash")) {
         if (m->readsize != 0 && m->readsize < m->page_size)
           PDATA(pgm)->flash_pagesize = m->readsize;
         else
@@ -1347,7 +1347,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         u32_to_b4(md.flash_size, (flashsize = m->size));
         // do we need it?  just a wild guess
         u32_to_b4(md.boot_address, (m->size - m->page_size * 4) / 2);
-      } else if (strcmp(m->desc, "eeprom") == 0) {
+      } else if (str_eq(m->desc, "eeprom")) {
         PDATA(pgm)->eeprom_pagesize = m->page_size;
         md.eeprom_page_size = m->page_size;
         u16_to_b2(md.eeprom_size, m->size);
@@ -1402,7 +1402,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (use_ext_reset > 1) {
-    if(strcmp(pgm->type, "JTAGICE3") == 0 && (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG)))
+    if(str_eq(pgm->type, "JTAGICE3") && (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG)))
       pmsg_error("JTAGEN fuse disabled?\n");
     return -1;
   }
@@ -1522,7 +1522,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    else if ((strcmp(extended_param, "hvupdi") == 0) && (lsize(pgm->hvupdi_support) > 1)) {
+    else if ((str_eq(extended_param, "hvupdi")) && (lsize(pgm->hvupdi_support) > 1)) {
       PDATA(pgm)->use_hvupdi = true;
       continue;
     }
@@ -1866,10 +1866,10 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
       cmd[3] = XMEGA_ERASE_APP_PAGE;
     else
       cmd[3] = XMEGA_ERASE_BOOT_PAGE;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     cmd[3] = XMEGA_ERASE_EEPROM_PAGE;
-  } else if (strcmp(m->desc, "usersig") == 0 ||
-             strcmp(m->desc, "userrow") == 0) {
+  } else if (str_eq(m->desc, "usersig") ||
+             str_eq(m->desc, "userrow")) {
     cmd[3] = XMEGA_ERASE_USERSIG;
   } else {
     cmd[3] = XMEGA_ERASE_APP_PAGE;
@@ -1920,13 +1920,13 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   cmd[0] = SCOPE_AVR;
   cmd[1] = CMD3_WRITE_MEMORY;
   cmd[2] = 0;
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
     cmd[3] = jtag3_memtype(pgm, p, addr);
     if (p->prog_modes & PM_PDI)
       /* dynamically decide between flash/boot memtype */
       dynamic_memtype = 1;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     if (pgm->flag & PGM_FL_IS_DW) {
       /*
        * jtag3_paged_write() to EEPROM attempted while in
@@ -1944,10 +1944,10 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     }
     cmd[3] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM_XMEGA: MTYPE_EEPROM_PAGE;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (strcmp(m->desc, "usersig") == 0 ||
-             strcmp(m->desc, "userrow") == 0) {
+  } else if (str_eq(m->desc, "usersig") ||
+             str_eq(m->desc, "userrow")) {
     cmd[3] = MTYPE_USERSIG;
-  } else if (strcmp(m->desc, "boot") == 0) {
+  } else if (str_eq(m->desc, "boot")) {
     cmd[3] = MTYPE_BOOT_FLASH;
   } else if (p->prog_modes & (PM_PDI | PM_UPDI)) {
     cmd[3] = MTYPE_FLASH;
@@ -2023,21 +2023,21 @@ static int jtag3_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   cmd[1] = CMD3_READ_MEMORY;
   cmd[2] = 0;
 
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     cmd[3] = jtag3_memtype(pgm, p, addr);
     if (p->prog_modes & PM_PDI)
       /* dynamically decide between flash/boot memtype */
       dynamic_memtype = 1;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     cmd[3] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM: MTYPE_EEPROM_PAGE;
     if (pgm->flag & PGM_FL_IS_DW)
       return -1;
-  } else if (strcmp(m->desc, "prodsig") == 0) {
+  } else if (str_eq(m->desc, "prodsig")) {
     cmd[3] = MTYPE_PRODSIG;
-  } else if (strcmp(m->desc, "usersig") == 0 ||
-             strcmp(m->desc, "userrow") == 0) {
+  } else if (str_eq(m->desc, "usersig") ||
+             str_eq(m->desc, "userrow")) {
     cmd[3] = MTYPE_USERSIG;
-  } else if (strcmp(m->desc, "boot") == 0) {
+  } else if (str_eq(m->desc, "boot")) {
     cmd[3] = MTYPE_BOOT_FLASH;
   } else if (p->prog_modes & PM_PDI) {
     cmd[3] = MTYPE_FLASH;
@@ -2171,15 +2171,15 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     cmd[3] = MTYPE_SIGN_JTAG;
   } else if (str_eq(mem->desc, "tempsense")) {
     cmd[3] = MTYPE_SIGN_JTAG;
-  } else if (strcmp(mem->desc, "osc16err") == 0) {
+  } else if (str_eq(mem->desc, "osc16err")) {
     cmd[3] = MTYPE_SIGN_JTAG;
-  } else if (strcmp(mem->desc, "osc20err") == 0) {
+  } else if (str_eq(mem->desc, "osc20err")) {
     cmd[3] = MTYPE_SIGN_JTAG;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     cmd[3] = MTYPE_OSCCAL_BYTE;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "io") == 0) {
+  } else if (str_eq(mem->desc, "io")) {
     cmd[3] = MTYPE_SRAM;
   } else if (str_eq(mem->desc, "sib")) {
     if(addr >= AVR_SIBLEN) {
@@ -2193,7 +2193,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     }
     *value = PDATA(pgm)->sib_string[addr];
     return 0;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     static unsigned char signature_cache[2];
 
     cmd[3] = MTYPE_SIGN_JTAG;
@@ -2307,13 +2307,13 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   cmd[1] = CMD3_WRITE_MEMORY;
   cmd[2] = 0;
   cmd[3] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_FLASH: MTYPE_SPM;
-  if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash")) {
      cache_ptr = PDATA(pgm)->flash_pagecache;
      pagesize = PDATA(pgm)->flash_pagesize;
      PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
      if (pgm->flag & PGM_FL_IS_DW)
        unsupp = 1;
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (str_eq(mem->desc, "eeprom")) {
     if (pgm->flag & PGM_FL_IS_DW) {
       cmd[3] = MTYPE_EEPROM;
     } else {
@@ -2321,17 +2321,17 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
       pagesize = PDATA(pgm)->eeprom_pagesize;
     }
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (strcmp(mem->desc, "lfuse") == 0) {
+  } else if (str_eq(mem->desc, "lfuse")) {
     cmd[3] = MTYPE_FUSE_BITS;
     addr = 0;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     cmd[3] = MTYPE_FUSE_BITS;
     addr = 1;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     cmd[3] = MTYPE_FUSE_BITS;
     addr = 2;
     if (pgm->flag & PGM_FL_IS_DW)
@@ -2340,14 +2340,14 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
     cmd[3] = MTYPE_FUSE_BITS;
     if (!(p->prog_modes & PM_UPDI))
       addr = mem->offset & 7;
-  } else if (strcmp(mem->desc, "usersig") == 0 ||
-             strcmp(mem->desc, "userrow") == 0) {
+  } else if (str_eq(mem->desc, "usersig") ||
+             str_eq(mem->desc, "userrow")) {
     cmd[3] = MTYPE_USERSIG;
   } else if (str_starts(mem->desc, "lock")) {
     cmd[3] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "io") == 0)
+  } else if (str_eq(mem->desc, "io"))
     cmd[3] = MTYPE_SRAM;
 
   // Read-only memories or unsupported by debugWire
@@ -2782,15 +2782,15 @@ static unsigned int jtag3_memaddr(const PROGRAMMER *pgm, const AVRPART *p, const
 
 unsigned char tpi_get_memtype(const AVRMEM *mem) {
   unsigned char memtype;
-  if (strcmp(mem->desc, "fuse") == 0) {
+  if (str_eq(mem->desc, "fuse")) {
     memtype = XPRG_MEM_TYPE_FUSE;
-  } else if (strcmp(mem->desc, "lock") == 0) {
+  } else if (str_eq(mem->desc, "lock")) {
     memtype = XPRG_MEM_TYPE_LOCKBITS;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     memtype = XPRG_MEM_TYPE_LOCKBITS;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     memtype = XPRG_MEM_TYPE_LOCKBITS;
-  } else if (strcmp(mem->desc, "sigrow") == 0) {
+  } else if (str_eq(mem->desc, "sigrow")) {
     memtype = XPRG_MEM_TYPE_LOCKBITS;
   } else {
     memtype = XPRG_MEM_TYPE_APPL;
@@ -2983,9 +2983,9 @@ static int jtag3_erase_tpi(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   unsigned long paddr = 0UL;
 
   cmd[0] = XPRG_CMD_ERASE;
-  if (strcmp(mem->desc, "fuse") == 0) {
+  if (str_eq(mem->desc, "fuse")) {
     cmd[1] = XPRG_ERASE_CONFIG;
-  } else if (strcmp(mem->desc, "flash") == 0) {
+  } else if (str_eq(mem->desc, "flash")) {
     cmd[1] = XPRG_ERASE_APP;
   } else {
     pmsg_error("jtag3_erase_tpi() unsupported memory: %s\n", mem->desc);

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2135,7 +2135,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     cmd[3] = MTYPE_FUSE_BITS;
     if (str_eq(mem->desc, "lfuse"))
       addr = 0;
@@ -2314,7 +2314,7 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
       pagesize = PDATA(pgm)->eeprom_pagesize;
     }
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     cmd[3] = MTYPE_FUSE_BITS;
     if (str_eq(mem->desc, "lfuse"))
       addr = 0;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -880,15 +880,14 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_eq(mem->desc, "lfuse")) {
+  } else if (str_contains(mem->desc, "fuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
-    addr = 0;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    addr = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    addr = 2;
+    if (str_eq(mem->desc, "lfuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
   } else if (str_eq(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
   } else if (str_eq(mem->desc, "calibration")) {
@@ -981,18 +980,15 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     need_progmode = 0;
     need_dummy_read = 1;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (str_eq(mem->desc, "lfuse")) {
+  } else if (str_contains(mem->desc, "fuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     need_dummy_read = 1;
-    addr = 0;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    need_dummy_read = 1;
-    addr = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    need_dummy_read = 1;
-    addr = 2;
+    if (str_eq(mem->desc, "lfuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
   } else if (str_eq(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
     need_dummy_read = 1;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -367,10 +367,10 @@ static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   sendbuf.dd.ucIDRAddress = p->idr;
   for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
     m = ldata(ln);
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       PDATA(pgm)->flash_pagesize = m->page_size;
       u16_to_b2(sendbuf.dd.uiFlashPageSize, PDATA(pgm)->flash_pagesize);
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       sendbuf.dd.ucEepromPageSize = PDATA(pgm)->eeprom_pagesize = m->page_size;
     }
   }
@@ -678,12 +678,12 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   }
 
   cmd[0] = CMD_WRITE_MEM;
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     cmd[1] = MTYPE_FLASH_PAGE;
     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
     page_size = PDATA(pgm)->flash_pagesize;
     is_flash = 1;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     cmd[1] = MTYPE_EEPROM_PAGE;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
     page_size = PDATA(pgm)->eeprom_pagesize;
@@ -786,10 +786,10 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   page_size = m->readsize;
 
   cmd[0] = CMD_READ_MEM;
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     cmd[1] = MTYPE_FLASH_PAGE;
     is_flash = 1;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     cmd[1] = MTYPE_EEPROM_PAGE;
   }
 
@@ -867,33 +867,33 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
   cmd[0] = CMD_READ_MEM;
 
-  if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash")) {
     cmd[1] = MTYPE_FLASH_PAGE;
     pagesize = mem->page_size;
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->flash_pageaddr;
     cache_ptr = PDATA(pgm)->flash_pagecache;
     is_flash = 1;
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (str_eq(mem->desc, "eeprom")) {
     cmd[1] = MTYPE_EEPROM_PAGE;
     pagesize = mem->page_size;
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (strcmp(mem->desc, "lfuse") == 0) {
+  } else if (str_eq(mem->desc, "lfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 0;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 2;
-  } else if (strcmp(mem->desc, "lock") == 0) {
+  } else if (str_eq(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     cmd[1] = MTYPE_OSCCAL_BYTE;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     cmd[1] = MTYPE_SIGN_JTAG;
   }
 
@@ -972,34 +972,34 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   writedata = data;
   cmd[0] = CMD_WRITE_MEM;
-  if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash")) {
     cmd[1] = MTYPE_SPM;
     need_progmode = 0;
     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (str_eq(mem->desc, "eeprom")) {
     cmd[1] = MTYPE_EEPROM;
     need_progmode = 0;
     need_dummy_read = 1;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (strcmp(mem->desc, "lfuse") == 0) {
+  } else if (str_eq(mem->desc, "lfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     need_dummy_read = 1;
     addr = 0;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     need_dummy_read = 1;
     addr = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     need_dummy_read = 1;
     addr = 2;
-  } else if (strcmp(mem->desc, "lock") == 0) {
+  } else if (str_eq(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
     need_dummy_read = 1;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     cmd[1] = MTYPE_OSCCAL_BYTE;
     need_dummy_read = 1;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     cmd[1] = MTYPE_SIGN_JTAG;
   }
 

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -880,7 +880,7 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     cmd[1] = MTYPE_FUSE_BITS;
     if (str_eq(mem->desc, "lfuse"))
       addr = 0;
@@ -980,7 +980,7 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     need_progmode = 0;
     need_dummy_read = 1;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     cmd[1] = MTYPE_FUSE_BITS;
     need_dummy_read = 1;
     if (str_eq(mem->desc, "lfuse"))

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2184,27 +2184,20 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
       cache_ptr = PDATA(pgm)->eeprom_pagecache;
     }
-  } else if (str_eq(mem->desc, "lfuse")) {
+    } else if (str_contains(mem->desc, "fuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
-    addr = 0;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    addr = 1;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    addr = 2;
+    if (str_eq(mem->desc, "lfuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
   } else if (str_starts(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (str_starts(mem->desc, "fuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
   } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
     cmd[1] = MTYPE_USERSIG;
   } else if (str_eq(mem->desc, "prodsig")) {
@@ -2229,24 +2222,23 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       unsigned char parm[4];
 
       switch (addr) {
-      case 0:
-	*value = 0x1E;		/* Atmel vendor ID */
-	break;
+        case 0:
+          *value = 0x1E;		/* Atmel vendor ID */
+          break;
 
-      case 1:
-      case 2:
-	if (jtagmkII_getparm(pgm, PAR_TARGET_SIGNATURE, parm) < 0)
-	  return -1;
-	*value = parm[2 - addr];
-	break;
+        case 1:
+        case 2:
+          if (jtagmkII_getparm(pgm, PAR_TARGET_SIGNATURE, parm) < 0)
+            return -1;
+          *value = parm[2 - addr];
+          break;
 
-      default:
-	pmsg_error("illegal address %lu for signature memory\n", addr);
-	return -1;
-      }
+        default:
+          pmsg_error("illegal address %lu for signature memory\n", addr);
+          return -1;
+        }
       return 0;
     }
-
   }
 
   /*
@@ -2353,23 +2345,16 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if(strcmp(p->family_id, "AVR    ") && strcmp(p->family_id, "    AVR")) // Unless DX
       need_progmode = 0;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (str_eq(mem->desc, "lfuse")) {
+  } else if (str_contains(mem->desc, "fuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
-    addr = 0;
+    if (str_eq(mem->desc, "lfuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    addr = 1;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
-    addr = 2;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (str_starts(mem->desc, "fuse")) {
-    cmd[1] = MTYPE_FUSE_BITS;
   } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
     cmd[1] = MTYPE_USERSIG;
   } else if (str_eq(mem->desc, "prodsig")) {

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2335,14 +2335,14 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
        addr &= ~1L;
      }
      writesize = 2;
-     if(strcmp(p->family_id, "AVR    ") && strcmp(p->family_id, "    AVR")) // Unless it's a DX part
+     if(str_eq(p->family_id, "megaAVR") || str_eq(p->family_id, "tinyAVR")) // AVRs with UPDI except AVR-Dx/Ex
        need_progmode = 0;
      PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
      if (pgm->flag & PGM_FL_IS_DW)
        unsupp = 1;
   } else if (str_eq(mem->desc, "eeprom")) {
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM_XMEGA: MTYPE_EEPROM;
-    if(strcmp(p->family_id, "AVR    ") && strcmp(p->family_id, "    AVR")) // Unless DX
+    if(str_eq(p->family_id, "megaAVR") || str_eq(p->family_id, "tinyAVR")) // AVRs with UPDI except AVR-Dx/Ex
       need_progmode = 0;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
   } else if (str_contains(mem->desc, "fuse")) {

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2184,7 +2184,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
       cache_ptr = PDATA(pgm)->eeprom_pagecache;
     }
-    } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     cmd[1] = MTYPE_FUSE_BITS;
     if (str_eq(mem->desc, "lfuse"))
       addr = 0;
@@ -2345,7 +2345,7 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if(str_eq(p->family_id, "megaAVR") || str_eq(p->family_id, "tinyAVR")) // AVRs with UPDI except AVR-Dx/Ex
       need_progmode = 0;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     cmd[1] = MTYPE_FUSE_BITS;
     if (str_eq(mem->desc, "lfuse"))
       addr = 0;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -664,9 +664,9 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
 
   pmsg_debug("jtagmkII_getsync()\n");
 
-  if (strncmp(pgm->type, "JTAG", strlen("JTAG")) == 0) {
+  if (str_starts(pgm->type, "JTAG")) {
     is_dragon = 0;
-  } else if (strncmp(pgm->type, "DRAGON", strlen("DRAGON")) == 0) {
+  } else if (str_starts(pgm->type, "DRAGON")) {
     is_dragon = 1;
   } else {
     pmsg_error("programmer is neither JTAG ICE mkII nor AVR Dragon\n");
@@ -919,7 +919,7 @@ static void jtagmkII_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
     (p->flags & AVRPART_ENABLEPAGEPROGRAMMING) != 0;
   for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
     AVRMEM *m = ldata(ln);
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       if (m->page_size > 256)
         PDATA(pgm)->flash_pagesize = 256;
       else
@@ -931,7 +931,7 @@ static void jtagmkII_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
 	memcpy(sendbuf.dd.ucFlashInst, p->flash_instr, FLASH_INSTR_SIZE);
 	memcpy(sendbuf.dd.ucEepromInst, p->eeprom_instr, EEPROM_INSTR_SIZE);
       }
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       sendbuf.dd.ucEepromPageSize = PDATA(pgm)->eeprom_pagesize = m->page_size;
     }
   }
@@ -980,32 +980,31 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
 
   for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
     m = ldata(ln);
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       if (m->page_size > 256)
         PDATA(pgm)->flash_pagesize = 256;
       else
         PDATA(pgm)->flash_pagesize = m->page_size;
       u16_to_b2(sendbuf.dd.flash_page_size, m->page_size);
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       sendbuf.dd.eeprom_page_size = m->page_size;
       u16_to_b2(sendbuf.dd.eeprom_size, m->size);
       u32_to_b4(sendbuf.dd.nvm_eeprom_offset, m->offset);
-    } else if (strcmp(m->desc, "application") == 0) {
+    } else if (str_eq(m->desc, "application")) {
       u32_to_b4(sendbuf.dd.app_size, m->size);
       u32_to_b4(sendbuf.dd.nvm_app_offset, m->offset);
-    } else if (strcmp(m->desc, "boot") == 0) {
+    } else if (str_eq(m->desc, "boot")) {
       u16_to_b2(sendbuf.dd.boot_size, m->size);
       u32_to_b4(sendbuf.dd.nvm_boot_offset, m->offset);
-    } else if (strcmp(m->desc, "fuse1") == 0) {
+    } else if (str_eq(m->desc, "fuse1")) {
       u32_to_b4(sendbuf.dd.nvm_fuse_offset, m->offset & ~7);
-    } else if (strncmp(m->desc, "lock", 4) == 0) {
+    } else if (str_starts(m->desc, "lock")) {
       u32_to_b4(sendbuf.dd.nvm_lock_offset, m->offset);
-    } else if (strcmp(m->desc, "usersig") == 0 ||
-               strcmp(m->desc, "userrow") == 0) {
+    } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
       u32_to_b4(sendbuf.dd.nvm_user_sig_offset, m->offset);
-    } else if (strcmp(m->desc, "prodsig") == 0) {
+    } else if (str_eq(m->desc, "prodsig")) {
       u32_to_b4(sendbuf.dd.nvm_prod_sig_offset, m->offset);
-    } else if (strcmp(m->desc, "data") == 0) {
+    } else if (str_eq(m->desc, "data")) {
       u32_to_b4(sendbuf.dd.nvm_data_offset, m->offset);
     }
   }
@@ -1470,7 +1469,7 @@ static int jtagmkII_open(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -1522,7 +1521,7 @@ static int jtagmkII_open_dw(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -1574,7 +1573,7 @@ static int jtagmkII_open_pdi(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -1633,7 +1632,7 @@ static int jtagmkII_dragon_open(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -1686,7 +1685,7 @@ static int jtagmkII_dragon_open_dw(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -1739,7 +1738,7 @@ static int jtagmkII_dragon_open_pdi(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -1856,17 +1855,16 @@ static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AV
     return -1;
 
   cmd[0] = CMND_XMEGA_ERASE;
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     if (jtagmkII_memtype(pgm, p, addr) == MTYPE_FLASH)
       cmd[1] = XMEGA_ERASE_APP_PAGE;
     else
       cmd[1] = XMEGA_ERASE_BOOT_PAGE;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     cmd[1] = XMEGA_ERASE_EEPROM_PAGE;
-  } else if (strcmp(m->desc, "usersig") == 0 ||
-             strcmp(m->desc, "userrow") == 0) {
+  } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
     cmd[1] = XMEGA_ERASE_USERSIG;
-  } else if (strcmp(m->desc, "boot") == 0) {
+  } else if (str_eq(m->desc, "boot")) {
     cmd[1] = XMEGA_ERASE_BOOT_PAGE;
   } else {
     cmd[1] = XMEGA_ERASE_APP_PAGE;
@@ -1943,13 +1941,13 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   }
 
   cmd[0] = CMND_WRITE_MEMORY;
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
     cmd[1] = jtagmkII_memtype(pgm, p, addr);
     if (p->prog_modes & (PM_PDI | PM_UPDI))
       /* dynamically decide between flash/boot memtype */
       dynamic_memtype = 1;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     if (pgm->flag & PGM_FL_IS_DW) {
       /*
        * jtagmkII_paged_write() to EEPROM attempted while in
@@ -1967,10 +1965,9 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     }
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM: MTYPE_EEPROM_PAGE;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (strcmp(m->desc, "usersig") == 0 ||
-             strcmp(m->desc, "userrow") == 0) {
+  } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
     cmd[1] = MTYPE_USERSIG;
-  } else if (strcmp(m->desc, "boot") == 0) {
+  } else if (str_eq(m->desc, "boot")) {
     cmd[1] = MTYPE_BOOT_FLASH;
   } else if (p->prog_modes & (PM_PDI | PM_UPDI)) {
     cmd[1] = MTYPE_FLASH;
@@ -2062,21 +2059,20 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
   page_size = m->readsize;
 
   cmd[0] = CMND_READ_MEMORY;
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     cmd[1] = jtagmkII_memtype(pgm, p, addr);
     if (p->prog_modes & (PM_PDI | PM_UPDI))
       /* dynamically decide between flash/boot memtype */
       dynamic_memtype = 1;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM: MTYPE_EEPROM_PAGE;
     if (pgm->flag & PGM_FL_IS_DW)
       return -1;
-  } else if (strcmp(m->desc, "prodsig") == 0) {
+  } else if (str_eq(m->desc, "prodsig")) {
     cmd[1] = MTYPE_PRODSIG;
-  } else if (strcmp(m->desc, "usersig") == 0 ||
-             strcmp(m->desc, "userrow") == 0) {
+  } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
     cmd[1] = MTYPE_USERSIG;
-  } else if (strcmp(m->desc, "boot") == 0) {
+  } else if (str_eq(m->desc, "boot")) {
     cmd[1] = MTYPE_BOOT_FLASH;
   } else if (p->prog_modes & (PM_PDI | PM_UPDI)) {
     cmd[1] = MTYPE_FLASH;
@@ -2188,41 +2184,40 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
       paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
       cache_ptr = PDATA(pgm)->eeprom_pagecache;
     }
-  } else if (strcmp(mem->desc, "lfuse") == 0) {
+  } else if (str_eq(mem->desc, "lfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 0;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 1;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 2;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strncmp(mem->desc, "lock", 4) == 0) {
+  } else if (str_starts(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
+  } else if (str_starts(mem->desc, "fuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
-  } else if (strcmp(mem->desc, "usersig") == 0 ||
-             strcmp(mem->desc, "userrow") == 0) {
+  } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
     cmd[1] = MTYPE_USERSIG;
-  } else if (strcmp(mem->desc, "prodsig") == 0) {
+  } else if (str_eq(mem->desc, "prodsig")) {
     cmd[1] = MTYPE_PRODSIG;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     cmd[1] = MTYPE_OSCCAL_BYTE;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "io") == 0) {
+  } else if (str_eq(mem->desc, "io")) {
     cmd[1] = MTYPE_FLASH;
     AVRMEM *data = avr_locate_mem(p, "data");
     addr += data->offset;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     cmd[1] = MTYPE_SIGN_JTAG;
 
     if (pgm->flag & PGM_FL_IS_DW) {
@@ -2340,7 +2335,7 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
   writedata = data;
   cmd[0] = CMND_WRITE_MEMORY;
   cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_FLASH: MTYPE_SPM;
-  if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash")) {
      if ((addr & 1) == 1) {
        /* odd address = high byte */
        writedata = 0xFF;	/* don't modify the low byte */
@@ -2353,46 +2348,45 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
      PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
      if (pgm->flag & PGM_FL_IS_DW)
        unsupp = 1;
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (str_eq(mem->desc, "eeprom")) {
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM_XMEGA: MTYPE_EEPROM;
     if(strcmp(p->family_id, "AVR    ") && strcmp(p->family_id, "    AVR")) // Unless DX
       need_progmode = 0;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (strcmp(mem->desc, "lfuse") == 0) {
+  } else if (str_eq(mem->desc, "lfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 0;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 1;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
     addr = 2;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
+  } else if (str_starts(mem->desc, "fuse")) {
     cmd[1] = MTYPE_FUSE_BITS;
-  } else if (strcmp(mem->desc, "usersig") == 0 ||
-             strcmp(mem->desc, "userrow") == 0) {
+  } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
     cmd[1] = MTYPE_USERSIG;
-  } else if (strcmp(mem->desc, "prodsig") == 0) {
+  } else if (str_eq(mem->desc, "prodsig")) {
     cmd[1] = MTYPE_PRODSIG;
-  } else if (strncmp(mem->desc, "lock", 4) == 0) {
+  } else if (str_starts(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     cmd[1] = MTYPE_OSCCAL_BYTE;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "io") == 0) {
+  } else if (str_eq(mem->desc, "io")) {
     cmd[1] = MTYPE_FLASH; // Works with jtag2updi, does not work with any xmega
     AVRMEM *data = avr_locate_mem(p, "data");
     addr += data->offset;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     cmd[1] = MTYPE_SIGN_JTAG;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
@@ -3229,7 +3223,7 @@ static int jtagmkII_open32(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -151,7 +151,7 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
     struct gpiohandle_request req;
     int ret;
 
-    if (!strcmp(port, "unknown")) {
+    if (str_eq(port, "unknown")) {
         port = port_default;
     }
 
@@ -385,11 +385,11 @@ static int linuxspi_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
     s = str;
     while ((cp = strtok(s, ","))) {
         s = NULL;
-        if (!strcmp(cp, "reset")) {
+        if (str_eq(cp, "reset")) {
             pgm->exit_reset = EXIT_RESET_ENABLED;
             continue;
         }
-        if (!strcmp(cp, "noreset")) {
+        if (str_eq(cp, "noreset")) {
             pgm->exit_reset = EXIT_RESET_DISABLED;
             continue;
         }

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -654,14 +654,14 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
     char* dev_name = NULL;
 
     // if no -P was given or '-P usb' was given
-    if (strcmp(port, "usb") == 0)
+    if (str_eq(port, "usb"))
     {
         port = NULL;
     }
     else
     {
         // calculate bus and device names from -P option
-        if (strncmp(port, "usb", 3) == 0 && ':' == port[3])
+        if (str_starts(port, "usb") && ':' == port[3])
         {
             bus_name = port + 4;
             dev_name = strchr(bus_name, ':');
@@ -738,7 +738,7 @@ static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
                     // if -P was given, match device by device name and bus name
                     if (port != NULL)
                     {
-                        if (dev_name == NULL || strcmp(bus->dirname, bus_name) || strcmp(device->filename, dev_name))
+                        if (dev_name == NULL || !str_eq(bus->dirname, bus_name) || !str_eq(device->filename, dev_name))
                         {
                             continue;
                         }
@@ -814,10 +814,10 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
 {
     pmsg_debug("micronucleus_read_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
 
-    if (strcmp(mem->desc, "lfuse") == 0 ||
-        strcmp(mem->desc, "hfuse") == 0 ||
-        strcmp(mem->desc, "efuse") == 0 ||
-        strcmp(mem->desc, "lock") == 0)
+    if (str_eq(mem->desc, "lfuse") ||
+        str_eq(mem->desc, "hfuse") ||
+        str_eq(mem->desc, "efuse") ||
+        str_eq(mem->desc, "lock"))
     {
         *value = 0xFF;
         return 0;
@@ -850,7 +850,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 {
     pmsg_debug("micronucleus_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
 
-    if (strcmp(mem->desc, "flash") == 0)
+    if (str_eq(mem->desc, "flash"))
     {
         pdata_t* pdata = PDATA(pgm);
 

--- a/src/par.c
+++ b/src/par.c
@@ -338,22 +338,22 @@ static int par_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
 
   s = str;
   while((cp = strtok(s, ","))) {
-    if(strcmp(cp, "reset") == 0)
+    if(str_eq(cp, "reset"))
       pgm->exit_reset = EXIT_RESET_ENABLED;
 
-    else if(strcmp(cp, "noreset") == 0)
+    else if(str_eq(cp, "noreset"))
       pgm->exit_reset = EXIT_RESET_DISABLED;
 
-    else if(strcmp(cp, "vcc") == 0)
+    else if(str_eq(cp, "vcc"))
       pgm->exit_vcc = EXIT_VCC_ENABLED;
 
-    else if(strcmp(cp, "novcc") == 0)
+    else if(str_eq(cp, "novcc"))
       pgm->exit_vcc = EXIT_VCC_DISABLED;
 
-    else if(strcmp(cp, "d_high") == 0)
+    else if(str_eq(cp, "d_high"))
       pgm->exit_datahigh = EXIT_DATAHIGH_ENABLED;
 
-    else if(strcmp(cp, "d_low") == 0)
+    else if(str_eq(cp, "d_low"))
       pgm->exit_datahigh = EXIT_DATAHIGH_DISABLED;
 
     else {

--- a/src/pgm_type.c
+++ b/src/pgm_type.c
@@ -118,7 +118,7 @@ const PROGRAMMER_TYPE programmers_types[] = { // Name(s) the programmers call th
 
 const PROGRAMMER_TYPE *locate_programmer_type(const char *id) {
   for(size_t i = 0; i < sizeof programmers_types/sizeof*programmers_types; i++)
-    if(strcasecmp(id, programmers_types[i].id) == 0)
+    if(str_caseeq(id, programmers_types[i].id))
       return programmers_types + i;
 
   return NULL;

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -459,7 +459,7 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned int page_size, unsigned int addr, unsigned int n_bytes) {
 
     // only supporting flash & eeprom page reads
-    if ((!mem->paged || page_size <= 1) || (strcmp(mem->desc, "flash") != 0 && strcmp(mem->desc, "eeprom") != 0))
+    if ((!mem->paged || page_size <= 1) || (!str_eq(mem->desc, "flash") && !str_eq(mem->desc, "eeprom")))
     {
         return -1;
     }
@@ -601,7 +601,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
                          unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
     // only paged write for flash implemented
-    if (strcmp(mem->desc, "flash") != 0 && strcmp(mem->desc, "eeprom") != 0)
+    if (!str_eq(mem->desc, "flash") && !str_eq(mem->desc, "eeprom"))
     {
         pmsg_error("part does not support %d paged write of %s\n", page_size, mem->desc);
         return -1;

--- a/src/ppiwin.c
+++ b/src/ppiwin.c
@@ -101,7 +101,7 @@ void ppi_open(const char *port, union filedescriptor *fdp) {
     fd = -1;
     for(i = 0; i < DEVICE_MAX; i++)
     {
-        if(strcmp(winports[i].name, port) == 0)
+        if(str_eq(winports[i].name, port))
         {
             /* Set the file descriptor with the Windows parallel port base address. */
             fd = winports[i].base_address;

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -389,7 +389,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
    * If the port is of the form "net:<host>:<port>", then
    * handle it as a TCP connection to a terminal server.
    */
-  if (strncmp(port, "net:", strlen("net:")) == 0) {
+  if (str_starts(port, "net:")) {
     return net_open(port + strlen("net:"), fdp);
   }
 

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -249,11 +249,11 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	 * If the port is of the form "net:<host>:<port>", then
 	 * handle it as a TCP connection to a terminal server.
 	 */
-	if (strncmp(port, "net:", strlen("net:")) == 0) {
+	if (str_starts(port, "net:")) {
 		return net_open(port + strlen("net:"), fdp);
 	}
 
-	if (strncasecmp(port, "com", strlen("com")) == 0) {
+	if (str_casestarts(port, "com")) {
 
 	    // prepend "\\\\.\\" to name, required for port # >= 10
 	    newname = malloc(strlen("\\\\.\\") + strlen(port) + 1);

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -717,18 +717,18 @@ static int serialupdi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
     Return("cannot write byte to %s %s as address 0x%04lx outside range [0, 0x%04x]",
       p->desc, mem->desc, addr, mem->size-1);
 
-  if (strstr(mem->desc, "fuse") != 0) {
+  if (str_contains(mem->desc, "fuse")) {
     return updi_nvm_write_fuse(pgm, p, mem->offset + addr, value);
   }
-  if (strcmp(mem->desc, "lock") == 0) {
+  if (str_eq(mem->desc, "lock")) {
     return updi_nvm_write_fuse(pgm, p, mem->offset + addr, value);
   }
-  if (strcmp(mem->desc, "eeprom") == 0) {
+  if (str_eq(mem->desc, "eeprom")) {
     unsigned char buffer[1];
     buffer[0]=value;
     return updi_nvm_write_eeprom(pgm, p, mem->offset + addr, buffer, 1);
   }
-  if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash")) {
     unsigned char buffer[1];
     buffer[0]=value;
     return updi_nvm_write_flash(pgm, p, mem->offset + addr, buffer, 1);
@@ -800,16 +800,16 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 
     while (remaining_bytes > 0) {
 
-      if (strcmp(m->desc, "eeprom")==0) {
+      if (str_eq(m->desc, "eeprom")) {
         rc = updi_nvm_write_eeprom(pgm, p, m->offset + write_offset, m->buf + write_offset, 
                                    remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
-      } else if (strcmp(m->desc, "flash")==0) {
+      } else if (str_eq(m->desc, "flash")) {
         rc = updi_nvm_write_flash(pgm, p, m->offset + write_offset, m->buf + write_offset, 
                                   remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
-      } else if (strcmp(m->desc, "userrow")==0) {
+      } else if (str_eq(m->desc, "userrow")) {
         rc = serialupdi_write_userrow(pgm, p, m, page_size, write_offset, 
                                       remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
-      } else if (strcmp(m->desc, "fuses")==0) {
+      } else if (str_eq(m->desc, "fuses")) {
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         return -1;
       } else {
@@ -828,13 +828,13 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     }
     return write_bytes;
   } else {
-    if (strcmp(m->desc, "eeprom")==0) {
+    if (str_eq(m->desc, "eeprom")) {
       rc = updi_nvm_write_eeprom(pgm, p, m->offset+addr, m->buf+addr, n_bytes);
-    } else if (strcmp(m->desc, "flash")==0) {
+    } else if (str_eq(m->desc, "flash")) {
       rc = updi_nvm_write_flash(pgm, p, m->offset+addr, m->buf+addr, n_bytes);
-    } else if (strcmp(m->desc, "userrow")==0) {
+    } else if (str_eq(m->desc, "userrow")) {
       rc = serialupdi_write_userrow(pgm, p, m, page_size, addr, n_bytes);
-    } else if (strcmp(m->desc, "fuses")==0) {
+    } else if (str_eq(m->desc, "fuses")) {
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         rc = -1;
     } else {

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -981,9 +981,9 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
     extended_param = ldata(ln);
 
     if (sscanf(extended_param, "rtsdtr=%4s", rts_mode) == 1) {
-      if (strcasecmp(rts_mode, "low") == 0) {
+      if (str_caseeq(rts_mode, "low")) {
         updi_set_rts_mode(pgm, RTS_MODE_LOW);
-      } else if (strcasecmp(rts_mode, "high") == 0) {
+      } else if (str_caseeq(rts_mode, "high")) {
         updi_set_rts_mode(pgm, RTS_MODE_HIGH);
       } else {
         pmsg_error("RTS/DTR mode must be LOW or HIGH\n");

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2261,7 +2261,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     buf[0] = mode == PPMODE? CMD_READ_FUSE_PP: CMD_READ_FUSE_HVSP;
     if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse"))
       addr = 0;
@@ -2390,7 +2390,7 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     return 0;
   }
 
-  if (str_contains(mem->desc, "fuse")) {
+  if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     buf[0] = CMD_READ_FUSE_ISP;
     if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse"))
       addr = 0;
@@ -2472,7 +2472,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_contains(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_FUSE_PP: CMD_PROGRAM_FUSE_HVSP;
     pulsewidth = p->programfusepulsewidth;
     timeout = p->programfusepolltimeout;
@@ -2633,7 +2633,7 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   }
 
   memset(buf, 0, sizeof buf);
-  if (str_contains(mem->desc, "fuse")) {
+  if (str_contains(mem->desc, "fuse") && strlen(mem->desc) <= 5) {
     buf[0] = CMD_PROGRAM_FUSE_ISP;
     if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse"))
       addr = 0;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2261,15 +2261,14 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse")) {
     buf[0] = mode == PPMODE? CMD_READ_FUSE_PP: CMD_READ_FUSE_HVSP;
-    addr = 0;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    buf[0] = mode == PPMODE? CMD_READ_FUSE_PP: CMD_READ_FUSE_HVSP;
-    addr = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    buf[0] = mode == PPMODE? CMD_READ_FUSE_PP: CMD_READ_FUSE_HVSP;
-    addr = 2;
+    if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
   } else if (str_eq(mem->desc, "lock")) {
     buf[0] = mode == PPMODE? CMD_READ_LOCK_PP: CMD_READ_LOCK_HVSP;
   } else if (str_eq(mem->desc, "calibration")) {
@@ -2391,15 +2390,14 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     return 0;
   }
 
-  if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
+  if (str_contains(mem->desc, "fuse")) {
     buf[0] = CMD_READ_FUSE_ISP;
-    addr = 0;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    buf[0] = CMD_READ_FUSE_ISP;
-    addr = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    buf[0] = CMD_READ_FUSE_ISP;
-    addr = 2;
+    if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
   } else if (str_eq(mem->desc, "lock")) {
     buf[0] = CMD_READ_LOCK_ISP;
   } else if (str_eq(mem->desc, "calibration")) {
@@ -2474,21 +2472,16 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
+  } else if (str_contains(mem->desc, "fuse")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_FUSE_PP: CMD_PROGRAM_FUSE_HVSP;
-    addr = 0;
     pulsewidth = p->programfusepulsewidth;
     timeout = p->programfusepolltimeout;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    buf[0] = mode == PPMODE? CMD_PROGRAM_FUSE_PP: CMD_PROGRAM_FUSE_HVSP;
-    addr = 1;
-    pulsewidth = p->programfusepulsewidth;
-    timeout = p->programfusepolltimeout;
-  } else if (str_eq(mem->desc, "efuse")) {
-    buf[0] = mode == PPMODE? CMD_PROGRAM_FUSE_PP: CMD_PROGRAM_FUSE_HVSP;
-    addr = 2;
-    pulsewidth = p->programfusepulsewidth;
-    timeout = p->programfusepolltimeout;
+    if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
   } else if (str_eq(mem->desc, "lock")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_LOCK_PP: CMD_PROGRAM_LOCK_HVSP;
     pulsewidth = p->programlockpulsewidth;
@@ -2611,11 +2604,11 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
       cache_ptr = PDATA(pgm)->flash_pagecache;
       if ((mem->mode & 1) == 0)
 	/* old, unpaged device, really write single bytes */
-	pagesize = 1;
+        pagesize = 1;
     } else {
       pagesize = mem->page_size;
       if (pagesize == 0)
-	pagesize = 1;
+        pagesize = 1;
       paddr = addr & ~(pagesize - 1);
       paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
       cache_ptr = PDATA(pgm)->eeprom_pagecache;
@@ -2640,15 +2633,14 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   }
 
   memset(buf, 0, sizeof buf);
-  if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
+  if (str_contains(mem->desc, "fuse")) {
     buf[0] = CMD_PROGRAM_FUSE_ISP;
-    addr = 0;
-  } else if (str_eq(mem->desc, "hfuse")) {
-    buf[0] = CMD_PROGRAM_FUSE_ISP;
-    addr = 1;
-  } else if (str_eq(mem->desc, "efuse")) {
-    buf[0] = CMD_PROGRAM_FUSE_ISP;
-    addr = 2;
+    if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse"))
+      addr = 0;
+    else if (str_eq(mem->desc, "hfuse"))
+      addr = 1;
+    else if (str_eq(mem->desc, "efuse"))
+      addr = 2;
   } else if (str_eq(mem->desc, "lock")) {
     buf[0] = CMD_PROGRAM_LOCK_ISP;
   } else {

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2081,7 +2081,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
 
   PDATA(pgm)->pgmtype = PGMTYPE_UNKNOWN;
 
-  if(strcasecmp(port, "avrdoper") == 0){
+  if(str_caseeq(port, "avrdoper")){
 #if defined(HAVE_LIBHIDAPI)
     serdev = &avrdoper_serdev;
     PDATA(pgm)->pgmtype = PGMTYPE_STK500;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1361,14 +1361,14 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   PDATA(pgm)->eeprom_pagesize = 1;
   for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
     m = ldata(ln);
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       if (m->page_size > 1) {
         if (m->page_size > 256)
           PDATA(pgm)->flash_pagesize = 256;
         else
           PDATA(pgm)->flash_pagesize = m->page_size;
       }
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       if (m->page_size > 1)
 	PDATA(pgm)->eeprom_pagesize = m->page_size;
     }
@@ -1510,14 +1510,14 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   PDATA(pgm)->eeprom_pagesize = 1;
   for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
     m = ldata(ln);
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       if (m->page_size > 1) {
         if (m->page_size > 256)
           PDATA(pgm)->flash_pagesize = 256;
         else
           PDATA(pgm)->flash_pagesize = m->page_size;
       }
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       if (m->page_size > 1)
 	PDATA(pgm)->eeprom_pagesize = m->page_size;
     }
@@ -1676,14 +1676,14 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   PDATA(pgm)->eeprom_pagesize = 1;
   for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
     m = ldata(ln);
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       if (m->page_size > 1) {
         if (m->page_size > 256)
           PDATA(pgm)->flash_pagesize = 256;
         else
           PDATA(pgm)->flash_pagesize = m->page_size;
       }
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       if (m->page_size > 1)
 	PDATA(pgm)->eeprom_pagesize = m->page_size;
     }
@@ -2097,7 +2097,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev_frame;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -2153,7 +2153,7 @@ static int stk600_open(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev_frame;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -2235,7 +2235,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   pmsg_notice2("stk500hv_read_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
-  if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash")) {
     buf[0] = mode == PPMODE? CMD_READ_FLASH_PP: CMD_READ_FLASH_HVSP;
     cmdlen = 3;
     pagesize = PDATA(pgm)->flash_pagesize;
@@ -2252,7 +2252,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if (mem->op[AVR_OP_LOAD_EXT_ADDR] != NULL) {
       use_ext_addr = (1U << 31);
     }
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (str_eq(mem->desc, "eeprom")) {
     buf[0] = mode == PPMODE? CMD_READ_EEPROM_PP: CMD_READ_EEPROM_HVSP;
     cmdlen = 3;
     pagesize = mem->page_size;
@@ -2261,21 +2261,20 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (strcmp(mem->desc, "lfuse") == 0 ||
-	     strcmp(mem->desc, "fuse") == 0) {
+  } else if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
     buf[0] = mode == PPMODE? CMD_READ_FUSE_PP: CMD_READ_FUSE_HVSP;
     addr = 0;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     buf[0] = mode == PPMODE? CMD_READ_FUSE_PP: CMD_READ_FUSE_HVSP;
     addr = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     buf[0] = mode == PPMODE? CMD_READ_FUSE_PP: CMD_READ_FUSE_HVSP;
     addr = 2;
-  } else if (strcmp(mem->desc, "lock") == 0) {
+  } else if (str_eq(mem->desc, "lock")) {
     buf[0] = mode == PPMODE? CMD_READ_LOCK_PP: CMD_READ_LOCK_HVSP;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     buf[0] = mode == PPMODE? CMD_READ_OSCCAL_PP: CMD_READ_OSCCAL_HVSP;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     buf[0] = mode == PPMODE? CMD_READ_SIGNATURE_PP: CMD_READ_SIGNATURE_HVSP;
   }
 
@@ -2361,10 +2360,9 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   pmsg_notice2("stk500isp_read_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
-  if (strcmp(mem->desc, "flash") == 0 ||
-      strcmp(mem->desc, "eeprom") == 0) {
+  if (str_eq(mem->desc, "flash") || str_eq(mem->desc, "eeprom")) {
     // use paged access, and cache result
-    if (strcmp(mem->desc, "flash") == 0) {
+    if (str_eq(mem->desc, "flash")) {
       pagesize = PDATA(pgm)->flash_pagesize;
       paddr = addr & ~(pagesize - 1);
       paddr_ptr = &PDATA(pgm)->flash_pageaddr;
@@ -2372,7 +2370,7 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     } else {
       pagesize = mem->page_size;
       if (pagesize == 0)
-	pagesize = 1;
+        pagesize = 1;
       paddr = addr & ~(pagesize - 1);
       paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
       cache_ptr = PDATA(pgm)->eeprom_pagecache;
@@ -2393,21 +2391,20 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     return 0;
   }
 
-  if (strcmp(mem->desc, "lfuse") == 0 ||
-	     strcmp(mem->desc, "fuse") == 0) {
+  if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
     buf[0] = CMD_READ_FUSE_ISP;
     addr = 0;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     buf[0] = CMD_READ_FUSE_ISP;
     addr = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     buf[0] = CMD_READ_FUSE_ISP;
     addr = 2;
-  } else if (strcmp(mem->desc, "lock") == 0) {
+  } else if (str_eq(mem->desc, "lock")) {
     buf[0] = CMD_READ_LOCK_ISP;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
+  } else if (str_eq(mem->desc, "calibration")) {
     buf[0] = CMD_READ_OSCCAL_ISP;
-  } else if (strcmp(mem->desc, "signature") == 0) {
+  } else if (str_eq(mem->desc, "signature")) {
     buf[0] = CMD_READ_SIGNATURE_ISP;
   }
 
@@ -2453,7 +2450,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   pmsg_notice2("stk500hv_write_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
-  if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_FLASH_PP: CMD_PROGRAM_FLASH_HVSP;
     pagesize = PDATA(pgm)->flash_pagesize;
     paddr = addr & ~(pagesize - 1);
@@ -2469,7 +2466,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     if (mem->op[AVR_OP_LOAD_EXT_ADDR] != NULL) {
       use_ext_addr = (1U << 31);
     }
-  } else if (strcmp(mem->desc, "eeprom") == 0) {
+  } else if (str_eq(mem->desc, "eeprom")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_EEPROM_PP: CMD_PROGRAM_EEPROM_HVSP;
     pagesize = mem->page_size;
     if (pagesize == 0)
@@ -2477,23 +2474,22 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->eeprom_pageaddr;
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
-  } else if (strcmp(mem->desc, "lfuse") == 0 ||
-	     strcmp(mem->desc, "fuse") == 0) {
+  } else if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_FUSE_PP: CMD_PROGRAM_FUSE_HVSP;
     addr = 0;
     pulsewidth = p->programfusepulsewidth;
     timeout = p->programfusepolltimeout;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_FUSE_PP: CMD_PROGRAM_FUSE_HVSP;
     addr = 1;
     pulsewidth = p->programfusepulsewidth;
     timeout = p->programfusepolltimeout;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_FUSE_PP: CMD_PROGRAM_FUSE_HVSP;
     addr = 2;
     pulsewidth = p->programfusepulsewidth;
     timeout = p->programfusepolltimeout;
-  } else if (strcmp(mem->desc, "lock") == 0) {
+  } else if (str_eq(mem->desc, "lock")) {
     buf[0] = mode == PPMODE? CMD_PROGRAM_LOCK_PP: CMD_PROGRAM_LOCK_HVSP;
     pulsewidth = p->programlockpulsewidth;
     timeout = p->programlockpolltimeout;
@@ -2607,9 +2603,8 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
 
   pmsg_notice2("stk500isp_write_byte(.., %s, 0x%lx, ...)\n", mem->desc, addr);
 
-  if (strcmp(mem->desc, "flash") == 0 ||
-      strcmp(mem->desc, "eeprom") == 0) {
-    if (strcmp(mem->desc, "flash") == 0) {
+  if (str_eq(mem->desc, "flash") || str_eq(mem->desc, "eeprom")) {
+    if (str_eq(mem->desc, "flash")) {
       pagesize = PDATA(pgm)->flash_pagesize;
       paddr = addr & ~(pagesize - 1);
       paddr_ptr = &PDATA(pgm)->flash_pageaddr;
@@ -2645,17 +2640,16 @@ static int stk500isp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   }
 
   memset(buf, 0, sizeof buf);
-  if (strcmp(mem->desc, "lfuse") == 0 ||
-	     strcmp(mem->desc, "fuse") == 0) {
+  if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse")) {
     buf[0] = CMD_PROGRAM_FUSE_ISP;
     addr = 0;
-  } else if (strcmp(mem->desc, "hfuse") == 0) {
+  } else if (str_eq(mem->desc, "hfuse")) {
     buf[0] = CMD_PROGRAM_FUSE_ISP;
     addr = 1;
-  } else if (strcmp(mem->desc, "efuse") == 0) {
+  } else if (str_eq(mem->desc, "efuse")) {
     buf[0] = CMD_PROGRAM_FUSE_ISP;
     addr = 2;
-  } else if (strcmp(mem->desc, "lock") == 0) {
+  } else if (str_eq(mem->desc, "lock")) {
     buf[0] = CMD_PROGRAM_LOCK_ISP;
   } else {
     pmsg_error("unsupported memory type: %s\n", mem->desc);
@@ -2714,7 +2708,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   use_ext_addr = 0;
 
   // determine which command is to be used
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     addrshift = 1;
     PDATA(pgm)->flash_pageaddr = ~0UL; // Invalidate cache
     commandbuf[0] = CMD_PROGRAM_FLASH_ISP;
@@ -2727,7 +2721,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     if (m->op[AVR_OP_LOAD_EXT_ADDR] != NULL) {
       use_ext_addr = (1U << 31);
     }
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     PDATA(pgm)->eeprom_pageaddr = ~0UL; // Invalidate cache
     commandbuf[0] = CMD_PROGRAM_EEPROM_ISP;
   }
@@ -2847,7 +2841,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   use_ext_addr = 0;
 
   // determine which command is to be used
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     addrshift = 1;
     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
     commandbuf[0] = mode == PPMODE? CMD_PROGRAM_FLASH_PP: CMD_PROGRAM_FLASH_HVSP;
@@ -2860,7 +2854,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     if (m->op[AVR_OP_LOAD_EXT_ADDR] != NULL) {
       use_ext_addr = (1U << 31);
     }
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
     commandbuf[0] = mode == PPMODE? CMD_PROGRAM_EEPROM_PP: CMD_PROGRAM_EEPROM_HVSP;
   }
@@ -2965,7 +2959,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
   use_ext_addr = 0;
 
   // determine which command is to be used
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     commandbuf[0] = CMD_READ_FLASH_ISP;
     rop = m->op[AVR_OP_READ_LO];
     addrshift = 1;
@@ -2979,7 +2973,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
       use_ext_addr = (1U << 31);
     }
   }
-  else if (strcmp(m->desc, "eeprom") == 0) {
+  else if (str_eq(m->desc, "eeprom")) {
     commandbuf[0] = CMD_READ_EEPROM_ISP;
   }
 
@@ -3055,7 +3049,7 @@ static int stk500hv_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
   use_ext_addr = 0;
 
   // determine which command is to be used
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     commandbuf[0] = mode == PPMODE? CMD_READ_FLASH_PP: CMD_READ_FLASH_HVSP;
     addrshift = 1;
     /*
@@ -3068,7 +3062,7 @@ static int stk500hv_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
       use_ext_addr = (1U << 31);
     }
   }
-  else if (strcmp(m->desc, "eeprom") == 0) {
+  else if (str_eq(m->desc, "eeprom")) {
     commandbuf[0] = mode == PPMODE? CMD_READ_EEPROM_PP: CMD_READ_EEPROM_HVSP;
   }
 
@@ -3794,7 +3788,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -3904,7 +3898,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -3980,7 +3974,7 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
    * the meaning of the "baud" parameter to be the USB device ID to
    * search for.
    */
-  if (strncmp(port, "usb", 3) == 0) {
+  if (str_starts(port, "usb")) {
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
     pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
@@ -4229,22 +4223,21 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
 
     memset(b, 0, sizeof(b));
 
-    if (strcmp(mem->desc, "flash") == 0) {
+    if (str_eq(mem->desc, "flash")) {
         memcode = stk600_xprog_memtype(pgm, addr);
-    } else if (strcmp(mem->desc, "application") == 0 ||
-               strcmp(mem->desc, "apptable") == 0) {
+    } else if (str_eq(mem->desc, "application") || str_eq(mem->desc, "apptable")) {
         memcode = XPRG_MEM_TYPE_APPL;
-    } else if (strcmp(mem->desc, "boot") == 0) {
+    } else if (str_eq(mem->desc, "boot")) {
         memcode = XPRG_MEM_TYPE_BOOT;
-    } else if (strcmp(mem->desc, "eeprom") == 0) {
+    } else if (str_eq(mem->desc, "eeprom")) {
         memcode = XPRG_MEM_TYPE_EEPROM;
-    } else if (strcmp(mem->desc, "io") == 0) {
+    } else if (str_eq(mem->desc, "io")) {
         memcode = XPRG_MEM_TYPE_APPL;
         AVRMEM *data = avr_locate_mem(p, "data");
         addr += data->offset;
-    } else if (strncmp(mem->desc, "lock", strlen("lock")) == 0) {
+    } else if (str_starts(mem->desc, "lock")) {
         memcode = XPRG_MEM_TYPE_LOCKBITS;
-    } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
+    } else if (str_starts(mem->desc, "fuse")) {
         memcode = XPRG_MEM_TYPE_FUSE;
         if (p->prog_modes & PM_TPI)
             /*
@@ -4252,8 +4245,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
              * fuses.
              */
             need_erase = 1;
-    } else if (strcmp(mem->desc, "usersig") == 0 ||
-               strcmp(mem->desc, "userrow") == 0) {
+    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
         memcode = XPRG_MEM_TYPE_USERSIG;
     } else {
         pmsg_error("unknown memory %s\n", mem->desc);
@@ -4306,30 +4298,27 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
 {
     unsigned char b[8];
 
-    if (strcmp(mem->desc, "flash") == 0) {
+    if (str_eq(mem->desc, "flash")) {
         b[1] = stk600_xprog_memtype(pgm, addr);
-    } else if (strcmp(mem->desc, "application") == 0 ||
-               strcmp(mem->desc, "apptable") == 0) {
+    } else if (str_eq(mem->desc, "application") || str_eq(mem->desc, "apptable")) {
         b[1] = XPRG_MEM_TYPE_APPL;
-    } else if (strcmp(mem->desc, "boot") == 0) {
+    } else if (str_eq(mem->desc, "boot")) {
         b[1] = XPRG_MEM_TYPE_BOOT;
-    } else if (strcmp(mem->desc, "eeprom") == 0) {
+    } else if (str_eq(mem->desc, "eeprom")) {
         b[1] = XPRG_MEM_TYPE_EEPROM;
-    } else if (strcmp(mem->desc, "io") == 0) {
+    } else if (str_eq(mem->desc, "io")) {
         b[1] = XPRG_MEM_TYPE_APPL;
         AVRMEM *data = avr_locate_mem(p, "data");
         addr += data->offset;
-    } else if (strcmp(mem->desc, "signature") == 0) {
+    } else if (str_eq(mem->desc, "signature")) {
         b[1] = XPRG_MEM_TYPE_APPL;
-    } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
+    } else if (str_starts(mem->desc, "fuse")) {
         b[1] = XPRG_MEM_TYPE_FUSE;
-    } else if (strncmp(mem->desc, "lock", strlen("lock")) == 0) {
+    } else if (str_starts(mem->desc, "lock")) {
         b[1] = XPRG_MEM_TYPE_LOCKBITS;
-    } else if (strcmp(mem->desc, "calibration") == 0 ||
-               strcmp(mem->desc, "prodsig") == 0) {
+    } else if (str_eq(mem->desc, "calibration") || str_eq(mem->desc, "prodsig")) {
         b[1] = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
-    } else if (strcmp(mem->desc, "usersig") == 0 ||
-               strcmp(mem->desc, "userrow") == 0) {
+    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
         b[1] = XPRG_MEM_TYPE_USERSIG;
     } else {
         pmsg_error("unknown memory %s\n", mem->desc);
@@ -4375,39 +4364,36 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
      * This is probably what AVR079 means when writing about the
      * "TIF address space".
      */
-    if (strcmp(mem->desc, "flash") == 0) {
+    if (str_eq(mem->desc, "flash")) {
         memtype = 0;
         dynamic_memtype = 1;
         if (mem->size > 64 * 1024)
             use_ext_addr = (1UL << 31);
-    } else if (strcmp(mem->desc, "application") == 0 ||
-               strcmp(mem->desc, "apptable") == 0) {
+    } else if (str_eq(mem->desc, "application") || str_eq(mem->desc, "apptable")) {
         memtype = XPRG_MEM_TYPE_APPL;
         if (mem->size > 64 * 1024)
             use_ext_addr = (1UL << 31);
-    } else if (strcmp(mem->desc, "boot") == 0) {
+    } else if (str_eq(mem->desc, "boot")) {
         memtype = XPRG_MEM_TYPE_BOOT;
         // Do we have to consider the total amount of flash
         // instead to decide whether to use extended addressing?
         if (mem->size > 64 * 1024)
             use_ext_addr = (1UL << 31);
-    } else if (strcmp(mem->desc, "eeprom") == 0) {
+    } else if (str_eq(mem->desc, "eeprom")) {
         memtype = XPRG_MEM_TYPE_EEPROM;
-    } else if (strcmp(mem->desc, "io") == 0) {
+    } else if (str_eq(mem->desc, "io")) {
         memtype = XPRG_MEM_TYPE_APPL;
         AVRMEM *data = avr_locate_mem(p, "data");
         addr += data->offset;
-    } else if (strcmp(mem->desc, "signature") == 0) {
+    } else if (str_eq(mem->desc, "signature")) {
         memtype = XPRG_MEM_TYPE_APPL;
-    } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
+    } else if (str_starts(mem->desc, "fuse")) {
         memtype = XPRG_MEM_TYPE_FUSE;
-    } else if (strncmp(mem->desc, "lock", strlen("lock")) == 0) {
+    } else if (str_starts(mem->desc, "lock")) {
         memtype = XPRG_MEM_TYPE_LOCKBITS;
-    } else if (strcmp(mem->desc, "calibration") == 0 ||
-               strcmp(mem->desc, "prodsig") == 0) {
+    } else if (str_eq(mem->desc, "calibration") || str_eq(mem->desc, "prodsig")) {
         memtype = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
-    } else if (strcmp(mem->desc, "usersig") == 0 ||
-               strcmp(mem->desc, "userrow") == 0) {
+    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
         memtype = XPRG_MEM_TYPE_USERSIG;
     } else {
         pmsg_error("unknown paged memory %s\n", mem->desc);
@@ -4482,42 +4468,40 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
      * This is probably what AVR079 means when writing about the
      * "TIF address space".
      */
-    if (strcmp(mem->desc, "flash") == 0) {
+    if (str_eq(mem->desc, "flash")) {
         memtype = 0;
         dynamic_memtype = 1;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
         if (mem->size > 64 * 1024)
             use_ext_addr = (1UL << 31);
-    } else if (strcmp(mem->desc, "application") == 0 ||
-               strcmp(mem->desc, "apptable") == 0) {
+    } else if (str_eq(mem->desc, "application") || str_eq(mem->desc, "apptable")) {
         memtype = XPRG_MEM_TYPE_APPL;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
         if (mem->size > 64 * 1024)
             use_ext_addr = (1UL << 31);
-    } else if (strcmp(mem->desc, "boot") == 0) {
+    } else if (str_eq(mem->desc, "boot")) {
         memtype = XPRG_MEM_TYPE_BOOT;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
         // Do we have to consider the total amount of flash
         // instead to decide whether to use extended addressing?
         if (mem->size > 64 * 1024)
             use_ext_addr = (1UL << 31);
-    } else if (strcmp(mem->desc, "eeprom") == 0) {
+    } else if (str_eq(mem->desc, "eeprom")) {
         memtype = XPRG_MEM_TYPE_EEPROM;
         writemode = (1 << XPRG_MEM_WRITE_WRITE) | (1 << XPRG_MEM_WRITE_ERASE);
-    } else if (strcmp(mem->desc, "signature") == 0) {
+    } else if (str_eq(mem->desc, "signature")) {
         memtype = XPRG_MEM_TYPE_APPL;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
-    } else if (strncmp(mem->desc, "fuse", strlen("fuse")) == 0) {
+    } else if (str_starts(mem->desc, "fuse")) {
         memtype = XPRG_MEM_TYPE_FUSE;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
-    } else if (strncmp(mem->desc, "lock", strlen("lock")) == 0) {
+    } else if (str_starts(mem->desc, "lock")) {
         memtype = XPRG_MEM_TYPE_LOCKBITS;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
-    } else if (strcmp(mem->desc, "calibration") == 0) {
+    } else if (str_eq(mem->desc, "calibration")) {
         memtype = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
-    } else if (strcmp(mem->desc, "usersig") == 0 ||
-               strcmp(mem->desc, "userrow") == 0) {
+    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
         memtype = XPRG_MEM_TYPE_USERSIG;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
     } else {
@@ -4657,18 +4641,16 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
 {
     unsigned char b[6];
 
-    if (strcmp(m->desc, "flash") == 0) {
+    if (str_eq(m->desc, "flash")) {
       b[1] = stk600_xprog_memtype(pgm, addr) == XPRG_MEM_TYPE_APPL?
         XPRG_ERASE_APP_PAGE: XPRG_ERASE_BOOT_PAGE;
-    } else if (strcmp(m->desc, "application") == 0 ||
-               strcmp(m->desc, "apptable") == 0) {
+    } else if (str_eq(m->desc, "application") || str_eq(m->desc, "apptable")) {
       b[1] = XPRG_ERASE_APP_PAGE;
-    } else if (strcmp(m->desc, "boot") == 0) {
+    } else if (str_eq(m->desc, "boot")) {
       b[1] = XPRG_ERASE_BOOT_PAGE;
-    } else if (strcmp(m->desc, "eeprom") == 0) {
+    } else if (str_eq(m->desc, "eeprom")) {
       b[1] = XPRG_ERASE_EEPROM_PAGE;
-    } else if (strcmp(m->desc, "usersig") == 0 ||
-               strcmp(m->desc, "userrow") == 0) {
+    } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
       b[1] = XPRG_ERASE_USERSIG;
     } else {
       pmsg_error("unknown paged memory %s\n", m->desc);

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -339,14 +339,14 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
     char* dev_name = NULL;
 
     // if no -P was given or '-P usb' was given
-    if (strcmp(port, "usb") == 0)
+    if (str_eq(port, "usb"))
     {
         port = NULL;
     }
     else
     {
         // calculate bus and device names from -P option
-        if (strncmp(port, "usb", 3) == 0 && ':' == port[3])
+        if (str_starts(port, "usb") && ':' == port[3])
         {
             bus_name = port + 4;
             dev_name = strchr(bus_name, ':');
@@ -463,10 +463,10 @@ static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
 {
     pmsg_debug("teensy_read_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
 
-    if (strcmp(mem->desc, "lfuse") == 0 ||
-        strcmp(mem->desc, "hfuse") == 0 ||
-        strcmp(mem->desc, "efuse") == 0 ||
-        strcmp(mem->desc, "lock") == 0)
+    if (str_eq(mem->desc, "lfuse") ||
+        str_eq(mem->desc, "hfuse") ||
+        str_eq(mem->desc, "efuse") ||
+        str_eq(mem->desc, "lock"))
     {
         *value = 0xFF;
         return 0;
@@ -499,7 +499,7 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 {
     pmsg_debug("teensy_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
 
-    if (strcmp(mem->desc, "flash") == 0)
+    if (str_eq(mem->desc, "flash"))
     {
         pdata_t* pdata = PDATA(pgm);
 

--- a/src/update.c
+++ b/src/update.c
@@ -239,7 +239,7 @@ int update_is_writeable(const char *fn) {
     return 0;
 
   // Assume writing to stdout will be OK
-  if(!strcmp(fn, "-"))
+  if(str_eq(fn, "-"))
     return 1;
 
   // File exists? If so return whether it's readable and an OK file type
@@ -260,7 +260,7 @@ int update_is_readable(const char *fn) {
     return 0;
 
   // Assume reading from stdin will be OK
-  if(!strcmp(fn, "-"))
+  if(str_eq(fn, "-"))
     return 1;
 
   // File exists, is readable by the process and an OK file type?
@@ -471,7 +471,7 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd, enum updat
     // Patch flash input, eg, for vector bootloaders
     if(pgm->flash_readhook) {
       AVRMEM *mem = avr_locate_mem(p, upd->memtype);
-      if(mem && !strcmp(mem->desc, "flash")) {
+      if(mem && str_eq(mem->desc, "flash")) {
         rc = pgm->flash_readhook(pgm, p, mem, upd->filename, rc);
         if (rc < 0) {
           pmsg_notice("readhook for file %s failed\n", str_inname(upd->filename));

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -155,7 +155,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		   * whether we have to search for a HID interface
 		   * below.
 		   */
-		  if(strstr(product, "CMSIS-DAP") != NULL)
+		  if(str_contains(product, "CMSIS-DAP"))
 		  {
 		      pinfo.usbinfo.flags |= PINFO_FL_USEHID;
 		      /* The JTAGICE3 running the CMSIS-DAP firmware doesn't
@@ -163,7 +163,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      fd->usb.eep = 0;
 		  }
 
-		  if(strstr(product, "mEDBG") != NULL)
+		  if(str_contains(product, "mEDBG"))
 		  {
 		      /* The AVR Xplained Mini uses different endpoints. */
 		      fd->usb.rep = 0x81;

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -179,7 +179,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		       * right-to-left.
 		       */
 		      x = strlen(string) - strlen(serno);
-		      if (strcasecmp(string + x, serno) != 0)
+		      if (!str_caseeq(string + x, serno))
 			{
                           pmsg_debug("usbdev_open(): serial number does not match\n");
 			  usb_close(udev);

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -439,7 +439,7 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
 		}
             } else {
                 pmsg_notice2("seen device from vendor >%s<\n", string);
-                if ((vendorName != NULL) && (vendorName[0] != 0) && (strcmp(string, vendorName) != 0))
+                if ((vendorName != NULL) && (vendorName[0] != 0) && !str_eq(string, vendorName))
                     errorCode = USB_ERROR_NOTFOUND;
             }
             /* if productName not given ignore it (any product matches) */
@@ -451,7 +451,7 @@ static int usbOpenDevice(libusb_device_handle **device, int vendor,
 		}
             } else {
                 pmsg_notice2("seen product >%s<\n", string);
-                if((productName != NULL) && (productName[0] != 0) && (strcmp(string, productName) != 0))
+                if((productName != NULL) && (productName[0] != 0) && !str_eq(string, productName))
                     errorCode = USB_ERROR_NOTFOUND;
             }
             if (errorCode == 0)
@@ -508,7 +508,7 @@ static int           didUsbInit = 0;
 		    }
                 } else {
                     pmsg_notice2("seen device from vendor >%s<\n", string);
-                    if((vendorName != NULL) && (vendorName[0] != 0) && (strcmp(string, vendorName) != 0))
+                    if((vendorName != NULL) && (vendorName[0] != 0) && !str_eq(string, vendorName))
                         errorCode = USB_ERROR_NOTFOUND;
                 }
                 /* if productName not given ignore it (any product matches) */
@@ -521,7 +521,7 @@ static int           didUsbInit = 0;
 		    }
                 } else {
                     pmsg_notice2("seen product >%s<\n", string);
-                    if((productName != NULL) && (productName[0] != 0) && (strcmp(string, productName) != 0))
+                    if((productName != NULL) && (productName[0] != 0) && !str_eq(string, productName))
                         errorCode = USB_ERROR_NOTFOUND;
                 }
                 if (errorCode == 0)
@@ -771,9 +771,9 @@ static int usbasp_spi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 
   pmsg_debug("usbasp_program_paged_load(\"%s\", 0x%x, %d)\n", m->desc, address, n_bytes);
 
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     function = USBASP_FUNC_READFLASH;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     function = USBASP_FUNC_READEEPROM;
   } else {
     return -2;
@@ -836,9 +836,9 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 
   pmsg_debug("usbasp_program_paged_write(\"%s\", 0x%x, %d)\n", m->desc, address, n_bytes);
 
-  if (strcmp(m->desc, "flash") == 0) {
+  if (str_eq(m->desc, "flash")) {
     function = USBASP_FUNC_WRITEFLASH;
-  } else if (strcmp(m->desc, "eeprom") == 0) {
+  } else if (str_eq(m->desc, "eeprom")) {
     function = USBASP_FUNC_WRITEEEPROM;
   } else {
     return -2;
@@ -1172,7 +1172,7 @@ static int usbasp_tpi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
   writed = 0;
 
   /* must erase fuse first */
-  if(strcmp(m->desc, "fuse") == 0)
+  if(str_eq(m->desc, "fuse"))
   {
     /* Set PR */
     usbasp_tpi_send_byte(pgm, TPI_OP_SSTPR(0));

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -561,7 +561,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
     /* try alternatives */
     if(str_eq(pgmid, "usbasp")) {
     /* for id usbasp autodetect some variants */
-      if(strcasecmp(port, "nibobee") == 0) {
+      if(str_caseeq(port, "nibobee")) {
         pmsg_error("using -C usbasp -P nibobee is deprecated, use -C nibobee instead\n");
         if (usbOpenDevice(&PDATA(pgm)->usbhandle, USBASP_NIBOBEE_VID, "www.nicai-systems.com",
 		        USBASP_NIBOBEE_PID, "NIBObee") != 0) {

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -304,12 +304,12 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   int vid, pid;
 
   // if no -P was given or '-P usb' was given
-  if(strcmp(name, "usb") == 0)
+  if(str_eq(name, "usb"))
     name = NULL;
   else {
     // calculate bus and device names from -P option
     const size_t usb_len = strlen("usb");
-    if(strncmp(name, "usb", usb_len) == 0 && ':' == name[usb_len]) {
+    if(str_starts(name, "usb") && ':' == name[usb_len]) {
         bus_name = name + usb_len + 1;
         dev_name = strchr(bus_name, ':');
         if(NULL != dev_name)
@@ -347,8 +347,8 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
     // if -P was given, match device by device name and bus name
     if(name != NULL &&
       (NULL == dev_name ||
-       strcmp(bus->dirname, bus_name) ||
-       strcmp(dev->filename, dev_name)))
+       !str_eq(bus->dirname, bus_name) ||
+       !str_eq(dev->filename, dev_name)))
       continue;
 	PDATA(pgm)->usb_handle = usb_open(dev);           // attempt to connect to device
 
@@ -643,8 +643,7 @@ static int usbtiny_paged_load (const PROGRAMMER *pgm, const AVRPART *p, const AV
   unsigned char cmd[8];
 
   // First determine what we're doing
-  function = strcmp(m->desc, "eeprom")==0?
-    USBTINY_EEPROM_READ: USBTINY_FLASH_READ;
+  function = str_eq(m->desc, "eeprom")? USBTINY_EEPROM_READ: USBTINY_FLASH_READ;
 
   // paged_load() only called for pages, so OK to set ext addr once at start
   if((lext = m->op[AVR_OP_LOAD_EXT_ADDR])) {
@@ -714,7 +713,7 @@ static int usbtiny_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   int delay;        // delay required between SPI commands
 
   // First determine what we're doing
-  if (strcmp( m->desc, "flash" ) == 0) {
+  if (str_eq(m->desc, "flash")) {
     function = USBTINY_FLASH_WRITE;
   } else {
     function = USBTINY_EEPROM_WRITE;


### PR DESCRIPTION
This PR replaces the `strcmp`/`strncmp`/`strcasecmp`/`strncmp` string comparison functions with Avrdude's own `str_eq`/`str_starts`/`str_caseeq` etc.

I've so far only modified `jtag3.c`, `stk500v2.c`, `jtagmkii.c` and `jtagmki.c`, but I can go through the entire code base if that's OK. When grepping for `strcmp` or `strncmp`, I realize there aren't that many occurrences left in the codebase.

I've also slightly simplified the way jtag3/jtagmkii/jtagmki/stk500v2 deals with the various fuses.