### PR TITLE
Add id as comment to avrdude.conf definitions

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -471,7 +471,7 @@ allow_subshells    = no;
 # https://github.com/avrdudes/avrdude/blob/main/supporting-docs/avrprog.pdf
 #
 
-programmer
+programmer # bsd
     id                     = "bsd";
     desc                   = "Brian S. Dean's parallel programmer";
     type                   = "par";
@@ -487,7 +487,7 @@ programmer
 # stk200
 #------------------------------------------------------------
 
-programmer
+programmer # stk200
     id                     = "stk200";
     desc                   = "STK200";
     type                   = "par";
@@ -508,7 +508,7 @@ programmer
 # except that there is a LED indicating that the
 # programming is currently in progress.
 
-programmer parent "stk200"
+programmer parent "stk200" # pony-stk200
     id                     = "pony-stk200";
     desc                   = "Pony Prog STK200";
     pgmled                 = 8;
@@ -518,7 +518,7 @@ programmer parent "stk200"
 # dt006
 #------------------------------------------------------------
 
-programmer
+programmer # dt006
     id                     = "dt006";
     desc                   = "Dontronics DT006";
     type                   = "par";
@@ -533,7 +533,7 @@ programmer
 # bascom
 #------------------------------------------------------------
 
-programmer parent "dt006"
+programmer parent "dt006" # bascom
     id                     = "bascom";
     desc                   = "Bascom SAMPLE programming cable";
 ;
@@ -545,7 +545,7 @@ programmer parent "dt006"
 # PC Parallel Port Programmer
 # https://web.archive.org/web/20050928233713fw_/http://nightshade.homeip.net/ALF-PgmAVR.htm
 
-programmer
+programmer # alf
     id                     = "alf";
     desc                   = "Nightshade ALF-PgmAVR via PC parallel port";
     type                   = "par";
@@ -566,7 +566,7 @@ programmer
 # sp12
 #------------------------------------------------------------
 
-programmer
+programmer # sp12
     id                     = "sp12";
     desc                   = "Steve Bolt's Programmer";
     type                   = "par";
@@ -582,7 +582,7 @@ programmer
 # picoweb
 #------------------------------------------------------------
 
-programmer
+programmer # picoweb
     id                     = "picoweb";
     desc                   = "Picoweb Programming Cable, http://www.picoweb.net/";
     type                   = "par";
@@ -597,7 +597,7 @@ programmer
 # abcmini
 #------------------------------------------------------------
 
-programmer
+programmer # abcmini
     id                     = "abcmini";
     desc                   = "ABCmini Board, aka Dick Smith HOTCHIP";
     type                   = "par";
@@ -612,7 +612,7 @@ programmer
 # futurlec
 #------------------------------------------------------------
 
-programmer
+programmer # futurlec
     id                     = "futurlec";
     desc                   = "Futurlec.com programming cable.";
     type                   = "par";
@@ -635,7 +635,7 @@ programmer
 # With this, TMS connects to RESET, TDI to SDO, TDO to SDI and TCK
 # to SCK (plus vcc/gnd of course)
 
-programmer
+programmer # xil
     id                     = "xil";
     desc                   = "Xilinx JTAG cable";
     type                   = "par";
@@ -652,7 +652,7 @@ programmer
 # dapa
 #------------------------------------------------------------
 
-programmer
+programmer # dapa
     id                     = "dapa";
     desc                   = "Direct AVR Parallel Access cable";
     type                   = "par";
@@ -670,7 +670,7 @@ programmer
 
 # https://micro-research.co.th
 
-programmer
+programmer # atisp
     id                     = "atisp";
     desc                   = "AT-ISP v1.1 programming cable for AVR-SDK1";
     type                   = "par";
@@ -687,7 +687,7 @@ programmer
 
 # No longer exists: http://www.ere.co.th/download/sch050713.pdf
 
-programmer
+programmer # ere-isp-avr
     id                     = "ere-isp-avr";
     desc                   = "ERE ISP-AVR";
     type                   = "par";
@@ -702,7 +702,7 @@ programmer
 # blaster
 #------------------------------------------------------------
 
-programmer
+programmer # blaster
     id                     = "blaster";
     desc                   = "Altera ByteBlaster";
     type                   = "par";
@@ -721,7 +721,7 @@ programmer
 # It is almost same as pony-stk200, except vcc on pin 5 to auto
 # disconnect port, see http://electropol.free.fr/spip/spip.php?article27
 
-programmer parent "pony-stk200"
+programmer parent "pony-stk200" # frank-stk200
     id                     = "frank-stk200";
     desc                   = "Frank STK200";
     vcc                    = 5;
@@ -737,7 +737,7 @@ programmer parent "pony-stk200"
 # https://ww1.microchip.com/downloads/en/appnotes/doc3310.pdf
 # https://ww1.microchip.com/downloads/en/DeviceDoc/AT89ISP_Update3.3.zip
 
-programmer
+programmer # 89isp
     id                     = "89isp";
     desc                   = "Atmel at89isp cable";
     type                   = "par";
@@ -785,7 +785,7 @@ programmer
 # Program from a Raspberry Pi GPIO port using linuxgpio
 #------------------------------------------------------------
 
-programmer
+programmer # raspberry_pi_gpio
     id                     = "raspberry_pi_gpio";
     desc                   = "Bitbang Raspberry Pi GPIO via linuxgpio (sysfs or libgpiod)";
     type                   = "linuxgpio";
@@ -809,7 +809,7 @@ programmer
 # suitable since they would release /RESET too early.
 #
 
-programmer
+programmer # linuxspi
     id                     = "linuxspi";
     desc                   = "Use Linux SPI device in /dev/spidev*";
     type                   = "linuxspi";
@@ -839,7 +839,7 @@ programmer
 # avrdude -c dryrun -p ATmega2560 -U flash:w:myapplication.hex:i
 # avrdude -c dryrun -p AVR64DB48 -Tconfig
 
-programmer
+programmer # dryrun
     id                     = "dryrun";
     desc                   = "Emulates programming without a programmer";
     type                   = "dryrun";
@@ -853,7 +853,7 @@ programmer
 # http://wiring.org.co/
 # Basically STK500v2 protocol, with some glue to trigger the bootloader
 
-programmer
+programmer # wiring
     id                     = "wiring";
     desc                   = "Wiring for bootloader using STK500 v2 protocol";
     type                   = "wiring";
@@ -872,7 +872,7 @@ programmer
 # bootloaders. Same as the stk500v1 except that it resets the attached
 # board and treats EEPROM as the optiboot bootloaders expect.
 
-programmer
+programmer # arduino
     id                     = "arduino";
     desc                   = "Arduino for bootloader using STK500 v1 protocol";
     type                   = "arduino";
@@ -901,7 +901,7 @@ programmer
 #
 # See https://github.com/stefanrueger/urboot
 
-programmer
+programmer # urclock
     id                     = "urclock";
     desc                   = "Urclock programmer for urboot bootloaders using urprotocol";
     type                   = "urclock";
@@ -913,7 +913,7 @@ programmer
 # xbee
 #------------------------------------------------------------
 
-programmer
+programmer # xbee
     id                     = "xbee";
     desc                   = "XBee for Series 2 Over-The-Air (XBeeBoot) bootloader using STK500 v1 protocol";
     type                   = "xbee";
@@ -950,7 +950,7 @@ programmer
 # Data sheet of the FT2232H chip:
 #   https://ftdichip.com/wp-content/uploads/2020/08/DS_FT2232H.pdf
 
-programmer
+programmer # avrftdi
     id                     = "avrftdi", "2232h";
     desc                   = "FT2232H/D based generic programmer";
     type                   = "avrftdi";
@@ -973,7 +973,7 @@ programmer
 # The ft2232h programmer is the same as above 2232h but it can be
 # used to address the port of a particular board via -P ft2232h
 
-programmer parent "2232h"
+programmer parent "2232h" # ft2232h
     id                     = "ft2232h";
     is_serialadapter       = yes;
 ;
@@ -985,7 +985,7 @@ programmer parent "2232h"
 # This is an implementation of the above 2232h with a buffer IC
 # (74AC244) and 4 LEDs directly attached, all active low.
 
-programmer parent "2232h"
+programmer parent "2232h" # 2232hio
     id                     = "2232hio";
     desc                   = "2232hio based on FT2232H with buffer and LEDs";
     buff                   = ~4;
@@ -1003,7 +1003,7 @@ programmer parent "2232h"
 # Tigard - FT2232H based multi-protocol tool for hardware hacking
 # https://github.com/tigard-tools/tigard
 
-programmer parent "2232h"
+programmer parent "2232h" # tigard
     id                     = "tigard";
     desc                   = "Tigard interface board";
     usbdev                 = "B";
@@ -1019,7 +1019,7 @@ programmer parent "2232h"
 # Adds a buffer and a LED indicating that the programming is in progress.
 # https://www.kanda.com/products/Kanda/AVRISP-U.html
 
-programmer parent "2232h"
+programmer parent "2232h" # avrisp-u
     id                     = "avrisp-u";
     desc                   = "Kanda AVRISP-U";
     usbsn                  = "AVR";
@@ -1034,7 +1034,7 @@ programmer parent "2232h"
 
 # Here a FTDI ft2232h chip is used for JTAG programming.
 
-programmer
+programmer # ft2232h_jtag
     id                     = "ft2232h_jtag";
     desc                   = "FT2232H based generic JTAG programmer";
     type                   = "avrftdi_jtag";
@@ -1057,7 +1057,7 @@ programmer
 # The FT4232H can be treated as FT2232H but with a different USB
 # device ID of 0x6011
 
-programmer parent "ft2232h"
+programmer parent "ft2232h" # ft4232h
     id                     = "ft4232h";
     desc                   = "FT4232H based generic programmer";
     usbpid                 = 0x6011;
@@ -1067,7 +1067,7 @@ programmer parent "ft2232h"
 # 4232h
 #------------------------------------------------------------
 
-programmer parent "2232h"
+programmer parent "2232h" # 4232h
     id                     = "4232h";
     desc                   = "FT4232H based generic programmer";
     usbpid                 = 0x6011;
@@ -1077,7 +1077,7 @@ programmer parent "2232h"
 # jtagkey
 #------------------------------------------------------------
 
-programmer
+programmer # jtagkey
     id                     = "jtagkey";
     desc                   = "Amontec JTAGKey, JTAGKey-Tiny and JTAGKey2";
     type                   = "avrftdi";
@@ -1102,7 +1102,7 @@ programmer
 # ft232h
 #------------------------------------------------------------
 
-programmer
+programmer # ft232h
     id                     = "ft232h";
     desc                   = "FT232H based generic programmer";
     type                   = "avrftdi";
@@ -1123,7 +1123,7 @@ programmer
 # ft232h_jtag
 #------------------------------------------------------------
 
-programmer
+programmer # ft232h_jtag
     id                     = "ft232h_jtag";
     desc                   = "FT232H based generic JTAG programmer";
     type                   = "avrftdi_jtag";
@@ -1151,7 +1151,7 @@ programmer
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
 
-programmer parent "ft232h"
+programmer parent "ft232h" # um232h
     id                     = "um232h";
     desc                   = "UM232H module from FTDI";
     is_serialadapter       = no;
@@ -1169,7 +1169,7 @@ programmer parent "ft232h"
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
 # a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
 
-programmer parent "um232h"
+programmer parent "um232h" # c232hm
     id                     = "c232hm";
     desc                   = "C232HM cable from FTDI";
 ;
@@ -1184,7 +1184,7 @@ programmer parent "um232h"
 # sources call it O-Link or just have a look at ebay ... It is basically the same
 # entry as jtagkey with different usb ids. See www.100ask.net
 
-programmer parent "jtagkey"
+programmer parent "jtagkey" # o-link
     id                     = "o-link";
     desc                   = "O-Link, OpenJTAG ARM JTAG USB";
     usbvid                 = 0x1457;
@@ -1199,7 +1199,7 @@ programmer parent "jtagkey"
 
 # http://wiki.openmoko.org/wiki/Debug_Board_v3
 
-programmer
+programmer # openmoko
     id                     = "openmoko";
     desc                   = "Openmoko debug board (v3)";
     type                   = "avrftdi";
@@ -1220,7 +1220,7 @@ programmer
 # Only Rev. A boards.
 # Schematic and user manual: http://www.cs.put.poznan.pl/wswitala/download/pdf/811EVBK.pdf
 
-programmer
+programmer # lm3s811
     id                     = "lm3s811";
     desc                   = "Luminary Micro LM3S811 Eval Board (Rev. A)";
     type                   = "avrftdi";
@@ -1247,7 +1247,7 @@ programmer
 # First SPI connector
 # User manual: https://www.tiaowiki.com/w/TIAO_USB_Multi_Protocol_Adapter_User%27s_Manual
 
-programmer parent "2232h"
+programmer parent "2232h" # tumpa
     id                     = "tumpa";
     desc                   = "TIAO USB Multi-Protocol Adapter";
     usbpid                 = 0x8a98;
@@ -1260,7 +1260,7 @@ programmer parent "2232h"
 
 # Second SPI connector
 
-programmer parent "tumpa"
+programmer parent "tumpa" # tumpa-b
     id                     = "tumpa-b";
     usbdev                 = "B";
 ;
@@ -1269,7 +1269,7 @@ programmer parent "tumpa"
 # tumpa_jtag
 #------------------------------------------------------------
 
-programmer parent "ft2232h_jtag"
+programmer parent "ft2232h_jtag" # tumpa_jtag
     id                     = "tumpa_jtag";
     desc                   = "TIAO USB Multi-Protocol Adapter (JTAG)";
     usbpid                 = 0x8a98;
@@ -1303,7 +1303,7 @@ programmer parent "ft2232h_jtag"
 #  * For TPI connection use resistors: TDO --[470R]-- TPIDATA --[470R]-- TDI.
 #  * Powering target from JTAG pin 19 allows KT-LINK current measurement.
 
-programmer
+programmer # ktlink
     id                     = "ktlink";
     desc                   = "KT-LINK FT2232H interface with IO switching and voltage buffers";
     type                   = "avrftdi";
@@ -1327,7 +1327,7 @@ programmer
 # Digilent JTAG HS2 programmer. FT232H-based dongle with buffers.
 # https://digilent.com/reference/_media/reference/programmers/jtag-hs2/jtag-hs2_rm.pdf
 
-programmer
+programmer # digilent-hs2
     id                     = "digilent-hs2";
     desc                   = "Digilent JTAG HS2 (MPSSE)";
     type                   = "avrftdi";
@@ -1350,7 +1350,7 @@ programmer
 # FT2232H based JTAG programmer. Requires a buff pin to be set.
 # https://www.tincantools.com/flyswatter2
 
-programmer
+programmer # flyswatter2
     id                     = "flyswatter2";
     desc                   = "TinCan Tools Flyswatter 2";
     type                   = "avrftdi";
@@ -1374,7 +1374,7 @@ programmer
 # serialupdi
 #------------------------------------------------------------
 
-programmer
+programmer # serialupdi
     id                     = "serialupdi";
     desc                   = "SerialUPDI";
     type                   = "serialupdi";
@@ -1387,7 +1387,7 @@ programmer
 # avrisp
 #------------------------------------------------------------
 
-programmer
+programmer # avrisp
     id                     = "avrisp";
     desc                   = "Atmel AVR ISP";
     type                   = "stk500";
@@ -1399,7 +1399,7 @@ programmer
 # avrispv2
 #------------------------------------------------------------
 
-programmer
+programmer # avrispv2
     id                     = "avrispv2";
     desc                   = "Atmel AVR ISP v2";
     type                   = "stk500v2";
@@ -1411,7 +1411,7 @@ programmer
 # avrispmkII
 #------------------------------------------------------------
 
-programmer
+programmer # avrispmkII
     id                     = "avrispmkII", "avrisp2";
     desc                   = "Atmel AVR ISP mkII";
     type                   = "stk500v2";
@@ -1424,7 +1424,7 @@ programmer
 # buspirate
 #------------------------------------------------------------
 
-programmer
+programmer # buspirate
     id                     = "buspirate";
     desc                   = "The Bus Pirate";
     type                   = "buspirate";
@@ -1436,7 +1436,7 @@ programmer
 # buspirate_bb
 #------------------------------------------------------------
 
-programmer
+programmer # buspirate_bb
     id                     = "buspirate_bb";
     desc                   = "The Bus Pirate (bitbang interface, supports TPI)";
     type                   = "buspirate_bb";
@@ -1460,7 +1460,7 @@ programmer
 # by probing for it.  Better use one of the entries
 # below instead.
 
-programmer
+programmer # stk500
     id                     = "stk500";
     desc                   = "Atmel STK500 (probes STK500v2 first then STK500v1)";
     type                   = "stk500generic";
@@ -1473,7 +1473,7 @@ programmer
 # stk500v1
 #------------------------------------------------------------
 
-programmer
+programmer # stk500v1
     id                     = "stk500v1";
     desc                   = "Atmel STK500 version 1.x firmware";
     type                   = "stk500";
