### PR TITLE
Review LED support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -189,6 +189,7 @@ add_library(libavrdude
     jtag3.c
     jtag3.h
     jtag3_private.h
+    leds.c
     libavrdude.h
     linuxgpio.c
     linuxgpio.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -138,6 +138,7 @@ libavrdude_a_SOURCES = \
 	jtag3.c \
 	jtag3.h \
 	jtag3_private.h \
+	leds.c \
 	libavrdude.h \
 	linuxgpio.c \
 	linuxgpio.h \

--- a/src/avr.c
+++ b/src/avr.c
@@ -81,7 +81,7 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     };
 
     while (avr_tpi_poll_nvmbsy(pgm))
-        ;
+      continue;
 
     err = pgm->cmd_tpi(pgm, cmd, sizeof(cmd), NULL, 0);
     if(err) {
@@ -91,7 +91,7 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     }
 
     while (avr_tpi_poll_nvmbsy(pgm))
-        ;
+      continue;
 
     led_clr(pgm, LED_PGM);
     return 0;
@@ -204,7 +204,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
     }
 
     while (avr_tpi_poll_nvmbsy(pgm))
-      ;
+      continue;
 
     /* setup for read */
     avr_tpi_setup_rw(pgm, mem, addr, TPI_NVMCMD_NO_OPERATION);
@@ -372,7 +372,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     led_set(pgm, LED_PGM);
 
     while (avr_tpi_poll_nvmbsy(pgm))
-      ;
+      contine;
 
     /* setup for read (NOOP) */
     avr_tpi_setup_rw(pgm, mem, 0, TPI_NVMCMD_NO_OPERATION);
@@ -669,7 +669,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     }
 
     while (avr_tpi_poll_nvmbsy(pgm))
-      ;
+      continue;
 
     /* must erase fuse first */
     if (str_eq(mem->desc, "fuse")) {
@@ -683,7 +683,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
         goto error;
 
       while (avr_tpi_poll_nvmbsy(pgm))
-        ;
+        continue;
     }
 
     /* setup for WORD_WRITE */
@@ -700,7 +700,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
       goto error;
 
     while (avr_tpi_poll_nvmbsy(pgm))
-      ;
+      continue;
 
     goto success;
   }
@@ -963,7 +963,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     }
 
     while (avr_tpi_poll_nvmbsy(pgm))
-      ;
+      continue;
 
     /* setup for WORD_WRITE */
     avr_tpi_setup_rw(pgm, m, 0, TPI_NVMCMD_WORD_WRITE);

--- a/src/avr.c
+++ b/src/avr.c
@@ -1183,9 +1183,10 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
       continue;
 
     if (do_write) {
-      if(avr_write_byte(pgm, p, m, i, data))
+      if(avr_write_byte(pgm, p, m, i, data)) {
         msg_error(" ***failed;\n");
         led_set(pgm, LED_ERR);
+      }
     }
 
     if (flush_page) {           // Time to flush the page with a page write

--- a/src/avr.c
+++ b/src/avr.c
@@ -53,12 +53,15 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   AVRMEM *mem;
 
   if (p->prog_modes & PM_TPI) {
-    pgm->pgm_led(pgm, ON);
+    led_clr(pgm, LED_ERR);
+    led_set(pgm, LED_PGM);
 
     /* Set Pointer Register */
     mem = avr_locate_mem(p, "flash");
     if (mem == NULL) {
       pmsg_error("no flash memory to erase for part %s\n", p->desc);
+      led_set(pgm, LED_ERR);
+      led_clr(pgm, LED_PGM);
       return -1;
     }
 
@@ -81,13 +84,16 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
         ;
 
     err = pgm->cmd_tpi(pgm, cmd, sizeof(cmd), NULL, 0);
-    if(err)
+    if(err) {
+      led_set(pgm, LED_ERR);
+      led_clr(pgm, LED_PGM);
       return err;
+    }
 
-    while (avr_tpi_poll_nvmbsy(pgm));
+    while (avr_tpi_poll_nvmbsy(pgm))
+        ;
 
-    pgm->pgm_led(pgm, OFF);
-
+    led_clr(pgm, LED_PGM);
     return 0;
   } else {
     pmsg_error("part has no TPI\n");
@@ -179,7 +185,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
   unsigned char cmd[4];
   unsigned char res[4];
   unsigned char data;
-  int r;
+  int rc;
   OPCODE * readop, * lext;
 
   if (pgm->cmd == NULL) {
@@ -188,27 +194,28 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
     return -1;
   }
 
-  pgm->pgm_led(pgm, ON);
-  pgm->err_led(pgm, OFF);
+  led_clr(pgm, LED_ERR);
+  led_set(pgm, LED_PGM);
 
   if (p->prog_modes & PM_TPI) {
     if (pgm->cmd_tpi == NULL) {
       pmsg_error("%s programmer does not support TPI\n", pgm->type);
-      return -1;
+      goto error;
     }
 
-    while (avr_tpi_poll_nvmbsy(pgm));
+    while (avr_tpi_poll_nvmbsy(pgm))
+      ;
 
     /* setup for read */
     avr_tpi_setup_rw(pgm, mem, addr, TPI_NVMCMD_NO_OPERATION);
 
     /* load byte */
     cmd[0] = TPI_CMD_SLD;
-    r = pgm->cmd_tpi(pgm, cmd, 1, value, 1);
-    if (r == -1) 
-      return -1;
+    rc = pgm->cmd_tpi(pgm, cmd, 1, value, 1);
+    if (rc == -1)
+      goto error;
 
-    return 0;
+    goto success;
   }
 
   /*
@@ -229,7 +236,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 #if DEBUG
     pmsg_error("operation not supported on memory type %s\n", mem->desc);
 #endif
-    return -1;
+    goto error;
   }
 
   /*
@@ -241,26 +248,34 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
     avr_set_bits(lext, cmd);
     avr_set_addr(lext, cmd, addr);
-    r = pgm->cmd(pgm, cmd, res);
-    if (r < 0)
-      return r;
+    rc = pgm->cmd(pgm, cmd, res);
+    if(rc < 0)
+      goto rcerror;
   }
 
   memset(cmd, 0, sizeof(cmd));
 
   avr_set_bits(readop, cmd);
   avr_set_addr(readop, cmd, addr);
-  r = pgm->cmd(pgm, cmd, res);
-  if (r < 0)
-    return r;
+  rc = pgm->cmd(pgm, cmd, res);
+  if(rc < 0)
+    goto rcerror;
+
   data = 0;
   avr_get_output(readop, res, &data);
-
-  pgm->pgm_led(pgm, OFF);
-
   *value = data;
 
+success:
+  led_clr(pgm, LED_PGM);
   return 0;
+
+error:
+  rc = -1;
+
+rcerror:
+  led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+  return rc;
 }
 
 
@@ -353,7 +368,11 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
   if ((p->prog_modes & PM_TPI) && mem->page_size > 1 &&
       mem->size % mem->page_size == 0 && pgm->cmd_tpi != NULL) {
 
-    while (avr_tpi_poll_nvmbsy(pgm));
+    led_clr(pgm, LED_ERR);
+    led_set(pgm, LED_PGM);
+
+    while (avr_tpi_poll_nvmbsy(pgm))
+      ;
 
     /* setup for read (NOOP) */
     avr_tpi_setup_rw(pgm, mem, 0, TPI_NVMCMD_NO_OPERATION);
@@ -373,11 +392,16 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
         lastaddr++;
         if (rc == -1) {
           pmsg_error("unable to read address 0x%04lx\n", i);
+          report_progress(1, -1, NULL);
+          led_set(pgm, LED_ERR);
+          led_clr(pgm, LED_PGM);
           return -1;
         }
       }
       report_progress(i, mem->size, NULL);
     }
+
+    led_clr(pgm, LED_PGM);
     return avr_mem_hiaddr(mem);
   }
 
@@ -425,7 +449,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
           break;
         }
       if (need_read) {
-        rc = pgm->paged_load(pgm, p, mem, mem->page_size,
+        rc = led_paged_load(pgm, p, mem, mem->page_size,
                             pageaddr, mem->page_size);
         if (rc < 0)
           /* paged load failed, fall back to byte-at-a-time read below */
@@ -447,6 +471,9 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     }
   }
 
+  led_clr(pgm, LED_ERR);
+  led_set(pgm, LED_PGM);
+
   for (i=0; i < (unsigned long) mem->size; i++) {
     if (vmem == NULL || (vmem->tags[i] & TAG_ALLOCATED) != 0) {
       rc = pgm->read_byte(pgm, p, mem, i, mem->buf + i);
@@ -454,15 +481,22 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
         pmsg_error("unable to read byte at address 0x%04lx\n", i);
         if (rc == LIBAVRDUDE_GENERAL_FAILURE) {
           pmsg_error("read operation not supported for memory %s\n", mem->desc);
+          report_progress(1, -1, NULL);
+          led_set(pgm, LED_ERR);
+          led_clr(pgm, LED_PGM);
           return LIBAVRDUDE_NOTSUPPORTED;
         }
         pmsg_error("read operation failed for memory %s\n", mem->desc);
+        report_progress(1, -1, NULL);
+        led_set(pgm, LED_ERR);
+        led_clr(pgm, LED_PGM);
         return LIBAVRDUDE_SOFTFAIL;
       }
     }
     report_progress(i, mem->size, NULL);
   }
 
