### PR TITLE
Update build.yml to revert PR #1513

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,9 +270,6 @@ jobs:
             mingw-w64-${{matrix.env}}-libusb-compat-git
             mingw-w64-${{matrix.env}}-hidapi
             mingw-w64-${{matrix.env}}-libftdi
-            mingw-w64-${{matrix.env}}-readline
-            mingw-w64-${{matrix.env}}-ncurses
-            mingw-w64-${{matrix.env}}-termcap
             mingw-w64-${{matrix.env}}-libserialport
       - name: Configure
         run: >-


### PR DESCRIPTION
PR #1513 (Add GNU Readline to mingw github action) brings in undesired dependency of libwinpthread-1.dll to the mingw32/mingw64 binaries.

This PR reverts PR#1513.