### PR TITLE
wiring: set reset discharge time to 80ms

### DIFF
--- a/src/wiring.c
+++ b/src/wiring.c
@@ -180,7 +180,7 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
     pmsg_notice2("wiring_open(): asserting DTR/RTS\n");
 
     serial_set_dtr_rts(&pgm->fd, 1);
-    usleep(50*1000);
+    usleep(80*1000);
 
     /* Set high, so a direct connection to reset works. */
     serial_set_dtr_rts(&pgm->fd, 0);


### PR DESCRIPTION
Geeetech GT2560 boards [1] use 1uF capacitors in their DTR/RESET line and 50ms seem to be a tad too short. 80ms works well (here).

fixes #1503

[1]
https://www.geeetech.com/wiki/images/d/d3/Hardware_GT2560_RevA%2B.pdf