### PR TITLE
Enable prodsig read for avrftdi_jtag type programmers

### DIFF
--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1591,6 +1591,15 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3600, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0xff;
 
+	} else if (str_eq(m->desc, "prodsig")) {
+		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
+		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_SIGCAL_READ, 15);
+		avrftdi_jtag_dr_out(pgm, 0x0300 | (addr/2 & 0xff), 15);
+
+		/* Read prodsig byte either through signature (even addr) or calibration (odd) */
+		avrftdi_jtag_dr_out(pgm, addr&1? 0x3600: 0x3200, 15);
+		*value = avrftdi_jtag_dr_inout(pgm, addr&1? 0x3700: 0x3300, 15) & 0xff;
+
 	} else {
 		return -1;
 	}


### PR DESCRIPTION
This PR is an educated guess for the `avrfdi_jtag` type programmers.