@@ -1489,7 +1489,7 @@ programmer
 # Not to be confused with arduinoISP, this is the same as `-c stk500v1`
 # but treats EEPROM r/w correctly for arduino_as_isp programmers
 
-programmer
+programmer # arduino_as_isp
     id                     = "arduino_as_isp";
     desc                   = "Arduino board as programmer using arduino as ISP firmware";
     type                   = "stk500";
@@ -1501,7 +1501,7 @@ programmer
 # mib510
 #------------------------------------------------------------
 
-programmer
+programmer # mib510
     id                     = "mib510";
     desc                   = "Crossbow MIB510 programming board";
     type                   = "stk500";
@@ -1513,7 +1513,7 @@ programmer
 # stk500v2
 #------------------------------------------------------------
 
-programmer
+programmer # stk500v2
     id                     = "stk500v2", "scratchmonkey";
     desc                   = "Atmel STK500 version 2.x firmware";
     type                   = "stk500v2";
@@ -1526,7 +1526,7 @@ programmer
 # stk500pp
 #------------------------------------------------------------
 
-programmer
+programmer # stk500pp
     id                     = "stk500pp", "scratchmonkey_pp";
     desc                   = "Atmel STK500 v2 in parallel programming mode";
     type                   = "stk500pp";
@@ -1539,7 +1539,7 @@ programmer
 # stk500hvsp
 #------------------------------------------------------------
 
-programmer
+programmer # stk500hvsp
     id                     = "stk500hvsp", "scratchmonkey_hvsp";
     desc                   = "Atmel STK500 v2 in high-voltage serial programming mode";
     type                   = "stk500hvsp";
@@ -1552,7 +1552,7 @@ programmer
 # stk600
 #------------------------------------------------------------
 
-programmer
+programmer # stk600
     id                     = "stk600";
     desc                   = "Atmel STK600";
     type                   = "stk600";
@@ -1565,7 +1565,7 @@ programmer
 # stk600pp
 #------------------------------------------------------------
 
-programmer
+programmer # stk600pp
     id                     = "stk600pp";
     desc                   = "Atmel STK600 in parallel programming mode";
     type                   = "stk600pp";
@@ -1578,7 +1578,7 @@ programmer
 # stk600hvsp
 #------------------------------------------------------------
 
-programmer
+programmer # stk600hvsp
     id                     = "stk600hvsp";
     desc                   = "Atmel STK600 in high-voltage serial programming mode";
     type                   = "stk600hvsp";
@@ -1591,7 +1591,7 @@ programmer
 # avr910
 #------------------------------------------------------------
 
-programmer
+programmer # avr910
     id                     = "avr910";
     desc                   = "Atmel Low Cost Serial Programmer";
     type                   = "avr910";
@@ -1609,7 +1609,7 @@ programmer
 # somewhat arbitrary and will be determined by the actual routing
 # of the FTDI IC pins to the ISP header of the physical programmer.
 
-programmer
+programmer # ft245r
     id                     = "ft245r";
     desc                   = "FT245R based generic programmer";
     type                   = "ftdi_syncbb";
@@ -1625,7 +1625,7 @@ programmer
 # ft232r
 #------------------------------------------------------------
 
-programmer
+programmer # ft232r
     id                     = "ft232r";
     desc                   = "FT232R based generic programmer";
     type                   = "ftdi_syncbb";
@@ -1646,7 +1646,7 @@ programmer
 
 # see http://www.bitwizard.nl/wiki/index.php/FTDI_ATmega
 
-programmer
+programmer # bwmega
     id                     = "bwmega";
     desc                   = "BitWizard ftdi_atmega builtin programmer";
     type                   = "ftdi_syncbb";
@@ -1669,7 +1669,7 @@ programmer
 # Note that the -c diecimila avrdude.conf entry mentioned in above post
 # is the same as the -c arduino-ft232r entry here.
 
-programmer
+programmer # arduino-ft232r
     id                     = "arduino-ft232r", "diecimila";
     desc                   = "Arduino: FT232R connected to ISP";
     type                   = "ftdi_syncbb";
@@ -1685,7 +1685,7 @@ programmer
 # tc2030
 #------------------------------------------------------------
 
-programmer
+programmer # tc2030
     id                     = "tc2030";
     desc                   = "Tag-Connect TC2030";
     type                   = "ftdi_syncbb";
@@ -1709,7 +1709,7 @@ programmer
 # http://akizukidenshi.com/catalog/g/gP-07487/
 # http://akizukidenshi.com/download/ds/akizuki/k6096_manual_20130816.pdf
 
-programmer
+programmer # uncompatino
     id                     = "uncompatino";
     desc                   = "uncompatino with all pairs of pins shorted";
     type                   = "ftdi_syncbb";
@@ -1741,7 +1741,7 @@ programmer
 # Except for VCC and GND, you can connect arbitrary pairs as long as the
 # following table is adjusted.
 
-programmer
+programmer # ttl232r
     id                     = "ttl232r";
     desc                   = "FTDI TTL232R-5V with ICSP adapter";
     type                   = "ftdi_syncbb";
@@ -1781,7 +1781,7 @@ programmer
 #   As above plus HID UART support, setting unique serial number and
 #   AT89S51/AT89S52 support
 
-programmer
+programmer # usbasp
     id                     = "usbasp";
     desc                   = "USBasp ISP and TPI programmer";
     type                   = "usbasp";
@@ -1804,7 +1804,7 @@ programmer
 
 # http://www.nicai-systems.com/en/nibobee
 
-programmer
+programmer # nibobee
     id                     = "nibobee";
     desc                   = "NIBObee";
     type                   = "usbasp";
@@ -1820,7 +1820,7 @@ programmer
 # usbasp-clone
 #------------------------------------------------------------
 
-programmer
+programmer # usbasp-clone
     id                     = "usbasp-clone";
     desc                   = "Any usbasp clone with correct VID/PID";
     type                   = "usbasp";
@@ -1841,7 +1841,7 @@ programmer
 # pins of the connector, and SDI (pin 1 of the 6-pin connector)
 # connects to TPIDATA.
 
-programmer
+programmer # usbtiny
     id                     = "usbtiny";
     desc                   = "USBtiny simple USB programmer";
     type                   = "usbtiny";
@@ -1857,7 +1857,7 @@ programmer
 
 # https://github.com/arduino/ArduinoCore-avr/tree/master/bootloaders/gemma
 
-programmer
+programmer # arduino_gemma
     id                     = "arduino_gemma";
     desc                   = "Arduino Gemma bootloader disguised as USBtiny";
     type                   = "usbtiny";
@@ -1873,7 +1873,7 @@ programmer
 
 # https://github.com/adafruit/Adafruit-Trinket-Gemma-Bootloader
 
-programmer
+programmer # adafruit_gemma
     id                     = "adafruit_gemma";
     desc                   = "Adafruit Trinket Gemma bootloader disguised as USBtiny";
     type                   = "usbtiny";
@@ -1887,7 +1887,7 @@ programmer
 # arduinoisp
 #------------------------------------------------------------
 
-programmer
+programmer # arduinoisp
     id                     = "arduinoisp";
     desc                   = "Arduino ISP Programmer";
     type                   = "usbtiny";
@@ -1901,7 +1901,7 @@ programmer
 # arduinoisporg
 #------------------------------------------------------------
 
-programmer
+programmer # arduinoisporg
     id                     = "arduinoisporg";
     desc                   = "Arduino ISP Programmer";
     type                   = "usbtiny";
@@ -1918,7 +1918,7 @@ programmer
 # Commercial version of USBtiny using a separate VID/PID from
 # http://www.eHaJo.de (closed from end of 2023)
 
-programmer
+programmer # ehajo-isp
     id                     = "ehajo-isp";
     desc                   = "AVR ISP programmer from eHaJo.de";
     type                   = "usbtiny";
@@ -1937,7 +1937,7 @@ programmer
 #
 # https://github.com/IowaScaledEngineering/ckt-avrprogrammer
 
-programmer
+programmer # iseavrprog
     id                     = "iseavrprog";
     desc                   = "AVR ISP programmer from iascaled.com";
     type                   = "usbtiny";
@@ -1951,7 +1951,7 @@ programmer
 # micronucleus
 #------------------------------------------------------------
 
-programmer
+programmer # micronucleus
     id                     = "micronucleus";
     desc                   = "Micronucleus for bootloader";
     type                   = "micronucleus";
@@ -1965,7 +1965,7 @@ programmer
 # teensy
 #------------------------------------------------------------
 
-programmer
+programmer # teensy
     id                     = "teensy";
     desc                   = "Teensy for bootloader";
     type                   = "teensy";
@@ -1994,7 +1994,7 @@ programmer
 #          GND -- GND
 #           5V -- Vcc/Vin (or disconnect if separately powered)
 
-programmer
+programmer # ch341a
     id                     = "ch341a";
     desc                   = "ch341a programmer (AVR must have minimum F_CPU of 6.8 MHz)";
     type                   = "ch341a";
@@ -2012,7 +2012,7 @@ programmer
 # butterfly
 #------------------------------------------------------------
 
-programmer
+programmer # butterfly
     id                     = "butterfly";
     desc                   = "Atmel for bootloader (Butterfly Development Board)";
     type                   = "butterfly";
@@ -2024,7 +2024,7 @@ programmer
 # avr109
 #------------------------------------------------------------
 
-programmer
+programmer # avr109
     id                     = "avr109";
     desc                   = "Atmel for bootloader using AppNote AVR109";
     type                   = "butterfly";
@@ -2036,7 +2036,7 @@ programmer
 # avr911
 #------------------------------------------------------------
 
-programmer
+programmer # avr911
     id                     = "avr911";
     desc                   = "Atmel for bootloader using AppNote AVR911 AVROSP";
     type                   = "butterfly";
@@ -2050,7 +2050,7 @@ programmer
 
 # http://forum.mikrokopter.de
 
-programmer
+programmer # butterfly_mk
     id                     = "butterfly_mk", "mkbutterfly";
     desc                   = "Mikrokopter.de Butterfly for bootloader";
     type                   = "butterfly_mk";
@@ -2062,7 +2062,7 @@ programmer
 # jtagmkI
 #------------------------------------------------------------
 
-programmer
+programmer # jtagmkI
     id                     = "jtagmkI", "jtag1";
     desc                   = "Atmel JTAG ICE (mkI)";
     type                   = "jtagmki";
@@ -2076,7 +2076,7 @@ programmer
 # jtag1slow
 #------------------------------------------------------------
 
-programmer parent "jtag1"
+programmer parent "jtag1" # jtag1slow
     id                     = "jtag1slow";
     baudrate               = 19200;
 ;
@@ -2090,7 +2090,7 @@ programmer parent "jtag1"
 # that way), we make connection_type = usb the default.  Users are
 # still free to use a serial port with the -P option.
 
-programmer
+programmer # jtagmkII
     id                     = "jtagmkII";
     desc                   = "Atmel JTAG ICE mkII";
     type                   = "jtagmkii";
@@ -2104,7 +2104,7 @@ programmer
 # jtag2slow
 #------------------------------------------------------------
 
-programmer parent "jtagmkII"
+programmer parent "jtagmkII" # jtag2slow
     id                     = "jtag2slow";
 ;
 
@@ -2114,7 +2114,7 @@ programmer parent "jtagmkII"
 
 # JTAG ICE mkII @ 115200 Bd (and alias jtag2 the fast version)
 
-programmer parent "jtag2slow"
+programmer parent "jtag2slow" # jtag2fast
     id                     = "jtag2fast", "jtag2";
     baudrate               = 115200;
 ;
@@ -2125,7 +2125,7 @@ programmer parent "jtag2slow"
 
 # JTAG ICE mkII in ISP mode
 
-programmer
+programmer # jtag2isp
     id                     = "jtag2isp";
     desc                   = "Atmel JTAG ICE mkII in ISP mode";
     type                   = "jtagmkii_isp";
@@ -2141,7 +2141,7 @@ programmer
 
 # JTAG ICE mkII in debugWire mode
 
-programmer
+programmer # jtag2dw
     id                     = "jtag2dw";
     desc                   = "Atmel JTAG ICE mkII in debugWire mode";
     type                   = "jtagmkii_dw";
@@ -2157,7 +2157,7 @@ programmer
 
 # JTAG ICE mkII in AVR32 mode
 
-programmer
+programmer # jtagmkII_avr32
     id                     = "jtagmkII_avr32", "jtag2avr32";
     desc                   = "Atmel JTAG ICE mkII in AVR32 mode";
     type                   = "jtagmkii_avr32";
@@ -2173,7 +2173,7 @@ programmer
 
 # JTAG ICE mkII in PDI mode
 
-programmer
+programmer # jtag2pdi
     id                     = "jtag2pdi";
     desc                   = "Atmel JTAG ICE mkII in PDI mode";
     type                   = "jtagmkii_pdi";
@@ -2189,7 +2189,7 @@ programmer
 
 # AVR Dragon in JTAG mode
 
-programmer
+programmer # dragon_jtag
     id                     = "dragon_jtag";
     desc                   = "Atmel AVR Dragon in JTAG mode";
     type                   = "dragon_jtag";
@@ -2205,7 +2205,7 @@ programmer
 
 # AVR Dragon in ISP mode
 
-programmer
+programmer # dragon_isp
     id                     = "dragon_isp";
     desc                   = "Atmel AVR Dragon in ISP mode";
     type                   = "dragon_isp";
@@ -2221,7 +2221,7 @@ programmer
 
 # AVR Dragon in PP mode
 
-programmer
+programmer # dragon_pp
     id                     = "dragon_pp";
     desc                   = "Atmel AVR Dragon in PP mode";
     type                   = "dragon_pp";
@@ -2237,7 +2237,7 @@ programmer
 
 # AVR Dragon in HVSP mode
 
-programmer
+programmer # dragon_hvsp
     id                     = "dragon_hvsp";
     desc                   = "Atmel AVR Dragon in HVSP mode";
     type                   = "dragon_hvsp";
@@ -2253,7 +2253,7 @@ programmer
 
 # AVR Dragon in debugWire mode
 
-programmer
+programmer # dragon_dw
     id                     = "dragon_dw";
     desc                   = "Atmel AVR Dragon in debugWire mode";
     type                   = "dragon_dw";
@@ -2269,7 +2269,7 @@ programmer
 
 # AVR Dragon in PDI mode
 
-programmer
+programmer # dragon_pdi
     id                     = "dragon_pdi";
     desc                   = "Atmel AVR Dragon in PDI mode";
     type                   = "dragon_pdi";
@@ -2283,7 +2283,7 @@ programmer
 # jtag3
 #------------------------------------------------------------
 
-programmer
+programmer # jtag3
     id                     = "jtag3";
     desc                   = "Atmel AVR JTAGICE3 in JTAG mode";
     type                   = "jtagice3";
@@ -2297,7 +2297,7 @@ programmer
 # jtag3pdi
 #------------------------------------------------------------
 
-programmer
+programmer # jtag3pdi
     id                     = "jtag3pdi";
     desc                   = "Atmel AVR JTAGICE3 in PDI mode";
     type                   = "jtagice3_pdi";
@@ -2311,7 +2311,7 @@ programmer
 # jtag3updi
 #------------------------------------------------------------
 
-programmer
+programmer # jtag3updi
     id                     = "jtag3updi";
     desc                   = "Atmel AVR JTAGICE3 in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2326,7 +2326,7 @@ programmer
 # jtag3dw
 #------------------------------------------------------------
 
-programmer
+programmer # jtag3dw
     id                     = "jtag3dw";
     desc                   = "Atmel AVR JTAGICE3 in debugWIRE mode";
     type                   = "jtagice3_dw";
@@ -2340,7 +2340,7 @@ programmer
 # jtag3isp
 #------------------------------------------------------------
 
-programmer
+programmer # jtag3isp
     id                     = "jtag3isp";
     desc                   = "Atmel AVR JTAGICE3 in ISP mode";
     type                   = "jtagice3_isp";
@@ -2354,7 +2354,7 @@ programmer
 # xplainedpro
 #------------------------------------------------------------
 
-programmer
+programmer # xplainedpro
     id                     = "xplainedpro";
     desc                   = "Atmel AVR XplainedPro in JTAG mode";
     type                   = "jtagice3";
@@ -2368,7 +2368,7 @@ programmer
 # xplainedpro_pdi
 #------------------------------------------------------------
 
-programmer
+programmer # xplainedpro_pdi
     id                     = "xplainedpro_pdi";
     desc                   = "Atmel AVR XplainedPro in PDI mode";
     type                   = "jtagice3_pdi";
@@ -2383,7 +2383,7 @@ programmer
 # xplainedpro_updi
 #------------------------------------------------------------
 
-programmer
+programmer # xplainedpro_updi
     id                     = "xplainedpro_updi";
     desc                   = "Atmel AVR XplainedPro in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2398,7 +2398,7 @@ programmer
 # xplainedmini / xplainedmini_isp
 #------------------------------------------------------------
 
