### PR TITLE
Read sigrow for ATmega32[48]PB using ISP

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1403,10 +1403,10 @@ const char *avr_mem_order[100] = {
   "codesize",     "fuse8",        "fuse9",        "bootend",
   "bootsize",     "fusea",        "pdicfg",       "fuses",
   "lock",         "lockbits",     "tempsense",    "signature",
-  "prodsig",      "sernum",       "calibration",  "osccal16",
-  "osccal20",     "osc16err",     "osc20err",     "bootrow",
-  "usersig",      "userrow",      "data",         "io",
-  "sib",
+  "sigrow",       "sigrow_pb",    "prodsig",      "sernum",
+  "calibration",  "osccal16",     "osccal20",     "osc16err",
+  "osc20err",     "bootrow",      "usersig",      "userrow",
+  "data",         "io",           "sib",
 };
 
 void avr_add_mem_order(const char *str) {
@@ -1427,7 +1427,8 @@ int avr_memtype_is_flash_type(const char *memtype) {
      str_eq(memtype, "flash") ||
      str_eq(memtype, "application") ||
      str_eq(memtype, "apptable") ||
-     str_eq(memtype, "boot"));
+     str_eq(memtype, "boot") ||
+     str_eq(memtype, "sigrow_pb"));
 }
 
 int avr_mem_is_flash_type(const AVRMEM *mem) {

--- a/src/avr.c
+++ b/src/avr.c
@@ -1403,10 +1403,10 @@ const char *avr_mem_order[100] = {
   "codesize",     "fuse8",        "fuse9",        "bootend",
   "bootsize",     "fusea",        "pdicfg",       "fuses",
   "lock",         "lockbits",     "tempsense",    "signature",
-  "sigrow",       "sigrow_pb",    "prodsig",      "sernum",
-  "calibration",  "osccal16",     "osccal20",     "osc16err",
-  "osc20err",     "bootrow",      "usersig",      "userrow",
-  "data",         "io",           "sib",
+  "sigrow",       "prodsig",      "sernum",       "calibration",
+  "osccal16",     "osccal20",     "osc16err",     "osc20err",
+  "bootrow",      "usersig",      "userrow",      "data",
+  "io",           "sib",
 };
 
 void avr_add_mem_order(const char *str) {
@@ -1427,8 +1427,7 @@ int avr_memtype_is_flash_type(const char *memtype) {
      str_eq(memtype, "flash") ||
      str_eq(memtype, "application") ||
      str_eq(memtype, "apptable") ||
-     str_eq(memtype, "boot") ||
-     str_eq(memtype, "sigrow_pb"));
+     str_eq(memtype, "boot"));
 }
 
 int avr_mem_is_flash_type(const AVRMEM *mem) {

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -791,6 +791,12 @@ High fuse byte
 Low fuse byte
 .It   lock
 Lock byte
+.It prodsig
+Signature, calibration byte and serial number in a small read-only memory,
+which is only documented to be available for ATmega324PB, ATmega328PB,
+ATtiny102 and ATtiny104; programmers may or may not be able to read this memory
+.It sigrow
+Memory alias for prodsig
 .It usersig
 Three extra flash pages for firmware settings; this memory is not erased
 during a chip erase. Only some classic parts,
@@ -828,7 +834,13 @@ Other fuse bytes of ATxmega devices, where
 .Em N
 is 2, 4 or 5, for system configuration
 .It prodsig
-Production signature (calibration) area
+The production signature row is a read-only memory section for factory
+programmed data such as the signature and calibration values for
+oscillators or analogue modules; it also contains a serial number that
+consists of the production lot number, wafer number and wafer coordinates
+for the part
+.It sigrow
+Memory alias for prodsig
 .It usersig
 Additional flash memory page that can be used for firmware settings; this
 memory is not erased during a chip erase
@@ -870,9 +882,12 @@ Two oscillator calibration bytes for 16 MHz
 .It osccal20
 Two oscillator calibration bytes for 20 MHz
 .It prodsig
-Production signature (calibration) area
+Read-only memory section for factory programmed data such as the
+signature, calibration values and serial number
+.It sigrow
+Memory alias for prodsig
 .It sernum
-Serial number with a unique ID for the part (10 bytes)
+Serial number with a unique ID for the part (10 or 16 bytes)
 .It tempsense
 Temperature sensor calibration values
 .It bootrow

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -18880,7 +18880,7 @@ part parent ".reduced_core_tiny"
     memory "prodsig"
         size               = 16;
         page_size          = 16;
-        offset             = 0x3fc6;
+        offset             = 0x3fc0;
     ;
 
     memory "sigrow"
@@ -18922,7 +18922,7 @@ part parent ".reduced_core_tiny"
     memory "prodsig"
         size               = 16;
         page_size          = 16;
-        offset             = 0x3fc6;
+        offset             = 0x3fc0;
     ;
 
     memory "sigrow"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -5717,18 +5717,9 @@ part parent "m324p"
         write              = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
     ;
 
-    memory "sigrow_pb"
-        paged              = yes;
+    memory "sigrow"
         size               = 24;
-        page_size          = 4;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
-        mode               = 0x41;
-        delay              = 10;
-        blocksize          = 4;
-        readsize           = 256;
-        read_lo            = "0011.0000--0000.0000--0000.aaaa--oooo.oooo";
-        read_hi            = "0011.1000--0000.0000--0000.aaaa--oooo.oooo";
+        read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
     ;
 ;
 
@@ -10369,18 +10360,9 @@ part parent "m328"
         write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
-    memory "sigrow_pb"
-        paged              = yes;
+    memory "sigrow"
         size               = 24;
-        page_size          = 4;
-        min_write_delay    = 9000;
-        max_write_delay    = 9000;
-        mode               = 0x41;
-        delay              = 10;
-        blocksize          = 4;
-        readsize           = 256;
-        read_lo            = "0011.0000--0000.0000--0000.aaaa--oooo.oooo";
-        read_hi            = "0011.1000--0000.0000--0000.aaaa--oooo.oooo";
+        read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -5716,6 +5716,20 @@ part parent "m324p"
         bitmask            = 0x0f;
         write              = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
     ;
+
+    memory "sigrow_pb"
+        paged              = yes;
+        size               = 24;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 0x41;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read_lo            = "0011.0000--0000.0000--0000.aaaa--oooo.oooo";
+        read_hi            = "0011.1000--0000.0000--0000.aaaa--oooo.oooo";
+    ;
 ;
 
 #------------------------------------------------------------
@@ -10353,6 +10367,20 @@ part parent "m328"
         initval            = 0xf7;
         bitmask            = 0x0f;
         write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
+    ;
+
+    memory "sigrow_pb"
+        paged              = yes;
+        size               = 24;
+        page_size          = 4;
+        min_write_delay    = 9000;
+        max_write_delay    = 9000;
+        mode               = 0x41;
+        delay              = 10;
+        blocksize          = 4;
+        readsize           = 256;
+        read_lo            = "0011.0000--0000.0000--0000.aaaa--oooo.oooo";
+        read_hi            = "0011.1000--0000.0000--0000.aaaa--oooo.oooo";
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -5717,9 +5717,13 @@ part parent "m324p"
         write              = "1010.1100--1010.0100--xxxx.xxxx--1111.iiii";
     ;
 
-    memory "sigrow"
+    memory "prodsig"
         size               = 24;
         read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
     ;
 ;
 
@@ -10360,9 +10364,13 @@ part parent "m328"
         write              = "1010.1100--1010.0100--xxxx.xxxx--xxxx.iiii";
     ;
 
-    memory "sigrow"
+    memory "prodsig"
         size               = 24;
         read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
     ;
 ;
 
@@ -18869,10 +18877,14 @@ part parent ".reduced_core_tiny"
         size               = 64;
     ;
 
-    memory "sigrow"
+    memory "prodsig"
         size               = 16;
         page_size          = 16;
         offset             = 0x3fc6;
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
     ;
 ;
 
@@ -18907,10 +18919,14 @@ part parent ".reduced_core_tiny"
         size               = 64;
     ;
 
-    memory "sigrow"
+    memory "prodsig"
         size               = 16;
         page_size          = 16;
         offset             = 0x3fc6;
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
     ;
 ;
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -137,7 +137,7 @@ int avr_set_addr_mem(const AVRMEM *mem, int opnum, unsigned char *cmd, unsigned 
   if(!(op = mem->op[opnum]))
     return -1;
 
-  isflash = str_eq(mem->desc, "flash"); // ISP parts have only one flash-like memory
+  isflash = avr_mem_is_flash_type(mem);
   memsize = mem->size >> isflash;        // word addresses for flash
   pagesize = mem->page_size >> isflash;
 

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1356,11 +1356,11 @@ static int parse_cmdbits(OPCODE * op, int opnum)
         case 'a':
           sb = opnum == AVR_OP_LOAD_EXT_ADDR? bitno+8: bitno-8; // should be this number
           if(bitno < 8 || bitno > 23) {
-            if(!current_mem || !str_eq(current_mem->desc, "sigrow")) // Exempt sigrow
+            if(!current_mem || !str_eq(current_mem->desc, "prodsig")) // Known exemption
               yywarning("address bits don't normally appear in Bytes 0 or 3 of SPI commands");
           } else if((bn & 31) != sb) {
-            if(!current_part || !str_casestarts(current_part->desc, "AT89S5")) // Exempt AT89S5x from warning
-              if(!current_mem || !str_eq(current_mem->desc, "sigrow")) // Exempt sigrow
+            if(!current_part || !str_casestarts(current_part->desc, "AT89S5")) // Exempt AT89S5x
+              if(!current_mem || !str_eq(current_mem->desc, "prodsig")) // and prodsig
                 yywarning("a%d would normally be expected to be a%d", bn, sb);
           } else if(bn < 0 || bn > 31)
             yywarning("invalid address bit a%d, using a%d", bn, bn & 31);

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1355,11 +1355,13 @@ static int parse_cmdbits(OPCODE * op, int opnum)
         switch(*s) {
         case 'a':
           sb = opnum == AVR_OP_LOAD_EXT_ADDR? bitno+8: bitno-8; // should be this number
-          if(bitno < 8 || bitno > 23)
-            yywarning("address bits don't normally appear in Bytes 0 or 3 of SPI commands");
-          else if((bn & 31) != sb) {
-            if(!str_casestarts(current_part->desc, "AT89S5")) // Exempt AT89S5x from warning
-              yywarning("a%d would normally be expected to be a%d", bn, sb);
+          if(bitno < 8 || bitno > 23) {
+            if(!current_mem || !str_eq(current_mem->desc, "sigrow")) // Exempt sigrow
+              yywarning("address bits don't normally appear in Bytes 0 or 3 of SPI commands");
+          } else if((bn & 31) != sb) {
+            if(!current_part || !str_casestarts(current_part->desc, "AT89S5")) // Exempt AT89S5x from warning
+              if(!current_mem || !str_eq(current_mem->desc, "sigrow")) // Exempt sigrow
+                yywarning("a%d would normally be expected to be a%d", bn, sb);
           } else if(bn < 0 || bn > 31)
             yywarning("invalid address bit a%d, using a%d", bn, bn & 31);
 

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -821,6 +821,12 @@ Fuse byte in devices that have only a single fuse byte
 High fuse byte
 @item lfuse
 Low fuse byte
+@item prodsig
+Signature, calibration byte and serial number in a small read-only memory,
+which is only documented to be available for ATmega324PB, ATmega328PB,
+ATtiny102 and ATtiny104; programmers may or may not be able to read this memory
+@item sigrow
+Memory alias for prodsig
 @item usersig
 Three extra flash pages for firmware settings; this memory is not erased
 during a chip erase. Only some classic parts,
@@ -856,7 +862,13 @@ Fault detection action configuration TC4/5 for ATxmega E series parts
 @item fuse@emph{N}
 Other fuse bytes of ATxmega devices, where @emph{N} is 2, 4 or 5, for system configuration
 @item prodsig
-Production signature (calibration) area
+The production signature row is a read-only memory section for factory
+programmed data such as the signature and calibration values for
+oscillators or analogue modules; it also contains a serial number that
+consists of the production lot number, wafer number and wafer coordinates
+for the part
+@item sigrow
+Memory alias for prodsig
 @item usersig
 Additional flash memory page that can be used for firmware settings; this
 memory is not erased during a chip erase
@@ -897,9 +909,12 @@ Two oscillator calibration bytes for 16 MHz
 @item osccal20
 Two oscillator calibration bytes for 20 MHz
 @item prodsig
-Production signature (calibration) area
+Read-only memory section for factory programmed data such as the
+signature, calibration values and serial number
+@item sigrow
+Memory alias for prodsig
 @item sernum
-Serial number with a unique ID for the pary (10 bytes)
+Serial number with a unique ID for the part (10 or 16 bytes)
 @item tempsense
 Temperature sensor calibration values
 @item bootrow


### PR DESCRIPTION
Fixes #1509 for ISP (well, a first shot anyway).

<s>This PR introduces `sigrow_pb` memory, which needs a different name than `sigrow` (used for Attiny102/104) at least until Issue #1330 is addressed.</s>