### PR TITLE
Fix candidate for issues with NVM v3 controller

### DIFF
--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -161,9 +161,9 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
       updi_set_datalink_mode(pgm, UPDI_LINK_MODE_24BIT);
       break;
     case '3':
-      pmsg_notice("NVM type 3: 16-bit, page oriented\n");
+      pmsg_notice("NVM type 3: 24-bit, page oriented\n");
       updi_set_nvm_mode(pgm, UPDI_NVM_MODE_V3);
-      updi_set_datalink_mode(pgm, UPDI_LINK_MODE_16BIT);
+      updi_set_datalink_mode(pgm, UPDI_LINK_MODE_24BIT);
       break;
     default:
       pmsg_warning("unsupported NVM type: %c, please update software\n", sib_info->nvm_version);


### PR DESCRIPTION
Candidate fix for issue #1529 - please note, this fix only addresses the issue of 16/24 bit addressing mode for NVM v3 controller. It has not been tested against any physical device, as I don't have one to test it yet. 