-programmer
+programmer # xplainedmini
     id                     = "xplainedmini", "xplainedmini_isp";
     desc                   = "Atmel AVR XplainedMini in ISP mode";
     type                   = "jtagice3_isp";
@@ -2412,7 +2412,7 @@ programmer
 # xplainedmini_dw
 #------------------------------------------------------------
 
-programmer
+programmer # xplainedmini_dw
     id                     = "xplainedmini_dw";
     desc                   = "Atmel AVR XplainedMini in debugWIRE mode";
     type                   = "jtagice3_dw";
@@ -2426,7 +2426,7 @@ programmer
 # xplainedmini_updi
 #------------------------------------------------------------
 
-programmer
+programmer # xplainedmini_updi
     id                     = "xplainedmini_updi";
     desc                   = "Atmel AVR XplainedMini in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2441,7 +2441,7 @@ programmer
 # xplainedmini_tpi
 #------------------------------------------------------------
 
-programmer
+programmer # xplainedmini_tpi
     id                     = "xplainedmini_tpi";
     desc                   = "Atmel AVR XplainedMini in TPI mode";
     type                   = "jtagice3_tpi";
@@ -2454,7 +2454,7 @@ programmer
 # atmelice / atmelice_jtag
 #------------------------------------------------------------
 
-programmer
+programmer # atmelice
     id                     = "atmelice", "atmelice_jtag";
     desc                   = "Atmel-ICE (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
@@ -2468,7 +2468,7 @@ programmer
 # atmelice_pdi
 #------------------------------------------------------------
 
-programmer
+programmer # atmelice_pdi
     id                     = "atmelice_pdi";
     desc                   = "Atmel-ICE (ARM/AVR) in PDI mode";
     type                   = "jtagice3_pdi";
@@ -2482,7 +2482,7 @@ programmer
 # atmelice_updi
 #------------------------------------------------------------
 
-programmer
+programmer # atmelice_updi
     id                     = "atmelice_updi";
     desc                   = "Atmel-ICE (ARM/AVR) in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2497,7 +2497,7 @@ programmer
 # atmelice_dw
 #------------------------------------------------------------
 
-programmer
+programmer # atmelice_dw
     id                     = "atmelice_dw";
     desc                   = "Atmel-ICE (ARM/AVR) in debugWIRE mode";
     type                   = "jtagice3_dw";
@@ -2511,7 +2511,7 @@ programmer
 # atmelice_isp
 #------------------------------------------------------------
 
-programmer
+programmer # atmelice_isp
     id                     = "atmelice_isp";
     desc                   = "Atmel-ICE (ARM/AVR) in ISP mode";
     type                   = "jtagice3_isp";
@@ -2525,7 +2525,7 @@ programmer
 # atmelice_tpi
 #------------------------------------------------------------
 
-programmer
+programmer # atmelice_tpi
     id                     = "atmelice_tpi";
     desc                   = "Atmel-ICE (ARM/AVR) in TPI mode";
     type                   = "jtagice3_tpi";
@@ -2539,7 +2539,7 @@ programmer
 # powerdebugger / powerdebugger_jtag
 #------------------------------------------------------------
 
-programmer
+programmer # powerdebugger
     id                     = "powerdebugger", "powerdebugger_jtag";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in JTAG mode";
     type                   = "jtagice3";
@@ -2553,7 +2553,7 @@ programmer
 # powerdebugger_pdi
 #------------------------------------------------------------
 
-programmer
+programmer # powerdebugger_pdi
     id                     = "powerdebugger_pdi";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in PDI mode";
     type                   = "jtagice3_pdi";
@@ -2567,7 +2567,7 @@ programmer
 # powerdebugger_updi
 #------------------------------------------------------------
 
-programmer
+programmer # powerdebugger_updi
     id                     = "powerdebugger_updi";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2582,7 +2582,7 @@ programmer
 # powerdebugger_dw
 #------------------------------------------------------------
 
-programmer
+programmer # powerdebugger_dw
     id                     = "powerdebugger_dw";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in debugWire mode";
     type                   = "jtagice3_dw";
@@ -2596,7 +2596,7 @@ programmer
 # powerdebugger_isp
 #------------------------------------------------------------
 
-programmer
+programmer # powerdebugger_isp
     id                     = "powerdebugger_isp";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in ISP mode";
     type                   = "jtagice3_isp";
@@ -2610,7 +2610,7 @@ programmer
 # powerdebugger_tpi
 #------------------------------------------------------------
 
-programmer
+programmer # powerdebugger_tpi
     id                     = "powerdebugger_tpi";
     desc                   = "Atmel PowerDebugger (ARM/AVR) in TPI mode";
     type                   = "jtagice3_tpi";
@@ -2624,7 +2624,7 @@ programmer
 # pickit4 / pickit4_jtag
 #------------------------------------------------------------
 
-programmer
+programmer # pickit4
     id                     = "pickit4", "pickit4_jtag";
     desc                   = "MPLAB(R) PICkit 4 in JTAG mode";
     type                   = "jtagice3";
@@ -2638,7 +2638,7 @@ programmer
 # pickit4_updi
 #------------------------------------------------------------
 
-programmer
+programmer # pickit4_updi
     id                     = "pickit4_updi";
     desc                   = "MPLAB(R) PICkit 4 in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2653,7 +2653,7 @@ programmer
 # pickit4_pdi
 #------------------------------------------------------------
 
-programmer
+programmer # pickit4_pdi
     id                     = "pickit4_pdi";
     desc                   = "MPLAB(R) PICkit 4 in PDI mode";
     type                   = "jtagice3_pdi";
@@ -2667,7 +2667,7 @@ programmer
 # pickit4_isp
 #------------------------------------------------------------
 
-programmer
+programmer # pickit4_isp
     id                     = "pickit4_isp";
     desc                   = "MPLAB(R) PICkit 4 in ISP mode";
     type                   = "jtagice3_isp";
@@ -2681,7 +2681,7 @@ programmer
 # pickit4_tpi
 #------------------------------------------------------------
 
-programmer
+programmer # pickit4_tpi
     id                     = "pickit4_tpi";
     desc                   = "MPLAB(R) PICkit 4 in TPI mode";
     type                   = "jtagice3_tpi";
@@ -2695,7 +2695,7 @@ programmer
 # snap /snap_jtag
 #------------------------------------------------------------
 
-programmer
+programmer # snap
     id                     = "snap", "snap_jtag";
     desc                   = "MPLAB(R) Snap in JTAG mode";
     type                   = "jtagice3";
@@ -2709,7 +2709,7 @@ programmer
 # snap_updi
 #------------------------------------------------------------
 
-programmer
+programmer # snap_updi
     id                     = "snap_updi";
     desc                   = "MPLAB(R) SNAP in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2724,7 +2724,7 @@ programmer
 # snap_pdi
 #------------------------------------------------------------
 
-programmer
+programmer # snap_pdi
     id                     = "snap_pdi";
     desc                   = "MPLAB(R) SNAP in PDI mode";
     type                   = "jtagice3_pdi";
@@ -2738,7 +2738,7 @@ programmer
 # snap_isp
 #------------------------------------------------------------
 
-programmer
+programmer # snap_isp
     id                     = "snap_isp";
     desc                   = "MPLAB(R) SNAP in ISP mode";
     type                   = "jtagice3_isp";
@@ -2752,7 +2752,7 @@ programmer
 # snap_tpi
 #------------------------------------------------------------
 
-programmer
+programmer # snap_tpi
     id                     = "snap_tpi";
     desc                   = "MPLAB(R) SNAP in TPI mode";
     type                   = "jtagice3_tpi";
@@ -2766,7 +2766,7 @@ programmer
 # pkobn_updi
 #------------------------------------------------------------
 
-programmer
+programmer # pkobn_updi
     id                     = "pkobn_updi";
     desc                   = "Curiosity nano (nEDBG) in UPDI mode";
     type                   = "jtagice3_updi";
@@ -2781,7 +2781,7 @@ programmer
 # pavr
 #------------------------------------------------------------
 
-programmer
+programmer # pavr
     id                     = "pavr";
     desc                   = "Jason Kyle's pAVR Serial Programmer";
     type                   = "avr910";
@@ -2793,7 +2793,7 @@ programmer
 # pickit2
 #------------------------------------------------------------
 
-programmer
+programmer # pickit2
     id                     = "pickit2";
     desc                   = "MicroChip's PICkit2 Programmer";
     type                   = "pickit2";
@@ -2805,7 +2805,7 @@ programmer
 # flip1
 #------------------------------------------------------------
 
-programmer
+programmer # flip1
     id                     = "flip1";
     desc                   = "FLIP for bootloader using USB DFU protocol version 1 (doc7618)";
     type                   = "flip1";
@@ -2817,7 +2817,7 @@ programmer
 # flip2
 #------------------------------------------------------------
 
-programmer
+programmer # flip2
     id                     = "flip2";
     desc                   = "FLIP for bootloader using USB DFU protocol version 2 (AVR4023)";
     type                   = "flip2";
@@ -2849,7 +2849,7 @@ programmer
 # serial ponyprog design (dasa2 in uisp)
 # reset=!txd sck=rts sdo=dtr sdi=cts
 
-programmer
+programmer # ponyser
     id                     = "ponyser";
     desc                   = "design ponyprog serial, reset=!txd sck=rts sdo=dtr sdi=cts";
     type                   = "serbb";
@@ -2868,7 +2868,7 @@ programmer
 # Serial port adapter http://www.lancos.com/siprogsch.html
 # Same as above, different name
 
-programmer parent "ponyser"
+programmer parent "ponyser" # siprog
     id                     = "siprog";
     desc                   = "Lancos SI-Prog (same as ponyser)";
 ;
@@ -2880,7 +2880,7 @@ programmer parent "ponyser"
 # unknown (dasa in uisp)
 # reset=rts sck=dtr sdo=txd sdi=cts
 
-programmer
+programmer # dasa
     id                     = "dasa";
     desc                   = "serial port banging, reset=rts sck=dtr sdo=txd sdi=cts";
     type                   = "serbb";
@@ -2899,7 +2899,7 @@ programmer
 # unknown (dasa3 in uisp)
 # reset=!dtr sck=rts sdo=txd sdi=cts
 
-programmer
+programmer # dasa3
     id                     = "dasa3";
     desc                   = "serial port banging, reset=!dtr sck=rts sdo=txd sdi=cts";
     type                   = "serbb";
@@ -2918,7 +2918,7 @@ programmer
 # C2N232i (jumper configuration "auto")
 # reset=dtr sck=!rts sdo=!txd sdi=!cts
 
-programmer
+programmer # c2n232i
     id                     = "c2n232i";
     desc                   = "serial port banging, reset=dtr sck=!rts sdo=!txd sdi=!cts";
     type                   = "serbb";
@@ -2937,7 +2937,7 @@ programmer
 # JTAG2UPDI
 # https://github.com/ElTangas/jtag2updi
 
-programmer
+programmer # jtag2updi
     id                     = "jtag2updi";
     desc                   = "JTAGv2 to UPDI bridge";
     type                   = "jtagmkii_updi";
@@ -2974,7 +2974,7 @@ programmer
 # ch340
 #------------------------------------------------------------
 
-serialadapter
+serialadapter # ch340
     id                     = "ch340";
     desc                   = "WCH CH340 USB to serial adapter";
     usbvid                 = 0x1a86;
@@ -2985,7 +2985,7 @@ serialadapter
 # ch9102
 #------------------------------------------------------------
 
-serialadapter
+serialadapter # ch9102
     id                     = "ch9102";
     desc                   = "WCH CH9102 USB to serial adapter";
     usbvid                 = 0x1a86;
@@ -2996,7 +2996,7 @@ serialadapter
 # cp210x
 #------------------------------------------------------------
 
-serialadapter
+serialadapter # cp210x
     id                     = "cp210x";
     desc                   = "Silabs CP210x USB to serial adapter";
     usbvid                 = 0x10c4;
@@ -3007,7 +3007,7 @@ serialadapter
 # ft231x / ft234x / ft230x
 #------------------------------------------------------------
 
-serialadapter
+serialadapter # ft231x
     id                     = "ft231x", "ft234x", "ft230x";
     desc                   = "FTDI FT23X series USB to serial adapter";
     usbvid                 = 0x0403;
@@ -3018,7 +3018,7 @@ serialadapter
 # pl2303
 #------------------------------------------------------------
 
-serialadapter
+serialadapter # pl2303
     id                     = "pl2303";
     desc                   = "Profilic PL2303 USB to serial adapter";
     usbvid                 = 0x067b;
@@ -3035,7 +3035,7 @@ serialadapter
 
 # This is an HVSP-only device.
 
-part
+part # t11
     desc                   = "ATtiny11";
     id                     = "t11";
     variants               =
@@ -3119,7 +3119,7 @@ part
 # ATtiny12
 #------------------------------------------------------------
 
-part
+part # t12
     desc                   = "ATtiny12";
     id                     = "t12";
     variants               =
@@ -3231,7 +3231,7 @@ part
 # ATtiny13
 #------------------------------------------------------------
 
-part
+part # t13
     desc                   = "ATtiny13";
     id                     = "t13";
     variants               =
@@ -3384,7 +3384,7 @@ part
 # ATtiny13A
 #------------------------------------------------------------
 
-part parent "t13"
+part parent "t13" # t13a
     desc                   = "ATtiny13A";
     id                     = "t13a";
     variants               =
@@ -3415,7 +3415,7 @@ part parent "t13"
 # ATtiny15
 #------------------------------------------------------------
 
-part
+part # t15
     desc                   = "ATtiny15";
     id                     = "t15";
     variants               =
@@ -3532,7 +3532,7 @@ part
 #   - Tested with -c avrisp
 #   - USBASP programmers may require different firmware
 
-part
+part # 89S51
     desc                   = "AT89S51";
     id                     = "89S51";
     variants               =
@@ -3594,7 +3594,7 @@ part
 # AT89S52
 #------------------------------------------------------------
 
-part parent "89S51"
+part parent "89S51" # 89S52
     desc                   = "AT89S52";
     id                     = "89S52";
     variants               =
@@ -3616,7 +3616,7 @@ part parent "89S51"
 # AT90S1200
 #------------------------------------------------------------
 
-part
+part # 1200
     desc                   = "AT90S1200";
     id                     = "1200";
     variants               =
@@ -3727,7 +3727,7 @@ part
 # AT90S4414
 #------------------------------------------------------------
 
-part
+part # 4414
     desc                   = "AT90S4414";
     id                     = "4414";
     variants               =
@@ -3824,7 +3824,7 @@ part
 # AT90S2313
 #------------------------------------------------------------
 
-part
+part # 2313
     desc                   = "AT90S2313";
     id                     = "2313";
     variants               =
@@ -3917,7 +3917,7 @@ part
 # AT90S2333
 #------------------------------------------------------------
 
-part
+part # 2333
 ##### WARNING: No XML file for device 'AT90S2333'! #####
     desc                   = "AT90S2333";
     id                     = "2333";
@@ -4011,7 +4011,7 @@ part
 # AT90S2343 (also AT90S2323 and ATtiny22)
 #------------------------------------------------------------
 
-part
+part # 2343
     desc                   = "AT90S2343";
     id                     = "2343";
     variants               =
@@ -4110,7 +4110,7 @@ part
 # AT90S2323
 #------------------------------------------------------------
 
-part parent "2343"
+part parent "2343" # 2323
     desc                   = "AT90S2323";
     id                     = "2323";
     variants               =
@@ -4128,7 +4128,7 @@ part parent "2343"
 # ATtiny22
 #------------------------------------------------------------
 
-part parent "2343"
+part parent "2343" # t22
     desc                   = "ATtiny22";
     id                     = "t22";
     variants               =
@@ -4150,7 +4150,7 @@ part parent "2343"
 # AT90S4433
 #------------------------------------------------------------
 
-part parent "2333"
+part parent "2333" # 4433
     desc                   = "AT90S4433";
     id                     = "4433";
     variants               =
@@ -4190,7 +4190,7 @@ part parent "2333"
 # AT90S8515
 #------------------------------------------------------------
 
-part
+part # 8515
     desc                   = "AT90S8515";
     id                     = "8515";
     variants               =
@@ -4277,7 +4277,7 @@ part
 # AT90S8535
 #------------------------------------------------------------
 
-part
+part # 8535
     desc                   = "AT90S8535";
     id                     = "8535";
     variants               =
@@ -4376,7 +4376,7 @@ part
 # No XML file for device AT90S4434, so parenting off AT90S8535
 # with which it shares the datasheet.
 
-part parent "8535"
+part parent "8535" # 4434
     desc                   = "AT90S4434";
     id                     = "4434";
     variants               =
@@ -4418,7 +4418,7 @@ part parent "8535"
 # ATmega103
 #------------------------------------------------------------
 
-part
+part # m103
     desc                   = "ATmega103";
     id                     = "m103";
     variants               =
@@ -4518,7 +4518,7 @@ part
 # ATmega64
 #------------------------------------------------------------
 
