### PR TITLE
Support for serial port "touch" functionality using libserialport

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -367,10 +367,13 @@ for more information run avrdude -p x/h.
 Override the RS-232 connection baud rate specified in the respective
 programmer's entry of the configuration file.
 .It Fl r
-Opens the serial port at 1200 baud and immedeatly closes it, prior to
-establishing communication with the programmer. This is commonly knows as A
-"1200bps touch", and is used to trigger programming mode for certain boards
-like Arduino Leonardo, Arduino Micro/Pro Micro and the Arduino Nano Every.
+Opens the serial port at 1200 baud and immediately closes it, waits 400 ms
+for each -r on the command line and then establishes communication with
+the programmer. This is commonly known as a "1200bps touch", and is used
+to trigger programming mode for certain boards like Arduino Leonardo,
+Arduino Micro/Pro Micro and the Arduino Nano Every. Longer waits, and
+therefore multiple -r options are sometimes needed for slower, less
+powerful hosts.
 .It Fl B Ar bitclock
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -29,6 +29,7 @@
 .Nm
 .Fl p Ar partno
 .Op Fl b Ar baudrate
+.Op Fl r Ar baudrate
 .Op Fl B Ar bitclock
 .Op Fl c Ar programmer-id
 .Op Fl C Ar config-file
@@ -365,6 +366,12 @@ for more information run avrdude -p x/h.
 .It Fl b Ar baudrate
 Override the RS-232 connection baud rate specified in the respective
 programmer's entry of the configuration file.
+.It Fl r Ar baudrate
+Sets the baudrate used to open and close a serial port prior to establishing
+communication with the programmer, often referred to a "port touch".
+The most common speed used for this is 1200 baud. Common hardware that
+requires this in order to enter programming mode is the Arduino Leonardo,
+Arduino Micro/Pro Micro and the Arduino Nano Every.
 .It Fl B Ar bitclock
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -372,7 +372,7 @@ for each -r on the command line and then establishes communication with
 the programmer. This is commonly known as a "1200bps touch", and is used
 to trigger programming mode for certain boards like Arduino Leonardo,
 Arduino Micro/Pro Micro and the Arduino Nano Every. Longer waits, and
-therefore multiple -r options are sometimes needed for slower, less
+therefore multiple -r options, are sometimes needed for slower, less
 powerful hosts.
 .It Fl B Ar bitclock
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -29,7 +29,7 @@
 .Nm
 .Fl p Ar partno
 .Op Fl b Ar baudrate
-.Op Fl r Ar baudrate
+.Op Fl r
 .Op Fl B Ar bitclock
 .Op Fl c Ar programmer-id
 .Op Fl C Ar config-file
@@ -366,12 +366,11 @@ for more information run avrdude -p x/h.
 .It Fl b Ar baudrate
 Override the RS-232 connection baud rate specified in the respective
 programmer's entry of the configuration file.
-.It Fl r Ar baudrate
-Sets the baudrate used to open and close a serial port prior to establishing
-communication with the programmer, often referred to a "port touch".
-The most common speed used for this is 1200 baud. Common hardware that
-requires this in order to enter programming mode is the Arduino Leonardo,
-Arduino Micro/Pro Micro and the Arduino Nano Every.
+.It Fl r
+Opens the serial port at 1200 baud and immedeatly closes it, prior to
+establishing communication with the programmer. This is commonly knows as A
+"1200bps touch", and is used to trigger programming mode for certain boards
+like Arduino Leonardo, Arduino Micro/Pro Micro and the Arduino Nano Every.
 .It Fl B Ar bitclock
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -469,11 +469,14 @@ ATmega328P MCU properties; for more information run @code{avrdude -p x/h}.
 Override the RS-232 connection baud rate specified in the respective
 programmer's entry of the configuration file.
 
