### PR TITLE
Review and update prodsig memories for U/PDI parts

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16405,6 +16405,10 @@ part
         readsize           = 50;
     ;
 
+    memory "sigrow"
+        alias "prodsig";
+    ;
+
     memory "data"
         # SRAM, only used to supply the offset
         offset             = 0x1000000;
@@ -19288,6 +19292,10 @@ part
         readsize           = 64;
     ;
 
+    memory "sigrow"
+        alias "prodsig";
+    ;
+
     memory "sernum"
         size               = 10;
         offset             = 0x1103;
@@ -21516,6 +21524,10 @@ part
         page_size          = 128;
         offset             = 0x1100;
         readsize           = 128;
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
     ;
 
     memory "sernum"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16557,6 +16557,7 @@ part parent "x16a4u"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 ;
@@ -16717,6 +16718,7 @@ part parent "x32a4u"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 ;
@@ -16838,6 +16840,7 @@ part parent ".xmega-a"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 
@@ -16876,6 +16879,7 @@ part parent "x32a4u"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 ;
@@ -16963,6 +16967,7 @@ part parent "x64a4u"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -17021,6 +17026,7 @@ part parent "x64a4u"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -17050,6 +17056,7 @@ part parent "x64a1"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 ;
@@ -17244,6 +17251,7 @@ part parent ".xmega"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 
@@ -17276,6 +17284,7 @@ part parent "x128c3"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -17342,6 +17351,7 @@ part parent "x128c3"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -17383,6 +17393,7 @@ part parent "x128a1"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 ;
@@ -17576,6 +17587,7 @@ part parent ".xmega-a"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 
@@ -17741,6 +17753,7 @@ part parent ".xmega"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 
@@ -17773,6 +17786,7 @@ part parent "x192c3"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -17856,6 +17870,7 @@ part parent "x192c3"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -17908,6 +17923,7 @@ part parent "x192a1"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -17969,6 +17985,7 @@ part parent ".xmega"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 
@@ -18001,6 +18018,7 @@ part parent "x256c3"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -18094,6 +18112,7 @@ part parent "x256a1"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -18146,6 +18165,7 @@ part parent "x256a1"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -18196,6 +18216,7 @@ part parent "x256a1"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -18245,6 +18266,7 @@ part parent "x256a1"
 
     memory "prodsig"
         size               = 52;
+        page_size          = 1;
         readsize           = 52;
     ;
 ;
@@ -18306,6 +18328,7 @@ part parent ".xmega"
 
     memory "prodsig"
         size               = 64;
+        page_size          = 64;
         readsize           = 64;
     ;
 
@@ -19259,9 +19282,10 @@ part
     ;
 
     memory "prodsig"
-        size               = 61;
-        offset             = 0x1103;
-        readsize           = 61;
+        size               = 64;
+        page_size          = 64;
+        offset             = 0x1100;
+        readsize           = 64;
     ;
 
     memory "sernum"
@@ -21211,8 +21235,9 @@ part parent ".avr8x_mega"
     ;
 
     memory "prodsig"
-        size               = 125;
-        readsize           = 125;
+        size               = 128;
+        page_size          = 128;
+        readsize           = 128;
     ;
 ;
 
@@ -21255,8 +21280,9 @@ part parent ".avr8x_mega"
     ;
 
     memory "prodsig"
-        size               = 125;
-        readsize           = 125;
+        size               = 128;
+        page_size          = 128;
+        readsize           = 128;
     ;
 ;
 
@@ -21303,8 +21329,9 @@ part parent ".avr8x_mega"
     ;
 
     memory "prodsig"
-        size               = 125;
-        readsize           = 125;
+        size               = 128;
+        page_size          = 128;
+        readsize           = 128;
     ;
 ;
 
@@ -21348,8 +21375,9 @@ part parent ".avr8x_mega"
     ;
 
     memory "prodsig"
-        size               = 125;
-        readsize           = 125;
+        size               = 128;
+        page_size          = 128;
+        readsize           = 128;
     ;
 ;
 
@@ -21484,9 +21512,10 @@ part
     ;
 
     memory "prodsig"
-        size               = 125;
-        offset             = 0x1103;
-        readsize           = 125;
+        size               = 128;
+        page_size          = 128;
+        offset             = 0x1100;
+        readsize           = 128;
     ;
 
     memory "sernum"