-part
+part # m64
     desc                   = "ATmega64";
     id                     = "m64";
     variants               =
@@ -4670,7 +4670,7 @@ part
 # ATmega64A
 #------------------------------------------------------------
 
-part parent "m64"
+part parent "m64" # m64a
     desc                   = "ATmega64A";
     id                     = "m64a";
     variants               =
@@ -4688,7 +4688,7 @@ part parent "m64"
 # ATmega128
 #------------------------------------------------------------
 
-part
+part # m128
     desc                   = "ATmega128";
     id                     = "m128";
     variants               =
@@ -4840,7 +4840,7 @@ part
 # ATmega128A
 #------------------------------------------------------------
 
-part parent "m128"
+part parent "m128" # m128a
     desc                   = "ATmega128A";
     id                     = "m128a";
     variants               =
@@ -4860,7 +4860,7 @@ part parent "m128"
 # AT90CAN128
 #------------------------------------------------------------
 
-part
+part # c128
     desc                   = "AT90CAN128";
     id                     = "c128";
     variants               =
@@ -5004,7 +5004,7 @@ part
 # AT90CAN64
 #------------------------------------------------------------
 
-part
+part # c64
     desc                   = "AT90CAN64";
     id                     = "c64";
     variants               =
@@ -5146,7 +5146,7 @@ part
 # AT90CAN32
 #------------------------------------------------------------
 
-part
+part # c32
     desc                   = "AT90CAN32";
     id                     = "c32";
     variants               =
@@ -5288,7 +5288,7 @@ part
 # ATmega16
 #------------------------------------------------------------
 
-part
+part # m16
     desc                   = "ATmega16";
     id                     = "m16";
     variants               =
@@ -5430,7 +5430,7 @@ part
 # ATmega16A
 #------------------------------------------------------------
 
-part parent "m16"
+part parent "m16" # m16a
     desc                   = "ATmega16A";
     id                     = "m16a";
     variants               =
@@ -5447,7 +5447,7 @@ part parent "m16"
 # ATmega324P
 #------------------------------------------------------------
 
-part
+part # m324p
     desc                   = "ATmega324P";
     id                     = "m324p";
     variants               =
@@ -5604,7 +5604,7 @@ part
 # ATmega164P
 #------------------------------------------------------------
 
-part parent "m324p"
+part parent "m324p" # m164p
     desc                   = "ATmega164P";
     id                     = "m164p";
     variants               =
@@ -5647,7 +5647,7 @@ part parent "m324p"
 # ATmega164PA
 #------------------------------------------------------------
 
-part parent "m164p"
+part parent "m164p" # m164pa
     desc                   = "ATmega164PA";
     id                     = "m164pa";
     variants               =
@@ -5673,7 +5673,7 @@ part parent "m164p"
 # ATmega164A
 #------------------------------------------------------------
 
-part parent "m164p"
+part parent "m164p" # m164a
     desc                   = "ATmega164A";
     id                     = "m164a";
     variants               =
@@ -5695,7 +5695,7 @@ part parent "m164p"
 # ATmega324PB
 #------------------------------------------------------------
 
-part parent "m324p"
+part parent "m324p" # m324pb
     desc                   = "ATmega324PB";
     id                     = "m324pb";
     variants               =
@@ -5731,7 +5731,7 @@ part parent "m324p"
 # ATmega324PA
 #------------------------------------------------------------
 
-part parent "m324p"
+part parent "m324p" # m324pa
     desc                   = "ATmega324PA";
     id                     = "m324pa";
     variants               =
@@ -5756,7 +5756,7 @@ part parent "m324p"
 # ATmega324A
 #------------------------------------------------------------
 
-part parent "m324p"
+part parent "m324p" # m324a
     desc                   = "ATmega324A";
     id                     = "m324a";
     variants               =
@@ -5776,7 +5776,7 @@ part parent "m324p"
 # ATmega644
 #------------------------------------------------------------
 
-part
+part # m644
     desc                   = "ATmega644";
     id                     = "m644";
     variants               =
@@ -5925,7 +5925,7 @@ part
 # ATmega644A
 #------------------------------------------------------------
 
-part parent "m644"
+part parent "m644" # m644a
     desc                   = "ATmega644A";
     id                     = "m644a";
     variants               =
@@ -5943,7 +5943,7 @@ part parent "m644"
 # ATmega644P
 #------------------------------------------------------------
 
-part parent "m644"
+part parent "m644" # m644p
     desc                   = "ATmega644P";
     id                     = "m644p";
     variants               =
@@ -5983,7 +5983,7 @@ part parent "m644"
 # ATmega644PA
 #------------------------------------------------------------
 
-part parent "m644"
+part parent "m644" # m644pa
     desc                   = "ATmega644PA";
     id                     = "m644pa";
     variants               =
@@ -6006,7 +6006,7 @@ part parent "m644"
 # ATmega1284
 #------------------------------------------------------------
 
-part
+part # m1284
     desc                   = "ATmega1284";
     id                     = "m1284";
     variants               =
@@ -6150,7 +6150,7 @@ part
 # ATmega1284P
 #------------------------------------------------------------
 
-part parent "m1284"
+part parent "m1284" # m1284p
     desc                   = "ATmega1284P";
     id                     = "m1284p";
     variants               =
@@ -6170,7 +6170,7 @@ part parent "m1284"
 # ATmega162
 #------------------------------------------------------------
 
-part
+part # m162
     desc                   = "ATmega162";
     id                     = "m162";
     variants               =
@@ -6340,7 +6340,7 @@ part
 # ATmega163
 #------------------------------------------------------------
 
-part
+part # m163
     desc                   = "ATmega163";
     id                     = "m163";
     variants               =
@@ -6461,7 +6461,7 @@ part
 # ATmega169
 #------------------------------------------------------------
 
-part
+part # m169
     desc                   = "ATmega169";
     id                     = "m169";
     variants               =
@@ -6609,7 +6609,7 @@ part
 # ATmega169A
 #------------------------------------------------------------
 
-part parent "m169"
+part parent "m169" # m169a
     desc                   = "ATmega169A";
     id                     = "m169a";
     variants               =
@@ -6648,7 +6648,7 @@ part parent "m169"
 # ATmega169P
 #------------------------------------------------------------
 
-part parent "m169"
+part parent "m169" # m169p
     desc                   = "ATmega169P";
     id                     = "m169p";
     variants               =
@@ -6695,7 +6695,7 @@ part parent "m169"
 # ATmega169PA
 #------------------------------------------------------------
 
-part parent "m169"
+part parent "m169" # m169pa
     desc                   = "ATmega169PA";
     id                     = "m169pa";
     variants               =
@@ -6737,7 +6737,7 @@ part parent "m169"
 # ATmega329
 #------------------------------------------------------------
 
-part
+part # m329
     desc                   = "ATmega329";
     id                     = "m329";
     variants               =
@@ -6882,7 +6882,7 @@ part
 # ATmega329A
 #------------------------------------------------------------
 
-part parent "m329"
+part parent "m329" # m329a
     desc                   = "ATmega329A";
     id                     = "m329a";
     variants               =
@@ -6898,7 +6898,7 @@ part parent "m329"
 # ATmega329P
 #------------------------------------------------------------
 
-part parent "m329"
+part parent "m329" # m329p
     desc                   = "ATmega329P";
     id                     = "m329p";
     variants               =
@@ -6924,7 +6924,7 @@ part parent "m329"
 # ATmega329PA
 #------------------------------------------------------------
 
-part parent "m329"
+part parent "m329" # m329pa
     desc                   = "ATmega329PA";
     id                     = "m329pa";
     variants               =
@@ -6942,7 +6942,7 @@ part parent "m329"
 # ATmega3290
 #------------------------------------------------------------
 
-part parent "m329"
+part parent "m329" # m3290
     desc                   = "ATmega3290";
     id                     = "m3290";
     variants               =
@@ -6960,7 +6960,7 @@ part parent "m329"
 # ATmega3290A
 #------------------------------------------------------------
 
-part parent "m329"
+part parent "m329" # m3290a
     desc                   = "ATmega3290A";
     id                     = "m3290a";
     variants               =
@@ -6976,7 +6976,7 @@ part parent "m329"
 # ATmega3290P
 #------------------------------------------------------------
 
-part parent "m329"
+part parent "m329" # m3290p
     desc                   = "ATmega3290P";
     id                     = "m3290p";
     variants               =
@@ -6994,7 +6994,7 @@ part parent "m329"
 # ATmega3290PA
 #------------------------------------------------------------
 
-part parent "m329"
+part parent "m329" # m3290pa
     desc                   = "ATmega3290PA";
     id                     = "m3290pa";
     variants               =
@@ -7010,7 +7010,7 @@ part parent "m329"
 # ATmega649
 #------------------------------------------------------------
 
-part
+part # m649
     desc                   = "ATmega649";
     id                     = "m649";
     variants               =
@@ -7158,7 +7158,7 @@ part
 # ATmega649A
 #------------------------------------------------------------
 
-part parent "m649"
+part parent "m649" # m649a
     desc                   = "ATmega649A";
     id                     = "m649a";
     variants               =
@@ -7173,7 +7173,7 @@ part parent "m649"
 # ATmega649P
 #------------------------------------------------------------
 
-part parent "m649"
+part parent "m649" # m649p
     desc                   = "ATmega649P";
     id                     = "m649p";
     variants               =
@@ -7189,7 +7189,7 @@ part parent "m649"
 # ATmega6490
 #------------------------------------------------------------
 
-part parent "m649"
+part parent "m649" # m6490
     desc                   = "ATmega6490";
     id                     = "m6490";
     variants               =
@@ -7207,7 +7207,7 @@ part parent "m649"
 # ATmega6490A
 #------------------------------------------------------------
 
-part parent "m649"
+part parent "m649" # m6490a
     desc                   = "ATmega6490A";
     id                     = "m6490a";
     variants               =
@@ -7223,7 +7223,7 @@ part parent "m649"
 # ATmega6490P
 #------------------------------------------------------------
 
-part parent "m649"
+part parent "m649" # m6490p
     desc                   = "ATmega6490P";
     id                     = "m6490p";
     variants               =
@@ -7239,7 +7239,7 @@ part parent "m649"
 # ATmega32
 #------------------------------------------------------------
 
-part
+part # m32
     desc                   = "ATmega32";
     id                     = "m32";
     variants               =
@@ -7379,7 +7379,7 @@ part
 # ATmega161
 #------------------------------------------------------------
 
-part
+part # m161
     desc                   = "ATmega161";
     id                     = "m161";
     variants               =
@@ -7485,7 +7485,7 @@ part
 # ATmega32A
 #------------------------------------------------------------
 
-part parent "m32"
+part parent "m32" # m32a
     desc                   = "ATmega32A";
     id                     = "m32a";
     variants               =
@@ -7506,7 +7506,7 @@ part parent "m32"
 # ATmega8
 #------------------------------------------------------------
 
-part
+part # m8
     desc                   = "ATmega8";
     id                     = "m8";
     variants               =
@@ -7646,7 +7646,7 @@ part
 # ATmega8A
 #------------------------------------------------------------
 
-part parent "m8"
+part parent "m8" # m8a
     desc                   = "ATmega8A";
     id                     = "m8a";
     variants               =
@@ -7668,7 +7668,7 @@ part parent "m8"
 # ATmega8515
 #------------------------------------------------------------
 
-part
+part # m8515
     desc                   = "ATmega8515";
     id                     = "m8515";
     variants               =
@@ -7801,7 +7801,7 @@ part
 # ATmega8535
 #------------------------------------------------------------
 
-part
+part # m8535
     desc                   = "ATmega8535";
     id                     = "m8535";
     variants               =
@@ -7934,7 +7934,7 @@ part
 # ATtiny26
 #------------------------------------------------------------
 
-part
+part # t26
     desc                   = "ATtiny26";
     id                     = "t26";
     variants               =
@@ -8065,7 +8065,7 @@ part
 # ATtiny261
 #------------------------------------------------------------
 
-part
+part # t261
     desc                   = "ATtiny261";
     id                     = "t261";
     variants               =
@@ -8212,7 +8212,7 @@ part
 # ATtiny261A
 #------------------------------------------------------------
 
-part parent "t261"
+part parent "t261" # t261a
     desc                   = "ATtiny261A";
     id                     = "t261a";
     variants               =
@@ -8234,7 +8234,7 @@ part parent "t261"
 # ATtiny461
 #------------------------------------------------------------
 
-part
+part # t461
     desc                   = "ATtiny461";
     id                     = "t461";
     variants               =
@@ -8385,7 +8385,7 @@ part
 # ATtiny461A
 #------------------------------------------------------------
 
-part parent "t461"
+part parent "t461" # t461a
     desc                   = "ATtiny461A";
     id                     = "t461a";
     variants               =
@@ -8403,7 +8403,7 @@ part parent "t461"
 # ATtiny861
 #------------------------------------------------------------
 
-part
+part # t861
     desc                   = "ATtiny861";
     id                     = "t861";
     variants               =
@@ -8554,7 +8554,7 @@ part
 # ATtiny861A
 #------------------------------------------------------------
 
-part parent "t861"
+part parent "t861" # t861a
     desc                   = "ATtiny861A";
     id                     = "t861a";
     variants               =
@@ -8575,7 +8575,7 @@ part parent "t861"
 
 # This is an HVPP-only device.
 
-part
+part # t28
     desc                   = "ATtiny28";
     id                     = "t28";
     variants               =
@@ -8645,7 +8645,7 @@ part
 # ATmega48
 #------------------------------------------------------------
 
-part
+part # m48
     desc                   = "ATmega48";
     id                     = "m48";
     variants               =
@@ -8802,7 +8802,7 @@ part
 # ATmega48A
 #------------------------------------------------------------
 
-part parent "m48"
+part parent "m48" # m48a
     desc                   = "ATmega48A";
     id                     = "m48a";
     variants               =
@@ -8821,7 +8821,7 @@ part parent "m48"
 # ATmega48P
 #------------------------------------------------------------
 
-part parent "m48"
+part parent "m48" # m48p
     desc                   = "ATmega48P";
     id                     = "m48p";
     variants               =
@@ -8847,7 +8847,7 @@ part parent "m48"
 # ATmega48PA
 #------------------------------------------------------------
 
-part parent "m48"
+part parent "m48" # m48pa
     desc                   = "ATmega48PA";
     id                     = "m48pa";
     variants               =
@@ -8875,7 +8875,7 @@ part parent "m48"
 # ATmega48PB
 #------------------------------------------------------------
 
-part parent "m48"
+part parent "m48" # m48pb
     desc                   = "ATmega48PB";
     id                     = "m48pb";
     variants               =
@@ -8897,7 +8897,7 @@ part parent "m48"
 # ATmega88
 #------------------------------------------------------------
 
-part
+part # m88
     desc                   = "ATmega88";
     id                     = "m88";
     variants               =
@@ -9051,7 +9051,7 @@ part
 # ATmega88A
 #------------------------------------------------------------
 
-part parent "m88"
+part parent "m88" # m88a
     desc                   = "ATmega88A";
     id                     = "m88a";
     variants               =
@@ -9071,7 +9071,7 @@ part parent "m88"
 # ATmega88P
 #------------------------------------------------------------
 
-part parent "m88"
+part parent "m88" # m88p
     desc                   = "ATmega88P";
     id                     = "m88p";
     variants               =
@@ -9093,7 +9093,7 @@ part parent "m88"
 # ATmega88PA
 #------------------------------------------------------------
 
-part parent "m88"
+part parent "m88" # m88pa
     desc                   = "ATmega88PA";
     id                     = "m88pa";
     variants               =
@@ -9123,7 +9123,7 @@ part parent "m88"
 # ATmega88PB
 #------------------------------------------------------------
 
-part parent "m88"
+part parent "m88" # m88pb
     desc                   = "ATmega88PB";
     id                     = "m88pb";
     variants               =
@@ -9145,7 +9145,7 @@ part parent "m88"
 # ATmega168
 #------------------------------------------------------------
 
-part
+part # m168
     desc                   = "ATmega168";
     id                     = "m168";
     variants               =
@@ -9304,7 +9304,7 @@ part
 # ATmega168A
 #------------------------------------------------------------
 
-part parent "m168"
+part parent "m168" # m168a
     desc                   = "ATmega168A";
     id                     = "m168a";
     variants               =
@@ -9324,7 +9324,7 @@ part parent "m168"
 # ATmega168P
 #------------------------------------------------------------
 
-part parent "m168"
+part parent "m168" # m168p
     desc                   = "ATmega168P";
     id                     = "m168p";
     variants               =
@@ -9351,7 +9351,7 @@ part parent "m168"
 # ATmega168PA
 #------------------------------------------------------------
 
-part parent "m168"
+part parent "m168" # m168pa
     desc                   = "ATmega168PA";
     id                     = "m168pa";
     variants               =
@@ -9377,7 +9377,7 @@ part parent "m168"
 # ATmega168PB
 #------------------------------------------------------------
 
-part parent "m168"
+part parent "m168" # m168pb
     desc                   = "ATmega168PB";
     id                     = "m168pb";
     variants               =