+  led_clr(pgm, LED_PGM);
   return avr_mem_hiaddr(mem);
 }
 
@@ -477,16 +511,19 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p_unused, const AVRMEM 
   unsigned char res[4];
   OPCODE * wp, * lext;
 
+  led_clr(pgm, LED_ERR);
+  led_set(pgm, LED_PGM);
+
   if (pgm->cmd == NULL) {
     pmsg_error("%s programmer uses avr_write_page() but does not\n", pgm->type);
     imsg_error("provide a cmd() method\n");
-    return -1;
+    goto error;
   }
 
   wp = mem->op[AVR_OP_WRITEPAGE];
   if (wp == NULL) {
     pmsg_error("memory %s not configured for page writes\n", mem->desc);
-    return -1;
+    goto error;
   }
 
   /*
@@ -495,9 +532,6 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p_unused, const AVRMEM 
    */
   if ((mem->op[AVR_OP_LOADPAGE_LO]) || (mem->op[AVR_OP_READ_LO]))
     addr = addr / 2;
-
-  pgm->pgm_led(pgm, ON);
-  pgm->err_led(pgm, OFF);
 
   /*
    * If this device has a "load extended address" command, issue it.
@@ -508,14 +542,15 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p_unused, const AVRMEM 
 
     avr_set_bits(lext, cmd);
     avr_set_addr(lext, cmd, addr);
-    pgm->cmd(pgm, cmd, res);
+    if(pgm->cmd(pgm, cmd, res) < 0)
+      goto error;
   }
 
   memset(cmd, 0, sizeof(cmd));
-
   avr_set_bits(wp, cmd);
   avr_set_addr(wp, cmd, addr);
-  pgm->cmd(pgm, cmd, res);
+  if(pgm->cmd(pgm, cmd, res) < 0)
+    goto error;
 
   /*
    * since we don't know what voltage the target AVR is powered by, be
@@ -523,8 +558,13 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p_unused, const AVRMEM 
    */
   usleep(mem->max_write_delay);
 
-  pgm->pgm_led(pgm, OFF);
+  led_clr(pgm, LED_PGM);
   return 0;
+
+error:
+  led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+  return -1;
 }
 
 
@@ -603,10 +643,13 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   int rc;
   int readok=0;
 
+  led_clr(pgm, LED_ERR);
+  led_set(pgm, LED_PGM);
+
   if (pgm->cmd == NULL) {
     pmsg_error("%s programmer uses avr_write_byte_default() but does not\n", pgm->type);
     imsg_error("provide a cmd() method\n");
-    return -1;
+    goto error;
   }
 
   data = avr_bitmask_data(pgm, p, mem, addr, data);
@@ -614,18 +657,19 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   if (p->prog_modes & PM_TPI) {
     if (pgm->cmd_tpi == NULL) {
       pmsg_error("%s programmer does not support TPI\n", pgm->type);
-      return -1;
+      goto error;
     }
 
     if (str_eq(mem->desc, "flash")) {
       pmsg_error("writing a byte to flash is not supported for %s\n", p->desc);
-      return -1;
+      goto error;
     } else if ((mem->offset + addr) & 1) {
       pmsg_error("writing a byte to an odd location is not supported for %s\n", p->desc);
-      return -1;
+      goto error;
     }
 
-    while (avr_tpi_poll_nvmbsy(pgm));
+    while (avr_tpi_poll_nvmbsy(pgm))
+      ;
 
     /* must erase fuse first */
     if (str_eq(mem->desc, "fuse")) {
@@ -635,9 +679,11 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
       /* write dummy byte */
       cmd[0] = TPI_CMD_SST;
       cmd[1] = 0xFF;
-      rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+      if((rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0)) < 0)
+        goto error;
 
-      while (avr_tpi_poll_nvmbsy(pgm));
+      while (avr_tpi_poll_nvmbsy(pgm))
+        ;
     }
 
     /* setup for WORD_WRITE */
@@ -645,15 +691,18 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
     cmd[0] = TPI_CMD_SST_PI;
     cmd[1] = data;
-    rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+    if((rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0)) < 0)
+      goto error;
     /* dummy high byte to start WORD_WRITE */
     cmd[0] = TPI_CMD_SST_PI;
     cmd[1] = data;
-    rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+    if((rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0)) < 0)
+      goto error;
 
-    while (avr_tpi_poll_nvmbsy(pgm));
+    while (avr_tpi_poll_nvmbsy(pgm))
+      ;
 
-    return 0;
+    goto success;
   }
 
   if (!mem->paged && (p->flags & AVRPART_IS_AT90S1200) == 0) {
@@ -670,17 +719,15 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     rc = pgm->read_byte(pgm, p, mem, addr, &b);
     if (rc != 0) {
       if (rc != -1) {
-        return -2;
+        rc = -2;
+        goto rcerror;
       }
-      /*
-       * the read operation is not support on this memory type
-       */
+      // Read operation is not support on this memory type
     }
     else {
       readok = 1;
-      if (b == data) {
-        return 0;
-      }
+      if (b == data)
+        goto success;
     }
   }
 
@@ -710,19 +757,16 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 #if DEBUG
     pmsg_error("write not supported for memory type %s\n", mem->desc);
 #endif
-    return -1;
+    goto error;
   }
 
 
-  pgm->pgm_led(pgm, ON);
-  pgm->err_led(pgm, OFF);
-
   memset(cmd, 0, sizeof(cmd));
-
   avr_set_bits(writeop, cmd);
   avr_set_addr(writeop, cmd, caddr);
   avr_set_input(writeop, cmd, data);
-  pgm->cmd(pgm, cmd, res);
+  if(pgm->cmd(pgm, cmd, res) < 0)
+    goto error;
 
   if (mem->paged) {
     /*
@@ -730,8 +774,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
      * page complete immediately, we only need to delay when we commit
      * the whole page via the avr_write_page() routine.
      */
-    pgm->pgm_led(pgm, OFF);
-    return 0;
+    goto success;
   }
 
   if (readok == 0) {
@@ -740,8 +783,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
      * the max programming time and then return 
      */
     usleep(mem->max_write_delay); /* maximum write delay */
-    pgm->pgm_led(pgm, OFF);
-    return 0;
+    goto success;
   }
 
   tries = 0;
@@ -759,9 +801,8 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
       usleep(mem->max_write_delay);
       rc = pgm->read_byte(pgm, p, mem, addr, &r);
       if (rc != 0) {
-        pgm->pgm_led(pgm, OFF);
-        pgm->err_led(pgm, OFF);
-        return -5;
+        rc = -5;
+        goto rcerror;
       }
     }
     else {
@@ -770,9 +811,8 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
         // Do polling, but timeout after max_write_delay
         rc = pgm->read_byte(pgm, p, mem, addr, &r);
         if (rc != 0) {
-          pgm->pgm_led(pgm, OFF);
-          pgm->err_led(pgm, ON);
-          return -4;
+          rc = -4;
+          goto rcerror;
         }
         prog_time = avr_ustimestamp();
       } while (r != data &&  mem->max_write_delay >= 0 &&
@@ -795,7 +835,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
        * memory bits but not all.  We only actually power-off the
        * device if the data read back does not match what we wrote.
        */
-      pgm->pgm_led(pgm, OFF);
+
       pmsg_info("this device must be powered off and back on to continue\n");
       if ((pgm->pinno[PPI_AVR_VCC] & PIN_MASK) <= PIN_MAX) {
         pmsg_info("attempting to do this now ...\n");
@@ -806,11 +846,12 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
           pmsg_error("initialization failed, rc=%d\n", rc);
           imsg_error("cannot re-initialize device after programming the %s bits\n", mem->desc);
           imsg_error("you must manually power-down the device and restart %s to continue\n", progname);
-          return -3;
+          rc = -3;
+          goto rcerror;
         }
         
         pmsg_info("device was successfully re-initialized\n");
-        return 0;
+        goto success;
       }
     }
 
@@ -821,15 +862,22 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
        * been plenty of time, the memory cell still doesn't match what
        * we wrote.  Indicate a write error.
        */
-      pgm->pgm_led(pgm, OFF);
-      pgm->err_led(pgm, ON);
-      
-      return -6;
+      rc = -6;
+      goto rcerror;
     }
   }
 
-  pgm->pgm_led(pgm, OFF);
+success:
+  led_clr(pgm, LED_PGM);
   return 0;
+
+error:
+  rc = -1;
+
+rcerror:
+  led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+  return rc;
 }
 
 