@@ -23402,7 +23431,7 @@ part parent ".avrex"
     ;
 
     memory "prodsig"
-        offset             = 0x1083;
+        offset             = 0x1080;
     ;
 
     memory "bootrow"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16401,7 +16401,6 @@ part
 
     memory "prodsig"
         size               = 50;
-        page_size          = 50;
         offset             = 0x8e0200;
         readsize           = 50;
     ;
@@ -16517,6 +16516,11 @@ part parent ".xmega-a"
         initval            = 0xfe;
     ;
 
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
+
     memory "usersig"
         size               = 256;
         page_size          = 256;
@@ -16549,6 +16553,11 @@ part parent "x16a4u"
     memory "fuse4"
         initval            = 0xff;
         bitmask            = 0x1e;
+    ;
+
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
     ;
 ;
 
@@ -16667,6 +16676,11 @@ part parent ".xmega-a"
         initval            = 0xfe;
     ;
 
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
+
     memory "usersig"
         size               = 256;
         page_size          = 256;
@@ -16699,6 +16713,11 @@ part parent "x32a4u"
     memory "fuse4"
         initval            = 0xff;
         bitmask            = 0x1e;
+    ;
+
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
     ;
 ;
 
@@ -16817,6 +16836,11 @@ part parent ".xmega-a"
         initval            = 0xfe;
     ;
 
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
+    ;
+
     memory "usersig"
         size               = 256;
         page_size          = 256;
@@ -16848,6 +16872,11 @@ part parent "x32a4u"
     memory "fuse4"
         initval            = 0xff;
         bitmask            = 0x1e;
+    ;
+
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
     ;
 ;
 
@@ -16931,6 +16960,11 @@ part parent "x64a4u"
         initval            = 0xff;
         bitmask            = 0x1e;
     ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16984,6 +17018,11 @@ part parent "x64a4u"
     memory "fuse2"
         bitmask            = 0x43;
     ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17007,6 +17046,11 @@ part parent "x64a1"
 
     memory "fuse2"
         bitmask            = 0x63;
+    ;
+
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
     ;
 ;
 
@@ -17198,6 +17242,11 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
+    ;
+
     memory "usersig"
         size               = 512;
         page_size          = 512;
@@ -17224,6 +17273,11 @@ part parent "x128c3"
     mcuid                  = 262;
     n_interrupts           = 114;
     signature              = 0x1e 0x97 0x48;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17285,6 +17339,11 @@ part parent "x128c3"
         initval            = 0xfe;
         bitmask            = 0x1f;
     ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17320,6 +17379,11 @@ part parent "x128a1"
 
     memory "fuse2"
         bitmask            = 0x63;
+    ;
+
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
     ;
 ;
 
@@ -17510,6 +17574,11 @@ part parent ".xmega-a"
         initval            = 0xfe;
     ;
 
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
+    ;
+
     memory "usersig"
         size               = 256;
         page_size          = 256;
@@ -17581,6 +17650,11 @@ part parent ".xmega"
 
     memory "fuse4"
         bitmask            = 0x1f;
+    ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
     ;
 
     memory "usersig"
@@ -17665,6 +17739,11 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
+    ;
+
     memory "usersig"
         size               = 512;
         page_size          = 512;
@@ -17691,6 +17770,11 @@ part parent "x192c3"
     mcuid                  = 270;
     n_interrupts           = 114;
     signature              = 0x1e 0x97 0x49;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17769,6 +17853,11 @@ part parent "x192c3"
         initval            = 0xfe;
         bitmask            = 0x1f;
     ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17815,6 +17904,11 @@ part parent "x192a1"
 
     memory "lock"
         initval            = 0xff;
+    ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
     ;
 ;
 
@@ -17873,6 +17967,11 @@ part parent ".xmega"
         readsize           = 256;
     ;
 
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
+    ;
+
     memory "usersig"
         size               = 512;
         page_size          = 512;
@@ -17899,6 +17998,11 @@ part parent "x256c3"
     mcuid                  = 277;
     n_interrupts           = 114;
     signature              = 0x1e 0x98 0x44;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17987,6 +18091,11 @@ part parent "x256a1"
     memory "lock"
         initval            = 0xff;
     ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -18034,6 +18143,11 @@ part parent "x256a1"
     memory "lock"
         initval            = 0xff;
     ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -18079,6 +18193,11 @@ part parent "x256a1"
     memory "lock"
         initval            = 0xff;
     ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -18122,6 +18241,11 @@ part parent "x256a1"
 
     memory "lock"
         initval            = 0xff;