@@ -9398,7 +9398,7 @@ part parent "m168"
 # ATtiny828
 #------------------------------------------------------------
 
-part
+part # t828
     desc                   = "ATtiny828";
     id                     = "t828";
     variants               =
@@ -9547,7 +9547,7 @@ part
 # ATtiny828R
 #------------------------------------------------------------
 
-part parent "t828"
+part parent "t828" # t828r
     desc                   = "ATtiny828R";
     id                     = "t828r";
     variants               =
@@ -9560,7 +9560,7 @@ part parent "t828"
 # ATtiny87
 #------------------------------------------------------------
 
-part
+part # t87
     desc                   = "ATtiny87";
     id                     = "t87";
     variants               =
@@ -9710,7 +9710,7 @@ part
 # ATtiny167
 #------------------------------------------------------------
 
-part
+part # t167
     desc                   = "ATtiny167";
     id                     = "t167";
     variants               =
@@ -9863,7 +9863,7 @@ part
 # ATtiny48
 #------------------------------------------------------------
 
-part
+part # t48
     desc                   = "ATtiny48";
     id                     = "t48";
     variants               =
@@ -10014,7 +10014,7 @@ part
 # ATtiny88
 #------------------------------------------------------------
 
-part
+part # t88
     desc                   = "ATtiny88";
     id                     = "t88";
     variants               =
@@ -10165,7 +10165,7 @@ part
 # ATmega328
 #------------------------------------------------------------
 
-part
+part # m328
     desc                   = "ATmega328";
     id                     = "m328";
     variants               =
@@ -10315,7 +10315,7 @@ part
 # ATmega328P
 #------------------------------------------------------------
 
-part parent "m328"
+part parent "m328" # m328p
     desc                   = "ATmega328P";
     id                     = "m328p";
     variants               =
@@ -10341,7 +10341,7 @@ part parent "m328"
 # ATmega328PB
 #------------------------------------------------------------
 
-part parent "m328"
+part parent "m328" # m328pb
     desc                   = "ATmega328PB";
     id                     = "m328pb";
     variants               =
@@ -10378,7 +10378,7 @@ part parent "m328"
 # ATmega64M1
 #------------------------------------------------------------
 
-part
+part # m64m1
     desc                   = "ATmega64M1";
     id                     = "m64m1";
     variants               =
@@ -10522,7 +10522,7 @@ part
 # ATmega32M1
 #------------------------------------------------------------
 
-part parent "m64m1"
+part parent "m64m1" # m32m1
     desc                   = "ATmega32M1";
     id                     = "m32m1";
     variants               =
@@ -10560,7 +10560,7 @@ part parent "m64m1"
 # ATmega16M1
 #------------------------------------------------------------
 
-part parent "m32m1"
+part parent "m32m1" # m16m1
     desc                   = "ATmega16M1";
     id                     = "m16m1";
     variants               =
@@ -10589,7 +10589,7 @@ part parent "m32m1"
 # ATmega32C1
 #------------------------------------------------------------
 
-part parent "m32m1"
+part parent "m32m1" # m32c1
     desc                   = "ATmega32C1";
     id                     = "m32c1";
     variants               =
@@ -10609,7 +10609,7 @@ part parent "m32m1"
 # ATmega64C1
 #------------------------------------------------------------
 
-part parent "m64m1"
+part parent "m64m1" # m64c1
     desc                   = "ATmega64C1";
     id                     = "m64c1";
     variants               =
@@ -10629,7 +10629,7 @@ part parent "m64m1"
 # ATA5505
 #------------------------------------------------------------
 
-part parent "t167"
+part parent "t167" # ata5505
     desc                   = "ATA5505";
     id                     = "ata5505";
     variants               =
@@ -10672,7 +10672,7 @@ part parent "t167"
 # ATA6612C
 #------------------------------------------------------------
 
-part parent "m88"
+part parent "m88" # ata6612c
     desc                   = "ATA6612C";
     id                     = "ata6612c";
     variants               =
@@ -10700,7 +10700,7 @@ part parent "m88"
 # ATA6613C
 #------------------------------------------------------------
 
-part parent "m168"
+part parent "m168" # ata6613c
     desc                   = "ATA6613C";
     id                     = "ata6613c";
     variants               =
@@ -10722,7 +10722,7 @@ part parent "m168"
 # ATA6614Q
 #------------------------------------------------------------
 
-part parent "m328"
+part parent "m328" # ata6614q
     desc                   = "ATA6614Q";
     id                     = "ata6614q";
     variants               =
@@ -10745,7 +10745,7 @@ part parent "m328"
 # ATA6616C
 #------------------------------------------------------------
 
-part parent "t87"
+part parent "t87" # ata6616c
     desc                   = "ATA6616C";
     id                     = "ata6616c";
     variants               =
@@ -10795,7 +10795,7 @@ part parent "t87"
 # ATA6617C
 #------------------------------------------------------------
 
-part parent "t167"
+part parent "t167" # ata6617c
     desc                   = "ATA6617C";
     id                     = "ata6617c";
     variants               =
@@ -10838,7 +10838,7 @@ part parent "t167"
 # ATA664251
 #------------------------------------------------------------
 
-part parent "t167"
+part parent "t167" # ata664251
     desc                   = "ATA664251";
     id                     = "ata664251";
     variants               =
@@ -10882,7 +10882,7 @@ part parent "t167"
 # ATmega16HVA
 #------------------------------------------------------------
 
-part
+part # m16hva
     desc                   = "ATmega16HVA";
     id                     = "m16hva";
     variants               =
@@ -11008,7 +11008,7 @@ part
 # ATmega8HVA
 #------------------------------------------------------------
 
-part parent "m16hva"
+part parent "m16hva" # m8hva
     desc                   = "ATmega8HVA";
     id                     = "m8hva";
     variants               =
@@ -11033,7 +11033,7 @@ part parent "m16hva"
 # ATmega16HVB
 #------------------------------------------------------------
 
-part
+part # m16hvb
     desc                   = "ATmega16HVB";
     id                     = "m16hvb";
     variants               =
@@ -11165,7 +11165,7 @@ part
 # ATmega16HVBrevB
 #------------------------------------------------------------
 
-part parent "m16hvb"
+part parent "m16hvb" # m16hvbrevb
     desc                   = "ATmega16HVBrevB";
     id                     = "m16hvbrevb";
     variants               =
@@ -11177,7 +11177,7 @@ part parent "m16hvb"
 # ATmega32HVB
 #------------------------------------------------------------
 
-part parent "m16hvb"
+part parent "m16hvb" # m32hvb
     desc                   = "ATmega32HVB";
     id                     = "m32hvb";
     variants               =
@@ -11207,7 +11207,7 @@ part parent "m16hvb"
 # ATmega32HVBrevB
 #------------------------------------------------------------
 
-part parent "m32hvb"
+part parent "m32hvb" # m32hvbrevb
     desc                   = "ATmega32HVBrevB";
     id                     = "m32hvbrevb";
     variants               =
@@ -11219,7 +11219,7 @@ part parent "m32hvb"
 # ATmega64HVE2
 #------------------------------------------------------------
 
-part
+part # m64hve2
     desc                   = "ATmega64HVE2";
     id                     = "m64hve2";
     variants               =
@@ -11355,7 +11355,7 @@ part
 # ATmega32HVE2
 #------------------------------------------------------------
 
-part parent "m64hve2"
+part parent "m64hve2" # m32hve2
     desc                   = "ATmega32HVE2";
     id                     = "m32hve2";
     variants               =
@@ -11374,7 +11374,7 @@ part parent "m64hve2"
 # ATtiny2313
 #------------------------------------------------------------
 
-part
+part # t2313
     desc                   = "ATtiny2313";
     id                     = "t2313";
     variants               =
@@ -11534,7 +11534,7 @@ part
 # ATtiny2313A
 #------------------------------------------------------------
 
-part parent "t2313"
+part parent "t2313" # t2313a
     desc                   = "ATtiny2313A";
     id                     = "t2313a";
     variants               =
@@ -11559,7 +11559,7 @@ part parent "t2313"
 # ATtiny4313
 #------------------------------------------------------------
 
-part
+part # t4313
     desc                   = "ATtiny4313";
     id                     = "t4313";
     variants               =
@@ -11710,7 +11710,7 @@ part
 # AT90PWM1
 #------------------------------------------------------------
 
-part
+part # pwm1
     desc                   = "AT90PWM1";
     id                     = "pwm1";
     variants               =
@@ -11855,7 +11855,7 @@ part
 # AT90PWM2
 #------------------------------------------------------------
 
-part
+part # pwm2
     desc                   = "AT90PWM2";
     id                     = "pwm2";
     variants               =
@@ -11998,7 +11998,7 @@ part
 
 # Completely identical to AT90PWM2 (including the signature!)
 
-part parent "pwm2"
+part parent "pwm2" # pwm3
     desc                   = "AT90PWM3";
     id                     = "pwm3";
     variants               =
@@ -12031,7 +12031,7 @@ part parent "pwm2"
 #------------------------------------------------------------
 # Same as AT90PWM2 but different signature.
 
-part parent "pwm2"
+part parent "pwm2" # pwm2b
     desc                   = "AT90PWM2B";
     id                     = "pwm2b";
     variants               =
@@ -12066,7 +12066,7 @@ part parent "pwm2"
 
 # Completely identical to AT90PWM2B (including the signature!)
 
-part parent "pwm2b"
+part parent "pwm2b" # pwm3b
     desc                   = "AT90PWM3B";
     id                     = "pwm3b";
     variants               =
@@ -12080,7 +12080,7 @@ part parent "pwm2b"
 # AT90PWM161
 #------------------------------------------------------------
 
-part
+part # pwm161
     desc                   = "AT90PWM161";
     id                     = "pwm161";
     variants               =
@@ -12225,7 +12225,7 @@ part
 # AT90PWM81
 #------------------------------------------------------------
 
-part parent "pwm161"
+part parent "pwm161" # pwm81
     desc                   = "AT90PWM81";
     id                     = "pwm81";
     variants               =
@@ -12255,7 +12255,7 @@ part parent "pwm161"
 
 # Similar to AT90PWM3B, but with 16 kiB flash, 512 B EEPROM, and 1024 B SRAM.
 
-part parent "pwm3b"
+part parent "pwm3b" # pwm316
     desc                   = "AT90PWM316";
     id                     = "pwm316";
     variants               =
@@ -12282,7 +12282,7 @@ part parent "pwm3b"
 #------------------------------------------------------------
 # Completely identical to AT90PWM316 (including the signature!)
 
-part parent "pwm316"
+part parent "pwm316" # pwm216
     desc                   = "AT90PWM216";
     id                     = "pwm216";
     variants               =
@@ -12296,7 +12296,7 @@ part parent "pwm316"
 # ATtiny25
 #------------------------------------------------------------
 
-part
+part # t25
     desc                   = "ATtiny25";
     id                     = "t25";
     variants               =
@@ -12482,7 +12482,7 @@ part
 # ATtiny45
 #------------------------------------------------------------
 
-part
+part # t45
     desc                   = "ATtiny45";
     id                     = "t45";
     variants               =
@@ -12647,7 +12647,7 @@ part
 # ATtiny85
 #------------------------------------------------------------
 
-part
+part # t85
     desc                   = "ATtiny85";
     id                     = "t85";
     variants               =
@@ -12810,7 +12810,7 @@ part
 #------------------------------------------------------------
 # Almost same as ATmega1280, except for different memory sizes
 
-part
+part # m640
     desc                   = "ATmega640";
     id                     = "m640";
     variants               =
@@ -12956,7 +12956,7 @@ part
 # ATmega1280
 #------------------------------------------------------------
 
-part
+part # m1280
     desc                   = "ATmega1280";
     id                     = "m1280";
     variants               =
@@ -13103,7 +13103,7 @@ part
 #------------------------------------------------------------
 # Identical to ATmega1280
 
-part parent "m1280"
+part parent "m1280" # m1281
     desc                   = "ATmega1281";
     id                     = "m1281";
     variants               =
@@ -13124,7 +13124,7 @@ part parent "m1280"
 # ATmega2560
 #------------------------------------------------------------
 
-part
+part # m2560
     desc                   = "ATmega2560";
     id                     = "m2560";
     variants               =
@@ -13272,7 +13272,7 @@ part
 # ATmega2561
 #------------------------------------------------------------
 
-part parent "m2560"
+part parent "m2560" # m2561
     desc                   = "ATmega2561";
     id                     = "m2561";
     variants               =
@@ -13294,7 +13294,7 @@ part parent "m2560"
 #------------------------------------------------------------
 # Identical to ATmega2561 but half the ROM
 
-part parent "m2561"
+part parent "m2561" # m128rfa1
     desc                   = "ATmega128RFA1";
     id                     = "m128rfa1";
     variants               =
@@ -13357,7 +13357,7 @@ part parent "m2561"
 # ATmega256RFR2
 #------------------------------------------------------------
 
-part parent "m128rfa1"
+part parent "m128rfa1" # m256rfr2
     desc                   = "ATmega256RFR2";
     id                     = "m256rfr2";
     variants               =
@@ -13415,7 +13415,7 @@ part parent "m128rfa1"
 # ATmega128RFR2
 #------------------------------------------------------------
 
-part parent "m256rfr2"
+part parent "m256rfr2" # m128rfr2
     desc                   = "ATmega128RFR2";
     id                     = "m128rfr2";
     variants               =
@@ -13442,7 +13442,7 @@ part parent "m256rfr2"
 # ATmega64RFR2
 #------------------------------------------------------------
 
-part parent "m128rfr2"
+part parent "m128rfr2" # m64rfr2
     desc                   = "ATmega64RFR2";
     id                     = "m64rfr2";
     variants               =
@@ -13473,7 +13473,7 @@ part parent "m128rfr2"
 # ATmega2564RFR2
 #------------------------------------------------------------
 
-part parent "m256rfr2"
+part parent "m256rfr2" # m2564rfr2
     desc                   = "ATmega2564RFR2";
     id                     = "m2564rfr2";
     variants               =
@@ -13489,7 +13489,7 @@ part parent "m256rfr2"
 # ATmega1284RFR2
 #------------------------------------------------------------
 
-part parent "m128rfr2"
+part parent "m128rfr2" # m1284rfr2
     desc                   = "ATmega1284RFR2";
     id                     = "m1284rfr2";
     variants               =
@@ -13505,7 +13505,7 @@ part parent "m128rfr2"
 # ATmega644RFR2
 #------------------------------------------------------------
 
-part parent "m64rfr2"
+part parent "m64rfr2" # m644rfr2
     desc                   = "ATmega644RFR2";
     id                     = "m644rfr2";
     variants               =
@@ -13521,7 +13521,7 @@ part parent "m64rfr2"
 # ATtiny24
 #------------------------------------------------------------
 
-part
+part # t24
     desc                   = "ATtiny24";
     id                     = "t24";
     variants               =
@@ -13677,7 +13677,7 @@ part
 # ATtiny24A
 #------------------------------------------------------------
 
-part parent "t24"
+part parent "t24" # t24a
     desc                   = "ATtiny24A";
     id                     = "t24a";
     variants               =
@@ -13706,7 +13706,7 @@ part parent "t24"
 # ATtiny44
 #------------------------------------------------------------
 
-part
+part # t44
     desc                   = "ATtiny44";
     id                     = "t44";
     variants               =
@@ -13862,7 +13862,7 @@ part
 # ATtiny44A
 #------------------------------------------------------------
 
-part parent "t44"
+part parent "t44" # t44a
     desc                   = "ATtiny44A";
     id                     = "t44a";
     variants               =
@@ -13889,7 +13889,7 @@ part parent "t44"
 # ATtiny84
 #------------------------------------------------------------
 
-part
+part # t84
     desc                   = "ATtiny84";
     id                     = "t84";
     variants               =
@@ -14046,7 +14046,7 @@ part
 # ATtiny84A
 #------------------------------------------------------------
 
-part parent "t84"
+part parent "t84" # t84a
     desc                   = "ATtiny84A";
     id                     = "t84a";
     variants               =
@@ -14070,7 +14070,7 @@ part parent "t84"
 # ATtiny441
 #------------------------------------------------------------
 
-part parent "t44"
+part parent "t44" # t441
     desc                   = "ATtiny441";
     id                     = "t441";
     variants               =
@@ -14116,7 +14116,7 @@ part parent "t44"
 # ATtiny841
 #------------------------------------------------------------
 
-part parent "t84"
+part parent "t84" # t841
     desc                   = "ATtiny841";
     id                     = "t841";
     variants               =
@@ -14162,7 +14162,7 @@ part parent "t84"
 # ATtiny43U
 #------------------------------------------------------------
 
-part
+part # t43u
     desc                   = "ATtiny43U";
     id                     = "t43u";
     variants               =
@@ -14311,7 +14311,7 @@ part
 # ATmega16u4
 #------------------------------------------------------------
 