@@ -875,16 +923,13 @@ int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype, int 
  * Return the number of bytes written, or LIBAVRDUDE_GENERAL_FAILURE on error.
  */
 int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int size, int auto_erase) {
-  int              rc;
   int              wsize;
   unsigned int     i, lastaddr;
   unsigned char    data;
-  int              werror;
   unsigned char    cmd[4];
 
-  pgm->err_led(pgm, OFF);
-
-  werror  = 0;
+  led_clr(pgm, LED_ERR);
+  led_set(pgm, LED_PGM);
 
   wsize = m->size;
   if (size < wsize) {
@@ -894,19 +939,31 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     imsg_warning("Only %d bytes will actually be written\n", wsize);
   }
 
-  if(wsize <= 0)
+  if(wsize <= 0) {
+    if(wsize < 0)
+      led_set(pgm, LED_ERR);
+    led_clr(pgm, LED_PGM);
     return wsize;
+  }
 
   if ((p->prog_modes & PM_TPI) && m->page_size > 1 && pgm->cmd_tpi) {
     unsigned int    chunk; /* number of words for each write command */
     unsigned int    j, writeable_chunk;
 
     if (wsize == 1) {
-      /* fuse (configuration) memory: only single byte to write */
-      return avr_write_byte(pgm, p, m, 0, m->buf[0]) == 0? 1: LIBAVRDUDE_GENERAL_FAILURE;
+      // Fuse (configuration) memory: only single byte to write
+      if(avr_write_byte(pgm, p, m, 0, m->buf[0])) {
+        led_set(pgm, LED_ERR);
+        led_clr(pgm, LED_PGM);
+        return LIBAVRDUDE_GENERAL_FAILURE;
+      } else {
+        led_clr(pgm, LED_PGM);
+        return 1;
+      }
     }
 
-    while (avr_tpi_poll_nvmbsy(pgm));
+    while (avr_tpi_poll_nvmbsy(pgm))
+      ;
 
     /* setup for WORD_WRITE */
     avr_tpi_setup_rw(pgm, m, 0, TPI_NVMCMD_WORD_WRITE);
@@ -920,6 +977,8 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
       msg_error("\n");
       pmsg_error("unsupported n_word_writes value of %d for %s memory\n",
         m->n_word_writes, m->desc);
+      led_set(pgm, LED_ERR);
+      led_clr(pgm, LED_PGM);
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
     chunk = m->n_word_writes > 0 ? 2*m->n_word_writes : 2;
@@ -944,7 +1003,12 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
         cmd[0] = TPI_CMD_SST_PI;
         for (j = 0; j < chunk; j++) {
           cmd[1] = m->buf[i+j];
-          rc = pgm->cmd_tpi(pgm, cmd, 2, NULL, 0);
+          if(pgm->cmd_tpi(pgm, cmd, 2, NULL, 0) < 0) {
+            report_progress(1, -1, NULL);
+            led_set(pgm, LED_ERR);
+            led_clr(pgm, LED_PGM);
+            return LIBAVRDUDE_GENERAL_FAILURE;
+          }
         }
 
         lastaddr += chunk;
@@ -954,6 +1018,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
       report_progress(i, wsize, NULL);
     }
 
+    led_clr(pgm, LED_PGM);
     return i;
   }
 
@@ -991,7 +1056,9 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     if((pgsize & (pgsize-1)) || pgsize < 1) {
       pmsg_error("effective page size %d implausible\n", pgsize);
       avr_free_mem(cm);
-      return -1;
+      led_set(pgm, LED_ERR);
+      led_clr(pgm, LED_PGM);
+      return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
     uint8_t *spc = cfg_malloc(__func__, cm->page_size);
@@ -1053,7 +1120,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
         }
 
       if (need_write) {
-        rc = 0;
+        int rc = 0;
         if (auto_erase && pgm->page_erase)
           rc = pgm->page_erase(pgm, p, cm, pageaddr);
         if (rc >= 0)
@@ -1062,7 +1129,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
           /* paged write failed, fall back to byte-at-a-time write below */
           failure = 1;
       } else {
-        pmsg_debug("avr_write_mem(): skipping page %u: no interesting data\n", pageaddr / cm->page_size);
+        pmsg_debug("%s(): skipping page %u: no interesting data\n", __func__, pageaddr / cm->page_size);
       }
       nwritten++;
       report_progress(nwritten, npages, NULL);
@@ -1071,8 +1138,10 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     avr_free_mem(cm);
     free(spc);
 
-    if (!failure)
+    if (!failure) {
+      led_clr(pgm, LED_PGM);
       return wsize;
+    }
     /* else: fall back to byte-at-a-time write, for historical reasons */
   }
 
@@ -1114,30 +1183,23 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
       continue;
 
     if (do_write) {
-      rc = avr_write_byte(pgm, p, m, i, data);
-      if (rc) {
+      if(avr_write_byte(pgm, p, m, i, data))
         msg_error(" ***failed;\n");
-        pgm->err_led(pgm, ON);
-        werror = 1;
-      }
+        led_set(pgm, LED_ERR);
     }
 
     if (flush_page) {           // Time to flush the page with a page write
       flush_page = 0;
-      rc = avr_write_page(pgm, p, m, i);
-      if (rc) {
+
+      if(avr_write_page(pgm, p, m, i)) {
         msg_error(" *** page %d (addresses 0x%04x - 0x%04x) failed to write\n\n",
           i / m->page_size, i - m->page_size + 1, i);
-        pgm->err_led(pgm, ON);
-          werror = 1;
+        led_set(pgm, LED_ERR);
       }
     }
-
-    // Ensure error led stays on lest it was cleared in avr_write_byte()
-    if (werror)
-      pgm->err_led(pgm, ON);
   }
 
+  led_clr(pgm, LED_PGM);
   return i;
 }
 