-@item -r @var{baudrate}
-Opens the serial port at 1200 baud and immedeatly closes it, prior to
-establishing communication with the programmer. This is commonly knows as A
-"1200bps touch", and is used to trigger programming mode for certain boards
-like Arduino Leonardo, Arduino Micro/Pro Micro and the Arduino Nano Every.
+@item -r
+Opens the serial port at 1200 baud and immediately closes it, waits 400 ms
+for each @code{-r} on the command line and then establishes communication
+with the programmer. This is commonly known as a "1200bps touch", and is
+used to trigger programming mode for certain boards like Arduino Leonardo,
+Arduino Micro/Pro Micro and the Arduino Nano Every. Longer waits, and
+therefore multiple @code{-r} options are sometimes needed for slower, less
+powerful hosts.
 
 @item -B @var{bitclock}
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -470,11 +470,10 @@ Override the RS-232 connection baud rate specified in the respective
 programmer's entry of the configuration file.
 
 @item -r @var{baudrate}
-Sets the baudrate used to open and close a serial port prior to establishing
-communication with the programmer, often referred to a "port touch".
-The most common speed used for this is 1200 baud. Common hardware that
-requires this in order to enter programming mode is the Arduino Leonardo,
-Arduino Micro/Pro Micro and the Arduino Nano Every.
+Opens the serial port at 1200 baud and immedeatly closes it, prior to
+establishing communication with the programmer. This is commonly knows as A
+"1200bps touch", and is used to trigger programming mode for certain boards
+like Arduino Leonardo, Arduino Micro/Pro Micro and the Arduino Nano Every.
 
 @item -B @var{bitclock}
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -469,6 +469,13 @@ ATmega328P MCU properties; for more information run @code{avrdude -p x/h}.
 Override the RS-232 connection baud rate specified in the respective
 programmer's entry of the configuration file.
 
+@item -r @var{baudrate}
+Sets the baudrate used to open and close a serial port prior to establishing
+communication with the programmer, often referred to a "port touch".
+The most common speed used for this is 1200 baud. Common hardware that
+requires this in order to enter programming mode is the Arduino Leonardo,
+Arduino Micro/Pro Micro and the Arduino Nano Every.
+
 @item -B @var{bitclock}
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -475,7 +475,7 @@ for each @code{-r} on the command line and then establishes communication
 with the programmer. This is commonly known as a "1200bps touch", and is
 used to trigger programming mode for certain boards like Arduino Leonardo,
 Arduino Micro/Pro Micro and the Arduino Nano Every. Longer waits, and