-part
+part # m16u4
     desc                   = "ATmega16U4";
     id                     = "m16u4";
     variants               =
@@ -14455,7 +14455,7 @@ part
 # ATmega32u4
 #------------------------------------------------------------
 
-part
+part # m32u4
     desc                   = "ATmega32U4";
     id                     = "m32u4";
     variants               =
@@ -14601,7 +14601,7 @@ part
 # AT90USB646
 #------------------------------------------------------------
 
-part
+part # usb646
     desc                   = "AT90USB646";
     id                     = "usb646";
     variants               =
@@ -14746,7 +14746,7 @@ part
 #------------------------------------------------------------
 # identical to AT90USB646
 
-part parent "usb646"
+part parent "usb646" # usb647
     desc                   = "AT90USB647";
     id                     = "usb647";
     variants               =
@@ -14762,7 +14762,7 @@ part parent "usb646"
 # AT90USB1286
 #------------------------------------------------------------
 
-part
+part # usb1286
     desc                   = "AT90USB1286";
     id                     = "usb1286";
     variants               =
@@ -14908,7 +14908,7 @@ part
 #------------------------------------------------------------
 # identical to AT90USB1286
 
-part parent "usb1286"
+part parent "usb1286" # usb1287
     desc                   = "AT90USB1287";
     id                     = "usb1287";
     variants               =
@@ -14924,7 +14924,7 @@ part parent "usb1286"
 # AT90USB162
 #------------------------------------------------------------
 
-part
+part # usb162
     desc                   = "AT90USB162";
     id                     = "usb162";
     variants               =
@@ -15072,7 +15072,7 @@ part
 # AT90USB82
 #------------------------------------------------------------
 
-part
+part # usb82
     desc                   = "AT90USB82";
     id                     = "usb82";
     variants               =
@@ -15218,7 +15218,7 @@ part
 # ATmega32U2
 #------------------------------------------------------------
 
-part
+part # m32u2
     desc                   = "ATmega32U2";
     id                     = "m32u2";
     variants               =
@@ -15365,7 +15365,7 @@ part
 # ATmega16U2
 #------------------------------------------------------------
 
-part
+part # m16u2
     desc                   = "ATmega16U2";
     id                     = "m16u2";
     variants               =
@@ -15512,7 +15512,7 @@ part
 # ATmega8U2
 #------------------------------------------------------------
 
-part
+part # m8u2
     desc                   = "ATmega8U2";
     id                     = "m8u2";
     variants               =
@@ -15659,7 +15659,7 @@ part
 # ATmega165P
 #------------------------------------------------------------
 
-part
+part # m165p
     desc                   = "ATmega165P";
     id                     = "m165p";
     variants               =
@@ -15810,7 +15810,7 @@ part
 # ATmega165A
 #------------------------------------------------------------
 
-part parent "m165p"
+part parent "m165p" # m165a
     desc                   = "ATmega165A";
     id                     = "m165a";
     variants               =
@@ -15827,7 +15827,7 @@ part parent "m165p"
 # ATmega165
 #------------------------------------------------------------
 
-part parent "m165p"
+part parent "m165p" # m165
     desc                   = "ATmega165";
     id                     = "m165";
     variants               =
@@ -15852,7 +15852,7 @@ part parent "m165p"
 # ATmega165PA
 #------------------------------------------------------------
 
-part parent "m165p"
+part parent "m165p" # m165pa
     desc                   = "ATmega165PA";
     id                     = "m165pa";
     variants               =
@@ -15869,7 +15869,7 @@ part parent "m165p"
 # ATmega325
 #------------------------------------------------------------
 
-part
+part # m325
     desc                   = "ATmega325";
     id                     = "m325";
     variants               =
@@ -16014,7 +16014,7 @@ part
 # ATmega325A
 #------------------------------------------------------------
 
-part parent "m325"
+part parent "m325" # m325a
     desc                   = "ATmega325A";
     id                     = "m325a";
     variants               =
@@ -16034,7 +16034,7 @@ part parent "m325"
 # ATmega325P
 #------------------------------------------------------------
 
-part parent "m325"
+part parent "m325" # m325p
     desc                   = "ATmega325P";
     id                     = "m325p";
     variants               =
@@ -16054,7 +16054,7 @@ part parent "m325"
 # ATmega325PA
 #------------------------------------------------------------
 
-part parent "m325"
+part parent "m325" # m325pa
     desc                   = "ATmega325PA";
     id                     = "m325pa";
     variants               =
@@ -16071,7 +16071,7 @@ part parent "m325"
 # ATmega645
 #------------------------------------------------------------
 
-part
+part # m645
     desc                   = "ATmega645";
     id                     = "m645";
     variants               =
@@ -16219,7 +16219,7 @@ part
 # ATmega645A
 #------------------------------------------------------------
 
-part parent "m645"
+part parent "m645" # m645a
     desc                   = "ATmega645A";
     id                     = "m645a";
     variants               =
@@ -16235,7 +16235,7 @@ part parent "m645"
 # ATmega645P
 #------------------------------------------------------------
 
-part parent "m645"
+part parent "m645" # m645p
     desc                   = "ATmega645P";
     id                     = "m645p";
     variants               =
@@ -16252,7 +16252,7 @@ part parent "m645"
 # ATmega3250
 #------------------------------------------------------------
 
-part parent "m325"
+part parent "m325" # m3250
     desc                   = "ATmega3250";
     id                     = "m3250";
     variants               =
@@ -16270,7 +16270,7 @@ part parent "m325"
 # ATmega3250A
 #------------------------------------------------------------
 
-part parent "m325"
+part parent "m325" # m3250a
     desc                   = "ATmega3250A";
     id                     = "m3250a";
     variants               =
@@ -16286,7 +16286,7 @@ part parent "m325"
 # ATmega3250P
 #------------------------------------------------------------
 
-part parent "m325"
+part parent "m325" # m3250p
     desc                   = "ATmega3250P";
     id                     = "m3250p";
     variants               =
@@ -16304,7 +16304,7 @@ part parent "m325"
 # ATmega3250PA
 #------------------------------------------------------------
 
-part parent "m325"
+part parent "m325" # m3250pa
     desc                   = "ATmega3250PA";
     id                     = "m3250pa";
     variants               =
@@ -16320,7 +16320,7 @@ part parent "m325"
 # ATmega6450
 #------------------------------------------------------------
 
-part parent "m645"
+part parent "m645" # m6450
     desc                   = "ATmega6450";
     id                     = "m6450";
     variants               =
@@ -16338,7 +16338,7 @@ part parent "m645"
 # ATmega6450A
 #------------------------------------------------------------
 
-part parent "m645"
+part parent "m645" # m6450a
     desc                   = "ATmega6450A";
     id                     = "m6450a";
     variants               =
@@ -16354,7 +16354,7 @@ part parent "m645"
 # ATmega6450P
 #------------------------------------------------------------
 
-part parent "m645"
+part parent "m645" # m6450p
     desc                   = "ATmega6450P";
     id                     = "m6450p";
     variants               =
@@ -16370,7 +16370,7 @@ part parent "m645"
 # AVR XMEGA family common values
 #------------------------------------------------------------
 
-part
+part # .xmega
     desc                   = "AVR XMEGA family common values";
     id                     = ".xmega";
     prog_modes             = PM_SPM | PM_PDI;
@@ -16444,7 +16444,7 @@ part
 
 # Fuse for fault detection action on Px0..5 (unique to XMEGA-E)
 
-part parent ".xmega"
+part parent ".xmega" # .xmega-e
     desc                   = "AVR XMEGA-E family common values";
     id                     = ".xmega-e";
 
@@ -16461,7 +16461,7 @@ part parent ".xmega"
 
 # JTAG user ID (unique to XMEGA-A and XMEGA-B)
 
-part parent ".xmega"
+part parent ".xmega" # .xmega-a
     desc                   = "AVR XMEGA-A family common values";
     id                     = ".xmega-a";
 
@@ -16480,7 +16480,7 @@ part parent ".xmega"
 # ATxmega16A4U
 #------------------------------------------------------------
 
-part parent ".xmega-a"
+part parent ".xmega-a" # x16a4u
     desc                   = "ATxmega16A4U";
     id                     = "x16a4u";
     variants               =
@@ -16555,7 +16555,7 @@ part parent ".xmega-a"
 # ATxmega16C4
 #------------------------------------------------------------
 
-part parent "x16a4u"
+part parent "x16a4u" # x16c4
     desc                   = "ATxmega16C4";
     id                     = "x16c4";
     variants               =
@@ -16588,7 +16588,7 @@ part parent "x16a4u"
 # ATxmega16D4
 #------------------------------------------------------------
 
-part parent "x16a4u"
+part parent "x16a4u" # x16d4
     desc                   = "ATxmega16D4";
     id                     = "x16d4";
     variants               =
@@ -16617,7 +16617,7 @@ part parent "x16a4u"
 # ATxmega16A4
 #------------------------------------------------------------
 
-part parent "x16a4u"
+part parent "x16a4u" # x16a4
     desc                   = "ATxmega16A4";
     id                     = "x16a4";
     variants               =
@@ -16641,7 +16641,7 @@ part parent "x16a4u"
 # ATxmega32A4U
 #------------------------------------------------------------
 
-part parent ".xmega-a"
+part parent ".xmega-a" # x32a4u
     desc                   = "ATxmega32A4U";
     id                     = "x32a4u";
     variants               =
@@ -16716,7 +16716,7 @@ part parent ".xmega-a"
 # ATxmega32C4
 #------------------------------------------------------------
 
-part parent "x32a4u"
+part parent "x32a4u" # x32c4
     desc                   = "ATxmega32C4";
     id                     = "x32c4";
     variants               =
@@ -16749,7 +16749,7 @@ part parent "x32a4u"
 # ATxmega32D4
 #------------------------------------------------------------
 
-part parent "x32a4u"
+part parent "x32a4u" # x32d4
     desc                   = "ATxmega32D4";
     id                     = "x32d4";
     variants               =
@@ -16779,7 +16779,7 @@ part parent "x32a4u"
 # ATxmega32A4
 #------------------------------------------------------------
 
-part parent "x32a4u"
+part parent "x32a4u" # x32a4
     desc                   = "ATxmega32A4";
     id                     = "x32a4";
     variants               =
@@ -16803,7 +16803,7 @@ part parent "x32a4u"
 # ATxmega64A4U
 #------------------------------------------------------------
 
-part parent ".xmega-a"
+part parent ".xmega-a" # x64a4u
     desc                   = "ATxmega64A4U";
     id                     = "x64a4u";
     variants               =
@@ -16878,7 +16878,7 @@ part parent ".xmega-a"
 # ATxmega32C3
 #------------------------------------------------------------
 
-part parent "x32a4u"
+part parent "x32a4u" # x32c3
     desc                   = "ATxmega32C3";
     id                     = "x32c3";
     variants               =
@@ -16910,7 +16910,7 @@ part parent "x32a4u"
 # ATxmega32D3
 #------------------------------------------------------------
 
-part parent "x32a4u"
+part parent "x32a4u" # x32d3
     desc                   = "ATxmega32D3";
     id                     = "x32d3";
     variants               =
@@ -16937,7 +16937,7 @@ part parent "x32a4u"
 # ATxmega64C3
 #------------------------------------------------------------
 
-part parent "x64a4u"
+part parent "x64a4u" # x64c3
     desc                   = "ATxmega64C3";
     id                     = "x64c3";
     variants               =
@@ -16964,7 +16964,7 @@ part parent "x64a4u"
 # ATxmega64D3
 #------------------------------------------------------------
 
-part parent "x64a4u"
+part parent "x64a4u" # x64d3
     desc                   = "ATxmega64D3";
     id                     = "x64d3";
     variants               =
@@ -16998,7 +16998,7 @@ part parent "x64a4u"
 # ATxmega64D4
 #------------------------------------------------------------
 
-part parent "x64a4u"
+part parent "x64a4u" # x64d4
     desc                   = "ATxmega64D4";
     id                     = "x64d4";
     variants               =
@@ -17026,7 +17026,7 @@ part parent "x64a4u"
 # ATxmega64A1
 #------------------------------------------------------------
 
-part parent "x64a4u"
+part parent "x64a4u" # x64a1
     desc                   = "ATxmega64A1";
     id                     = "x64a1";
     variants               =
@@ -17057,7 +17057,7 @@ part parent "x64a4u"
 # ATxmega64A1U
 #------------------------------------------------------------
 
-part parent "x64a1"
+part parent "x64a1" # x64a1u
     desc                   = "ATxmega64A1U";
     id                     = "x64a1u";
     variants               =
@@ -17087,7 +17087,7 @@ part parent "x64a1"
 # ATxmega64A3
 #------------------------------------------------------------
 
-part parent "x64a1"
+part parent "x64a1" # x64a3
     desc                   = "ATxmega64A3";
     id                     = "x64a3";
     variants               =
@@ -17106,7 +17106,7 @@ part parent "x64a1"
 # ATxmega64A3U
 #------------------------------------------------------------
 
-part parent "x64a1"
+part parent "x64a1" # x64a3u
     desc                   = "ATxmega64A3U";
     id                     = "x64a3u";
     variants               =
@@ -17129,7 +17129,7 @@ part parent "x64a1"
 # ATxmega64A4
 #------------------------------------------------------------
 
-part parent "x64a1"
+part parent "x64a1" # x64a4
     desc                   = "ATxmega64A4";
     id                     = "x64a4";
     variants               =
@@ -17169,7 +17169,7 @@ part parent "x64a1"
 # ATxmega64B1
 #------------------------------------------------------------
 
-part parent "x64a1"
+part parent "x64a1" # x64b1
     desc                   = "ATxmega64B1";
     id                     = "x64b1";
     variants               =
@@ -17195,7 +17195,7 @@ part parent "x64a1"
 # ATxmega64B3
 #------------------------------------------------------------
 
-part parent "x64a1"
+part parent "x64a1" # x64b3
     desc                   = "ATxmega64B3";
     id                     = "x64b3";
     variants               =
@@ -17220,7 +17220,7 @@ part parent "x64a1"
 # ATxmega128C3
 #------------------------------------------------------------
 
-part parent ".xmega"
+part parent ".xmega" # x128c3
     desc                   = "ATxmega128C3";
     id                     = "x128c3";
     variants               =
@@ -17289,7 +17289,7 @@ part parent ".xmega"
 # ATxmega128D3
 #------------------------------------------------------------
 
-part parent "x128c3"
+part parent "x128c3" # x128d3
     desc                   = "ATxmega128D3";
     id                     = "x128d3";
     variants               =
@@ -17315,7 +17315,7 @@ part parent "x128c3"
 # ATxmega128D4
 #------------------------------------------------------------
 
-part parent "x128c3"
+part parent "x128c3" # x128d4
     desc                   = "ATxmega128D4";
     id                     = "x128d4";
     variants               =
@@ -17340,7 +17340,7 @@ part parent "x128c3"
 # ATxmega128A1
 #------------------------------------------------------------
 
-part parent "x128c3"
+part parent "x128c3" # x128a1
     desc                   = "ATxmega128A1";
     id                     = "x128a1";
     variants               =
@@ -17382,7 +17382,7 @@ part parent "x128c3"
 # ATxmega128A1 revision D
 #------------------------------------------------------------
 
-part parent "x128a1"
+part parent "x128a1" # x128a1d
     desc                   = "ATxmega128A1revD";
     id                     = "x128a1d";
     mcuid                  = 255;
@@ -17393,7 +17393,7 @@ part parent "x128a1"
 # ATxmega128A1U
 #------------------------------------------------------------
 
-part parent "x128a1"
+part parent "x128a1" # x128a1u
     desc                   = "ATxmega128A1U";
     id                     = "x128a1u";
     variants               =
@@ -17424,7 +17424,7 @@ part parent "x128a1"
 # ATxmega128A3
 #------------------------------------------------------------
 
-part parent "x128a1"
+part parent "x128a1" # x128a3
     desc                   = "ATxmega128A3";
     id                     = "x128a3";
     variants               =
@@ -17443,7 +17443,7 @@ part parent "x128a1"
 # ATxmega128A3U
 #------------------------------------------------------------
 
-part parent "x128a1"
+part parent "x128a1" # x128a3u
     desc                   = "ATxmega128A3U";
     id                     = "x128a3u";
     variants               =
@@ -17467,7 +17467,7 @@ part parent "x128a1"
 # ATxmega128A4
 #------------------------------------------------------------
 
-part parent ".xmega"
+part parent ".xmega" # x128a4
     desc                   = "ATxmega128A4";
     id                     = "x128a4";
     variants               =
@@ -17551,7 +17551,7 @@ part parent ".xmega"
 # ATxmega128A4U
 #------------------------------------------------------------
 
-part parent ".xmega-a"
+part parent ".xmega-a" # x128a4u
     desc                   = "ATxmega128A4U";
     id                     = "x128a4u";
     variants               =
@@ -17625,7 +17625,7 @@ part parent ".xmega-a"
 # ATxmega128B1
 #------------------------------------------------------------
 