@@ -1468,7 +1530,7 @@ int avr_mem_might_be_known(const char *str) {
 
 
 int avr_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
-  return pgm->chip_erase(pgm, p);
+  return led_chip_erase(pgm, p);
 }
 
 int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p) {

--- a/src/avr.c
+++ b/src/avr.c
@@ -372,7 +372,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     led_set(pgm, LED_PGM);
 
     while (avr_tpi_poll_nvmbsy(pgm))
-      contine;
+      continue;
 
     /* setup for read (NOOP) */
     avr_tpi_setup_rw(pgm, mem, 0, TPI_NVMCMD_NO_OPERATION);

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -110,7 +110,7 @@ be taken about voltage level compatibility. Also, although not strictly
 required, it is strongly advisable to protect the GPIO pins from 
 overcurrent situations in some way. The simplest would be to just put
 some resistors in series or better yet use a 3-state buffer driver like
-the 74HC244. Have a look at http://kolev.info/blog/2013/01/06/avrdude-linuxgpio/ for a more
+the 74HC244. Have a look at https://kolev.info/blog/2013/01/06/avrdude-linuxgpio/ for a more
 detailed tutorial about using this programmer type.
 .Pp
 Under a Linux installation with direct access to the SPI bus and GPIO
@@ -188,10 +188,10 @@ supported on a serial port.
 .Pp
 Atmel's JTAG ICE (mkI, mkII, and 3) is supported as well to up- or download memory
 areas from/to an AVR target (no support for on-chip debugging).
-For the JTAG ICE mkII, JTAG, debugWire and ISP mode are supported, provided
+For the JTAG ICE mkII, JTAG, debugWIRE and ISP mode are supported, provided
 it has a firmware revision of at least 4.14 (decimal).
 JTAGICE3 also supports all of JTAG, debugWIRE, and ISP mode.
-See below for the limitations of debugWire.
+See below for the limitations of debugWIRE.
 For ATxmega devices, the JTAG ICE mkII is supported in PDI mode, provided it
 has a revision 1 hardware and firmware version of at least 5.37 (decimal).
 For ATxmega devices, the JTAGICE3 is supported in PDI mode.
@@ -205,8 +205,8 @@ are supported using the "jtag3" programmer type.
 Atmel's XplainedMini boards, using the mEDBG protocol,
 are also supported using the "jtag3" programmer type.
 .Pp
-The AVR Dragon is supported in all modes (ISP, JTAG, HVSP, PP, debugWire).
-When used in JTAG and debugWire mode, the AVR Dragon behaves similar to a
+The AVR Dragon is supported in all modes (ISP, JTAG, HVSP, PP, debugWIRE).
+When used in JTAG and debugWIRE mode, the AVR Dragon behaves similar to a
 JTAG ICE mkII, so all device-specific comments for that device
 will apply as well.
 When used in ISP mode, the AVR Dragon behaves similar to an
@@ -684,7 +684,7 @@ For the USB programmer "AVR-Doper" running in HID mode, the port must
 be specified as
 .Ar avrdoper.
 Libhidapi support is required on Unix and Mac OS but not on Windows. For more
-information about AVR-Doper see http://www.obdev.at/avrusb/avrdoper.html.
+information about AVR-Doper see https://www.obdev.at/products/vusb/avrdoper.html.
 .Pp
 For the USBtinyISP, which is a simplistic device not implementing
 serial numbers, multiple devices can be distinguished by their
@@ -1365,13 +1365,13 @@ ll.
 10	SDI (from MCU)
 18-25	GND
 .TE
-.Ss debugWire limitations
-The debugWire protocol is Atmel's proprietary one-wire (plus ground)
+.Ss DebugWIRE limitations
+The debugWIRE protocol is Atmel's proprietary one-wire (plus ground)
 protocol to allow an in-circuit emulation of the smaller AVR devices,
 using the
 .Ql /RESET
 line.
-DebugWire mode is initiated by activating the
+DebugWIRE mode is initiated by activating the
 .Ql DWEN
 fuse, and then power-cycling the target.
 While this mode is mainly intended for debugging/emulation, it
@@ -1382,12 +1382,12 @@ It is also possible to read out the signature.
 All other memory areas cannot be accessed.
 There is no
 .Em chip erase
-functionality in debugWire mode; instead, while reprogramming the
+functionality in debugWIRE mode; instead, while reprogramming the
 flash ROM, each flash ROM page is erased right before updating it.
 This is done transparently by the JTAG ICE mkII (or AVR Dragon).
-The only way back from debugWire mode is to initiate a special
+The only way back from debugWIRE mode is to initiate a special
 sequence of commands to the JTAG ICE mkII (or AVR Dragon), so the
-debugWire mode will be temporarily disabled, and the target can
+debugWIRE mode will be temporarily disabled, and the target can
 be accessed using normal ISP programming.
 This sequence is automatically initiated by using the JTAG ICE mkII
 or AVR Dragon in ISP mode, when they detect that ISP mode cannot be
@@ -1929,12 +1929,12 @@ User manual
 .Sh DIAGNOSTICS
 .Bd -literal
 avrdude: jtagmkII_setparm(): bad response to set parameter command: RSP_FAILED
-avrdude: jtagmkII_getsync(): ISP activation failed, trying debugWire
+avrdude: jtagmkII_getsync(): ISP activation failed, trying debugWIRE
 avrdude: Target prepared for ISP, signed off.
 avrdude: Please restart avrdude without power-cycling the target.
 .Ed
 .Pp
-If the target AVR has been set up for debugWire mode (i.e., the
+If the target AVR has been set up for debugWIRE mode (i.e., the
 .Em DWEN
 fuse is programmed), normal ISP connection attempts will fail as
 the
@@ -1943,7 +1943,7 @@ pin is not available.
 When using the JTAG ICE mkII in ISP mode, the message shown indicates
 that
 .Nm
-has guessed this condition, and tried to initiate a debugWire reset
+has guessed this condition, and tried to initiate a debugWIRE reset
 to the target.
 When successful, this will leave the target AVR in a state where it
 can respond to normal ISP communication again (until the next power
@@ -1954,12 +1954,12 @@ normal ISP communication.
 .Sh SEE ALSO
 .Xr avr-objcopy 1 ,
 .Xr ppi 4 ,
-.Xr libelf 3,
+.Xr libelf 3 ,
 .Xr readline 3
 .Pp
 The AVR microcontroller product description can be found at
 .Pp
-.Dl "http://www.atmel.com/products/AVR/"
+.Dl "https://www.microchip.com/en-us/products/microcontrollers-and-microprocessors/8-bit-mcus/avr-mcus"
 .\" .Sh HISTORY
 .Sh AUTHORS
 .Nm Avrdude

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -290,19 +290,19 @@ static int set_pin(const PROGRAMMER *pgm, int pinfunc, int value) {
 /*
  * Mandatory callbacks which boil down to GPIO.
  */
-static int set_led_pgm(const PROGRAMMER *pgm, int value) {
-	return set_pin(pgm, PIN_LED_PGM, value);
-}
-
-static int set_led_rdy(const PROGRAMMER *pgm, int value) {
+static int avrftdi_rdy_led(const PROGRAMMER *pgm, int value) {
 	return set_pin(pgm, PIN_LED_RDY, value);
 }
 
-static int set_led_err(const PROGRAMMER *pgm, int value) {
+static int avrftdi_err_led(const PROGRAMMER *pgm, int value) {
 	return set_pin(pgm, PIN_LED_ERR, value);
 }
 
-static int set_led_vfy(const PROGRAMMER *pgm, int value) {
+static int avrftdi_pgm_led(const PROGRAMMER *pgm, int value) {
+	return set_pin(pgm, PIN_LED_PGM, value);
+}
+
+static int avrftdi_vfy_led(const PROGRAMMER *pgm, int value) {
 	return set_pin(pgm, PIN_LED_VFY, value);
 }
 
@@ -859,13 +859,6 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 
 	if(avrftdi_pin_setup(pgm))
 		return -1;
-
-	/**********************************************
-	 * set the ready LED and set our direction up *
-	 **********************************************/
-
-	set_led_rdy(pgm,0);
-	set_led_pgm(pgm,1);
 
 	return 0;
 }
@@ -1858,10 +1851,10 @@ void avrftdi_initpgm(PROGRAMMER *pgm)
 	pgm->setpin = set_pin;
 	pgm->setup = avrftdi_setup;
 	pgm->teardown = avrftdi_teardown;
-	pgm->rdy_led = set_led_rdy;
-	pgm->err_led = set_led_err;
-	pgm->pgm_led = set_led_pgm;
-	pgm->vfy_led = set_led_vfy;
+	pgm->rdy_led = avrftdi_rdy_led;
+	pgm->err_led = avrftdi_err_led;
+	pgm->pgm_led = avrftdi_pgm_led;
+	pgm->vfy_led = avrftdi_vfy_led;
 }
 
 void avrftdi_jtag_initpgm(PROGRAMMER *pgm)
@@ -1890,10 +1883,10 @@ void avrftdi_jtag_initpgm(PROGRAMMER *pgm)
 	pgm->paged_load = avrftdi_jtag_paged_read;
 	pgm->setup = avrftdi_setup;
 	pgm->teardown = avrftdi_teardown;
-	pgm->rdy_led = set_led_rdy;
-	pgm->err_led = set_led_err;
-	pgm->pgm_led = set_led_pgm;
-	pgm->vfy_led = set_led_vfy;
+	pgm->rdy_led = avrftdi_rdy_led;
+	pgm->err_led = avrftdi_err_led;
+	pgm->pgm_led = avrftdi_pgm_led;
+	pgm->vfy_led = avrftdi_vfy_led;
 	pgm->page_size = 256;
 	pgm->flag = PGM_FL_IS_JTAG;
 }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -535,7 +535,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
     }
     if (verbose > 4) {
       msg_trace2("%s  Memory Ops:\n"
-                      "%s    Oeration     Inst Bit  Bit Type  Bitno  Value\n"
+                      "%s    Operation    Inst Bit  Bit Type  Bitno  Value\n"
                       "%s    -----------  --------  --------  -----  -----\n",
                       prefix, prefix, prefix);
       for (i=0; i<AVR_OP_MAX; i++) {

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -344,8 +344,6 @@ int bitbang_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
 {
   int i, r;
 
-  pgm->pgm_led(pgm, ON);
-
   for (i=0; i<cmd_len; i++) {
     bitbang_tpi_tx(pgm, cmd[i]);
   }
@@ -371,7 +369,6 @@ int bitbang_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
     msg_notice2("]\n");
   }
 
-  pgm->pgm_led(pgm, OFF);
   if (r == -1)
     return -1;
   return 0;
@@ -420,7 +417,6 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   AVRMEM *mem;
 
   if (p->prog_modes & PM_TPI) {
-    pgm->pgm_led(pgm, ON);
 
     while (avr_tpi_poll_nvmbsy(pgm));
 
@@ -445,8 +441,6 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
     while (avr_tpi_poll_nvmbsy(pgm));
 
-    pgm->pgm_led(pgm, OFF);
-
     return 0;
   }
 
@@ -455,16 +449,12 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   }
 
-  pgm->pgm_led(pgm, ON);
-
   memset(cmd, 0, sizeof(cmd));
 
   avr_set_bits(p->op[AVR_OP_CHIP_ERASE], cmd);
   pgm->cmd(pgm, cmd, res);
   usleep(p->chip_erase_delay);
   pgm->initialize(pgm, p);
-
-  pgm->pgm_led(pgm, OFF);
 
   return 0;
 }

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -108,30 +108,8 @@ static int butterfly_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
 }
 
 
-static int butterfly_rdy_led(const PROGRAMMER *pgm, int value) {
-  /* Do nothing. */
-
-  return 0;
-}
-
-
-static int butterfly_err_led(const PROGRAMMER *pgm, int value) {
-  /* Do nothing. */
-
-  return 0;
-}
-
-
-static int butterfly_pgm_led(const PROGRAMMER *pgm, int value) {
-  /* Do nothing. */
-
-  return 0;
-}
-
-
-static int butterfly_vfy_led(const PROGRAMMER *pgm, int value) {
-  /* Do nothing. */
-
+static int butterfly_default_led(const PROGRAMMER *pgm, int value) {
+  // No LED: do nothing
   return 0;
 }
 
@@ -716,10 +694,10 @@ void butterfly_initpgm(PROGRAMMER *pgm) {
   /*
    * mandatory functions
    */
-  pgm->rdy_led        = butterfly_rdy_led;
-  pgm->err_led        = butterfly_err_led;
-  pgm->pgm_led        = butterfly_pgm_led;
-  pgm->vfy_led        = butterfly_vfy_led;
+  pgm->rdy_led        = butterfly_default_led;
+  pgm->err_led        = butterfly_default_led;
+  pgm->pgm_led        = butterfly_default_led;
+  pgm->vfy_led        = butterfly_default_led;
   pgm->initialize     = butterfly_initialize;
   pgm->display        = butterfly_display;
   pgm->enable         = butterfly_enable;

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -99,7 +99,7 @@ programs to Atmel AVR microcontrollers.
 
 For avrdude version @value{VERSION}, @value{UPDATED}.
 
-Use @uref{https://github.com/avrdudes/avrdude/issues} to report bugs and ask questions.
+Use @url{https://github.com/avrdudes/avrdude/issues} to report bugs and ask questions.
 
 Copyright @copyright{} Hans Eirik Bull, Brian S. Dean, Stefan R@"uger and J@"org Wunsch
 @end ifinfo
@@ -174,7 +174,8 @@ be taken about voltage level compatibility. Also, although not strictly
 required, it is strongly advisable to protect the GPIO pins from 
 overcurrent situations in some way. The simplest would be to just put
 some resistors in series or better yet use a 3-state buffer driver like
-the 74HC244. Have a look at http://kolev.info/blog/2013/01/06/avrdude-linuxgpio/ for a more
+the 74HC244. Have a look at
+@url{https://kolev.info/blog/2013/01/06/avrdude-linuxgpio/} for a more
 detailed tutorial about using this programmer type.
 
 Under a Linux installation with direct access to the SPI bus and GPIO
@@ -293,7 +294,7 @@ below for details.
 Urprotocol is a leaner version of the STK500 1.x protocol that is designed
 to be backwards compatible with STK500 v1.x; it allows bootloaders to be
 much smaller, e.g., as implemented in the urboot project
-@uref{https://github.com/stefanrueger/urboot}. The programmer type ``urclock''
+@url{https://github.com/stefanrueger/urboot}. The programmer type ``urclock''
 caters for these urboot bootloaders. Owing to its backward compatibility,
 bootloaders that can be served by the arduino programmer can normally also
 be served by the urclock programmer. This may require specifying the size
@@ -737,7 +738,7 @@ same method of specifying the port is required there.
 For the USB programmer "AVR-Doper" running in HID mode, the port must
 be specified as @var{avrdoper}. Libhidapi support is required on Unix
 and Mac OS but not on Windows. For more information about AVR-Doper see
-@url{http://www.obdev.at/avrusb/avrdoper.html}.
+@url{https://www.obdev.at/products/vusb/avrdoper.html}.
 
 For the USBtinyISP, which is a simplistic device not implementing
 serial numbers, multiple devices can be distinguished by their
@@ -3336,6 +3337,7 @@ Reading fuse and lock bits is fully supported.
 * Atmel STK600::
 * Atmel DFU bootloader using FLIP version 1::
 * SerialUPDI programmer::
+* Programmer LED management::
 @end menu
 
 @c
@@ -3467,7 +3469,7 @@ versions of the bootloader.
 @c
 @c Node
 @c
-@node SerialUPDI programmer, , Atmel DFU bootloader using FLIP version 1, Programmer Specific Information
+@node SerialUPDI programmer, Programmer LED management, Atmel DFU bootloader using FLIP version 1, Programmer Specific Information
 @cindex SerialUPDI
 @section SerialUPDI programmer
 
@@ -3480,15 +3482,16 @@ SerialUPDI programmer has been tested using FT232RL USB->UART interface
 with the following connection layout (copied from Spence Kohde's page linked
 above):
 
+@noindent
 @example
---------------------                                 To Target device
-                DTR|                                  __________________
-                Rx |--------------,------------------| UPDI---\/\/---------->
-  Tx---/\/\/\---Tx |-------|<|---'          .--------| Gnd    470 ohm 
-    resistor    Vcc|---------------------------------| Vcc
-        1k      CTS|                     .`          |__________________
-                Gnd|--------------------' 
---------------------
+------------------                              To Target device
+              DTR|                               _______________
+              Rx |-----------,------------------| UPDI---\/\/------->
+Tx---/\/\/\---Tx |----|<|---'          .--------| Gnd    470 ohm
+  resistor    Vcc|------------------------------| Vcc
+      1k      CTS|                  .`          |_______________
+              Gnd|-----------------'
+------------------
 @end example
 
 There are several limitations in current SerialUPDI/AVRDUDE integration,
@@ -3559,6 +3562,44 @@ utility with @option{-v debug} and provide its output too.
 You will notice that both outputs are pretty similar, and this
 was implemented like that on purpose - it was supposed to make
 analysis of UPDI protocol quirks easier.
+
+@c
+@c Node
+@c
+@node Programmer LED management, , SerialUPDI programmer, Programmer Specific Information
+@cindex LED management
+@section Programmer LED management
+
+Some hardware programmers have LEDs, and the firmware controls them fully
+without AVRDUDE having a way to influence their LED states. Other
+programmers have LEDs and expect the host downloader/uploader to handle
+them, for example bit-banging programmers, ftdi-based programmers or
+linuxgpio programmers. For those programmers AVRDUDE provides support of
+four LEDs (RDY, ERR, PGM and VFY) which can be set via corresponding
+subroutines in the code for the respective @code{-c} programmer.
+
+The RDY LED is set once the programmer is initialised and switched off
+when AVRDUDE exits. During reading, writing or erasing the target the PGM
+LED flashes with around 2.5 Hz, whilst the VFY LED comes on during -U
+verification of the uploaded contents. Errors are indicated with the ERR
+LED.
+
+Assuming AVRDUDE got to the point where LEDs are accessible and the RDY
+LED was switched on then, on exit, AVRDUDE will leave the LEDs in the
+following states:
+
+@multitable @columnfractions .075 .075 .075 .075 .6
+@item @tab @strong{PGM} @tab @strong{VFY} @tab @strong{ERR} @tab @strong{Semantics}
+@item @tab off @tab off @tab off @tab OK: all tasks done without errors
+@item @tab off @tab off @tab on  @tab Some error not related to read, write or erase
+@item @tab on  @tab off @tab on  @tab Read, write or erase error
+@item @tab off @tab on  @tab on  @tab Verification error but no read, write or erase error
+@item @tab on  @tab on  @tab on  @tab Verification error and read, write or erase error
+@end multitable
+
+@noindent
+Other combinations should not show after exit.
+
 
 @c
 @c Node

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -437,25 +437,25 @@ static int dryrun_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unused
 
 
 static int dryrun_rdy_led(const PROGRAMMER *pgm, int value) {
-  pmsg_debug("%s(%d)\n", __func__, value);
+  pmsg_info("%s(%d)\n", __func__, value);
 
   return 0;
 }
 
 static int dryrun_err_led(const PROGRAMMER *pgm, int value) {
-  pmsg_debug("%s(%d)\n", __func__, value);
+  pmsg_info("%s(%d)\n", __func__, value);
 
   return 0;
 }
 
 static int dryrun_pgm_led(const PROGRAMMER *pgm, int value) {
-  pmsg_debug("%s(%d)\n", __func__, value);
+  pmsg_info("%s(%d)\n", __func__, value);
 
   return 0;
 }
 
 static int dryrun_vfy_led(const PROGRAMMER *pgm, int value) {
-  pmsg_debug("%s(%d)\n", __func__, value);
+  pmsg_info("%s(%d)\n", __func__, value);
 
   return 0;
 }

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -437,25 +437,25 @@ static int dryrun_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unused
 
 
 static int dryrun_rdy_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
+  pmsg_debug("%s(%d)\n", __func__, value);
 
   return 0;
 }
 
 static int dryrun_err_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
+  pmsg_debug("%s(%d)\n", __func__, value);
 
   return 0;
 }
 
 static int dryrun_pgm_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
+  pmsg_debug("%s(%d)\n", __func__, value);
 
   return 0;
 }
 
 static int dryrun_vfy_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
+  pmsg_debug("%s(%d)\n", __func__, value);
 
   return 0;
 }

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -426,19 +426,19 @@ static int set_vcc(const PROGRAMMER *pgm, int value) {
 /* these functions are callbacks, which go into the
  * PROGRAMMER data structure ("optional functions")
  */
-static int set_led_pgm(const PROGRAMMER *pgm, int value) {
-    return set_pin(pgm, PIN_LED_PGM, value);
-}
-
-static int set_led_rdy(const PROGRAMMER *pgm, int value) {
+static int ft245_rdy_led(const PROGRAMMER *pgm, int value) {
     return set_pin(pgm, PIN_LED_RDY, value);
 }
 
-static int set_led_err(const PROGRAMMER *pgm, int value) {
+static int ft245_err_led(const PROGRAMMER *pgm, int value) {
     return set_pin(pgm, PIN_LED_ERR, value);
 }
 
-static int set_led_vfy(const PROGRAMMER *pgm, int value) {
+static int ft245_pgm_led(const PROGRAMMER *pgm, int value) {
+    return set_pin(pgm, PIN_LED_PGM, value);
+}
+
+static int ft245_vfy_led(const PROGRAMMER *pgm, int value) {
     return set_pin(pgm, PIN_LED_VFY, value);
 }
 
@@ -785,8 +785,6 @@ static int ft245r_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
 			  int cmd_len, unsigned char *res, int res_len) {
     int i, ret = 0;
 
-    pgm->pgm_led(pgm, ON);
-
     for (i = 0; i < cmd_len; ++i)
 	ft245r_tpi_tx(pgm, cmd[i]);
     for (i = 0; i < res_len; ++i)
@@ -802,7 +800,6 @@ static int ft245r_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
 	msg_notice2("]\n");
     }
 
-    pgm->pgm_led(pgm, OFF);
     return ret;
 }
 
@@ -1233,10 +1230,10 @@ void ft245r_initpgm(PROGRAMMER *pgm) {
     pgm->paged_write = ft245r_paged_write;
     pgm->paged_load = ft245r_paged_load;
 
-    pgm->rdy_led        = set_led_rdy;
-    pgm->err_led        = set_led_err;
-    pgm->pgm_led        = set_led_pgm;
-    pgm->vfy_led        = set_led_vfy;
+    pgm->rdy_led        = ft245_rdy_led;
+    pgm->err_led        = ft245_err_led;
+    pgm->pgm_led        = ft245_pgm_led;
+    pgm->vfy_led        = ft245_vfy_led;
     pgm->powerup        = ft245r_powerup;
     pgm->powerdown      = ft245r_powerdown;
 

--- a/src/leds.c
+++ b/src/leds.c
@@ -1,0 +1,263 @@
+/*
+ * AVRDUDE - A Downloader/Uploader for AVR device programmers
+ * Copyright (C) 2023 Stefan Rueger <stefan.rueger@urclocks.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ac_cfg.h"
+#include <string.h>
+#include "avrdude.h"
+#include "libavrdude.h"
+
+/*
+ * Handle physical LEDs for programmers that have them
+ *
+ * The RDY LED is set once the programmer is initialised and switched
+ * off when AVRDUDE exits. During reading, writing or erasing the target
+ * the PGM LED flashes with around 2.5 Hz, whilst the VFY LED comes on
+ * during -U verification of the uploaded contents. Errors are indicated
+ * with the ERR LED.
+ *
+ * Assuming AVRDUDE got to the point where LEDs are accessible and the RDY
+ * LED was switched on then, on exit, AVRDUDE will leave the LEDs in the
+ * following states:
+ *
+ * | PGM | VFY | ERR | Semantics                                        |
+ * | --- | --- | --- | ------------------------------------------------ |
+ * | off | off | off | OK: all tasks done w/o errors                    |
+ * | off | off | on  | Some error not related to read/write/erase       |
+ * | on  | off | on  | Read/write/erase error                           |
+ * | off | on  | on  | Verification error but no read/write/erase error |
+ * | on  | on  | on  | Read/write/erase error and verification error    |
+ *
+ * Other combinations should not show after exit.
+ *
+ */
+
+#define TOFF                 2 // Toggle LED into off state
+#define TON                  3 // Toggle LED into on state
+#define CHECK               15 // Check LED needs changing
+
+// Keep track of LED status and set LED 0 .. LED_N-1 physically on or off
+static void led_direct(const PROGRAMMER *pgm, leds_t *ls, int led, int what) {
+  if(what ^ !!(ls->phy & (1<<led))) {
+    switch(led) {
+    case LED_RDY:
+      pgm->rdy_led(pgm, what);
+      break;
+    case LED_ERR:
+      pgm->err_led(pgm, what);
+      break;
+    case LED_PGM:
+      pgm->pgm_led(pgm, what);
+      break;
+    case LED_VFY:
+      pgm->vfy_led(pgm, what);
+      break;
+    default:
+      pmsg_error("unknown LED %d in %s()\n", led, __func__);
+    }
+    ls->phy ^= 1<<led;
+  }
+}
+
+// Physical level of LED setting, deal with max blinking frequency LED_FMAX
+static void led_physical(const PROGRAMMER *pgm, leds_t *ls, int led, int what) {
+  if(led < 0 || led >= LED_N) // Sanity
+    return;
+
+  unsigned long now = avr_mstimestamp();
+
+  if(what == ON || what == OFF) {
+    if(what)                    // Force on or off
+      ls->phy &= ~(1<<led);
+    else
+      ls->phy |= 1<<led;
+    led_direct(pgm, ls, led, what);
+    ls->chg &= ~(1<<led);
+    ls->ms[led] = now;
+    return;
+  }
+
+  if(what == TON && !(ls->set & (1<<led))) {
+    // Never before set? Set immediately
+    led_direct(pgm, ls, led, ON);
+    ls->set |= 1<<led;
+    ls->chg &= ~(1<<led);
+    ls->ms[led] = now;
+  } else if(what == TON || what == TOFF) {
+    // Toggle led into on or off state once enough time has gone by
+    ls->chg |= 1<<led;
+  }
+
+  // Check all LEDs whether they need toggling or setting
+  for(int l = 0; l < LED_N; l++) {
+    unsigned long diff = now - ls->ms[l];
+    if(diff && diff >= (unsigned long) (1000.0/LED_FMAX/2)) {
+      ls->ms[l] = now; // Toggle a fast signal or set to current value
+      what = ls->chg & (1<<l)? !(ls->phy & (1<<l)): !!(ls->now & (1<<l));
+      led_direct(pgm, ls, l, what);
+      ls->chg &= ~(1<<l);
+    }
+  }
+}
+
+// Logical level of setting LEDs, passes on to physical level
+int led_set(const PROGRAMMER *pgm, int led) {
+  // leds should always be allocated, but if not use dummy
+  leds_t sanity = { 0, 0, 0, 0, 0, {0, } }, *ls = pgm->leds? pgm->leds: &sanity;
+  int what = led >= 0 && led < LED_N && !(ls->now & (1<<led))? TON: CHECK;
+
+  switch(led) {
+  case LED_BEG:
+    memset(ls, 0, sizeof *ls);
+    led_physical(pgm, ls, LED_RDY, OFF);
+    led_physical(pgm, ls, LED_ERR, OFF);
+    led_physical(pgm, ls, LED_PGM, OFF);
+    led_physical(pgm, ls, LED_VFY, OFF);
+    break;
+  case LED_END:
+    led_physical(pgm, ls, LED_RDY, OFF);
+    led_physical(pgm, ls, LED_ERR, ls->end & (1<<LED_ERR)? ON: OFF);
+    led_physical(pgm, ls, LED_PGM, ls->end & (1<<LED_PGM)? ON: OFF);
+    led_physical(pgm, ls, LED_VFY, ls->end & (1<<LED_VFY)? ON: OFF);
+    break;
+  case LED_NOP:
+    led_physical(pgm, ls, LED_RDY, CHECK); // All others will be checked, too
+    break;
+  case LED_ERR:                 // Record that error happened and in which mode
+    ls->end |= 1<<LED_ERR;
+    if(ls->now & (1<<LED_PGM))
+      ls->end |= 1<<LED_PGM;
+    if(ls->now & (1<<LED_VFY))
+      ls->end |= 1<<LED_VFY;
+  // Fall through
+  case LED_RDY:
+  case LED_PGM:
+  case LED_VFY:
+    ls->now |= 1<<led;
+    led_physical(pgm, ls, led, what);
+    break;
+  default:
+    pmsg_warning("unknown led %d in %s()\n", led, __func__);
+    return -1;
+  }
+
+  return ls->now;
+}
+
+// Logical level of clearing LEDs, passes on to physical level
+int led_clr(const PROGRAMMER *pgm, int led) {
+  if(led < 0 || led >= LED_N) {
+    pmsg_warning("unknown led %d in %s()\n", led, __func__);
+    return -1;
+  }
+
+  // pgm->leds should always be allocated, but if not use dummy
+  leds_t sanity = { 0, 0, 0, 0, 0, {0, } }, *ls = pgm->leds? pgm->leds: &sanity;
+  int what = ls->now & (1<<led)? TOFF: CHECK;
+
+  // Record logical level
+  if(led >= 0 && led < LED_N)
+    ls->now &= ~(1<<led);
+
+  led_physical(pgm, ls, led, what);
+
+  return ls->now;
+}
+
+// Programmer specific chip erase function with ERR/PGM LED info
+int led_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
+  int rc = pgm->chip_erase(pgm, p);
+
+  return rc;
+}
+
+// Programmer specific write byte function with ERR/PGM LED info
+int led_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned long addr, unsigned char value) {
+
+  led_clr(pgm, LED_ERR);
+  led_set(pgm, LED_PGM);
+
+  int rc = pgm->write_byte(pgm, p, m, addr, value);
+
+  if(rc < 0)
+    led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+
+  return rc;
+}
+
+// Programmer specific read byte function with ERR/PGM LED info
+int led_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned long addr, unsigned char *valuep) {
+
+  led_clr(pgm, LED_ERR);
+  led_set(pgm, LED_PGM);
+
+  int rc = pgm->read_byte(pgm, p, m, addr, valuep);
+
+  if(rc<0)
+    led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+
+  return rc;
+}
+
+// Programmer-specific paged write function with ERR/PGM LED info
+int led_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned int page_size, unsigned int baseaddr, unsigned int n_bytes) {
+
+  led_clr(pgm, LED_ERR);
+
+  int rc = pgm->paged_write? led_set(pgm, LED_PGM), pgm->paged_write(pgm, p, m, page_size, baseaddr, n_bytes): -1;
+
+  if(rc<0)
+    led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+
+  return rc;
+}
+
+// Programmer-specific paged load function with ERR/PGM LED info
+int led_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned int page_size, unsigned int baseaddr, unsigned int n_bytes) {
+
+  led_clr(pgm, LED_ERR);
+
+  int rc = pgm->paged_load? led_set(pgm, LED_PGM), pgm->paged_load(pgm, p, m, page_size, baseaddr, n_bytes): -1;
+
+  if(rc<0)
+    led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+
+  return rc;
+}
+
+// Programmer-specific page erase function with ERR/PGM LED info
+int led_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned int baseaddr) {
+
+  led_clr(pgm, LED_ERR);
+
+  int rc = pgm->page_erase? led_set(pgm, LED_PGM), pgm->page_erase(pgm, p, m, baseaddr): -1;
+
+  if(rc<0)
+    led_set(pgm, LED_ERR);
+  led_clr(pgm, LED_PGM);
+
+  return rc;
+}

--- a/src/leds.c
+++ b/src/leds.c
@@ -22,7 +22,14 @@
 #include "libavrdude.h"
 
 /*
- * Handle physical LEDs for programmers that have them
+ * Handle LEDs for some programmers
+ *
+ * Some hardware programmers have LEDs, and the firmware controls them
+ * fully without AVRDUDE having a way to influence the LED states. Other
+ * programmers have LEDs and expect the host downloader/uploader to handle
+ * them. For the latter type of programmers AVRDUDE provides support of
+ * four LEDs (RDY, ERR, PGM and VFY) which can be set via corresponding
+ * pgm->xxx_led(pgm, on_off) calls.
  *
  * The RDY LED is set once the programmer is initialised and switched
  * off when AVRDUDE exits. During reading, writing or erasing the target
@@ -36,7 +43,7 @@
  *
  * | PGM | VFY | ERR | Semantics                                        |
  * | --- | --- | --- | ------------------------------------------------ |
- * | off | off | off | OK: all tasks done w/o errors                    |
+ * | off | off | off | OK: all tasks done without errors                |
  * | off | off | on  | Some error not related to read/write/erase       |
  * | on  | off | on  | Read/write/erase error                           |
  * | off | on  | on  | Verification error but no read/write/erase error |

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -756,7 +756,7 @@ typedef enum {
 
 typedef struct {
   int now, chg, phy, end, set;  // LED states (current, change needed next period, physical, at end, ever set)
-  unsigned long ms[LED_N];      // time in ms after last physical change
+  unsigned long ms[LED_N];      // Time in ms after last physical change
 } leds_t;
 
 /*

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -708,8 +708,8 @@ typedef struct {                // Memory cache for a subset of cached pages
 
 /* formerly pgm.h */
 
-#define ON  1
-#define OFF 0
+#define OFF                  0 // Many contexts: reset, power, LEDs, ...
+#define ON                   1 // Many contexts
 
 #define PGM_PORTLEN PATH_MAX
 #define PGM_TYPELEN 32
@@ -739,6 +739,25 @@ typedef enum {
   CONNTYPE_SPI,
   CONNTYPE_LINUXGPIO
 } conntype_t;
+
+
+#define LED_N                 4 // Max number of LEDs driven by programmers
+#define LED_RDY               0 // led_set(pgm, LED_RDY) or led_clr(pgm, LED_RDY)
+#define LED_ERR               1 // led_set(pgm, LED_ERR) or led_clr(pgm, LED_ERR)
+#define LED_PGM               2 // led_set(pgm, LED_PGM) or led_clr(pgm, LED_PGM)
+#define LED_VFY               3 // led_set(pgm, LED_VFY) or led_clr(pgm, LED_VFY)
+#define LED_BEG            (-1) // led_set(pgm, LED_BEG) initally clear all LEDs
+#define LED_END            (-2) // led_set(pgm, LED_END) set error codes at extit
+#define LED_NOP            (-3) // led_set(pgm, LED_NOP) periodic nop for blinking
+
+#ifndef LED_FMAX
+#define LED_FMAX           2.51 // Hz (max frequency at which LEDs change)
+#endif
+
+typedef struct {
+  int now, chg, phy, end, set;  // LED states (current, change needed next period, physical, at end, ever set)
+  unsigned long ms[LED_N];      // time in ms after last physical change
+} leds_t;
 
 /*
  * Any changes in PROGRAMMER, please also ensure changes are made in
@@ -781,6 +800,7 @@ typedef struct programmer_t {
   int ispdelay;                 // ISP clock delay
   int page_size;                // Page size if the programmer supports paged write/load
   double bitclock;              // JTAG ICE clock period in microseconds
+  leds_t *leds;                 // State of LEDs as tracked by led_...()  functions in leds.c
 
   int  (*rdy_led)        (const struct programmer_t *pgm, int value);
   int  (*err_led)        (const struct programmer_t *pgm, int value);
@@ -1286,6 +1306,20 @@ void str_freedata(Str2data *sd);
 unsigned long long int str_int(const char *str, int type, const char **errpp);
 int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
 char *str_nexttok(char *buf, const char *delim, char **next);
+
+int led_set(const PROGRAMMER *pgm, int led);
+int led_clr(const PROGRAMMER *pgm, int led);
+int led_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
+int led_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned long addr, unsigned char value);
+int led_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned long addr, unsigned char *value);
+int led_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned int page_size, unsigned int baseaddr, unsigned int n_bytes);
+int led_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned int page_size, unsigned int baseaddr, unsigned int n_bytes);
+int led_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+  unsigned int baseaddr);
 
 int terminal_mode(const PROGRAMMER *pgm, const AVRPART *p);
 int terminal_mode_noninteractive(const PROGRAMMER *pgm, const AVRPART *p);

--- a/src/main.c
+++ b/src/main.c
@@ -1388,13 +1388,8 @@ skipopen:
    */
   pgm->enable(pgm, p);
 
-  /*
-   * turn off all the status leds
-   */
-  pgm->rdy_led(pgm, OFF);
-  pgm->err_led(pgm, OFF);
-  pgm->pgm_led(pgm, OFF);
-  pgm->vfy_led(pgm, OFF);
+  // Turn off all the status LEDs and reset LED states
+  led_set(pgm, LED_BEG);
 
   /*
    * initialize the chip in preparation for accepting commands
@@ -1419,8 +1414,8 @@ skipopen:
     }
   }
 
-  /* indicate ready */
-  pgm->rdy_led(pgm, ON);
+  // Indicate programmer is ready
+  led_set(pgm, LED_RDY);
 
   pmsg_info("AVR device initialized and ready to accept instructions\n");
 
@@ -1612,19 +1607,15 @@ skipopen:
 
 main_exit:
 
-  /*
-   * program complete
-   */
-
+  // Program complete
   if (is_open) {
     pgm->powerdown(pgm);
-
     pgm->disable(pgm);
-
-    pgm->rdy_led(pgm, OFF);
-
     pgm->close(pgm);
   }
+
+  // Clear rdy LED and summarise interaction in err, pgm and vfy LEDs
+  led_set(pgm, LED_END);
 
   msg_info("\n%s done.  Thank you.\n\n", progname);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1609,13 +1609,12 @@ main_exit:
 
   // Program complete
   if (is_open) {
+    // Clear rdy LED and summarise interaction in err, pgm and vfy LEDs
+    led_set(pgm, LED_END);
     pgm->powerdown(pgm);
     pgm->disable(pgm);
     pgm->close(pgm);
   }
-
-  // Clear rdy LED and summarise interaction in err, pgm and vfy LEDs
-  led_set(pgm, LED_END);
 
   msg_info("\n%s done.  Thank you.\n\n", progname);
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -385,9 +385,8 @@ static int  pickit2_pgm_led(const PROGRAMMER *pgm, int value) {
 }
 
 static int  pickit2_vfy_led(const PROGRAMMER *pgm, int value) {
-    // no such thing - maybe just call pgm_led
-
-    return pgm->pgm_led(pgm, value);
+    // no such thing
+    return 0;
 }
 
 static void pickit2_powerup(const PROGRAMMER *pgm) {
@@ -441,16 +440,12 @@ static int  pickit2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
         return -1;
     }
 
-    pgm->pgm_led(pgm, ON);
-
     memset(cmd, 0, sizeof(cmd));
 
     avr_set_bits(p->op[AVR_OP_CHIP_ERASE], cmd);
     pgm->cmd(pgm, cmd, res);
     usleep(p->chip_erase_delay);
     pgm->initialize(pgm, p);
-
-    pgm->pgm_led(pgm, OFF);
 
     return 0;
 }
@@ -470,8 +465,6 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     uint8_t data = 0, cmd[SPI_MAX_CHUNK], res[SPI_MAX_CHUNK];
     unsigned int addr_base;
     unsigned int max_addr = addr + n_bytes;
-
-    pgm->pgm_led(pgm, ON);
 
     if (lext) {
        memset(cmd, 0, sizeof(cmd));
@@ -523,7 +516,6 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
         if (bytes_read < 0)
         {
             pmsg_error("failed @ pgm->spi()\n");
-            pgm->err_led(pgm, ON);
             return -1;
         }
 
@@ -541,8 +533,6 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
         addr_base += blockSize;
     }
-
-    pgm->pgm_led(pgm, OFF);
 
     return n_bytes;
 }
@@ -615,8 +605,6 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     unsigned int addr_base;
     unsigned int max_addr = addr + n_bytes;
 
-    pgm->pgm_led(pgm, ON);
-
     for (addr_base = addr; addr_base < max_addr; )
     {
         uint32_t blockSize;
@@ -671,7 +659,6 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
             if (writeop == NULL)
             {
-                pgm->err_led(pgm, ON);
                 // not supported!
                 return -1;
             }
@@ -686,7 +673,6 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
         if (bytes_read < 0)
         {
             pmsg_error("failed @ pgm->spi()\n");
-            pgm->err_led(pgm, ON);
             return -1;
         }
 
@@ -703,8 +689,6 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
             usleep(mem->max_write_delay);
         }
     }
-
-    pgm->pgm_led(pgm, OFF);
 
     return n_bytes;
 }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -204,15 +204,11 @@ static int stk500_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   }
 