-therefore multiple @code{-r} options are sometimes needed for slower, less
+therefore multiple @code{-r} options, are sometimes needed for slower, less
 powerful hosts.
 
 @item -B @var{bitclock}

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -668,7 +668,7 @@ struct serial_device {
   int (*open)(const char *port, union pinfo pinfo, union filedescriptor *fd);
   int (*setparams)(const union filedescriptor *fd, long baud, unsigned long cflags);
   void (*close)(union filedescriptor *fd);
-  void (*rawclose)(union filedescriptor *fd); // Don't restore terminal attributes
+  void (*rawclose)(union filedescriptor *fd); // Don't restore terminal attributes (Linux)
 
   int (*send)(const union filedescriptor *fd, const unsigned char * buf, size_t buflen);
   int (*recv)(const union filedescriptor *fd, unsigned char * buf, size_t buflen);
@@ -692,6 +692,7 @@ extern struct serial_device usbhid_serdev;
 #define serial_open (serdev->open)
 #define serial_setparams (serdev->setparams)
 #define serial_close (serdev->close)
+#define serial_rawclose (serdev->rawclose)
 #define serial_send (serdev->send)
 #define serial_recv (serdev->recv)
 #define serial_drain (serdev->drain)

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -668,6 +668,7 @@ struct serial_device {
   int (*open)(const char *port, union pinfo pinfo, union filedescriptor *fd);
   int (*setparams)(const union filedescriptor *fd, long baud, unsigned long cflags);
   void (*close)(union filedescriptor *fd);
+  void (*rawclose)(union filedescriptor *fd); // Don't restore terminal attributes
 
   int (*send)(const union filedescriptor *fd, const unsigned char * buf, size_t buflen);
   int (*recv)(const union filedescriptor *fd, unsigned char * buf, size_t buflen);
@@ -1252,7 +1253,7 @@ extern "C" {
 int setport_from_serialadapter(char **portp, const SERIALADAPTER *ser, const char *sernum);
 int setport_from_vid_pid(char **portp, int vid, int pid, const char *sernum);
 int list_available_serialports(LISTID programmers);
-int touch_serialport(char **portp, int baudrate);
+int touch_serialport(char **portp, int baudrate, int nwaits);
 
 int str_starts(const char *str, const char *starts);
 int str_eq(const char *str1, const char *str2);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1252,6 +1252,7 @@ extern "C" {
 int setport_from_serialadapter(char **portp, const SERIALADAPTER *ser, const char *sernum);
 int setport_from_vid_pid(char **portp, int vid, int pid, const char *sernum);
 int list_available_serialports(LISTID programmers);
+int touch_serialport(char **portp, int baudrate);
 
 int str_starts(const char *str, const char *starts);
 int str_eq(const char *str1, const char *str2);

--- a/src/main.c
+++ b/src/main.c
@@ -1275,7 +1275,7 @@ int main(int argc, char * argv [])
 
   rc = pgm->open(pgm, port);
   if (rc < 0) {
-    pmsg_error("unable to open programmer %s on port %s\n", pgmid, port);
+    pmsg_error("unable to open port %s for programmer %s\n", port, pgmid);
     if (print_ports && pgm->conntype == CONNTYPE_SERIAL) {
       list_available_serialports(programmers);
       if(touch_1200bps == 1)

--- a/src/main.c
+++ b/src/main.c
@@ -526,7 +526,7 @@ int main(int argc, char * argv [])
   char  * e;           /* for strtod() error checking */
   const char  *errstr; /* for str_int() error checking */
   int     baudrate;    /* override default programmer baud rate */
-  int     touch_baudrate; /* baudrate to use when "touching" a serial port */
+  int     touch_baudrate = 0; /* baudrate to use when "touching" a serial port */
   double  bitclock;    /* Specify programmer bit clock (JTAG ICE) */
   int     ispdelay;    /* Specify the delay for ISP clock */
   int     init_ok;     /* Device initialization worked well */

--- a/src/main.c
+++ b/src/main.c
@@ -228,6 +228,8 @@ static void usage(void)
     "  -p <wildcard>/<flags>  Run developer options for matched AVR devices,\n"
     "                         e.g., -p ATmega328P/s or /S for part definition\n"
     "  -b <baudrate>          Override RS-232 baud rate\n"
+    "  -r <baudrate>          Open and close (\"touch\") the serial port before\n"
+    "                         establishing connection with the programmer."
     "  -B <bitclock>          Specify bit clock period (us)\n"
     "  -C <config-file>       Specify location of configuration file\n"
     "  -c <programmer>        Specify programmer; -c ? and -c ?type list all\n"

--- a/src/main.c
+++ b/src/main.c
@@ -228,8 +228,8 @@ static void usage(void)
     "  -p <wildcard>/<flags>  Run developer options for matched AVR devices,\n"
     "                         e.g., -p ATmega328P/s or /S for part definition\n"
     "  -b <baudrate>          Override RS-232 baud rate\n"
-    "  -r <baudrate>          Open and close (\"touch\") the serial port before\n"
-    "                         establishing connection with the programmer."
+    "  -r                     Open and close (\"touch\") the serial port at\n"
+    "                         1200 baud before establishing connection\n"
     "  -B <bitclock>          Specify bit clock period (us)\n"
     "  -C <config-file>       Specify location of configuration file\n"
     "  -c <programmer>        Specify programmer; -c ? and -c ?type list all\n"
@@ -528,7 +528,7 @@ int main(int argc, char * argv [])
   char  * e;           /* for strtod() error checking */
   const char  *errstr; /* for str_int() error checking */
   int     baudrate;    /* override default programmer baud rate */
-  int     touch_baudrate = 0; /* baudrate to use when "touching" a serial port */
+  bool    touch_1200bps = false; /* "touch" serial port prior to programming */
   double  bitclock;    /* Specify programmer bit clock (JTAG ICE) */
   int     ispdelay;    /* Specify the delay for ISP clock */
   int     init_ok;     /* Device initialization worked well */
@@ -638,7 +638,7 @@ int main(int argc, char * argv [])
   /*
    * process command line arguments
    */
-  while ((ch = getopt(argc,argv,"?Ab:B:c:C:DeE:Fi:l:np:OP:qr:stT:U:uvVx:yY:")) != -1) {
+  while ((ch = getopt(argc,argv,"?Ab:B:c:C:DeE:Fi:l:np:OP:qrstT:U:uvVx:yY:")) != -1) {
 
     switch (ch) {
       case 'b': /* override default programmer baud rate */
@@ -770,7 +770,7 @@ int main(int argc, char * argv [])
         break;
 
       case 'r' :
-        touch_baudrate = str_int(optarg, STR_INT32, &errstr);
+        touch_1200bps = true;
         break;
 
       case 't': /* enter terminal mode */
@@ -1238,8 +1238,8 @@ int main(int argc, char * argv [])
       free(port_tok[i]);
   }
 
-  if(touch_baudrate && pgm->conntype == CONNTYPE_SERIAL)
-    touch_serialport(&port, touch_baudrate);
+  if(touch_1200bps && pgm->conntype == CONNTYPE_SERIAL)
+    touch_serialport(&port, 1200);
 
   /*
    * open the programmer

--- a/src/main.c
+++ b/src/main.c
@@ -1276,8 +1276,11 @@ int main(int argc, char * argv [])
   rc = pgm->open(pgm, port);
   if (rc < 0) {
     pmsg_error("unable to open programmer %s on port %s\n", pgmid, port);
-    if (print_ports && pgm->conntype == CONNTYPE_SERIAL)
+    if (print_ports && pgm->conntype == CONNTYPE_SERIAL) {
       list_available_serialports(programmers);
+      if(touch_1200bps == 1)
+        pmsg_info("alternatively, try -rr or -rrr for longer delays\n");
+    }
     exitrc = 1;
     pgm->ppidata = 0; /* clear all bits at exit */
     goto main_exit;

--- a/src/main.c
+++ b/src/main.c
@@ -1238,7 +1238,7 @@ int main(int argc, char * argv [])
       free(port_tok[i]);
   }
 
-  if(touch_baudrate)
+  if(touch_baudrate && pgm->conntype == CONNTYPE_SERIAL)
     touch_serialport(&port, touch_baudrate);
 
   /*

--- a/src/main.c
+++ b/src/main.c
@@ -1245,7 +1245,7 @@ int main(int argc, char * argv [])
     for (int i = 0; i < 4; i++)
       free(port_tok[i]);
     if(touch_1200bps && touch_serialport(&port, 1200, touch_1200bps) < 0)
-      exit(1);
+      goto skipopen;
   }
 
 
@@ -1276,6 +1276,7 @@ int main(int argc, char * argv [])
   rc = pgm->open(pgm, port);
   if (rc < 0) {
     pmsg_error("unable to open port %s for programmer %s\n", port, pgmid);
+skipopen:
     if (print_ports && pgm->conntype == CONNTYPE_SERIAL) {
       list_available_serialports(programmers);
       if(touch_1200bps == 1)

--- a/src/main.c
+++ b/src/main.c
@@ -526,6 +526,7 @@ int main(int argc, char * argv [])
   char  * e;           /* for strtod() error checking */
   const char  *errstr; /* for str_int() error checking */
   int     baudrate;    /* override default programmer baud rate */
+  int     touch_baudrate; /* baudrate to use when "touching" a serial port */
   double  bitclock;    /* Specify programmer bit clock (JTAG ICE) */
   int     ispdelay;    /* Specify the delay for ISP clock */
   int     init_ok;     /* Device initialization worked well */
@@ -635,7 +636,7 @@ int main(int argc, char * argv [])
   /*
    * process command line arguments
    */
-  while ((ch = getopt(argc,argv,"?Ab:B:c:C:DeE:Fi:l:np:OP:qstT:U:uvVx:yY:")) != -1) {
+  while ((ch = getopt(argc,argv,"?Ab:B:c:C:DeE:Fi:l:np:OP:qr:stT:U:uvVx:yY:")) != -1) {
 
     switch (ch) {
       case 'b': /* override default programmer baud rate */
@@ -764,6 +765,10 @@ int main(int argc, char * argv [])
 
       case 'q' : /* Quell progress output */
         quell_progress++ ;
+        break;
+
+      case 'r' :
+        touch_baudrate = str_int(optarg, STR_INT32, &errstr);
         break;
 
       case 't': /* enter terminal mode */
@@ -1230,6 +1235,9 @@ int main(int argc, char * argv [])
     for (int i = 0; i < 4; i++)
       free(port_tok[i]);
   }
+
+  if(touch_baudrate)
+    touch_serialport(&port, touch_baudrate);
 
   /*
    * open the programmer

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -352,6 +352,7 @@ struct serial_device avrdoper_serdev =
 {
   .open = avrdoper_open,
   .close = avrdoper_close,
+  .rawclose = avrdoper_close,
   .send = avrdoper_send,
   .recv = avrdoper_recv,
   .drain = avrdoper_drain,

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -352,7 +352,6 @@ error:
   return ret;
 }
 
-
 static int ser_set_dtr_rts(const union filedescriptor *fdp, int is_on) {
   unsigned int	ctl;
   int           r;
@@ -431,6 +430,11 @@ static void ser_close(union filedescriptor *fd) {
   close(fd->ifd);
 }
 
+// Close but don't restore attributes
+static void ser_rawclose(union filedescriptor *fd) {
+  saved_original_termios = 0;
+  close(fd->ifd);
+}
 
 static int ser_send(const union filedescriptor *fd, const unsigned char * buf, size_t buflen) {
   int rc;
@@ -598,6 +602,7 @@ struct serial_device serial_serdev =
   .open = ser_open,
   .setparams = ser_setparams,
   .close = ser_close,
+  .rawclose = ser_rawclose,
   .send = ser_send,
   .recv = ser_recv,
   .drain = ser_drain,

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -756,6 +756,7 @@ struct serial_device serial_serdev =
   .open = ser_open,
   .setparams = ser_setparams,
   .close = ser_close,
+  .rawclose = ser_close,
   .send = ser_send,
   .recv = ser_recv,
   .drain = ser_drain,

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -395,7 +395,7 @@ int list_available_serialports(LISTID programmers) {
   return -1;
 }
 
-int touch_serialport(char **portp, int baudrate) {
+int touch_serialport(char **portp, int baudrate, int nwaits) {
   pmsg_error("avrdude built without libserialport support; please compile again with libserialport installed\n");
   return -1;
 }

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -323,7 +323,7 @@ int touch_serialport(char **portp, int baudrate, int nwaits) {
     return -1;
   }
   serial_set_dtr_rts(&fd, 0);
-  serial_close(&fd);
+  serial_rawclose(&fd);
 
   int nloops = 32, nap = 50;
 #if defined(__arm__)

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -337,8 +337,10 @@ int touch_serialport(char **portp, int baudrate) {
           free(*portp);
         *portp = cfg_strdup(__func__, (*diff)->port);
       }
+      free(diff);
       break;
     }
+    free(diff);
     usleep(500000);
   }
 

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -325,12 +325,12 @@ int touch_serialport(char **portp, int baudrate, int nwaits) {
   serial_set_dtr_rts(&fd, 0);
   serial_rawclose(&fd);
 
-  int nloops = 32, nap = 50;
-#if defined(__arm__)
+  const int nloops = 32, nap = 50;
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
   nwaits += 2;
 #endif
   pmsg_info("waiting for new port...");
-  usleep(400*nwaits*1000);
+  usleep(400*1000*nwaits);
   for(i = nloops; i > 0; i--) {
     usleep(nap*1000);
     if((sp2 = get_libserialport_data(&n2))) {

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -387,6 +387,11 @@ int list_available_serialports(LISTID programmers) {
   return -1;
 }
 
+int touch_serialport(char **portp, int baudrate) {
+  pmsg_error("avrdude built without libserialport support; please compile again with libserialport installed\n");
+  return -1;
+}
+
 #endif
 
 void list_serialadapters(FILE *fp, const char *prefix, LISTID programmers) {

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -322,6 +322,8 @@ int touch_serialport(char **portp, int baudrate, int nwaits) {
     pmsg_error("%s() failed to open port %s at %d baud\n", __func__, *portp, baudrate);
     return -1;
   }
+  serial_set_dtr_rts(&fd, 1);
+  usleep(100);
   serial_set_dtr_rts(&fd, 0);
   serial_rawclose(&fd);
 

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -318,6 +318,7 @@ static int usbhid_drain(const union filedescriptor *fd, int display) {
 struct serial_device usbhid_serdev = {
   .open = usbhid_open,
   .close = usbhid_close,
+  .rawclose = usbhid_close,
   .send = usbhid_send,
   .recv = usbhid_recv,
   .drain = usbhid_drain,

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -578,6 +578,7 @@ struct serial_device usb_serdev =
 {
   .open = usbdev_open,
   .close = usbdev_close,
+  .rawclose = usbdev_close,
   .send = usbdev_send,
   .recv = usbdev_recv,
   .drain = usbdev_drain,
@@ -591,6 +592,7 @@ struct serial_device usb_serdev_frame =
 {
   .open = usbdev_open,
   .close = usbdev_close,
+  .rawclose = usbdev_close,
   .send = usbdev_send,
   .recv = usbdev_recv_frame,
   .drain = usbdev_drain,

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1505,6 +1505,7 @@ static int xbeedev_set_dtr_rts(const union filedescriptor *fdp, int is_on)
 static struct serial_device xbee_serdev_frame = {
   .open = xbeedev_open,
   .close = xbeedev_close,
+  .rawclose = xbeedev_close,
   .send = xbeedev_send,
   .recv = xbeedev_recv,
   .drain = xbeedev_drain,


### PR DESCRIPTION
This draft PR makes it possible to upload to boards like the Arduino Leonardo and Arduino Nano Every without using an external tool to enter "upload mode".

This PR is a result of some test code I hacked together that turned out to work quite well. I'm open to suggestions on how this can be further improved.

Tested on an Arduino Pro Micro (running the Arduino Leonardo bootloader) and the Arduino Nano Every.
The Pro Micro has a different USB PID when in bootloader mode, while the Nano Every stays constant.

```
$ ./avrdude -cjtag2updi -patmega4809 -P /dev/cu.usbmodem14201 -r 1200
avrdude: touching serial port /dev/cu.usbmodem14201 at 1200 baud
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9651 (probably m4809)

avrdude done.  Thank you.


$ ./avrdude -cavr109 -patmega32u4 -P/dev/cu.usbmodem14201 -b57600 -r1200
avrdude: touching serial port /dev/cu.usbmodem14201 at 1200 baud
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9587 (probably m32u4)

avrdude done.  Thank you.
```

Resolves #1443