-part parent ".xmega"
+part parent ".xmega" # x128b1
     desc                   = "ATxmega128B1";
     id                     = "x128b1";
     variants               =
@@ -17703,7 +17703,7 @@ part parent ".xmega"
 # ATxmega128B3
 #------------------------------------------------------------
 
-part parent "x128b1"
+part parent "x128b1" # x128b3
     desc                   = "ATxmega128B3";
     id                     = "x128b3";
     variants               =
@@ -17723,7 +17723,7 @@ part parent "x128b1"
 # ATxmega192C3
 #------------------------------------------------------------
 
-part parent ".xmega"
+part parent ".xmega" # x192c3
     desc                   = "ATxmega192C3";
     id                     = "x192c3";
     variants               =
@@ -17791,7 +17791,7 @@ part parent ".xmega"
 # ATxmega192D3
 #------------------------------------------------------------
 
-part parent "x192c3"
+part parent "x192c3" # x192d3
     desc                   = "ATxmega192D3";
     id                     = "x192d3";
     variants               =
@@ -17817,7 +17817,7 @@ part parent "x192c3"
 # ATxmega192A1
 #------------------------------------------------------------
 
-part parent "x192c3"
+part parent "x192c3" # x192a1
     desc                   = "ATxmega192A1";
     id                     = "x192a1";
     variants               =
@@ -17860,7 +17860,7 @@ part parent "x192c3"
 # ATxmega192A3
 #------------------------------------------------------------
 
-part parent "x192c3"
+part parent "x192c3" # x192a3
     desc                   = "ATxmega192A3";
     id                     = "x192a3";
     variants               =
@@ -17901,7 +17901,7 @@ part parent "x192c3"
 # ATxmega192A3U
 #------------------------------------------------------------
 
-part parent "x192a1"
+part parent "x192a1" # x192a3u
     desc                   = "ATxmega192A3U";
     id                     = "x192a3u";
     variants               =
@@ -17954,7 +17954,7 @@ part parent "x192a1"
 # ATxmega256C3
 #------------------------------------------------------------
 
-part parent ".xmega"
+part parent ".xmega" # x256c3
     desc                   = "ATxmega256C3";
     id                     = "x256c3";
     variants               =
@@ -18023,7 +18023,7 @@ part parent ".xmega"
 # ATxmega256D3
 #------------------------------------------------------------
 
-part parent "x256c3"
+part parent "x256c3" # x256d3
     desc                   = "ATxmega256D3";
     id                     = "x256d3";
     variants               =
@@ -18049,7 +18049,7 @@ part parent "x256c3"
 # ATxmega256A1
 #------------------------------------------------------------
 
-part parent "x256c3"
+part parent "x256c3" # x256a1
     desc                   = "ATxmega256A1";
     id                     = "x256a1";
     variants               =
@@ -18091,7 +18091,7 @@ part parent "x256c3"
 # ATxmega256A3
 #------------------------------------------------------------
 
-part parent "x256a1"
+part parent "x256a1" # x256a3
     desc                   = "ATxmega256A3";
     id                     = "x256a3";
     variants               =
@@ -18143,7 +18143,7 @@ part parent "x256a1"
 # ATxmega256A3U
 #------------------------------------------------------------
 
-part parent "x256a1"
+part parent "x256a1" # x256a3u
     desc                   = "ATxmega256A3U";
     id                     = "x256a3u";
     variants               =
@@ -18196,7 +18196,7 @@ part parent "x256a1"
 # ATxmega256A3B
 #------------------------------------------------------------
 
-part parent "x256a1"
+part parent "x256a1" # x256a3b
     desc                   = "ATxmega256A3B";
     id                     = "x256a3b";
     variants               =
@@ -18247,7 +18247,7 @@ part parent "x256a1"
 # ATxmega256A3BU
 #------------------------------------------------------------
 
-part parent "x256a1"
+part parent "x256a1" # x256a3bu
     desc                   = "ATxmega256A3BU";
     id                     = "x256a3bu";
     variants               =
@@ -18297,7 +18297,7 @@ part parent "x256a1"
 # ATxmega384C3
 #------------------------------------------------------------
 
-part parent ".xmega"
+part parent ".xmega" # x384c3
     desc                   = "ATxmega384C3";
     id                     = "x384c3";
     variants               =
@@ -18366,7 +18366,7 @@ part parent ".xmega"
 # ATxmega384D3
 #------------------------------------------------------------
 
-part parent "x384c3"
+part parent "x384c3" # x384d3
     desc                   = "ATxmega384D3";
     id                     = "x384d3";
     variants               =
@@ -18384,7 +18384,7 @@ part parent "x384c3"
 # ATxmega8E5
 #------------------------------------------------------------
 
-part parent ".xmega-e"
+part parent ".xmega-e" # x8e5
     desc                   = "ATxmega8E5";
     id                     = "x8e5";
     variants               =
@@ -18460,7 +18460,7 @@ part parent ".xmega-e"
 # ATxmega16E5
 #------------------------------------------------------------
 
-part parent ".xmega-e"
+part parent ".xmega-e" # x16e5
     desc                   = "ATxmega16E5";
     id                     = "x16e5";
     variants               =
@@ -18536,7 +18536,7 @@ part parent ".xmega-e"
 # ATxmega32E5
 #------------------------------------------------------------
 
-part parent ".xmega-e"
+part parent ".xmega-e" # x32e5
     desc                   = "ATxmega32E5";
     id                     = "x32e5";
     variants               =
@@ -18612,7 +18612,7 @@ part parent ".xmega-e"
 # AVR32UC3A0512
 #------------------------------------------------------------
 
-part
+part # uc3a0512
     desc                   = "AT32UC3A0512";
     id                     = "uc3a0512";
     variants               =
@@ -18643,7 +18643,7 @@ part
 # deprecated, use 'uc3a0512'
 #------------------------------------------------------------
 
-part parent "uc3a0512"
+part parent "uc3a0512" # ucr2
     desc                   = "deprecated, use 'uc3a0512'";
     id                     = "ucr2";
 ;
@@ -18652,7 +18652,7 @@ part parent "uc3a0512"
 # ATtiny1634
 #------------------------------------------------------------
 
-part
+part # t1634
     desc                   = "ATtiny1634";
     id                     = "t1634";
     variants               =
@@ -18802,7 +18802,7 @@ part
 # ATtiny1634R
 #------------------------------------------------------------
 
-part parent "t1634"
+part parent "t1634" # t1634r
     desc                   = "ATtiny1634R";
     id                     = "t1634r";
     variants               =
@@ -18817,7 +18817,7 @@ part parent "t1634"
 # Common values for reduced core tinys (4/5/9/10/20/40)
 #------------------------------------------------------------
 
-part
+part # .reduced_core_tiny
     desc                   = "Common values for reduced core tinys";
     id                     = ".reduced_core_tiny";
     prog_modes             = PM_TPI;
@@ -18856,7 +18856,7 @@ part
 # ATtiny4
 #------------------------------------------------------------
 
-part parent ".reduced_core_tiny"
+part parent ".reduced_core_tiny" # t4
     desc                   = "ATtiny4";
     id                     = "t4";
     variants               =
@@ -18883,7 +18883,7 @@ part parent ".reduced_core_tiny"
 # ATtiny5
 #------------------------------------------------------------
 
-part parent "t4"
+part parent "t4" # t5
     desc                   = "ATtiny5";
     id                     = "t5";
     variants               =
@@ -18899,7 +18899,7 @@ part parent "t4"
 # ATtiny9
 #------------------------------------------------------------
 
-part parent ".reduced_core_tiny"
+part parent ".reduced_core_tiny" # t9
     desc                   = "ATtiny9";
     id                     = "t9";
     variants               =
@@ -18926,7 +18926,7 @@ part parent ".reduced_core_tiny"
 # ATtiny10
 #------------------------------------------------------------
 
-part parent "t9"
+part parent "t9" # t10
     desc                   = "ATtiny10";
     id                     = "t10";
     variants               =
@@ -18942,7 +18942,7 @@ part parent "t9"
 # ATtiny20
 #------------------------------------------------------------
 
-part parent ".reduced_core_tiny"
+part parent ".reduced_core_tiny" # t20
     desc                   = "ATtiny20";
     id                     = "t20";
     variants               =
@@ -18981,7 +18981,7 @@ part parent ".reduced_core_tiny"
 # ATtiny40
 #------------------------------------------------------------
 
-part parent ".reduced_core_tiny"
+part parent ".reduced_core_tiny" # t40
     desc                   = "ATtiny40";
     id                     = "t40";
     variants               =
@@ -19017,7 +19017,7 @@ part parent ".reduced_core_tiny"
 # ATtiny102
 #------------------------------------------------------------
 
-part parent ".reduced_core_tiny"
+part parent ".reduced_core_tiny" # t102
     desc                   = "ATtiny102";
     id                     = "t102";
     variants               =
@@ -19044,10 +19044,6 @@ part parent ".reduced_core_tiny"
         bitmask            = 0x0f;
     ;
 
-    memory "io"
-        size               = 64;
-    ;
-
     memory "prodsig"
         size               = 16;
         page_size          = 16;
@@ -19057,13 +19053,17 @@ part parent ".reduced_core_tiny"
     memory "sigrow"
         alias "prodsig";
     ;
+
+    memory "io"
+        size               = 64;
+    ;
 ;
 
 #------------------------------------------------------------
 # ATtiny104
 #------------------------------------------------------------
 
-part parent ".reduced_core_tiny"
+part parent ".reduced_core_tiny" # t104
     desc                   = "ATtiny104";
     id                     = "t104";
     variants               =
@@ -19086,10 +19086,6 @@ part parent ".reduced_core_tiny"
         bitmask            = 0x0f;
     ;
 
-    memory "io"
-        size               = 64;
-    ;
-
     memory "prodsig"
         size               = 16;
         page_size          = 16;
@@ -19099,13 +19095,17 @@ part parent ".reduced_core_tiny"
     memory "sigrow"
         alias "prodsig";
     ;
+
+    memory "io"
+        size               = 64;
+    ;
 ;
 
 #------------------------------------------------------------
 # ATmega406
 #------------------------------------------------------------
 
-part
+part # m406
     desc                   = "ATmega406";
     id                     = "m406";
     variants               =
@@ -19188,7 +19188,7 @@ part
 # AVR8X family common values
 #------------------------------------------------------------
 
-part
+part # .avr8x
     desc                   = "AVR8X family common values";
     id                     = ".avr8x";
     prog_modes             = PM_SPM | PM_UPDI;
@@ -19372,7 +19372,7 @@ part
 # AVR8X tiny family common values
 #------------------------------------------------------------
 
-part parent ".avr8x"
+part parent ".avr8x" # .avr8x_tiny
     desc                   = "AVR8X tiny family common values";
     id                     = ".avr8x_tiny";
     family_id              = "tinyAVR";
@@ -19395,7 +19395,7 @@ part parent ".avr8x"
 # AVR8X mega family common values
 #------------------------------------------------------------
 
-part parent ".avr8x"
+part parent ".avr8x" # .avr8x_mega
     desc                   = "AVR8X mega family common values";
     id                     = ".avr8x_mega";
     family_id              = "megaAVR";
@@ -19422,7 +19422,7 @@ part parent ".avr8x"
 # ATtiny202
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t202
     desc                   = "ATtiny202";
     id                     = "t202";
     variants               =
@@ -19468,7 +19468,7 @@ part parent ".avr8x_tiny"
 # ATtiny204
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t204
     desc                   = "ATtiny204";
     id                     = "t204";
     variants               =
@@ -19514,7 +19514,7 @@ part parent ".avr8x_tiny"
 # ATtiny402
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t402
     desc                   = "ATtiny402";
     id                     = "t402";
     variants               =
@@ -19560,7 +19560,7 @@ part parent ".avr8x_tiny"
 # ATtiny404
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t404
     desc                   = "ATtiny404";
     id                     = "t404";
     variants               =
@@ -19606,7 +19606,7 @@ part parent ".avr8x_tiny"
 # ATtiny406
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t406
     desc                   = "ATtiny406";
     id                     = "t406";
     variants               =
@@ -19654,7 +19654,7 @@ part parent ".avr8x_tiny"
 # ATtiny804
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t804
     desc                   = "ATtiny804";
     id                     = "t804";
     variants               =
@@ -19689,7 +19689,7 @@ part parent ".avr8x_tiny"
 # ATtiny806
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t806
     desc                   = "ATtiny806";
     id                     = "t806";
     variants               =
@@ -19728,7 +19728,7 @@ part parent ".avr8x_tiny"
 # ATtiny807
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t807
     desc                   = "ATtiny807";
     id                     = "t807";
     variants               =
@@ -19764,7 +19764,7 @@ part parent ".avr8x_tiny"
 # ATtiny1604
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1604
     desc                   = "ATtiny1604";
     id                     = "t1604";
     variants               =
@@ -19799,7 +19799,7 @@ part parent ".avr8x_tiny"
 # ATtiny1606
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1606
     desc                   = "ATtiny1606";
     id                     = "t1606";
     variants               =
@@ -19838,7 +19838,7 @@ part parent ".avr8x_tiny"
 # ATtiny1607
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1607
     desc                   = "ATtiny1607";
     id                     = "t1607";
     variants               =
@@ -19874,7 +19874,7 @@ part parent ".avr8x_tiny"
 # ATtiny212
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t212
     desc                   = "ATtiny212";
     id                     = "t212";
     variants               =
@@ -19920,7 +19920,7 @@ part parent ".avr8x_tiny"
 # ATtiny214
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t214
     desc                   = "ATtiny214";
     id                     = "t214";
     variants               =
@@ -19966,7 +19966,7 @@ part parent ".avr8x_tiny"
 # ATtiny412
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t412
     desc                   = "ATtiny412";
     id                     = "t412";
     variants               =
@@ -20012,7 +20012,7 @@ part parent ".avr8x_tiny"
 # ATtiny414
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t414
     desc                   = "ATtiny414";
     id                     = "t414";
     variants               =
@@ -20058,7 +20058,7 @@ part parent ".avr8x_tiny"
 # ATtiny416
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t416
     desc                   = "ATtiny416";
     id                     = "t416";
     variants               =
@@ -20106,7 +20106,7 @@ part parent ".avr8x_tiny"
 # ATtiny416auto
 #------------------------------------------------------------
 
-part parent "t416"
+part parent "t416" # t416auto
     desc                   = "ATtiny416auto";
     id                     = "t416auto";
     variants               =
@@ -20124,7 +20124,7 @@ part parent "t416"
 # ATtiny417
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t417
     desc                   = "ATtiny417";
     id                     = "t417";
     variants               =
@@ -20170,7 +20170,7 @@ part parent ".avr8x_tiny"
 # ATtiny814
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t814
     desc                   = "ATtiny814";
     id                     = "t814";
     variants               =
@@ -20217,7 +20217,7 @@ part parent ".avr8x_tiny"
 # ATtiny816
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t816
     desc                   = "ATtiny816";
     id                     = "t816";
     variants               =
@@ -20268,7 +20268,7 @@ part parent ".avr8x_tiny"
 # ATtiny817
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t817
     desc                   = "ATtiny817";
     id                     = "t817";
     variants               =
@@ -20315,7 +20315,7 @@ part parent ".avr8x_tiny"
 # ATtiny1614
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1614
     desc                   = "ATtiny1614";
     id                     = "t1614";
     variants               =
@@ -20361,7 +20361,7 @@ part parent ".avr8x_tiny"
 # ATtiny1616
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1616
     desc                   = "ATtiny1616";
     id                     = "t1616";
     variants               =
@@ -20409,7 +20409,7 @@ part parent ".avr8x_tiny"
 # ATtiny1617
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1617
     desc                   = "ATtiny1617";
     id                     = "t1617";
     variants               =
@@ -20455,7 +20455,7 @@ part parent ".avr8x_tiny"
 # ATtiny3216
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t3216
     desc                   = "ATtiny3216";
     id                     = "t3216";
     variants               =
@@ -20506,7 +20506,7 @@ part parent ".avr8x_tiny"
 # ATtiny3217
 #------------------------------------------------------------
 
-part parent "t3216"
+part parent "t3216" # t3217
     desc                   = "ATtiny3217";
     id                     = "t3217";
     variants               =
@@ -20522,7 +20522,7 @@ part parent "t3216"
 # ATtiny424
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t424
     desc                   = "ATtiny424";
     id                     = "t424";
     variants               =
@@ -20566,7 +20566,7 @@ part parent ".avr8x_tiny"
 # ATtiny426
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t426
     desc                   = "ATtiny426";
     id                     = "t426";
     variants               =
@@ -20614,7 +20614,7 @@ part parent ".avr8x_tiny"
 # ATtiny427
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t427
     desc                   = "ATtiny427";
     id                     = "t427";
     variants               =
@@ -20654,7 +20654,7 @@ part parent ".avr8x_tiny"
 # ATtiny824
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t824
     desc                   = "ATtiny824";
     id                     = "t824";
     variants               =