-  pgm->pgm_led(pgm, ON);
-
   memset(cmd, 0, sizeof(cmd));
   avr_set_bits(p->op[AVR_OP_CHIP_ERASE], cmd);
   pgm->cmd(pgm, cmd, res);
   usleep(p->chip_erase_delay);
   pgm->initialize(pgm, p);
-
-  pgm->pgm_led(pgm, OFF);
 
   return 0;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -979,8 +979,6 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
   }
 
-  pgm->pgm_led(pgm, ON);
-
   buf[0] = CMD_CHIP_ERASE_ISP;
   buf[1] = p->chip_erase_delay / 1000;
   buf[2] = 0;	// use delay (?)
@@ -992,8 +990,6 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     pgm->initialize(pgm, p); // should not be needed
   }
 
-  pgm->pgm_led(pgm, OFF);
-
   return result >= 0? 0: -1;
 }
 
@@ -1003,8 +999,6 @@ static int stk500v2_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int stk500hv_chip_erase(const PROGRAMMER *pgm, const AVRPART *p, enum hvmode mode) {
   int result;
   unsigned char buf[3];
-
-  pgm->pgm_led(pgm, ON);
 
   if (mode == PPMODE) {
     buf[0] = CMD_CHIP_ERASE_PP;
@@ -1018,8 +1012,6 @@ static int stk500hv_chip_erase(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   result = stk500v2_command(pgm, buf, 3, sizeof(buf));
   usleep(p->chip_erase_delay);
   pgm->initialize(pgm, p);
-
-  pgm->pgm_led(pgm, OFF);
 
   return result >= 0? 0: -1;
 }
@@ -2100,6 +2092,11 @@ static int scratchmonkey_rdy_led(const struct programmer_t *pgm, int value) {
   return 0;
 }
 
+static int scratchmonkey_err_led(const struct programmer_t *pgm, int value) {
+  scratchmonkey_led_state(pgm, SCRATCHMONKEY_ERR_LED, value);
+  return 0;
+}
+
 static int scratchmonkey_pgm_led(const struct programmer_t *pgm, int value) {
   scratchmonkey_led_state(pgm, SCRATCHMONKEY_PGM_LED, value);
   return 0;
@@ -2107,11 +2104,6 @@ static int scratchmonkey_pgm_led(const struct programmer_t *pgm, int value) {
 
 static int scratchmonkey_vfy_led(const struct programmer_t *pgm, int value) {
   scratchmonkey_led_state(pgm, SCRATCHMONKEY_VFY_LED, value);
-  return 0;
-}
-
-static int scratchmonkey_err_led(const struct programmer_t *pgm, int value) {
-  scratchmonkey_led_state(pgm, SCRATCHMONKEY_ERR_LED, value);
   return 0;
 }
 

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -221,6 +221,32 @@
 #include "urclock.h"
 #include "urclock_private.h"
 
+static int dryrun_rdy_led(const PROGRAMMER *pgm, int value) {
+  pmsg_info("%s(%d)\n", __func__, value);
+
+  return 0;
+}
+
+static int dryrun_err_led(const PROGRAMMER *pgm, int value) {
+  pmsg_info("%s(%d)\n", __func__, value);
+
+  return 0;
+}
+
+static int dryrun_pgm_led(const PROGRAMMER *pgm, int value) {
+  pmsg_info("%s(%d)\n", __func__, value);
+
+  return 0;
+}
+
+static int dryrun_vfy_led(const PROGRAMMER *pgm, int value) {
+  pmsg_info("%s(%d)\n", __func__, value);
+
+  return 0;
+}
+
+
+
 #define urmax(a, b) ((a) > (b)? (a): (b))
 #define urmin(a, b) ((a) < (b)? (a): (b))
 
@@ -2542,6 +2568,10 @@ void urclock_initpgm(PROGRAMMER *pgm) {
   pgm->read_sig_bytes = urclock_read_sig_bytes;
 
   // Mandatory functions
+  pgm->rdy_led = dryrun_rdy_led;
+  pgm->err_led = dryrun_err_led;
+  pgm->pgm_led = dryrun_pgm_led;
+  pgm->vfy_led = dryrun_vfy_led;
   pgm->initialize = urclock_initialize;
   pgm->display = urclock_display;
   pgm->enable = urclock_enable;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -221,32 +221,6 @@
 #include "urclock.h"
 #include "urclock_private.h"
 
-static int dryrun_rdy_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
-
-  return 0;
-}
-
-static int dryrun_err_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
-
-  return 0;
-}
-
-static int dryrun_pgm_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
-
-  return 0;
-}
-
-static int dryrun_vfy_led(const PROGRAMMER *pgm, int value) {
-  pmsg_info("%s(%d)\n", __func__, value);
-
-  return 0;
-}
-
-
-
 #define urmax(a, b) ((a) > (b)? (a): (b))
 #define urmin(a, b) ((a) < (b)? (a): (b))
 
@@ -2568,10 +2542,6 @@ void urclock_initpgm(PROGRAMMER *pgm) {
   pgm->read_sig_bytes = urclock_read_sig_bytes;
 
   // Mandatory functions
-  pgm->rdy_led = dryrun_rdy_led;
-  pgm->err_led = dryrun_err_led;
-  pgm->pgm_led = dryrun_pgm_led;
-  pgm->vfy_led = dryrun_vfy_led;
   pgm->initialize = urclock_initialize;
   pgm->display = urclock_display;
   pgm->enable = urclock_enable;


### PR DESCRIPTION
The RDY LED is set once the programmer is initialised and switched off when AVRDUDE exits. During reading, writing or erasing the target the PGM LED flashes with around 2.5 Hz, whilst the VFY LED comes on during -U verification of the uploaded contents. Errors are indicated with the ERR LED.

Assuming AVRDUDE got to the point where LEDs are accessible and the RDY LED was switched on then, on exit, AVRDUDE will leave the LEDs in the following states:

| PGM | VFY | ERR | Semantics                                        |
| --- | --- | --- | ------------------------------------------------ |
| off | off | off | OK: all tasks done w/o errors                    |
| off | off | on  | Some error not related to read/write/erase       |
| on  | off | on  | Read/write/erase error                           |
| off | on  | on  | Verification error but no read/write/erase error |
| on  | on  | on  | Read/write/erase error and verification error    |

Other combinations should not show after exit.

I don't have a programmer with LEDs. Probably best to test with ScratchMonkey. You can force errors by attempting to write to signature. Try, eg,
```
avrdude -qc urclock -p m328p -P ch340 -T "read flash 0 -1" -T "w signature 0 0" -t
```