+    ;
+
+    memory "prodsig"
+        size               = 52;
+        readsize           = 52;
     ;
 ;
 
@@ -18178,6 +18302,11 @@ part parent ".xmega"
         page_size          = 512;
         offset             = 0x860000;
         readsize           = 256;
+    ;
+
+    memory "prodsig"
+        size               = 64;
+        readsize           = 64;
     ;
 
     memory "usersig"
@@ -18269,6 +18398,11 @@ part parent ".xmega-e"
         bitmask            = 0x43;
     ;
 
+    memory "prodsig"
+        size               = 54;
+        readsize           = 54;
+    ;
+
     memory "usersig"
         size               = 128;
         page_size          = 128;
@@ -18340,6 +18474,11 @@ part parent ".xmega-e"
         bitmask            = 0x43;
     ;
 
+    memory "prodsig"
+        size               = 54;
+        readsize           = 54;
+    ;
+
     memory "usersig"
         size               = 128;
         page_size          = 128;
@@ -18409,6 +18548,11 @@ part parent ".xmega-e"
 
     memory "fuse2"
         bitmask            = 0x43;
+    ;
+
+    memory "prodsig"
+        size               = 54;
+        readsize           = 54;
     ;
 
     memory "usersig"
@@ -19116,7 +19260,6 @@ part
 
     memory "prodsig"
         size               = 61;
-        page_size          = 61;
         offset             = 0x1103;
         readsize           = 61;
     ;
@@ -21066,6 +21209,11 @@ part parent ".avr8x_mega"
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "prodsig"
+        size               = 125;
+        readsize           = 125;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21104,6 +21252,11 @@ part parent ".avr8x_mega"
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "prodsig"
+        size               = 125;
+        readsize           = 125;
     ;
 ;
 
@@ -21148,6 +21301,11 @@ part parent ".avr8x_mega"
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "prodsig"
+        size               = 125;
+        readsize           = 125;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21187,6 +21345,11 @@ part parent ".avr8x_mega"
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "prodsig"
+        size               = 125;
+        readsize           = 125;
     ;
 ;
 
@@ -21322,7 +21485,6 @@ part
 
     memory "prodsig"
         size               = 125;
-        page_size          = 125;
         offset             = 0x1103;
         readsize           = 125;
     ;
@@ -23223,17 +23385,6 @@ part parent ".avrex"
         readsize           = 256;
     ;
 
-    memory "lock"
-        initval            = 0x5cc5c55c;
-    ;
-
-    memory "bootrow"
-        size               = 64;
-        page_size          = 64;
-        offset             = 0x1100;
-        readsize           = 256;
-    ;
-
     memory "fusea"
         size               = 2;
         initval            = 0x03;
@@ -23244,6 +23395,21 @@ part parent ".avrex"
 
     memory "pdicfg"
         alias "fusea";
+    ;
+
+    memory "lock"
+        initval            = 0x5cc5c55c;
+    ;
+
+    memory "prodsig"
+        offset             = 0x1083;
+    ;
+
+    memory "bootrow"
+        size               = 64;
+        page_size          = 64;
+        offset             = 0x1100;
+        readsize           = 256;
     ;
 ;
 


### PR DESCRIPTION
AVRDUDE knows 145 parts with U/PDI interface, all of which have a production signature row.
 - Update prodsig memory size from .atdf files (some XMEGAs were wrong)
 - Include 3-bytes signature in the prodsig memory of UPDI parts: data sheets include the 3-byte signature in the production signature row (prodsig/sigrow memory) while .atdf excludes them.  For example the AVR16EB14 datasheet lets sigrow start at 0x1080  with a size of 128 while the atdf file specifies the start as 0x1083 with a size of 125.  The former makes more sense.
 - This commit also sets page_size to the prodsig size if it is a power of 2 otherwise it is set to 1.
 - Make sigrow an alias for prodsig in modern parts (U/PDI i/f): this reflects a change in language in data sheets over time for the production signature row memory.