@@ -20698,7 +20698,7 @@ part parent ".avr8x_tiny"
 # ATtiny826
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t826
     desc                   = "ATtiny826";
     id                     = "t826";
     variants               =
@@ -20746,7 +20746,7 @@ part parent ".avr8x_tiny"
 # ATtiny827
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t827
     desc                   = "ATtiny827";
     id                     = "t827";
     variants               =
@@ -20786,7 +20786,7 @@ part parent ".avr8x_tiny"
 # ATtiny1624
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1624
     desc                   = "ATtiny1624";
     id                     = "t1624";
     variants               =
@@ -20830,7 +20830,7 @@ part parent ".avr8x_tiny"
 # ATtiny1626
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1626
     desc                   = "ATtiny1626";
     id                     = "t1626";
     variants               =
@@ -20878,7 +20878,7 @@ part parent ".avr8x_tiny"
 # ATtiny1627
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t1627
     desc                   = "ATtiny1627";
     id                     = "t1627";
     variants               =
@@ -20918,7 +20918,7 @@ part parent ".avr8x_tiny"
 # ATtiny3224
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t3224
     desc                   = "ATtiny3224";
     id                     = "t3224";
     variants               =
@@ -20962,7 +20962,7 @@ part parent ".avr8x_tiny"
 # ATtiny3226
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t3226
     desc                   = "ATtiny3226";
     id                     = "t3226";
     variants               =
@@ -21010,7 +21010,7 @@ part parent ".avr8x_tiny"
 # ATtiny3227
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # t3227
     desc                   = "ATtiny3227";
     id                     = "t3227";
     variants               =
@@ -21050,7 +21050,7 @@ part parent ".avr8x_tiny"
 # ATmega808
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # m808
     desc                   = "ATmega808";
     id                     = "m808";
     variants               =
@@ -21097,7 +21097,7 @@ part parent ".avr8x_tiny"
 # ATmega809
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # m809
     desc                   = "ATmega809";
     id                     = "m809";
     variants               =
@@ -21140,7 +21140,7 @@ part parent ".avr8x_tiny"
 # ATmega1608
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # m1608
     desc                   = "ATmega1608";
     id                     = "m1608";
     variants               =
@@ -21187,7 +21187,7 @@ part parent ".avr8x_tiny"
 # ATmega1609
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny"
+part parent ".avr8x_tiny" # m1609
     desc                   = "ATmega1609";
     id                     = "m1609";
     variants               =
@@ -21230,7 +21230,7 @@ part parent ".avr8x_tiny"
 # ATmega3208
 #------------------------------------------------------------
 
-part parent ".avr8x_mega"
+part parent ".avr8x_mega" # m3208
     desc                   = "ATmega3208";
     id                     = "m3208";
     variants               =
@@ -21279,7 +21279,7 @@ part parent ".avr8x_mega"
 # ATmega3209
 #------------------------------------------------------------
 
-part parent ".avr8x_mega"
+part parent ".avr8x_mega" # m3209
     desc                   = "ATmega3209";
     id                     = "m3209";
     variants               =
@@ -21324,7 +21324,7 @@ part parent ".avr8x_mega"
 # ATmega4808
 #------------------------------------------------------------
 
-part parent ".avr8x_mega"
+part parent ".avr8x_mega" # m4808
     desc                   = "ATmega4808";
     id                     = "m4808";
     variants               =
@@ -21373,7 +21373,7 @@ part parent ".avr8x_mega"
 # ATmega4809
 #------------------------------------------------------------
 
-part parent ".avr8x_mega"
+part parent ".avr8x_mega" # m4809
     desc                   = "ATmega4809";
     id                     = "m4809";
     variants               =
@@ -21419,7 +21419,7 @@ part parent ".avr8x_mega"
 # AVR-Dx family common values
 #------------------------------------------------------------
 
-part
+part # .avrdx
     desc                   = "AVR-Dx family common values";
     id                     = ".avrdx";
     family_id              = "AVR    ";
@@ -21593,7 +21593,7 @@ part
 # AVR32DA28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32da28
     desc                   = "AVR32DA28";
     id                     = "avr32da28";
     variants               =
@@ -21640,7 +21640,7 @@ part parent ".avrdx"
 # AVR32DA32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32da32
     desc                   = "AVR32DA32";
     id                     = "avr32da32";
     variants               =
@@ -21685,7 +21685,7 @@ part parent ".avrdx"
 # AVR32DA48
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32da48
     desc                   = "AVR32DA48";
     id                     = "avr32da48";
     variants               =
@@ -21730,7 +21730,7 @@ part parent ".avrdx"
 # AVR64DA28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64da28
     desc                   = "AVR64DA28";
     id                     = "avr64da28";
     variants               =
@@ -21777,7 +21777,7 @@ part parent ".avrdx"
 # AVR64DA32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64da32
     desc                   = "AVR64DA32";
     id                     = "avr64da32";
     variants               =
@@ -21822,7 +21822,7 @@ part parent ".avrdx"
 # AVR64DA48
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64da48
     desc                   = "AVR64DA48";
     id                     = "avr64da48";
     variants               =
@@ -21867,7 +21867,7 @@ part parent ".avrdx"
 # AVR64DA64
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64da64
     desc                   = "AVR64DA64";
     id                     = "avr64da64";
     variants               =
@@ -21912,7 +21912,7 @@ part parent ".avrdx"
 # AVR128DA28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128da28
     desc                   = "AVR128DA28";
     id                     = "avr128da28";
     variants               =
@@ -21959,7 +21959,7 @@ part parent ".avrdx"
 # AVR128DA32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128da32
     desc                   = "AVR128DA32";
     id                     = "avr128da32";
     variants               =
@@ -22004,7 +22004,7 @@ part parent ".avrdx"
 # AVR128DA48
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128da48
     desc                   = "AVR128DA48";
     id                     = "avr128da48";
     variants               =
@@ -22049,7 +22049,7 @@ part parent ".avrdx"
 # AVR128DA64
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128da64
     desc                   = "AVR128DA64";
     id                     = "avr128da64";
     variants               =
@@ -22094,7 +22094,7 @@ part parent ".avrdx"
 # AVR32DB28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32db28
     desc                   = "AVR32DB28";
     id                     = "avr32db28";
     variants               =
@@ -22135,7 +22135,7 @@ part parent ".avrdx"
 # AVR32DB32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32db32
     desc                   = "AVR32DB32";
     id                     = "avr32db32";
     variants               =
@@ -22174,7 +22174,7 @@ part parent ".avrdx"
 # AVR32DB48
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32db48
     desc                   = "AVR32DB48";
     id                     = "avr32db48";
     variants               =
@@ -22213,7 +22213,7 @@ part parent ".avrdx"
 # AVR64DB28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64db28
     desc                   = "AVR64DB28";
     id                     = "avr64db28";
     variants               =
@@ -22254,7 +22254,7 @@ part parent ".avrdx"
 # AVR64DB32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64db32
     desc                   = "AVR64DB32";
     id                     = "avr64db32";
     variants               =
@@ -22293,7 +22293,7 @@ part parent ".avrdx"
 # AVR64DB48
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64db48
     desc                   = "AVR64DB48";
     id                     = "avr64db48";
     variants               =
@@ -22332,7 +22332,7 @@ part parent ".avrdx"
 # AVR64DB64
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64db64
     desc                   = "AVR64DB64";
     id                     = "avr64db64";
     variants               =
@@ -22371,7 +22371,7 @@ part parent ".avrdx"
 # AVR128DB28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128db28
     desc                   = "AVR128DB28";
     id                     = "avr128db28";
     variants               =
@@ -22412,7 +22412,7 @@ part parent ".avrdx"
 # AVR128DB32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128db32
     desc                   = "AVR128DB32";
     id                     = "avr128db32";
     variants               =
@@ -22451,7 +22451,7 @@ part parent ".avrdx"
 # AVR128DB48
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128db48
     desc                   = "AVR128DB48";
     id                     = "avr128db48";
     variants               =
@@ -22490,7 +22490,7 @@ part parent ".avrdx"
 # AVR128DB64
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr128db64
     desc                   = "AVR128DB64";
     id                     = "avr128db64";
     variants               =
@@ -22529,7 +22529,7 @@ part parent ".avrdx"
 # AVR16DD14
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr16dd14
     desc                   = "AVR16DD14";
     id                     = "avr16dd14";
     variants               =
@@ -22567,7 +22567,7 @@ part parent ".avrdx"
 # AVR16DD20
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr16dd20
     desc                   = "AVR16DD20";
     id                     = "avr16dd20";
     variants               =
@@ -22606,7 +22606,7 @@ part parent ".avrdx"
 # AVR16DD28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr16dd28
     desc                   = "AVR16DD28";
     id                     = "avr16dd28";
     variants               =
@@ -22647,7 +22647,7 @@ part parent ".avrdx"
 # AVR16DD32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr16dd32
     desc                   = "AVR16DD32";
     id                     = "avr16dd32";
     variants               =
@@ -22686,7 +22686,7 @@ part parent ".avrdx"
 # AVR32DD14
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32dd14
     desc                   = "AVR32DD14";
     id                     = "avr32dd14";
     variants               =
@@ -22724,7 +22724,7 @@ part parent ".avrdx"
 # AVR32DD20
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32dd20
     desc                   = "AVR32DD20";
     id                     = "avr32dd20";
     variants               =
@@ -22763,7 +22763,7 @@ part parent ".avrdx"
 # AVR32DD28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32dd28
     desc                   = "AVR32DD28";
     id                     = "avr32dd28";
     variants               =
@@ -22804,7 +22804,7 @@ part parent ".avrdx"
 # AVR32DD32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr32dd32
     desc                   = "AVR32DD32";
     id                     = "avr32dd32";
     variants               =
@@ -22843,7 +22843,7 @@ part parent ".avrdx"
 # AVR64DD14
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64dd14
     desc                   = "AVR64DD14";
     id                     = "avr64dd14";
     variants               =
@@ -22881,7 +22881,7 @@ part parent ".avrdx"
 # AVR64DD20
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64dd20
     desc                   = "AVR64DD20";
     id                     = "avr64dd20";
     variants               =
@@ -22919,7 +22919,7 @@ part parent ".avrdx"
 # AVR64DD28
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64dd28
     desc                   = "AVR64DD28";
     id                     = "avr64dd28";
     variants               =
@@ -22960,7 +22960,7 @@ part parent ".avrdx"
 # AVR64DD32
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # avr64dd32
     desc                   = "AVR64DD32";
     id                     = "avr64dd32";
     variants               =
@@ -22999,7 +22999,7 @@ part parent ".avrdx"
 # AVR-Ex family common values
 #------------------------------------------------------------
 
-part parent ".avrdx"
+part parent ".avrdx" # .avrex
     desc                   = "AVR-Ex family common values";
     id                     = ".avrex";
     # Shared UPDI pin, HV on _RESET
@@ -23030,7 +23030,7 @@ part parent ".avrdx"
 # AVR8EA28
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr8ea28
     desc                   = "AVR8EA28";
     id                     = "avr8ea28";
     mcuid                  = 327;
@@ -23086,7 +23086,7 @@ part parent ".avrex"
 # AVR8EA32
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr8ea32
     desc                   = "AVR8EA32";
     id                     = "avr8ea32";
     mcuid                  = 328;
@@ -23142,7 +23142,7 @@ part parent ".avrex"
 # AVR16EA28
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr16ea28
     desc                   = "AVR16EA28";
     id                     = "avr16ea28";
     variants               =
@@ -23173,7 +23173,7 @@ part parent ".avrex"
 # AVR16EA32
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr16ea32
     desc                   = "AVR16EA32";
     id                     = "avr16ea32";
     variants               =
@@ -23204,7 +23204,7 @@ part parent ".avrex"
 # AVR16EA48
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr16ea48
     desc                   = "AVR16EA48";
     id                     = "avr16ea48";
     variants               =
@@ -23235,7 +23235,7 @@ part parent ".avrex"
 # AVR32EA28
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr32ea28
     desc                   = "AVR32EA28";
     id                     = "avr32ea28";
     variants               =
@@ -23266,7 +23266,7 @@ part parent ".avrex"
 # AVR32EA32
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr32ea32
     desc                   = "AVR32EA32";
     id                     = "avr32ea32";
     variants               =
@@ -23297,7 +23297,7 @@ part parent ".avrex"
 # AVR32EA48
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr32ea48
     desc                   = "AVR32EA48";
     id                     = "avr32ea48";
     variants               =
@@ -23328,7 +23328,7 @@ part parent ".avrex"
 # AVR64EA28
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr64ea28
     desc                   = "AVR64EA28";
     id                     = "avr64ea28";
     variants               =
@@ -23362,7 +23362,7 @@ part parent ".avrex"
 # AVR64EA32
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr64ea32
     desc                   = "AVR64EA32";
     id                     = "avr64ea32";
     variants               =
@@ -23396,7 +23396,7 @@ part parent ".avrex"
 # AVR64EA48
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr64ea48
     desc                   = "AVR64EA48";
     id                     = "avr64ea48";
     variants               =
@@ -23430,7 +23430,7 @@ part parent ".avrex"
 # AVR16EB14
 #------------------------------------------------------------
 
-part parent ".avrex"
+part parent ".avrex" # avr16eb14
     desc                   = "AVR16EB14";
     id                     = "avr16eb14";
     variants               =
@@ -23484,7 +23484,7 @@ part parent ".avrex"
 # AVR16EB20
 #------------------------------------------------------------
 
-part parent "avr16eb14"
+part parent "avr16eb14" # avr16eb20
     desc                   = "AVR16EB20";
     id                     = "avr16eb20";
     variants               =
@@ -23498,7 +23498,7 @@ part parent "avr16eb14"
 # AVR16EB28
 #------------------------------------------------------------
 
-part parent "avr16eb14"
+part parent "avr16eb14" # avr16eb28
     desc                   = "AVR16EB28";
     id                     = "avr16eb28";
     variants               =
@@ -23512,7 +23512,7 @@ part parent "avr16eb14"
 # AVR16EB32
 #------------------------------------------------------------
 
-part parent "avr16eb14"
+part parent "avr16eb14" # avr16eb32
     desc                   = "AVR16EB32";
     id                     = "avr16eb32";
     variants               =
@@ -23525,7 +23525,7 @@ part parent "avr16eb14"
 # Logic Green parts
 #------------------------------------------------------------
 
-part parent "m88"
+part parent "m88" # lgt8f88p
     desc                   = "LGT8F88P";
     id                     = "lgt8f88p";
     mcuid                  = 227;
@@ -23555,7 +23555,7 @@ part parent "m88"
 # LGT8F168P
 #------------------------------------------------------------
 
-part parent "m168"
+part parent "m168" # lgt8f168p
     desc                   = "LGT8F168P";
     id                     = "lgt8f168p";
     mcuid                  = 228;
@@ -23585,7 +23585,7 @@ part parent "m168"
 # LGT8F328P
 #------------------------------------------------------------
 
-part parent "m328"
+part parent "m328" # lgt8f328p
     desc                   = "LGT8F328P";
     id                     = "lgt8f328p";
     mcuid                  = 229;

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -584,9 +584,9 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
       dev_print_comment(cp->comms);
 
     if(p->parent_id && *p->parent_id)
-      dev_info("part parent \"%s\"\n", p->parent_id);
+      dev_info("part parent \"%s\" # %s\n", p->parent_id, p->id);
     else
-      dev_info("part\n");
+      dev_info("part # %s\n", p->id);
   }
 
   _if_partout_str(strcmp, descstr, desc);
@@ -1295,9 +1295,9 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
 
     const char *prog_sea = is_programmer(pgm)? "programmer": is_serialadapter(pgm)? "serialadapter": "programmer";
     if(pgm->parent_id && *pgm->parent_id)
-      dev_info("%s parent \"%s\"\n", prog_sea, pgm->parent_id);
+      dev_info("%s parent \"%s\" # %s\n", prog_sea, pgm->parent_id, ldata(lfirst(pgm->id)));
     else
-      dev_info("%s\n", prog_sea);
+      dev_info("%s # %s\n", prog_sea, ldata(lfirst(pgm->id)));
   }
 
   if(tsv)


### PR DESCRIPTION
Reviewing changes in `avrdude.conf` can be tricky as it often remains unclear which part or programmer a change pertains to. For example, a git diff after changing one particular EEPROM size from 1024 to 1234 will not tell which part is affected:

``` diff
diff --git a/src/avrdude.conf.in b/src/avrdude.conf.in
index c4bddfa7..b8f62cd3 100644
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -10225,7 +10225,7 @@ part
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size               = 1024;
+        size               = 1234;
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
```

This PR adds the part id as comment to the opening of the definition, and voila, the reviewer can tell the part:

``` diff
diff --git a/src/avrdude.conf.in b/src/avrdude.conf.in
index d74224db..cf3b5520 100644
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -10225,7 +10225,7 @@ part # m328
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        size               = 1024;
+        size               = 1234;
         page_size          = 4;
         min_write_delay    = 3600;
         max_write_delay    = 3600;
```

