### PR TITLE
Introduce memory types in lieu of string comparisons with memory names

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -57,7 +57,7 @@ int avr_tpi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     led_set(pgm, LED_PGM);
 
     /* Set Pointer Register */
-    mem = avr_locate_mem(p, "flash");
+    mem = avr_locate_flash(p);
     if (mem == NULL) {
       pmsg_error("no flash memory to erase for part %s\n", p->desc);
       led_set(pgm, LED_ERR);
@@ -1372,17 +1372,16 @@ int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles) {
   int rc;
   int i;
 
-  a = avr_locate_mem(p, "eeprom");
-  if (a == NULL) {
+  a = avr_locate_eeprom(p);
+  if (a == NULL)
     return -1;
-  }
 
   for (i=4; i>0; i--) {
     rc = pgm->read_byte(pgm, p, a, a->size-i, &v1);
-  if (rc < 0) {
-    pmsg_warning("cannot read memory for cycle count, rc=%d\n", rc);
-    return -1;
-  }
+    if (rc < 0) {
+      pmsg_warning("cannot read memory for cycle count, rc=%d\n", rc);
+      return -1;
+    }
     cycle_count = (cycle_count << 8) | v1;
   }
 
@@ -1408,10 +1407,9 @@ int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles) {
   int rc;
   int i;
 
-  a = avr_locate_mem(p, "eeprom");
-  if (a == NULL) {
+  a = avr_locate_eeprom(p);
+  if (a == NULL)
     return -1;
-  }
 
   for (i=1; i<=4; i++) {
     v1 = cycles & 0xff;

--- a/src/avr.c
+++ b/src/avr.c
@@ -467,7 +467,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
     /* else: fall back to byte-at-a-time read, for historical reasons */
   }
 
-  if (str_eq(mem->desc, "signature")) {
+  if (mem_is_signature(mem)) {
     if (pgm->read_sig_bytes) {
       int rc = pgm->read_sig_bytes(pgm, p, mem);
       if (rc < 0)
@@ -663,7 +663,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
       goto error;
     }
 
-    if (str_eq(mem->desc, "flash")) {
+    if (mem_is_flash(mem)) {
       pmsg_error("writing a byte to flash is not supported for %s\n", p->desc);
       goto error;
     } else if ((mem->offset + addr) & 1) {
@@ -1231,7 +1231,7 @@ int avr_signature(const PROGRAMMER *pgm, const AVRPART *p) {
 int avr_mem_bitmask(const AVRPART *p, const AVRMEM *mem, int addr) {
   int bitmask = mem->bitmask;
   // Collective memory fuses will have a different bitmask for each address (ie, fuse)
-  if(str_eq(mem->desc, "fuses") && addr >=0 && addr < 16) { // Get right fuse in fuses memory
+  if(mem_is_fuses(mem) && addr >=0 && addr < 16) { // Get right fuse in fuses memory
     char memstr[64];
     AVRMEM *dfuse;
     sprintf(memstr, "fuse%x", addr);

--- a/src/avr.c
+++ b/src/avr.c
@@ -302,7 +302,7 @@ int avr_mem_hiaddr(const AVRMEM * mem)
     return mem->size;
 
   /* if the memory is not a flash-type memory do not remove trailing 0xff */
-  if(!avr_mem_is_flash_type(mem))
+  if(!mem_is_in_flash(mem))
     return mem->size;
 
   /* return the highest non-0xff address regardless of how much
@@ -1154,7 +1154,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
 
   int page_tainted = 0;
   int flush_page = 0;
-  int paged = avr_mem_is_flash_type(m) && m->paged;
+  int paged = mem_is_in_flash(m) && m->paged;
 
   if(paged)
     wsize = (wsize+1)/2*2;      // Round up write size for word boundary
@@ -1319,7 +1319,7 @@ int avr_verify(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, const 
           if(vroerror < 10) {
             if(!(verror + vroerror))
               pmsg_warning("verification mismatch%s\n",
-                avr_mem_is_flash_type(a)? " in r/o areas, expected for vectors and/or bootloader": "");
+                mem_is_in_flash(a)? " in r/o areas, expected for vectors and/or bootloader": "");
             imsg_warning("device 0x%02x != input 0x%02x at addr 0x%04x (read only location)\n",
               buf1[i], buf2[i], i);
           } else if(vroerror == 10)

--- a/src/avr.c
+++ b/src/avr.c
@@ -725,7 +725,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
         rc = -2;
         goto rcerror;
       }
-      // Read operation is not support on this memory type
+      // Read operation is not support on this memory
     }
     else {
       readok = 1;

--- a/src/avr.c
+++ b/src/avr.c
@@ -1524,32 +1524,16 @@ int avr_get_mem_type(const char *str) {
   exit(1);
 }
 
-int avr_memstr_is_flash_type(const char *memstr) {
-  return memstr && (
-     str_eq(memstr, "flash") ||
-     str_eq(memstr, "application") ||
-     str_eq(memstr, "apptable") ||
-     str_eq(memstr, "boot"));
-}
-
 int avr_mem_is_flash_type(const AVRMEM *mem) {
-  return avr_memstr_is_flash_type(mem->desc);
-}
-
-int avr_memstr_is_eeprom_type(const char *memstr) {
-  return memstr && str_eq(memstr, "eeprom");
+  return mem_is_in_flash(mem);
 }
 
 int avr_mem_is_eeprom_type(const AVRMEM *mem) {
-  return avr_memstr_is_eeprom_type(mem->desc);
-}
-
-int avr_memstr_is_usersig_type(const char *memstr) { // Bootrow is subsumed under usersig type
-  return memstr && (str_eq(memstr, "bootrow") || str_eq(memstr, "usersig") || str_eq(memstr, "userrow"));
+  return mem_is_eeprom(mem);
 }
 
 int avr_mem_is_usersig_type(const AVRMEM *mem) {
-  return avr_memstr_is_usersig_type(mem->desc);
+  return mem_is_user_type(mem);
 }
 
 int avr_mem_is_known(const char *str) {

--- a/src/avr.c
+++ b/src/avr.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <ctype.h>
 #include <sys/time.h>
 #include <time.h>
 
@@ -1616,4 +1617,24 @@ void report_progress(int completed, int total, const char *hdr) {
     last = percent;
     update_progress(percent, t - start_time, hdr, total < 0? -1: !!total);
   }
+}
+
+
+// Output comms buffer
+void trace_buffer(char *what, const unsigned char *buf, size_t buflen) {
+  pmsg_trace("%s", what);
+  while(buflen--) {
+    unsigned char c = *buf++;
+    msg_trace("%c [%02x]%s", isascii(c) && isprint(c)? c: '.', c, buflen? " ": "");
+  }
+  msg_trace("\n");
+}
+
+void trace2_buffer(char *what, const unsigned char *buf, size_t buflen) {
+  pmsg_trace2("%s", what);
+  while(buflen--) {
+    unsigned char c = *buf++;
+    msg_trace2("%c [%02x]%s", isascii(c) && isprint(c)? c: '.', c, buflen? " ": "");
+  }
+  msg_trace2("\n");
 }

--- a/src/avr.c
+++ b/src/avr.c
@@ -1621,20 +1621,11 @@ void report_progress(int completed, int total, const char *hdr) {
 
 
 // Output comms buffer
-void trace_buffer(char *what, const unsigned char *buf, size_t buflen) {
-  pmsg_trace("%s", what);
+void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen) {
+  pmsg_trace("%s: ", funstr);
   while(buflen--) {
     unsigned char c = *buf++;
     msg_trace("%c [%02x]%s", isascii(c) && isprint(c)? c: '.', c, buflen? " ": "");
   }
   msg_trace("\n");
-}
-
-void trace2_buffer(char *what, const unsigned char *buf, size_t buflen) {
-  pmsg_trace2("%s", what);
-  while(buflen--) {
-    unsigned char c = *buf++;
-    msg_trace2("%c [%02x]%s", isascii(c) && isprint(c)? c: '.', c, buflen? " ": "");
-  }
-  msg_trace2("\n");
 }

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -403,7 +403,7 @@ static int avr910_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 {
   char cmd[2];
 
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     if (addr & 0x01) {
       cmd[0] = 'C';             /* Write Program Mem high byte */
     }
@@ -413,7 +413,7 @@ static int avr910_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
     addr >>= 1;
   }
-  else if (str_eq(m->desc, "eeprom")) {
+  else if (mem_is_eeprom(m)) {
     cmd[0] = 'D';
   }
   else {
@@ -468,11 +468,11 @@ static int avr910_read_byte_eeprom(const PROGRAMMER *pgm, const AVRPART *p, cons
 static int avr910_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
                             unsigned long addr, unsigned char * value)
 {
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     return avr910_read_byte_flash(pgm, p, m, addr, value);
   }
 
-  if (str_eq(m->desc, "eeprom")) {
+  if (mem_is_eeprom(m)) {
     return avr910_read_byte_eeprom(pgm, p, m, addr, value);
   }
 
@@ -574,9 +574,9 @@ static int avr910_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 {
   int rval = 0;
   if (PDATA(pgm)->use_blockmode == 0) {
-    if (str_eq(m->desc, "flash")) {
+    if (mem_is_flash(m)) {
       rval = avr910_paged_write_flash(pgm, p, m, page_size, addr, n_bytes);
-    } else if (str_eq(m->desc, "eeprom")) {
+    } else if (mem_is_eeprom(m)) {
       rval = avr910_paged_write_eeprom(pgm, p, m, page_size, addr, n_bytes);
     } else {
       rval = -2;
@@ -589,7 +589,7 @@ static int avr910_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     unsigned int blocksize = PDATA(pgm)->buffersize;
     int wr_size;
 
-    if (!str_eq(m->desc, "flash") && !str_eq(m->desc, "eeprom"))
+    if (!mem_is_flash(m) && !mem_is_eeprom(m))
       return -2;
 
     if (m->desc[0] == 'e') {
@@ -640,10 +640,10 @@ static int avr910_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
   max_addr = addr + n_bytes;
 
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     cmd[0] = 'R';
     rd_size = 2;                /* read two bytes per addr */
-  } else if (str_eq(m->desc, "eeprom")) {
+  } else if (mem_is_eeprom(m)) {
     cmd[0] = 'd';
     rd_size = 1;
   } else {

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -629,7 +629,7 @@ int avr_read_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *
   }
 
   AVR_Cache *cp = mem_is_eeprom(mem)? pgm->cp_eeprom: mem_is_in_flash(mem)? pgm->cp_flash:
-    str_eq(mem->desc, "bootrow")? pgm->cp_bootrow: pgm->cp_usersig;
+    mem_is_bootrow(mem)? pgm->cp_bootrow: pgm->cp_usersig;
 
   if(!cp->cont)                 // Init cache if needed
     if(initCache(cp, pgm, p) < 0)
@@ -669,7 +669,7 @@ int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
     return avr_flush_cache(pgm, p);
 
   AVR_Cache *cp = mem_is_eeprom(mem)? pgm->cp_eeprom: mem_is_in_flash(mem)? pgm->cp_flash:
-    str_eq(mem->desc, "bootrow")? pgm->cp_bootrow: pgm->cp_usersig;
+    mem_is_bootrow(mem)? pgm->cp_bootrow: pgm->cp_usersig;
 
   if(!cp->cont)                 // Init cache if needed
     if(initCache(cp, pgm, p) < 0)
@@ -772,7 +772,7 @@ int avr_page_erase_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
   }
 
   AVR_Cache *cp = mem_is_eeprom(mem)? pgm->cp_eeprom: mem_is_in_flash(mem)? pgm->cp_flash:
-    str_eq(mem->desc, "bootrow")? pgm->cp_bootrow: pgm->cp_usersig;
+    mem_is_bootrow(mem)? pgm->cp_bootrow: pgm->cp_usersig;
 
   if(!cp->cont)                 // Init cache if needed
     if(initCache(cp, pgm, p) < 0)

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -50,9 +50,9 @@
  * int avr_reset_cache(const PROGRAMMER *pgm, const AVRPART *p);
  *
  * avr_read_byte_cached() and avr_write_byte_cached() use a cache if paged
- * routines are available and if the device memory type is flash, EEPROM,
- * bootrow or usersig. The AVRXMEGA memories application, apptable and boot
- * are subsumed under flash. Userrow is subsumed under usersig provided
+ * routines are available and if the device memory is flash, EEPROM, bootrow
+ * or usersig. The AVRXMEGA memories application, apptable and boot are
+ * subsumed under flash. Userrow is subsumed under usersig provided
  * avrdude.conf has a memory alias from usersig to userrow. In all other
  * cases the cached read/write functions fall back to pgm->read_byte() and
  * pgm->write_byte(), respectively. Bytewise cached read always gets its data

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -130,7 +130,7 @@ int avr_has_paged_access(const PROGRAMMER *pgm, const AVRMEM *mem) {
   return pgm->paged_load && pgm->paged_write &&
     mem->page_size > 0 && (mem->page_size & (mem->page_size-1)) == 0 &&
     mem->size > 0 && mem->size % mem->page_size == 0 &&
-    (avr_mem_is_flash_type(mem) || avr_mem_is_eeprom_type(mem) || avr_mem_is_usersig_type(mem));
+    mem_is_paged_type(mem);
 }
 
 
@@ -276,7 +276,7 @@ static int initCache(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p) {
   cp->copy = cfg_malloc("initCache()", cp->size);
   cp->iscached = cfg_malloc("initCache()", cp->size/cp->page_size);
 
-  if((pgm->prog_modes & PM_SPM) && avr_mem_is_flash_type(basemem)) { // Could be vector bootloader
+  if((pgm->prog_modes & PM_SPM) && mem_is_in_flash(basemem)) { // Could be vector bootloader
     // Caching the vector page hands over to the progammer that then can patch the reset vector
     if(loadCachePage(cp, pgm, p, basemem, 0, 0, 0) < 0)
       return LIBAVRDUDE_GENERAL_FAILURE;
@@ -449,7 +449,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       }
     }
 
-    if(!avr_mem_is_usersig_type(mems[i].mem)) // Only force CE if unable to write to flash/EEPROM
+    if(!mem_is_user_type(mems[i].mem)) // Only force CE if unable to write to flash/EEPROM
       chiperase = 1;
   }
 
@@ -471,7 +471,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       AVR_Cache *cp = mems[i].cp;
       if(!mem)
         continue;
-      if(avr_mem_is_usersig_type(mem)) // CE does not affect bootrow/usersig
+      if(mem_is_user_type(mem)) // CE does not affect bootrow/userrow
         continue;
 
       for(int pgno = 0, n = 0; n < cp->size; pgno++, n += cp->page_size)
@@ -487,7 +487,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
         AVR_Cache *cp = mems[i].cp;
         if(!mem)
           continue;
-        if(avr_mem_is_usersig_type(mem)) // CE does not affect bootrow/usersig
+        if(mem_is_user_type(mem)) // CE does not affect bootrow/userrow
           continue;
 
         for(int ird = 0, pgno = 0, n = 0; n < cp->size; pgno++, n += cp->page_size) {
@@ -516,7 +516,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       AVR_Cache *cp = mems[i].cp;
       if(!mem)
         continue;
-      if(avr_mem_is_usersig_type(mem)) // CE does not affect bootrow/usersig
+      if(mem_is_user_type(mem)) // CE does not affect bootrow/userrow
         continue;
 
       if(mems[i].isflash) {
@@ -628,8 +628,7 @@ int avr_read_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *
     return LIBAVRDUDE_SUCCESS;
   }
 
-  AVR_Cache *cp = avr_mem_is_eeprom_type(mem)? pgm->cp_eeprom:
-    avr_mem_is_flash_type(mem)? pgm->cp_flash:
+  AVR_Cache *cp = mem_is_eeprom(mem)? pgm->cp_eeprom: mem_is_in_flash(mem)? pgm->cp_flash:
     str_eq(mem->desc, "bootrow")? pgm->cp_bootrow: pgm->cp_usersig;
 
   if(!cp->cont)                 // Init cache if needed
@@ -669,8 +668,7 @@ int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
   if(addr >= (unsigned long) mem->size)
     return avr_flush_cache(pgm, p);
 
-  AVR_Cache *cp = avr_mem_is_eeprom_type(mem)? pgm->cp_eeprom:
-    avr_mem_is_flash_type(mem)? pgm->cp_flash:
+  AVR_Cache *cp = mem_is_eeprom(mem)? pgm->cp_eeprom: mem_is_in_flash(mem)? pgm->cp_flash:
     str_eq(mem->desc, "bootrow")? pgm->cp_bootrow: pgm->cp_usersig;
 
   if(!cp->cont)                 // Init cache if needed
@@ -773,8 +771,7 @@ int avr_page_erase_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
       return LIBAVRDUDE_GENERAL_FAILURE;
   }
 
-  AVR_Cache *cp = avr_mem_is_eeprom_type(mem)? pgm->cp_eeprom:
-    avr_mem_is_flash_type(mem)? pgm->cp_flash:
+  AVR_Cache *cp = mem_is_eeprom(mem)? pgm->cp_eeprom: mem_is_in_flash(mem)? pgm->cp_flash:
     str_eq(mem->desc, "bootrow")? pgm->cp_bootrow: pgm->cp_usersig;
 
   if(!cp->cont)                 // Init cache if needed

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -263,8 +263,8 @@ static int loadCachePage(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p,
 
 
 static int initCache(AVR_Cache *cp, const PROGRAMMER *pgm, const AVRPART *p) {
-  AVRMEM *basemem = avr_locate_mem(p,
-    cp == pgm->cp_flash? "flash": cp == pgm->cp_eeprom? "eeprom": cp == pgm->cp_bootrow? "bootrow": "usersig");
+  AVRMEM *basemem = cp == pgm->cp_flash? avr_locate_flash(p): cp == pgm->cp_eeprom? avr_locate_eeprom(p):
+    cp == pgm->cp_bootrow? avr_locate_bootrow(p): avr_locate_usersig(p);
 
   if(!basemem || !avr_has_paged_access(pgm, basemem))
     return LIBAVRDUDE_GENERAL_FAILURE;
@@ -377,10 +377,10 @@ typedef struct {
 // Write flash, EEPROM, bootrow and usersig caches to device and free them
 int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
   CacheDesc_t mems[] = {
-    { avr_locate_mem(p, "flash"), pgm->cp_flash, 1, 0, -1, 0 },
-    { avr_locate_mem(p, "eeprom"), pgm->cp_eeprom, 0, 1, -1, 0 },
-    { avr_locate_mem(p, "bootrow"), pgm->cp_bootrow, 0, 0, -1, 0 },
-    { avr_locate_mem(p, "usersig"), pgm->cp_usersig, 0, 0, -1, 0 },
+    { avr_locate_flash(p), pgm->cp_flash, 1, 0, -1, 0 },
+    { avr_locate_eeprom(p), pgm->cp_eeprom, 0, 1, -1, 0 },
+    { avr_locate_bootrow(p), pgm->cp_bootrow, 0, 0, -1, 0 },
+    { avr_locate_usersig(p), pgm->cp_usersig, 0, 0, -1, 0 },
   };
 
   int chpages = 0;
@@ -698,8 +698,8 @@ int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 // Erase the chip and set the cache accordingly
 int avr_chip_erase_cached(const PROGRAMMER *pgm, const AVRPART *p) {
   CacheDesc_t mems[3] = {
-    { avr_locate_mem(p, "flash"), pgm->cp_flash, 1, 0, -1, 0 },
-    { avr_locate_mem(p, "eeprom"), pgm->cp_eeprom, 0, 1, -1, 0 },
+    { avr_locate_flash(p), pgm->cp_flash, 1, 0, -1, 0 },
+    { avr_locate_eeprom(p), pgm->cp_eeprom, 0, 1, -1, 0 },
     // bootrow/usersig is unaffected by CE
   };
   int rc;

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -767,7 +767,7 @@ device-dependent, the actual configuration can be viewed with the
 .Cm part
 command in terminal mode.
 Typically, a device's memory configuration at least contains
-the memory types
+the memories
 .Ar flash ,
 .Ar eeprom ,
 .Ar signature
@@ -786,7 +786,7 @@ will also typically have fuse bytes, which are read/write memories for
 configuration of the device and calibration memories that typically
 contain read-only factory calibration values.
 .Pp
-Classic devices may have the following memory types in addition to eeprom, flash, signature and lock:
+Classic devices may have the following memories in addition to eeprom, flash, signature and lock:
 .Bl -tag -width "  calibration" -compact
 .It   calibration
 One or more bytes of RC oscillator calibration data
@@ -824,7 +824,7 @@ methods only by bootloaders, which has limited use unless the bootloader
 jumps to the application directly, i.e., without a WDT reset
 .El
 .Pp
-ATxmega devices have the following memory types in addition to eeprom, flash, signature and lock:
+ATxmega devices have the following memories in addition to eeprom, flash, signature and lock:
 .Bl -tag -width "calibration" -compact
 .It application
 Application flash area
@@ -859,7 +859,7 @@ Volatile register memory;
 can read this memory but not write to it using external programming
 .El
 .Pp
-Modern 8-bit AVR devices have the following memory types in addition to eeprom, flash, signature and lock:
+Modern 8-bit AVR devices have the following memories in addition to eeprom, flash, signature and lock:
 .Bl -tag -width "calibration" -compact
 .It fuse0
 A.k.a. wdtcfg: watchdog configuration
@@ -1252,7 +1252,7 @@ on a non-zero verbosity level the line numbers are printed, too.
 Display the device signature bytes.
 .It Ar part
 Display the current part settings and parameters.  Includes chip
-specific information including all memory types supported by the
+specific information including all memories supported by the
 device, read/write timing, etc.
 .It Ar verbose Op Ar level
 Change (when

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -240,13 +240,13 @@
 # NOTES:
 #   * 'devicecode' is the device code used by the STK500 (see codes
 #       listed below)
-#   * Not all memory types will implement all instructions
+#   * Not all memories will implement all instructions
 #   * AVR Fuse bits and Lock bits are implemented as a type of memory
-#   * Example memory types are:
+#   * Example memories are:
 #       "flash", "eeprom", "fuse", "lfuse" (low fuse), "hfuse" (high
 #       fuse), "signature", "calibration", "lock"
-#   * The memory type specified on the avrdude command line must match
-#     one of the memory types defined for the specified chip
+#   * The memory specified on the avrdude command line must match
+#     one of the memories defined for the specified chip
 #   * The pwroff_after_write flag causes avrdude to attempt to
 #     power the device off and back on after an unsuccessful write to
 #     the affected memory area if VCC programmer pins are defined. If

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -180,7 +180,7 @@
 #       # parameters for bootloaders
 #       autobaud_sync    = <num> ;                # autobaud detection byte, default 0x30
 #
-#       memory <memtype>
+#       memory <memstr>
 #           paged           = <yes/no> ;          # yes/no (flash only, do not use for EEPROM)
 #           offset          = <num> ;             # memory offset
 #           size            = <num> ;             # bytes

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -19202,6 +19202,12 @@ part # .avr8x
     ocd_base               = 0x0f80;
     syscfg_base            = 0x0f00;
 
+    memory "fuses"
+        size               = 10;
+        offset             = 0x1280;
+        readsize           = 1;
+    ;
+
     memory "fuse0"
         size               = 1;
         initval            = 0x00;
@@ -19288,13 +19294,6 @@ part # .avr8x
 
     memory "bootsize"
         alias "fuse8";
-    ;
-
-    memory "fuses"
-        size               = 10;
-        page_size          = 10;
-        offset             = 0x1280;
-        readsize           = 10;
     ;
 
     memory "lock"
@@ -21436,6 +21435,12 @@ part # .avrdx
     ocd_base               = 0x0f80;
     syscfg_base            = 0x0f00;
 
+    memory "fuses"
+        size               = 16;
+        offset             = 0x1050;
+        readsize           = 1;
+    ;
+
     memory "fuse0"
         size               = 1;
         initval            = 0x00;
@@ -21522,13 +21527,6 @@ part # .avrdx
 
     memory "bootend"
         alias "fuse8";
-    ;
-
-    memory "fuses"
-        size               = 16;
-        page_size          = 16;
-        offset             = 0x1050;
-        readsize           = 16;
     ;
 
     memory "lock"

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1534,7 +1534,7 @@ static int avrftdi_jtag_chip_erase(const PROGRAMMER *pgm, const AVRPART *p)
 static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		const AVRMEM *m, unsigned long addr, unsigned char *value)
 {
-	if (str_eq(m->desc, "lfuse")) {
+	if (mem_is_lfuse(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1542,7 +1542,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3200, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3300, 15) & 0xff;
 
-	} else if (str_eq(m->desc, "hfuse")) {
+	} else if (mem_is_hfuse(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1550,7 +1550,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3e00, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3f00, 15) & 0xff;
 
-	} else if (str_eq(m->desc, "efuse")) {
+	} else if (mem_is_efuse(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1558,7 +1558,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3a00, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3b00, 15) & 0xff;
 
-	} else if (str_eq(m->desc, "lock")) {
+	} else if (mem_is_lock(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_READ, 15);
 
@@ -1603,7 +1603,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		const AVRMEM *m, unsigned long addr, unsigned char value)
 {
-	if (str_eq(m->desc, "lfuse")) {
+	if (mem_is_lfuse(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_WRITE, 15);
 
@@ -1620,7 +1620,7 @@ static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3300, 15) & 0x0200))
 			;
 
-	} else if (str_eq(m->desc, "hfuse")) {
+	} else if (mem_is_hfuse(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_WRITE, 15);
 
@@ -1637,7 +1637,7 @@ static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0x0200))
 			;
 
-	} else if (str_eq(m->desc, "efuse")) {
+	} else if (mem_is_efuse(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FUSE_WRITE, 15);
 
@@ -1654,7 +1654,7 @@ static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3b00, 15) & 0x0200))
 			;
 
-	} else if (str_eq(m->desc, "lock")) {
+	} else if (mem_is_lock(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_LOCK_WRITE, 15);
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1584,7 +1584,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3600, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0xff;
 
-	} else if (str_eq(m->desc, "prodsig")) {
+	} else if (mem_is_sigrow(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_SIGCAL_READ, 15);
 		avrftdi_jtag_dr_out(pgm, 0x0300 | (addr/2 & 0xff), 15);

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1246,9 +1246,9 @@ static int avrftdi_flash_read(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 static int avrftdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
 		unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
-	if (str_eq(m->desc, "flash"))
+	if (mem_is_flash(m))
 		return avrftdi_flash_write(pgm, p, m, page_size, addr, n_bytes);
-	else if (str_eq(m->desc, "eeprom"))
+	else if (mem_is_eeprom(m))
 		return avrftdi_eeprom_write(pgm, p, m, page_size, addr, n_bytes);
 	else
 		return -2;
@@ -1257,9 +1257,9 @@ static int avrftdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
 static int avrftdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
 		unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
-	if (str_eq(m->desc, "flash"))
+	if (mem_is_flash(m))
 		return avrftdi_flash_read(pgm, p, m, page_size, addr, n_bytes);
-	else if(str_eq(m->desc, "eeprom"))
+	else if(mem_is_eeprom(m))
 		return avrftdi_eeprom_read(pgm, p, m, page_size, addr, n_bytes);
 	else
 		return -2;
@@ -1566,7 +1566,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3600, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0xff;
 
-	} else if (str_eq(m->desc, "signature")) {
+	} else if (mem_is_signature(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_SIGCAL_READ, 15);
 		avrftdi_jtag_dr_out(pgm, 0x0300 | (addr & 0xff), 15);
@@ -1575,7 +1575,7 @@ static int avrftdi_jtag_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		avrftdi_jtag_dr_out(pgm, 0x3200, 15);
 		*value = avrftdi_jtag_dr_inout(pgm, 0x3300, 15) & 0xff;
 
-	} else if (str_eq(m->desc, "calibration")) {
+	} else if (mem_is_calibration(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_SIGCAL_READ, 15);
 		avrftdi_jtag_dr_out(pgm, 0x0300 | (addr & 0xff), 15);
@@ -1685,7 +1685,7 @@ static int avrftdi_jtag_paged_write(const PROGRAMMER *pgm, const AVRPART *p,
 	unsigned int maxaddr = addr + n_bytes;
 	unsigned char byte;
 
-	if (str_eq(m->desc, "flash")) {
+	if (mem_is_flash(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FLASH_WRITE, 15);
 
@@ -1712,7 +1712,7 @@ static int avrftdi_jtag_paged_write(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3700, 15) & 0x0200))
 			;
 
-	} else if (str_eq(m->desc, "eeprom")) {
+	} else if (mem_is_eeprom(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_EEPROM_WRITE, 15);
 
@@ -1760,7 +1760,7 @@ static int avrftdi_jtag_paged_read(const PROGRAMMER *pgm, const AVRPART *p,
     buf = alloca(n_bytes * 8 + 1);
     ptr = buf;
 
-	if (str_eq(m->desc, "flash")) {
+	if (mem_is_flash(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_FLASH_READ, 15);
 
@@ -1800,7 +1800,7 @@ static int avrftdi_jtag_paged_read(const PROGRAMMER *pgm, const AVRPART *p,
 			m->buf[addr + i] = (buf[i * 2] >> 1) | (buf[(i * 2) + 1] << 2);
 		}
 
-	} else if (str_eq(m->desc, "eeprom")) {
+	} else if (mem_is_eeprom(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);
 		avrftdi_jtag_dr_out(pgm, 0x2300 | JTAG_DR_PROG_EEPROM_READ, 15);
 

--- a/src/avrintel.h
+++ b/src/avrintel.h
@@ -26,7 +26,7 @@ typedef struct {
   const char *name;             // Name of this configuration item
   int nvalues;                  // Number of (symbolic) values
   const Valueitem_t *vlist;     // Pointer to nvalues value items
-  const char *memtype;          // Fuse/Lock memory for this configuration
+  const char *memstr;           // Fuse/Lock memory for this configuration
   int memoffset;                // Byte offset within fuses (always 0 for lock)
   int mask;                     // Bit mask of fuse/lock memory
   int lsh;                      // Values need shifting left by lsh to be in mask

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -495,6 +495,29 @@ AVRMEM *avr_locate_fuse_by_offset(const AVRPART *p, unsigned int off) {
   return NULL;
 }
 
+// Return the first memory that shares the type including fuses identified by offset in fuses
+AVRMEM *avr_locate_mem_by_type(const AVRPART *p, memtype_t type) {
+  AVRMEM *m;
+  memtype_t off = type & MEM_FUSEOFF_MASK;
+  type &= ~(memtype_t) MEM_FUSEOFF_MASK;
+
+  if(p && p->mem)
+    for(LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln))
+      if((m = ldata(ln))->type & type)
+        if(type != MEM_IS_A_FUSE || off == mem_fuse_offset(m))
+          return m;
+
+  return NULL;
+}
+
+// Return offset of memory data
+unsigned int avr_data_offset(const AVRPART *p) {
+  AVRMEM *data = avr_locate_data(p);
+  if(!data)
+    pmsg_warning("cannot locate data memory; is avrdude.conf up to date?\n");
+  return data? data->offset: 0;
+}
+
 AVRMEM_ALIAS *avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig) {
   if(p && p->mem_alias && m_orig)
     for(LNODEID ln=lfirst(p->mem_alias); ln; ln=lnext(ln)) {

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -327,8 +327,8 @@ static char * bittype(int type)
  *** Elementary functions dealing with AVRMEM structures
  ***/
 
-AVRMEM *avr_new_memtype(void) {
-  AVRMEM *m = (AVRMEM *) cfg_malloc("avr_new_memtype()", sizeof(*m));
+AVRMEM *avr_new_mem(void) {
+  AVRMEM *m = (AVRMEM *) cfg_malloc("avr_new_mem()", sizeof(*m));
   m->desc = cache_string("");
   m->page_size = 1;             // Ensure not 0
   m->initval = -1;              // Unknown value represented as -1
@@ -363,7 +363,7 @@ int avr_initmem(const AVRPART *p) {
 
 
 AVRMEM *avr_dup_mem(const AVRMEM *m) {
-  AVRMEM *n = avr_new_memtype();
+  AVRMEM *n = avr_new_mem();
 
   if(m) {
     *n = *m;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -137,7 +137,7 @@ int avr_set_addr_mem(const AVRMEM *mem, int opnum, unsigned char *cmd, unsigned 
   if(!(op = mem->op[opnum]))
     return -1;
 
-  isflash = avr_mem_is_flash_type(mem);
+  isflash = mem_is_in_flash(mem);
   memsize = mem->size >> isflash;        // word addresses for flash
   pagesize = mem->page_size >> isflash;
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -495,7 +495,7 @@ AVRMEM *avr_locate_fuse_by_offset(const AVRPART *p, unsigned int off) {
   return NULL;
 }
 
-// Return the first memory that shares the type including fuses identified by offset in fuses
+// Return the first memory that shares the type incl any fuse identified by offset in fuses
 AVRMEM *avr_locate_mem_by_type(const AVRPART *p, memtype_t type) {
   AVRMEM *m;
   memtype_t off = type & MEM_FUSEOFF_MASK;

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -425,7 +425,7 @@ int bitbang_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     bitbang_tpi_tx(pgm, TPI_NVMCMD_CHIP_ERASE); /* CHIP_ERASE */
 
     /* Set Pointer Register */
-    mem = avr_locate_mem(p, "flash");
+    mem = avr_locate_flash(p);
     if (mem == NULL) {
       pmsg_error("no flash memory to erase for part %s\n", p->desc);
       return -1;

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -902,7 +902,7 @@ static int buspirate_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
 	}
 
 	// determine what type of memory to read, only flash is supported
-	if (!str_eq(m->desc, "flash")) {
+	if (!mem_is_flash(m)) {
 		return -1;
 	}
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -454,7 +454,7 @@ static int butterfly_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
       butterfly_set_addr(pgm, addr);
     }
   }
-  else if (str_eq(m->desc, "lock"))
+  else if (mem_is_lock(m))
   {
     cmd[0] = 'l';
     cmd[1] = value;
@@ -538,16 +538,16 @@ static int butterfly_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     return butterfly_read_byte_eeprom(pgm, p, m, addr, value);
   }
 
-  if (str_eq(m->desc, "lfuse")) {
+  if (mem_is_lfuse(m)) {
     cmd = 'F';
   }
-  else if (str_eq(m->desc, "hfuse")) {
+  else if (mem_is_hfuse(m)) {
     cmd = 'N';
   }
-  else if (str_eq(m->desc, "efuse")) {
+  else if (mem_is_efuse(m)) {
     cmd = 'Q';
   }
-  else if (str_eq(m->desc, "lock")) {
+  else if (mem_is_lock(m)) {
     cmd = 'r';
   }
   else

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -493,9 +493,9 @@ static int butterfly_read_byte_flash(const PROGRAMMER *pgm, const AVRPART *p, co
     }
     // Defaults to flash read ('F')
     char msg[4] = {'g', 0x00, 0x02, 'F'};
-    if (str_eq(m->desc, "prodsig"))
+    if (mem_is_sigrow(m))
       msg[3] = 'P';
-    else if (str_eq(m->desc, "usersig"))
+    else if (mem_is_userrow(m))
       msg[3] = 'U';
     butterfly_send(pgm, msg, 4);
     /* Read back the program mem word (MSB first) */
@@ -530,9 +530,7 @@ static int butterfly_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
 {
   char cmd;
 
-  if (mem_is_flash(m)   ||
-      str_eq(m->desc, "prodsig") ||
-      str_eq(m->desc, "usersig")) {
+  if (mem_is_flash(m) || mem_is_sigrow(m) || mem_is_userrow(m)) {
     return butterfly_read_byte_flash(pgm, p, m, addr, value);
   }
 
@@ -573,9 +571,7 @@ static int butterfly_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const 
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
   unsigned int wr_size = 2;
 
-  if (!mem_is_flash(m)  &&
-      !mem_is_eeprom(m) &&
-      !str_eq(m->desc, "usersig"))
+  if (!mem_is_flash(m) && !mem_is_eeprom(m) && !mem_is_userrow(m))
     return -2;
 
   if (m->desc[0] == 'e')
@@ -629,10 +625,8 @@ static int butterfly_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
   int blocksize = PDATA(pgm)->buffersize;
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
 
-  /* check parameter syntax: only "flash", "eeprom" or "usersig" is allowed */
-  if (!mem_is_flash(m)  &&
-      !mem_is_eeprom(m) &&
-      !str_eq(m->desc, "usersig"))
+  /* check parameter syntax: only "flash", "eeprom" or "usersig"/"userrow" is allowed */
+  if (!mem_is_flash(m) && !mem_is_eeprom(m) && !mem_is_userrow(m))
     return -2;
 
   if (m->desc[0] == 'e')

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -434,7 +434,7 @@ static int butterfly_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
   int size;
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
 
-  if (str_eq(m->desc, "flash") || str_eq(m->desc, "eeprom"))
+  if (mem_is_flash(m) || mem_is_eeprom(m))
   {
     cmd[0] = 'B';
     cmd[1] = 0;
@@ -530,13 +530,13 @@ static int butterfly_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
 {
   char cmd;
 
-  if (str_eq(m->desc, "flash")   ||
+  if (mem_is_flash(m)   ||
       str_eq(m->desc, "prodsig") ||
       str_eq(m->desc, "usersig")) {
     return butterfly_read_byte_flash(pgm, p, m, addr, value);
   }
 
-  if (str_eq(m->desc, "eeprom")) {
+  if (mem_is_eeprom(m)) {
     return butterfly_read_byte_eeprom(pgm, p, m, addr, value);
   }
 
@@ -573,8 +573,8 @@ static int butterfly_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const 
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
   unsigned int wr_size = 2;
 
-  if (!str_eq(m->desc, "flash")  &&
-      !str_eq(m->desc, "eeprom") &&
+  if (!mem_is_flash(m)  &&
+      !mem_is_eeprom(m) &&
       !str_eq(m->desc, "usersig"))
     return -2;
 
@@ -630,8 +630,8 @@ static int butterfly_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const A
   int use_ext_addr = m->op[AVR_OP_LOAD_EXT_ADDR] != NULL;
 
   /* check parameter syntax: only "flash", "eeprom" or "usersig" is allowed */
-  if (!str_eq(m->desc, "flash")  &&
-      !str_eq(m->desc, "eeprom") &&
+  if (!mem_is_flash(m)  &&
+      !mem_is_eeprom(m) &&
       !str_eq(m->desc, "usersig"))
     return -2;
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -119,7 +119,7 @@ static int butterfly_default_led(const PROGRAMMER *pgm, int value) {
  */
 static int butterfly_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   long bak_timeout = serial_recv_timeout;
-  AVRMEM *fl = avr_locate_mem(p, "flash");
+  AVRMEM *fl = avr_locate_flash(p);
   int ret = 0;
 
   // Estimated time it takes to erase all pages in bootloader

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -354,10 +354,10 @@ static int ch341a_spi_chip_erase(const struct programmer_t *pgm, const AVRPART *
 static int ch341a_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes) {
 
-  int isflash = avr_mem_is_flash_type(m);
+  int isflash = mem_is_in_flash(m);
 
   if(n_bytes) {
-    if(!isflash && !avr_mem_is_eeprom_type(m))
+    if(!isflash && !mem_is_eeprom(m))
       return -2;
 
     // Always called with addr at page boundary and n_bytes == m->page_size
@@ -376,10 +376,10 @@ static int ch341a_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 static int ch341a_spi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
   unsigned int page_size, unsigned int addr, unsigned int n_bytes) {
 
-  int isflash = avr_mem_is_flash_type(m);
+  int isflash = mem_is_in_flash(m);
 
   if(n_bytes) {
-    if(!isflash && !avr_mem_is_eeprom_type(m))
+    if(!isflash && !mem_is_eeprom(m))
       return -2;
 
     // Always called with addr at page boundary and n_bytes == m->page_size

--- a/src/config.c
+++ b/src/config.c
@@ -954,7 +954,7 @@ void cfg_update_mcuid(AVRPART *part) {
   for(size_t i=0; i < sizeof uP_table/sizeof *uP_table; i++)
     if(part->mcuid == (int) uP_table[i].mcuid) {
       // Complain unless it can be considered a variant, eg, ATmega32L and ATmega32
-      AVRMEM *flash = avr_locate_mem(part, "flash");
+      AVRMEM *flash = avr_locate_flash(part);
       if(flash) {
         size_t l1 = strlen(part->desc), l2 = strlen(uP_table[i].name);
         if(strncasecmp(part->desc, uP_table[i].name, l1 < l2? l1: l2) ||

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -991,8 +991,8 @@ part_parm :
         mem = avr_new_mem();
         mem->desc = cache_string($2->value.string);
         ladd(current_part->mem, mem);
+        mem->type = avr_get_mem_type($2->value.string);
       }
-      avr_add_mem_order($2->value.string);
       current_mem = mem;
       free_token($2);
     }

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -1356,11 +1356,11 @@ static int parse_cmdbits(OPCODE * op, int opnum)
         case 'a':
           sb = opnum == AVR_OP_LOAD_EXT_ADDR? bitno+8: bitno-8; // should be this number
           if(bitno < 8 || bitno > 23) {
-            if(!current_mem || !str_eq(current_mem->desc, "prodsig")) // Known exemption
+            if(!current_mem || !mem_is_sigrow(current_mem)) // Known exemption
               yywarning("address bits don't normally appear in Bytes 0 or 3 of SPI commands");
           } else if((bn & 31) != sb) {
             if(!current_part || !str_casestarts(current_part->desc, "AT89S5")) // Exempt AT89S5x
-              if(!current_mem || !str_eq(current_mem->desc, "prodsig")) // and prodsig
+              if(!current_mem || !mem_is_sigrow(current_mem)) // and prodsig
                 yywarning("a%d would normally be expected to be a%d", bn, sb);
           } else if(bn < 0 || bn > 31)
             yywarning("invalid address bit a%d, using a%d", bn, bn & 31);

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -988,7 +988,7 @@ part_parm :
     { /* select memory for extension or create if not there */
       AVRMEM *mem = avr_locate_mem_noalias(current_part, $2->value.string);
       if(!mem) {
-        mem = avr_new_memtype();
+        mem = avr_new_mem();
         mem->desc = cache_string($2->value.string);
         ladd(current_part->mem, mem);
       }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -982,12 +982,12 @@ void dev_output_part_defs(char *partdesc) {
     if(p->mem) {
       for(LNODEID lnm=lfirst(p->mem); lnm; lnm=lnext(lnm)) {
         AVRMEM *m = ldata(lnm);
-        if(!flashsize && str_eq(m->desc, "flash")) {
+        if(!flashsize && mem_is_flash(m)) {
           flashsize = m->size;
           flashpagesize = m->page_size;
           flashoffset = m->offset;
         }
-        if(!eepromsize && str_eq(m->desc, "eeprom")) {
+        if(!eepromsize && mem_is_eeprom(m)) {
           eepromsize = m->size;
           eepromoffset = m->offset;
           eeprompagesize = m->page_size;
@@ -1154,7 +1154,7 @@ void dev_output_part_defs(char *partdesc) {
         for(LNODEID lnm=lfirst(p->mem); lnm; lnm=lnext(lnm)) {
           AVRMEM *m = ldata(lnm);
           // Write delays not needed for read-only calibration and signature memories
-          if(!str_eq(m->desc, "calibration") && !str_eq(m->desc, "signature")) {
+          if(!mem_is_calibration(m) && !mem_is_signature(m)) {
             if(p->prog_modes & PM_ISP) {
               if(m->min_write_delay == m->max_write_delay)
                  dev_info(".wd_%s %.3f ms %s\n", m->desc, m->min_write_delay/1000.0, p->desc);

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -743,7 +743,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
       continue;
 
     if(base && !bm)
-      bm = avr_new_memtype();
+      bm = avr_new_mem();
 
     if(!tsv) {
       if(!memorycmp(bm, m)) {   // Same memory bit for bit, only instantiate on injected parameters

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -492,8 +492,8 @@ static int avrpart_deep_copy(AVRPARTdeep *d, const AVRPART *p) {
 
   // Fill in all memories we got in defined order
   di = 0;
-  for(size_t mi=0; mi < sizeof avr_mem_order/sizeof *avr_mem_order && avr_mem_order[mi]; mi++) {
-    m = dev_locate_mem(p, avr_mem_order[mi]);
+  for(size_t mi=0; mi < sizeof avr_mem_order/sizeof *avr_mem_order && avr_mem_order[mi].str; mi++) {
+    m = dev_locate_mem(p, avr_mem_order[mi].str);
     if(m) {
       if(di >= sizeof d->mems/sizeof *d->mems) {
         pmsg_error("ran out of mems[] space, increase size in AVRMEMdeep of developer_opts.c and recompile\n");
@@ -730,11 +730,11 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
     if(!base || opcodecmp(p->op[i], base->op[i], i))
       dev_part_strct_entry(tsv, ".ptop", p->desc, "part", opcodename(i), opcode2str(p->op[i], i, !tsv), p->comments);
 
-  for(size_t mi=0; mi < sizeof avr_mem_order/sizeof *avr_mem_order && avr_mem_order[mi]; mi++) {
+  for(size_t mi=0; mi < sizeof avr_mem_order/sizeof *avr_mem_order && avr_mem_order[mi].str; mi++) {
     AVRMEM *m, *bm;
 
-    m = dev_locate_mem(p, avr_mem_order[mi]);
-    bm = base? dev_locate_mem(base, avr_mem_order[mi]): NULL;
+    m = dev_locate_mem(p, avr_mem_order[mi].str);
+    bm = base? dev_locate_mem(base, avr_mem_order[mi].str): NULL;
 
     if(!m && bm && !tsv)
       dev_info("\n    memory \"%s\" %*s= NULL;\n", bm->desc, 13 > strlen(bm->desc)? 13-strlen(bm->desc): 0, "");
@@ -941,12 +941,12 @@ void dev_output_part_defs(char *partdesc) {
     AVRPART *p = ldata(ln1);
     if(p->mem)
       for(LNODEID lnm=lfirst(p->mem); lnm; lnm=lnext(lnm))
-        avr_add_mem_order(((AVRMEM *) ldata(lnm))->desc);
+        avr_get_mem_type(((AVRMEM *) ldata(lnm))->desc);
 
     // Same for aliased memories (though probably not needed)
     if(p->mem_alias)
       for(LNODEID lnm=lfirst(p->mem_alias); lnm; lnm=lnext(lnm))
-        avr_add_mem_order(((AVRMEM_ALIAS *) ldata(lnm))->desc);
+        avr_get_mem_type(((AVRMEM_ALIAS *) ldata(lnm))->desc);
   }
 
   if((nprinted = dev_nprinted)) {

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1010,7 +1010,7 @@ void dev_output_part_defs(char *partdesc) {
       if(!p->op[AVR_OP_CHIP_ERASE])
         ok &= ~DEV_SPI_EN_CE_SIG;
 
-      if((m = avr_locate_mem(p, "flash"))) {
+      if((m = avr_locate_flash(p))) {
         if((oc = m->op[AVR_OP_LOAD_EXT_ADDR])) {
           // @@@ to do: check whether address is put at lsb of third byte
         } else
@@ -1060,7 +1060,7 @@ void dev_output_part_defs(char *partdesc) {
       } else
         ok &= ~(DEV_SPI_PROGMEM_PAGED | DEV_SPI_PROGMEM);
 
-      if((m = avr_locate_mem(p, "eeprom"))) {
+      if((m = avr_locate_eeprom(p))) {
         if((oc = m->op[AVR_OP_READ])) {
           if(cmdok)
             checkaddr(m->size, 1, AVR_OP_READ, oc, p, m);
@@ -1087,33 +1087,33 @@ void dev_output_part_defs(char *partdesc) {
       } else
         ok &= ~(DEV_SPI_EEPROM_PAGED | DEV_SPI_EEPROM);
 
-      if((m = avr_locate_mem(p, "signature")) && (oc = m->op[AVR_OP_READ])) {
+      if((m = avr_locate_signature(p)) && (oc = m->op[AVR_OP_READ])) {
         if(cmdok)
           checkaddr(m->size, 1, AVR_OP_READ, oc, p, m);
       } else
         ok &= ~DEV_SPI_EN_CE_SIG;
 
-      if((m = avr_locate_mem(p, "calibration")) && (oc = m->op[AVR_OP_READ])) {
+      if((m = avr_locate_calibration(p)) && (oc = m->op[AVR_OP_READ])) {
         if(cmdok)
           checkaddr(m->size, 1, AVR_OP_READ, oc, p, m);
       } else
         ok &= ~DEV_SPI_CALIBRATION;
 
       // Actually, some AT90S... parts cannot read, only write lock bits :-0
-      if( ! ((m = avr_locate_mem(p, "lock")) && m->op[AVR_OP_WRITE]))
+      if( !((m = avr_locate_lock(p)) && m->op[AVR_OP_WRITE]))
         ok &= ~DEV_SPI_LOCK;
 
-      if(((m = avr_locate_mem(p, "fuse")) || (m = avr_locate_mem(p, "lfuse"))) && m->op[AVR_OP_READ] && m->op[AVR_OP_WRITE])
+      if((m = avr_locate_fuse(p)) && m->op[AVR_OP_READ] && m->op[AVR_OP_WRITE])
         nfuses++;
       else
         ok &= ~DEV_SPI_LFUSE;
 
-      if((m = avr_locate_mem(p, "hfuse")) && m->op[AVR_OP_READ] && m->op[AVR_OP_WRITE])
+      if((m = avr_locate_hfuse(p)) && m->op[AVR_OP_READ] && m->op[AVR_OP_WRITE])
         nfuses++;
       else
         ok &= ~DEV_SPI_HFUSE;
 
-      if((m = avr_locate_mem(p, "efuse")) && m->op[AVR_OP_READ] && m->op[AVR_OP_WRITE])
+      if((m = avr_locate_efuse(p)) && m->op[AVR_OP_READ] && m->op[AVR_OP_WRITE])
         nfuses++;
       else
         ok &= ~DEV_SPI_EFUSE;

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -131,13 +131,13 @@ supplies a direct instruction mode allowing one to issue any programming
 instruction to the AVR chip regardless of whether AVRDUDE implements
 that specific feature of a particular chip.
 
-AVRDUDE can be used effectively via the command line to read or write
-all chip memory types (eeprom, flash, fuse bits, lock bits, signature
-bytes) or via an interactive (terminal) mode. Using AVRDUDE from the
-command line works well for programming the entire memory of the chip
-from the contents of a file, while interactive mode is useful for
-exploring memory contents, modifying individual bytes of eeprom,
-programming fuse/lock bits, etc.
+AVRDUDE can be used via the command line to read or write chip memories
+(eeprom, flash, fuses, lock bits) and read memories such as signature or
+calibration bytes; the same can be achieved via an interactive terminal
+mode. Using AVRDUDE from the command line works well for programming the
+entire memory of the chip from the contents of a file, while interactive mode
+is useful for exploring memory contents, modifying individual bytes of
+eeprom, programming fuse/lock bits, etc.
 
 @cindex Programmers supported
 
@@ -806,7 +806,7 @@ Perform a memory operation when it is its turn in relation to other
 @code{-U} memory operations. The @var{memory} field specifies the memory
 type to operate on. Use the @option{-T part} option on the command line or
 the @code{part} command in the interactive terminal to display all the
-memory types supported by a particular device.
+memories supported by a particular device.
 
 Typically, a device's memory configuration at least contains the memory
 types @code{flash}, @code{eeprom}, @code{signature} and @code{lock}, which
@@ -818,7 +818,7 @@ parts of it, is allowed. Parts will also typically have fuse bytes, which
 are read/write memories for configuration of the device and calibration
 memories that typically contain read-only factory calibration values.
 
-Classic devices may have the following memory types in addition to
+Classic devices may have the following memories in addition to
 @code{eeprom}, @code{flash}, @code{signature} and @code{lock}:
 @table @code
 @item calibration
@@ -854,7 +854,7 @@ methods only by bootloaders, which has limited use unless the bootloader
 jumps to the application directly, i.e., without a WDT reset
 @end table
 
-ATxmega devices have the following memory types in addition to
+ATxmega devices have the following memories in addition to
 @code{eeprom}, @code{flash}, @code{signature} and @code{lock}:
 @table @code
 @item application
@@ -887,7 +887,7 @@ Volatile register memory; AVRDUDE can read this memory but not write to it
 using external programming
 @end table
 
-Modern 8-bit AVR devices have the following memory types in addition to
+Modern 8-bit AVR devices have the following memories in addition to
 @code{eeprom}, @code{flash}, @code{signature} and @code{lock}:
 @table @code
 @item fuse0
@@ -2408,7 +2408,7 @@ Display the device signature bytes.
 
 @item part
 Display the current part settings and parameters.  Includes chip
-specific information including all memory types supported by the
+specific information including all memories supported by the
 device, read/write timing, etc.
 
 @item verbose [@var{level}]
@@ -3286,19 +3286,19 @@ Atmel's AVR061 application note available from
 @url{http://www.atmel.com/dyn/resources/prod_documents/doc2525.pdf}.
 
 @item
-Not all memory types will implement all instructions.
+Not all memories will implement all instructions.
 
 @item
 AVR Fuse bits and Lock bits are implemented as a type of memory.
 
 @item
-Example memory types are: @code{flash}, @code{eeprom}, @code{fuse},
+Example memories are: @code{flash}, @code{eeprom}, @code{fuse},
 @code{lfuse} (low fuse), @code{hfuse} (high fuse), @code{efuse}
 (extended fuse), @code{signature}, @code{calibration}, @code{lock}.
 
 @item
-The memory type specified on the AVRDUDE command line must match one of
-the memory types defined for the specified chip.
+The memory specified on the AVRDUDE command line must match one of
+the memories defined for the specified chip.
 
 @item
 The @code{pwroff_after_write} flag causes AVRDUDE to attempt to power

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -3116,7 +3116,7 @@ part
     # parameters for bootloaders
     autobaud_sync    = <num> ;                # autobaud detection byte, default 0x30
 
-    memory <memory>
+    memory <memstr>
         paged           = <yes/no> ;          # yes/no (flash only, do not use for EEPROM)
         offset          = <num> ;             # memory offset
         size            = <num> ;             # bytes

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -73,7 +73,7 @@ static int dryrun_chip_erase(const PROGRAMMER *pgm, const AVRPART *punused) {
   pmsg_debug("%s()\n", __func__);
   if(!dry.dp)
     Return("no dryrun device? Raise an issue at https://github.com/avrdudes/avrdude/issues");
-  if(!(flm = avr_locate_mem(dry.dp, "flash")))
+  if(!(flm = avr_locate_flash(dry.dp)))
     Return("cannot locate %s flash memory for chip erase", dry.dp->desc);
   if(flm->size < 1)
     Return("cannot erase %s flash memory owing to its size %d", dry.dp->desc, flm->size);
@@ -181,7 +181,7 @@ static void dryrun_enable(PROGRAMMER *pgm, const AVRPART *p) {
             memcpy(prodsigm->buf + off, m->buf, cpy);
         }
       }
-      if(!(p->prog_modes & (PM_PDI|PM_UPDI)) && (calm = avr_locate_mem(dry.dp, "calibration"))) {
+      if(!(p->prog_modes & (PM_PDI|PM_UPDI)) && (calm = avr_locate_calibration(dry.dp))) {
         // Calibration bytes of classic parts are interspersed with signature
         for(int i=0; i<calm->size; i++)
           if(2*i+1 < prodsigm->size)
@@ -295,7 +295,7 @@ static int dryrun_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
                 memcpy(dm2->buf+cpaddr, dmem->buf+addr, chunk);
             }
           }
-        } else if((dm2 = avr_locate_mem(dry.dp, "flash"))) {
+        } else if((dm2 = avr_locate_flash(dry.dp))) {
           unsigned int cpaddr = addr + dmem->offset - dm2->offset;
           if(cpaddr < (unsigned int) dm2->size && cpaddr + chunk <= (unsigned int) dm2->size)
             memcpy(dm2->buf+cpaddr, dmem->buf+addr, chunk);
@@ -392,7 +392,7 @@ int dryrun_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
           dfuse->buf[1] = data;
       }
     }
-  } else if(mem_is_a_fuse(m) && (dfuse = avr_locate_mem(dry.dp, "fuses"))) { // Copy fuse to fuses
+  } else if(mem_is_a_fuse(m) && (dfuse = avr_locate_fuses(dry.dp))) { // Copy fuse to fuses
     int fidx = addr + mem_fuse_offset(m);
     if(fidx >=0 && fidx < dfuse->size)
       dfuse->buf[fidx] = data;

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -122,7 +122,7 @@ static void dryrun_enable(PROGRAMMER *pgm, const AVRPART *p) {
     // Initialise the device with fuse factory setting and erase flash/EEPROM to 0xff
     for (LNODEID ln=lfirst(dry.dp->mem); ln; ln=lnext(ln)) {
       AVRMEM *m = ldata(ln);
-      if(avr_mem_is_flash_type(m) || avr_mem_is_eeprom_type(m)) {
+      if(mem_is_in_flash(m) || mem_is_eeprom(m)) {
         memset(m->buf, 0xff, m->size);
       } else if(str_eq(m->desc, "fuses")) {
         fusesm = m;
@@ -264,8 +264,8 @@ static int dryrun_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     unsigned int end;
 
     // Paged writes only valid for flash and eeprom
-    mchr = avr_mem_is_flash_type(m)? 'F': 'E';
-    if(mchr == 'E' && !avr_mem_is_eeprom_type(m))
+    mchr = mem_is_in_flash(m)? 'F': 'E';
+    if(mchr == 'E' && !mem_is_eeprom(m))
       return -2;
 
     if(!(dmem = avr_locate_mem(dry.dp, m->desc)))
@@ -290,7 +290,7 @@ static int dryrun_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
         if(str_eq(dmem->desc, "flash")) {
           for(LNODEID ln=lfirst(dry.dp->mem); ln; ln=lnext(ln)) {
             dm2 = ldata(ln);
-            if(avr_mem_is_flash_type(dm2) && !str_eq(dm2->desc, "flash")) { // Overlapping region?
+            if(mem_is_in_flash(dm2) && !str_eq(dm2->desc, "flash")) { // Overlapping region?
               unsigned int cpaddr = addr + dmem->offset - dm2->offset;
               if(cpaddr < (unsigned int) dm2->size && cpaddr + chunk <= (unsigned int) dm2->size)
                 memcpy(dm2->buf+cpaddr, dmem->buf+addr, chunk);
@@ -322,8 +322,8 @@ static int dryrun_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     unsigned int end;
 
     // Paged load only valid for flash and eeprom
-    mchr = avr_mem_is_flash_type(m)? 'F': 'E';
-    if(mchr == 'E' && !avr_mem_is_eeprom_type(m))
+    mchr = mem_is_in_flash(m)? 'F': 'E';
+    if(mchr == 'E' && !mem_is_eeprom(m))
       return -2;
 
     if(!(dmem = avr_locate_mem(dry.dp, m->desc)))

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -384,13 +384,13 @@ int dryrun_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
   dmem->buf[addr] = data;
 
   if(str_eq(dmem->desc, "fuses") && addr < 16) { // Copy the byte to corresponding fuse[0-9a-f]
-    char memtype[64];
-    sprintf(memtype, "fuse%lx", addr);
-    if((dfuse = avr_locate_mem(dry.dp, memtype)))
+    char memstr[64];
+    sprintf(memstr, "fuse%lx", addr);
+    if((dfuse = avr_locate_mem(dry.dp, memstr)))
       dfuse->buf[0] = data;
     else if(addr > 0) {         // Could be high byte of two-byte fuse
-      sprintf(memtype, "fuse%lx", addr-1);
-      if((dfuse = avr_locate_mem(dry.dp, memtype)))
+      sprintf(memstr, "fuse%lx", addr-1);
+      if((dfuse = avr_locate_mem(dry.dp, memstr)))
         dfuse->buf[1] = data;
     }
   } else if(str_starts(m->desc, "fuse") && m->desc[4] && isxdigit(0xff & m->desc[4]) && !m->desc[5]) {

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -825,7 +825,7 @@ static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
    * than one sub-segment.
    */
   if ((p->prog_modes & PM_PDI) && mem_is_in_flash(mem) && !mem_is_flash(mem)) {
-    AVRMEM *flashmem = avr_locate_mem(p, "flash");
+    AVRMEM *flashmem = avr_locate_flash(p);
     if (flashmem == NULL) {
       pmsg_error("no flash memory region found, cannot compute bounds of %s sub-region\n", mem->desc);
       return -1;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -759,7 +759,7 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
   int rv = 0;
 
   if (p->prog_modes & PM_aWire) { // AVR32
-    if (str_eq(mem->desc, "flash")) {
+    if (mem_is_flash(mem)) {
       *lowbound = 0x80000000;
       *highbound = 0xffffffff;
       *fileoff = 0;
@@ -767,22 +767,22 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       rv = -1;
     }
   } else {
-    if (str_eq(mem->desc, "flash") ||
-        str_eq(mem->desc, "boot") ||
-        str_eq(mem->desc, "application") ||
-        str_eq(mem->desc, "apptable")) {
+    if (mem_is_flash(mem) ||
+        mem_is_boot(mem) ||
+        mem_is_application(mem) ||
+        mem_is_apptable(mem)) {
       *lowbound = 0;
       *highbound = 0x7Fffff;    // Max 8 MiB
       *fileoff = 0;
-    } else if (str_eq(mem->desc, "data")) { // SRAM for XMEGAs
+    } else if (mem_is_data(mem)) { // SRAM for XMEGAs
       *lowbound = 0x802000;
       *highbound = 0x80ffff;
       *fileoff = 0;
-    } else if (str_eq(mem->desc, "eeprom")) {
+    } else if (mem_is_eeprom(mem)) {
       *lowbound = 0x810000;
       *highbound = 0x81ffff;    // Max 64 KiB
       *fileoff = 0;
-    } else if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse") || str_eq(mem->desc, "fuses")) {
+    } else if (str_eq(mem->desc, "lfuse") || str_eq(mem->desc, "fuse") || mem_is_fuses(mem)) {
       *lowbound = 0x820000;
       *highbound = 0x82ffff;
       *fileoff = 0;
@@ -804,7 +804,7 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       *lowbound = 0x830000;
       *highbound = 0x83ffff;
       *fileoff = 0;
-    } else if (str_eq(mem->desc, "signature")) { // Read only
+    } else if (mem_is_signature(mem)) { // Read only
       *lowbound = 0x840000;
       *highbound = 0x84ffff;
       *fileoff = 0;
@@ -842,9 +842,9 @@ static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
    * than one sub-segment.
    */
   if ((p->prog_modes & PM_PDI) != 0 &&
-      (str_eq(mem->desc, "boot") ||
-       str_eq(mem->desc, "application") ||
-       str_eq(mem->desc, "apptable"))) {
+      (mem_is_boot(mem) ||
+       mem_is_application(mem) ||
+       mem_is_apptable(mem))) {
     AVRMEM *flashmem = avr_locate_mem(p, "flash");
     if (flashmem == NULL) {
       pmsg_error("no flash memory region found, cannot compute bounds of %s sub-region\n", mem->desc);

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1432,11 +1432,11 @@ int fileio_fmt_autodetect(const char *fname) {
 
 
 int fileio(int op, const char *filename, FILEFMT format,
-  const AVRPART *p, const char *memtype, int size) {
+  const AVRPART *p, const char *memstr, int size) {
 
-  AVRMEM *mem = avr_locate_mem(p, memtype);
+  AVRMEM *mem = avr_locate_mem(p, memstr);
   if(mem == NULL) {
-    pmsg_error("memory type %s not configured for device %s\n", memtype, p->desc);
+    pmsg_error("memory type %s not configured for device %s\n", memstr, p->desc);
     return -1;
   }
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -371,7 +371,7 @@ int flip1_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
   if (FLIP1(pgm)->dfu == NULL)
     return -1;
 
-  if (str_eq(mem->desc, "signature")) {
+  if (mem_is_signature(mem)) {
     if (flip1_read_sig_bytes(pgm, part, mem) < 0)
       return -1;
     if (addr >= (unsigned long) mem->size) {

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -92,7 +92,7 @@ struct flip1_cmd
 struct flip1_cmd_header         /* for memory read/write */
 {
   unsigned char cmd;
-  unsigned char memtype;
+  unsigned char memchr;
   unsigned char start_addr[2];
   unsigned char end_addr[2];
   unsigned char padding[26];

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -401,7 +401,7 @@ int flip2_read_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *me
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (str_eq(mem->desc, "flash"))
+    if (mem_is_flash(mem))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;
@@ -422,7 +422,7 @@ int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (str_eq(mem->desc, "flash"))
+    if (mem_is_flash(mem))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;
@@ -444,7 +444,7 @@ int flip2_paged_load(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (str_eq(mem->desc, "flash"))
+    if (mem_is_flash(mem))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;
@@ -475,7 +475,7 @@ int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *
 
   if (mem_unit == FLIP2_MEM_UNIT_UNKNOWN) {
     pmsg_error("%s memory not accessible using FLIP", mem->desc);
-    if (str_eq(mem->desc, "flash"))
+    if (mem_is_flash(mem))
       msg_error(" (did you mean \"application\"?)");
     msg_error("\n");
     return -1;

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -1098,10 +1098,10 @@ static int ft245r_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if(!n_bytes)
         return 0;
 
-    if(str_eq(m->desc, "flash"))
+    if(mem_is_flash(m))
         return ft245r_paged_write_flash(pgm, p, m, page_size, addr, n_bytes);
 
-    if(str_eq(m->desc, "eeprom"))
+    if(mem_is_eeprom(m))
         return ft245r_paged_write_gen(pgm, p, m, page_size, addr, n_bytes);
 
     return -2;
@@ -1196,10 +1196,10 @@ static int ft245r_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if(!n_bytes)
         return 0;
 
-    if(str_eq(m->desc, "flash"))
+    if(mem_is_flash(m))
         return ft245r_paged_load_flash(pgm, p, m, page_size, addr, n_bytes);
 
-    if(str_eq(m->desc, "eeprom"))
+    if(mem_is_eeprom(m))
         return ft245r_paged_load_gen(pgm, p, m, page_size, addr, n_bytes);
 
    return -2;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1440,7 +1440,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   // Read chip silicon revision
   if(pgm->read_chip_rev && p->prog_modes & (PM_PDI | PM_UPDI)) {
-    char chip_rev[AVR_CHIP_REVLEN];
+    unsigned char chip_rev[AVR_CHIP_REVLEN];
     pgm->read_chip_rev(pgm, p, chip_rev);
     pmsg_notice("silicon revision: %x.%x\n", chip_rev[0] >> 4, chip_rev[0] & 0x0f);
   }
@@ -2507,7 +2507,7 @@ int jtag3_read_sib(const PROGRAMMER *pgm, const AVRPART *p, char *sib) {
   return 0;
 }
 
-int jtag3_read_chip_rev(const PROGRAMMER *pgm, const AVRPART *p, char *chip_rev) {
+int jtag3_read_chip_rev(const PROGRAMMER *pgm, const AVRPART *p, unsigned char *chip_rev) {
   // XMEGA using JTAG or PDI, tinyAVR0/1/2, megaAVR0, AVR-Dx, AVR-Ex using UPDI
   if(p->prog_modes & (PM_PDI | PM_UPDI)) {
     AVRMEM *m = avr_locate_io(p);
@@ -2516,8 +2516,7 @@ int jtag3_read_chip_rev(const PROGRAMMER *pgm, const AVRPART *p, char *chip_rev)
       return -1;
     }
     int status = pgm->read_byte(pgm, p, m,
-        p->prog_modes & PM_PDI? p->mcu_base+3 :p->syscfg_base+1,
-        (unsigned char *)chip_rev);
+        p->prog_modes & PM_PDI? p->mcu_base+3 :p->syscfg_base+1, chip_rev);
     if (status < 0)
       return status;
   } else {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2133,7 +2133,8 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[3] = MTYPE_FUSE_BITS;
-    addr = mem_is_a_fuse(mem)? mem_fuse_offset(mem): 0;
+    if(mem_is_a_fuse(mem))
+      addr = mem_fuse_offset(mem);
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
   } else if (mem_is_lock(mem)) {
@@ -2314,7 +2315,8 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[3] = MTYPE_FUSE_BITS;
-    addr = mem_is_a_fuse(mem)? mem_fuse_offset(mem): 0;
+    if(mem_is_a_fuse(mem))
+      addr = mem_fuse_offset(mem);
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
   } else if (mem_is_lock(mem)) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1861,7 +1861,7 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   cmd[1] = CMD3_ERASE_MEMORY;
   cmd[2] = 0;
 
-  if (avr_mem_is_flash_type(m)) {
+  if (mem_is_in_flash(m)) {
     if (p->prog_modes & PM_UPDI || jtag3_mtype(pgm, p, addr) == MTYPE_FLASH)
       cmd[3] = XMEGA_ERASE_APP_PAGE;
     else
@@ -2119,13 +2119,13 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   cmd[2] = 0;
 
   cmd[3] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_FLASH: MTYPE_FLASH_PAGE;
-  if (avr_mem_is_flash_type(mem)) {
+  if (mem_is_in_flash(mem)) {
     addr += mem->offset & (512 * 1024 - 1); /* max 512 KiB flash */
     pagesize = PDATA(pgm)->flash_pagesize;
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->flash_pageaddr;
     cache_ptr = PDATA(pgm)->flash_pagecache;
-  } else if (avr_mem_is_eeprom_type(mem)) {
+  } else if (mem_is_eeprom(mem)) {
     if ( (pgm->flag & PGM_FL_IS_DW) || (p->prog_modes & PM_PDI) || (p->prog_modes & PM_UPDI) ) {
       cmd[3] = MTYPE_EEPROM;
     } else {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2133,7 +2133,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     cache_ptr = PDATA(pgm)->eeprom_pagecache;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[3] = MTYPE_FUSE_BITS;
-    if(mem_is_a_fuse(mem))
+    if(!(p->prog_modes & PM_UPDI) && mem_is_a_fuse(mem))
       addr = mem_fuse_offset(mem);
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
@@ -2315,7 +2315,7 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[3] = MTYPE_FUSE_BITS;
-    if(mem_is_a_fuse(mem))
+    if(!(p->prog_modes & PM_UPDI) && mem_is_a_fuse(mem))
       addr = mem_fuse_offset(mem);
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;

--- a/src/jtag3_private.h
+++ b/src/jtag3_private.h
@@ -156,7 +156,7 @@
 #define EVT3_SLEEP                 0x11 /* General scope, also wakeup */
 #define EVT3_POWER                 0x10 /* General scope */
 
-/* memory types */
+/* memories */
 #define MTYPE_SRAM        0x20	/* target's SRAM or [ext.] IO registers */
 #define MTYPE_EEPROM      0x22	/* EEPROM, what way? */
 #define MTYPE_SPM         0xA0	/* flash through LPM/SPM */
@@ -260,7 +260,7 @@
 #define PARM3_UPDI_HV_AUTO_POWER_TOGGLE 0x02  /* Toggle power automatically and then apply a high-voltage pulse */
 #define PARM3_UPDI_HV_USER_POWER_TOGGLE 0x03  /* The user toggles power, and the tool applies a high-voltage pulse on power-up */
 
-/* Xmega erase memory types, for CMND_XMEGA_ERASE */
+/* Xmega erase memories for CMND_XMEGA_ERASE */
 #define XMEGA_ERASE_CHIP        0x00
 #define XMEGA_ERASE_APP         0x01
 #define XMEGA_ERASE_BOOT        0x02
@@ -345,7 +345,7 @@
 #define XPRG_ERR_ILLEGAL_PARAM              0x04
 #define XPRG_ERR_UNKNOWN_COMMAND            0x10
 
-// TPI Memory types
+// TPI Memories
 #define XPRG_MEM_TYPE_APPL                  0x01
 #define XPRG_MEM_TYPE_BOOT                  0x02
 #define XPRG_MEM_TYPE_EEPROM                0x03

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -894,7 +894,7 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     cmd[1] = MTYPE_OSCCAL_BYTE;
   } else if (mem_is_signature(mem)) {
     cmd[1] = MTYPE_SIGN_JTAG;
-  } else if (str_eq(mem->desc, "prodsig")) {
+  } else if (mem_is_sigrow(mem)) {
     cmd[1] = addr&1? MTYPE_OSCCAL_BYTE: MTYPE_SIGN_JTAG;
     addr /= 2;
   } else {

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -550,7 +550,7 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (jtagmkI_reset(pgm) < 0)
     return -1;
 
-  AVRMEM *hf = avr_locate_mem(p, "hfuse");
+  AVRMEM *hf = avr_locate_hfuse(p);
   if (!hf || jtagmkI_read_byte(pgm, p, hf, 1, &b) < 0)
     return -1;
   if ((b & OCDEN) != 0)

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -367,10 +367,10 @@ static void jtagmkI_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
   sendbuf.dd.ucIDRAddress = p->idr;
   for (ln = lfirst(p->mem); ln; ln = lnext(ln)) {
     m = ldata(ln);
-    if (str_eq(m->desc, "flash")) {
+    if (mem_is_flash(m)) {
       PDATA(pgm)->flash_pagesize = m->page_size;
       u16_to_b2(sendbuf.dd.uiFlashPageSize, PDATA(pgm)->flash_pagesize);
-    } else if (str_eq(m->desc, "eeprom")) {
+    } else if (mem_is_eeprom(m)) {
       sendbuf.dd.ucEepromPageSize = PDATA(pgm)->eeprom_pagesize = m->page_size;
     }
   }
@@ -678,12 +678,12 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   }
 
   cmd[0] = CMD_WRITE_MEM;
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     cmd[1] = MTYPE_FLASH_PAGE;
     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
     page_size = PDATA(pgm)->flash_pagesize;
     is_flash = 1;
-  } else if (str_eq(m->desc, "eeprom")) {
+  } else if (mem_is_eeprom(m)) {
     cmd[1] = MTYPE_EEPROM_PAGE;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
     page_size = PDATA(pgm)->eeprom_pagesize;
@@ -786,10 +786,10 @@ static int jtagmkI_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   page_size = m->readsize;
 
   cmd[0] = CMD_READ_MEM;
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     cmd[1] = MTYPE_FLASH_PAGE;
     is_flash = 1;
-  } else if (str_eq(m->desc, "eeprom")) {
+  } else if (mem_is_eeprom(m)) {
     cmd[1] = MTYPE_EEPROM_PAGE;
   }
 
@@ -867,14 +867,14 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
   cmd[0] = CMD_READ_MEM;
 
-  if (str_eq(mem->desc, "flash")) {
+  if (mem_is_flash(mem)) {
     cmd[1] = MTYPE_FLASH_PAGE;
     pagesize = mem->page_size;
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->flash_pageaddr;
     cache_ptr = PDATA(pgm)->flash_pagecache;
     is_flash = 1;
-  } else if (str_eq(mem->desc, "eeprom")) {
+  } else if (mem_is_eeprom(mem)) {
     cmd[1] = MTYPE_EEPROM_PAGE;
     pagesize = mem->page_size;
     paddr = addr & ~(pagesize - 1);
@@ -890,9 +890,9 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
       addr = 2;
   } else if (str_eq(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
-  } else if (str_eq(mem->desc, "calibration")) {
+  } else if (mem_is_calibration(mem)) {
     cmd[1] = MTYPE_OSCCAL_BYTE;
-  } else if (str_eq(mem->desc, "signature")) {
+  } else if (mem_is_signature(mem)) {
     cmd[1] = MTYPE_SIGN_JTAG;
   } else if (str_eq(mem->desc, "prodsig")) {
     cmd[1] = addr&1? MTYPE_OSCCAL_BYTE: MTYPE_SIGN_JTAG;
@@ -977,11 +977,11 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   writedata = data;
   cmd[0] = CMD_WRITE_MEM;
-  if (str_eq(mem->desc, "flash")) {
+  if (mem_is_flash(mem)) {
     cmd[1] = MTYPE_SPM;
     need_progmode = 0;
     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
-  } else if (str_eq(mem->desc, "eeprom")) {
+  } else if (mem_is_eeprom(mem)) {
     cmd[1] = MTYPE_EEPROM;
     need_progmode = 0;
     need_dummy_read = 1;
@@ -998,10 +998,10 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   } else if (str_eq(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;
     need_dummy_read = 1;
-  } else if (str_eq(mem->desc, "calibration")) {
+  } else if (mem_is_calibration(mem)) {
     cmd[1] = MTYPE_OSCCAL_BYTE;
     need_dummy_read = 1;
-  } else if (str_eq(mem->desc, "signature")) {
+  } else if (mem_is_signature(mem)) {
     cmd[1] = MTYPE_SIGN_JTAG;
   } else {
     pmsg_error("unknown memory %s in %s()\n", mem->desc, __func__);

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -621,7 +621,7 @@ int jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg) {
       memmove(*msg, *msg + 8, rv);
 
       if(verbose > 3)
-        trace_buffer("jtagmkII_recv: ", *msg, rv);
+        trace_buffer(__func__, *msg, rv);
 
       return rv;
     }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2237,17 +2237,8 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
         }
       return 0;
     }
-  } else if (mem_is_in_sigrow(mem)) {
-    AVRMEM *sr = avr_locate_sigrow(p);
-    int doff;
-    if ((p->prog_modes & (PM_PDI | PM_UPDI)) && sr && (doff = mem->offset-sr->offset) >= 0 &&
-      (int) (addr + doff) < sr->size) {
-      cmd[1] = MTYPE_PRODSIG;
-      addr += doff;
-    } else {
-      pmsg_error("unable to handle memory %s\n", mem->desc);
-      return -1;
-    }
+  } else if ((p->prog_modes & (PM_PDI | PM_UPDI)) && mem_is_in_sigrow(mem)) {
+    cmd[1] = MTYPE_PRODSIG;
   } else if (mem_is_io(mem)) {
     cmd[1] = MTYPE_FLASH;
     addr += avr_data_offset(p);

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1000,9 +1000,9 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
       u32_to_b4(sendbuf.dd.nvm_fuse_offset, m->offset & ~15);
     } else if (str_starts(m->desc, "lock")) {
       u32_to_b4(sendbuf.dd.nvm_lock_offset, m->offset);
-    } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
+    } else if (mem_is_userrow(m)) {
       u32_to_b4(sendbuf.dd.nvm_user_sig_offset, m->offset);
-    } else if (str_eq(m->desc, "prodsig")) {
+    } else if (mem_is_sigrow(m)) {
       u32_to_b4(sendbuf.dd.nvm_prod_sig_offset, m->offset);
     } else if (mem_is_data(m)) {
       u32_to_b4(sendbuf.dd.nvm_data_offset, m->offset);
@@ -1842,7 +1842,7 @@ static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   pmsg_notice2("jtagmkII_page_erase(.., %s, 0x%x)\n", m->desc, addr);
 
-  if (!(p->prog_modes & (PM_PDI | PM_UPDI)) && !str_eq(m->desc, "usersig")) {
+  if (!(p->prog_modes & (PM_PDI | PM_UPDI)) && !mem_is_userrow(m)) {
     pmsg_error("page erase only available for AVR8X/XMEGAs or classic-part usersig mem\n");
     return -1;
   }
@@ -1862,7 +1862,7 @@ static int jtagmkII_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AV
       cmd[1] = XMEGA_ERASE_BOOT_PAGE;
   } else if (mem_is_eeprom(m)) {
     cmd[1] = XMEGA_ERASE_EEPROM_PAGE;
-  } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
+  } else if (mem_is_userrow(m)) {
     cmd[1] = XMEGA_ERASE_USERSIG;
   } else if (mem_is_boot(m)) {
     cmd[1] = XMEGA_ERASE_BOOT_PAGE;
@@ -1965,7 +1965,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
     }
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM: MTYPE_EEPROM_PAGE;
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
-  } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
+  } else if (mem_is_userrow(m)) {
     cmd[1] = MTYPE_USERSIG;
   } else if (mem_is_boot(m)) {
     cmd[1] = MTYPE_BOOT_FLASH;
@@ -2068,9 +2068,9 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM: MTYPE_EEPROM_PAGE;
     if (pgm->flag & PGM_FL_IS_DW)
       return -1;
-  } else if (str_eq(m->desc, "prodsig")) {
+  } else if (mem_is_sigrow(m)) {
     cmd[1] = MTYPE_PRODSIG;
-  } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
+  } else if (mem_is_userrow(m)) {
     cmd[1] = MTYPE_USERSIG;
   } else if (mem_is_boot(m)) {
     cmd[1] = MTYPE_BOOT_FLASH;
@@ -2198,9 +2198,9 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     cmd[1] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
+  } else if (mem_is_userrow(mem)) {
     cmd[1] = MTYPE_USERSIG;
-  } else if (str_eq(mem->desc, "prodsig")) {
+  } else if (mem_is_sigrow(mem)) {
     if (p->prog_modes & (PM_PDI | PM_UPDI)) {
       cmd[1] = MTYPE_PRODSIG;
     } else {
@@ -2363,9 +2363,9 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
       addr = 2;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
+  } else if (mem_is_userrow(mem)) {
     cmd[1] = MTYPE_USERSIG;
-  } else if (str_eq(mem->desc, "prodsig")) {
+  } else if (mem_is_sigrow(mem)) {
     cmd[1] = MTYPE_PRODSIG;
   } else if (str_starts(mem->desc, "lock")) {
     cmd[1] = MTYPE_LOCK_BITS;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1004,6 +1004,7 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
       u32_to_b4(sendbuf.dd.nvm_user_sig_offset, m->offset);
     } else if (mem_is_sigrow(m)) {
       u32_to_b4(sendbuf.dd.nvm_prod_sig_offset, m->offset);
+      pmsg_notice2("prod_sig_offset addr 0x%05x\n", m->offset);
     } else if (mem_is_data(m)) {
       u32_to_b4(sendbuf.dd.nvm_data_offset, m->offset);
     }
@@ -2200,6 +2201,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   } else if (mem_is_sigrow(mem)) {
     if (p->prog_modes & (PM_PDI | PM_UPDI)) {
       cmd[1] = MTYPE_PRODSIG;
+      pmsg_notice2("is_sigrow addr 0x%05lx\n", addr);
     } else {
       cmd[1] = addr&1? MTYPE_OSCCAL_BYTE: MTYPE_SIGN_JTAG;
       addr /= 2;
@@ -2239,6 +2241,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     }
   } else if ((p->prog_modes & (PM_PDI | PM_UPDI)) && mem_is_in_sigrow(mem)) {
     cmd[1] = MTYPE_PRODSIG;
+    pmsg_notice2("in_sigrow addr 0x%05lx\n", addr);
   } else if (mem_is_io(mem)) {
     cmd[1] = MTYPE_FLASH;
     addr += avr_data_offset(p);

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1334,7 +1334,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if (pgm->read_chip_rev && p->prog_modes & (PM_PDI | PM_UPDI)) {
-    char chip_rev[AVR_CHIP_REVLEN];
+    unsigned char chip_rev[AVR_CHIP_REVLEN];
     pgm->read_chip_rev(pgm, p, chip_rev);
     pmsg_notice("silicon revision: %x.%x\n", chip_rev[0] >> 4, chip_rev[0] & 0x0f);
   }
@@ -2110,7 +2110,7 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
   return n_bytes;
 }
 
-static int jtagmkII_read_chip_rev(const PROGRAMMER *pgm, const AVRPART *p, char *chip_rev) {
+static int jtagmkII_read_chip_rev(const PROGRAMMER *pgm, const AVRPART *p, unsigned char *chip_rev) {
   // XMEGA using JTAG or PDI, tinyAVR0/1/2, megaAVR0, AVR-Dx, AVR-Ex using UPDI
   if(p->prog_modes & (PM_PDI | PM_UPDI)) {
     AVRMEM *m = avr_locate_io(p);
@@ -2119,8 +2119,7 @@ static int jtagmkII_read_chip_rev(const PROGRAMMER *pgm, const AVRPART *p, char 
       return -1;
     }
     int status = pgm->read_byte(pgm, p, m,
-        p->prog_modes & PM_PDI? p->mcu_base+3 :p->syscfg_base+1,
-        (unsigned char *)chip_rev);
+        p->prog_modes & PM_PDI? p->mcu_base+3 :p->syscfg_base+1, chip_rev);
     if (status < 0)
       return status;
   } else {

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2168,12 +2168,12 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   addr += mem->offset;
   cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_FLASH: MTYPE_FLASH_PAGE;
-  if (avr_mem_is_flash_type(mem)) {
+  if (mem_is_in_flash(mem)) {
     pagesize = PDATA(pgm)->flash_pagesize;
     paddr = addr & ~(pagesize - 1);
     paddr_ptr = &PDATA(pgm)->flash_pageaddr;
     cache_ptr = PDATA(pgm)->flash_pagecache;
-  } else if (avr_mem_is_eeprom_type(mem)) {
+  } else if (mem_is_eeprom(mem)) {
     if ( (pgm->flag & PGM_FL_IS_DW) || (p->prog_modes & (PM_PDI | PM_UPDI)) ) {
       /* debugWire cannot use page access for EEPROM */
       cmd[1] = MTYPE_EEPROM;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2187,7 +2187,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     }
   } else if(mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[1] = MTYPE_FUSE_BITS;
-    if(mem_is_a_fuse(mem))
+    if(!(p->prog_modes & (PM_PDI | PM_UPDI)) && mem_is_a_fuse(mem))
       addr = mem_fuse_offset(mem);
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
@@ -2362,7 +2362,7 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[1] = MTYPE_FUSE_BITS;
-    if(mem_is_a_fuse(mem))
+    if(!(p->prog_modes & (PM_PDI | PM_UPDI)) && mem_is_a_fuse(mem))
       addr = mem_fuse_offset(mem);
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2511,21 +2511,22 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
    */
   unsigned char buf[2 + 4], *resp, c;
   size_t size;
+  const char *parstr = "???";
 
   pmsg_notice2("jtagmkII_setparm()\n");
 
   switch (parm) {
-  case PAR_HW_VERSION: size = 2; break;
-  case PAR_FW_VERSION: size = 4; break;
-  case PAR_EMULATOR_MODE: size = 1; break;
-  case PAR_BAUD_RATE: size = 1; break;
-  case PAR_OCD_VTARGET: size = 2; break;
-  case PAR_OCD_JTAG_CLK: size = 1; break;
-  case PAR_TIMERS_RUNNING: size = 1; break;
-  case PAR_EXTERNAL_RESET: size = 1; break;
-  case PAR_DAISY_CHAIN_INFO: size = 4; break;
-  case PAR_PDI_OFFSET_START:
-  case PAR_PDI_OFFSET_END: size = 4; break;
+  case PAR_HW_VERSION: size = 2; parstr ="hw_version"; break;
+  case PAR_FW_VERSION: size = 4; parstr ="fw_version"; break;
+  case PAR_EMULATOR_MODE: size = 1; parstr ="emulator_mode"; break;
+  case PAR_BAUD_RATE: size = 1; parstr ="baud_rate"; break;
+  case PAR_OCD_VTARGET: size = 2; parstr ="ocd_vtarget"; break;
+  case PAR_OCD_JTAG_CLK: size = 1; parstr ="ocd_jtag_clk"; break;
+  case PAR_TIMERS_RUNNING: size = 1; parstr ="timers_running"; break;
+  case PAR_EXTERNAL_RESET: size = 1; parstr ="external_reset"; break;
+  case PAR_DAISY_CHAIN_INFO: size = 4; parstr ="daisy_chain_info"; break;
+  case PAR_PDI_OFFSET_START: size = 4; parstr ="pdi_offset_start"; break;
+  case PAR_PDI_OFFSET_END: size = 4; parstr ="pdi_offset_end"; break;
   default:
     pmsg_error("unknown parameter 0x%02x\n", parm);
     return -1;
@@ -2534,8 +2535,8 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
   buf[0] = CMND_SET_PARAMETER;
   buf[1] = parm;
   memcpy(buf + 2, value, size);
-  pmsg_notice2("jtagmkII_setparm(): "
-    "Sending set parameter command (parm 0x%02x, %u bytes): ", parm, (unsigned)size);
+  pmsg_notice2("%s() sending set parameter command "
+    "(parm %s 0x%02x, %u bytes): ", __func__, parstr, parm, (unsigned) size);
   jtagmkII_send(pgm, buf, size + 2);
 
   status = jtagmkII_recv(pgm, &resp);
@@ -2552,7 +2553,7 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm,
   c = resp[0];
   free(resp);
   if (c != RSP_OK) {
-    pmsg_error("bad response to set parameter command: %s\n", jtagmkII_get_rc(c));
+    pmsg_error("bad response to set parameter %s: %s\n", parstr, jtagmkII_get_rc(c));
     return -1;
   }
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -620,27 +620,9 @@ int jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg) {
        */
       memmove(*msg, *msg + 8, rv);
 
-      if (verbose == 4)
-      {
-          int i = rv;
-          unsigned char *p = *msg;
-          pmsg_trace("recv: ");
+      if(verbose > 3)
+        trace_buffer("jtagmkII_recv: ", *msg, rv);
 
-          while (i) {
-            unsigned char c = *p;
-            if (isprint(c)) {
-              msg_trace("%c ", c);
-            }
-            else {
-              msg_trace(". ");
-            }
-            msg_trace("[%02x] ", c);
-
-            p++;
-            i--;
-          }
-          msg_trace("\n");
-      }
       return rv;
     }
     if (r_seqno == 0xffff) {
@@ -1010,8 +992,7 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
 
-  pmsg_notice2("jtagmkII_set_xmega_params(): "
-    "Sending set Xmega params command: ");
+  pmsg_notice2("%s() sending set Xmega params command: ", __func__);
   jtagmkII_send(pgm, (unsigned char *)&sendbuf, sizeof sendbuf);
 
   status = jtagmkII_recv(pgm, &resp);

--- a/src/jtagmkII_private.h
+++ b/src/jtagmkII_private.h
@@ -166,7 +166,7 @@
 #define EVT_ERROR_PHY_OPT_RECEIVED_BREAK    0xFA
 #define EVT_RESULT_PHY_NO_ACTIVITY          0xFB
 
-/* memory types for CMND_{READ,WRITE}_MEMORY */
+/* memories for CMND_{READ,WRITE}_MEMORY */
 #define MTYPE_IO_SHADOW   0x30	/* cached IO registers? */
 #define MTYPE_SRAM        0x20	/* target's SRAM or [ext.] IO registers */
 #define MTYPE_EEPROM      0x22	/* EEPROM, what way? */
@@ -278,7 +278,7 @@
 # define PAGEPROG_NOT_ALLOWED                    0x00
 # define PAGEPROG_ALLOWED                        0x01
 
-/* Xmega erase memory types, for CMND_XMEGA_ERASE */
+/* Xmega erase memories for CMND_XMEGA_ERASE */
 #define XMEGA_ERASE_CHIP        0x00
 #define XMEGA_ERASE_APP         0x01
 #define XMEGA_ERASE_BOOT        0x02

--- a/src/jtagmkI_private.h
+++ b/src/jtagmkI_private.h
@@ -132,7 +132,7 @@
 #define JTAG_BITRATE_250_kHz 0xfd
 #define JTAG_BITRATE_125_kHz 0xfb
 
-/* memory types for CMND_{READ,WRITE}_MEMORY */
+/* memories for CMND_{READ,WRITE}_MEMORY */
 #define MTYPE_IO_SHADOW 0x30	/* cached IO registers? */
 #define MTYPE_SRAM 0x20		/* target's SRAM or [ext.] IO registers */
 #define MTYPE_EEPROM 0x22	/* EEPROM, what way? */

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -401,6 +401,18 @@ typedef struct {
 #define mem_is_in_sigrow(mem) (!!((mem)->type & MEM_IN_SIGROW)) // If sigrow exists, that is
 #define mem_is_readonly(mem) (!!((mem)->type & MEM_READONLY))
 #define mem_is_paged_type(mem) (!!((mem)->type & (MEM_IN_FLASH | MEM_EEPROM | MEM_USER_TYPE)))
+#define mem_is_lfuse(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE0))
+#define mem_is_hfuse(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE1))
+#define mem_is_efuse(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE2))
+#define mem_is_fuse0(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE0))
+#define mem_is_fuse1(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE1))
+#define mem_is_fuse2(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE2))
+#define mem_is_fuse4(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE4))
+#define mem_is_fuse5(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE5))
+#define mem_is_fuse6(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE6))
+#define mem_is_fuse7(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE7))
+#define mem_is_fuse8(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSE8))
+#define mem_is_fusea(m) (((m)->type&(MEM_IS_A_FUSE|MEM_FUSEOFF_MASK)) == (MEM_IS_A_FUSE|MEM_FUSEA))
 
 #define mem_fuse_offset(mem) ((mem)->type & MEM_FUSEOFF_MASK) // Valid if mem_is_a_fuse(mem)
 
@@ -470,6 +482,7 @@ void     avr_free_mem(AVRMEM * m);
 void     avr_free_memalias(AVRMEM_ALIAS * m);
 AVRMEM * avr_locate_mem(const AVRPART *p, const char *desc);
 AVRMEM * avr_locate_mem_noalias(const AVRPART *p, const char *desc);
+AVRMEM * avr_locate_fuse_by_offset(const AVRPART *p, unsigned int off);
 AVRMEM_ALIAS * avr_locate_memalias(const AVRPART *p, const char *desc);
 AVRMEM_ALIAS * avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig);
 void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
@@ -481,8 +494,7 @@ AVRPART * avr_dup_part(const AVRPART *d);
 void      avr_free_part(AVRPART * d);
 AVRPART * locate_part(const LISTID parts, const char *partdesc);
 AVRPART * locate_part_by_avr910_devcode(const LISTID parts, int devcode);
-AVRPART * locate_part_by_signature(const LISTID parts, unsigned char *sig,
-                                   int sigsize);
+AVRPART * locate_part_by_signature(const LISTID parts, unsigned char *sig, int sigsize);
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose);
 
 typedef void (*walk_avrparts_cb)(const char *name, const char *desc,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1145,6 +1145,9 @@ int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p);
 
 void report_progress(int completed, int total, const char *hdr);
 
+void trace_buffer(char *what, const unsigned char *buf, size_t buflen);
+void trace2_buffer(char *what, const unsigned char *buf, size_t buflen);
+
 int avr_has_paged_access(const PROGRAMMER *pgm, const AVRMEM *m);
 
 int avr_read_page_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, int addr, unsigned char *buf);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -232,7 +232,7 @@ typedef struct opcode {
  *  - lexer.l
  *  - Either Component_t avr_comp[] of config.c or in config_gram.y
  *  - dev_part_strct() in developer_opts.c
- *  - avr_new_part() and/or avr_new_memtype() in avrpart.c for
+ *  - avr_new_part() and/or avr_new_mem() in avrpart.c for
  *    initialisation; note that all const char * must be initialised with ""
  */
 typedef struct avrpart {
@@ -379,7 +379,7 @@ const char *opcodename(int opnum);
 char *opcode2str(const OPCODE *op, int opnum, int detailed);
 
 /* Functions for AVRMEM structures */
-AVRMEM * avr_new_memtype(void);
+AVRMEM * avr_new_mem(void);
 AVRMEM_ALIAS * avr_new_memalias(void);
 int avr_initmem(const AVRPART *p);
 AVRMEM * avr_dup_mem(const AVRMEM *m);
@@ -937,7 +937,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
 int avr_read_mem(const PROGRAMMER * pgm, const AVRPART *p, const AVRMEM *mem, const AVRPART *v);
 
-int avr_read(const PROGRAMMER * pgm, const AVRPART *p, const char *memtype, const AVRPART *v);
+int avr_read(const PROGRAMMER * pgm, const AVRPART *p, const char *memstr, const AVRPART *v);
 
 int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr);
@@ -962,7 +962,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
 int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, int size, int auto_erase);
 
-int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memtype, int size, int auto_erase);
+int avr_write(const PROGRAMMER *pgm, const AVRPART *p, const char *memstr, int size, int auto_erase);
 
 int avr_signature(const PROGRAMMER *pgm, const AVRPART *p);
 
@@ -978,15 +978,15 @@ char *avr_prog_modes(int pm);
 
 void avr_add_mem_order(const char *str);
 
-int avr_memtype_is_flash_type(const char *mem);
+int avr_memstr_is_flash_type(const char *mem);
 
 int avr_mem_is_flash_type(const AVRMEM *mem);
 
-int avr_memtype_is_eeprom_type(const char *mem);
+int avr_memstr_is_eeprom_type(const char *mem);
 
 int avr_mem_is_eeprom_type(const AVRMEM *mem);
 
-int avr_memtype_is_usersig_type(const char *mem);
+int avr_memstr_is_usersig_type(const char *mem);
 
 int avr_mem_is_usersig_type(const AVRMEM *mem);
 
@@ -1077,7 +1077,7 @@ int fileio_fmt_autodetect_fp(FILE *f);
 int fileio_fmt_autodetect(const char *fname);
 
 int fileio(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, const char *memtype, int size);
+  const AVRPART *p, const char *memstr, int size);
 
 int segment_normalise(const AVRMEM *mem, Segment_t *segp);
 
@@ -1107,7 +1107,7 @@ enum updateflags {
 
 typedef struct update_t {
   const char *cmdline;          // -T line is stored here and takes precedence if it exists
-  char *memtype;                // Memory name for -U
+  char *memstr;                 // Memory name for -U
   int   op;                     // Symbolic memory operation DEVICE_... for -U
   char *filename;               // Filename for -U, can be -
   int   format;                 // File format FMT_...
@@ -1136,7 +1136,7 @@ extern void free_update(UPDATE *upd);
 char *update_str(const UPDATE *upd);
 int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd,
   enum updateflags flags);
-int memstats(const AVRPART *p, const char *memtype, int size, Filestats *fsp);
+int memstats(const AVRPART *p, const char *memstr, int size, Filestats *fsp);
 
 // Helper functions for dry run to determine file access
 int update_is_okfile(const char *fn);
@@ -1301,7 +1301,7 @@ bool is_bigendian();
 void change_endian(void *p, int size);
 int memall(const void *p, char c, size_t n);
 unsigned long long int str_ull(const char *str, char **endptr, int base);
-Str2data *str_todata(const char *str, int type, const AVRPART *part, const char *memtype);
+Str2data *str_todata(const char *str, int type, const AVRPART *part, const char *memstr);
 void str_freedata(Str2data *sd);
 unsigned long long int str_int(const char *str, int type, const char **errpp);
 int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -400,6 +400,7 @@ typedef struct {
 #define mem_is_user_type(mem) (!!((mem)->type & MEM_USER_TYPE))
 #define mem_is_in_sigrow(mem) (!!((mem)->type & MEM_IN_SIGROW)) // If sigrow exists, that is
 #define mem_is_readonly(mem) (!!((mem)->type & MEM_READONLY))
+#define mem_is_paged_type(mem) (!!((mem)->type & (MEM_IN_FLASH | MEM_EEPROM | MEM_USER_TYPE)))
 
 #define mem_fuse_offset(mem) ((mem)->type & MEM_FUSEOFF_MASK) // Valid if mem_is_a_fuse(mem)
 
@@ -1060,15 +1061,9 @@ char *avr_prog_modes(int pm);
 
 int avr_get_mem_type(const char *str);
 
-int avr_memstr_is_flash_type(const char *mem);
-
 int avr_mem_is_flash_type(const AVRMEM *mem);
 
-int avr_memstr_is_eeprom_type(const char *mem);
-
 int avr_mem_is_eeprom_type(const AVRMEM *mem);
-
-int avr_memstr_is_usersig_type(const char *mem);
 
 int avr_mem_is_usersig_type(const AVRMEM *mem);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -390,7 +390,7 @@ typedef struct {
 #define mem_is_osc20err(mem) (!!((mem)->type & MEM_OSC20ERR))
 #define mem_is_bootrow(mem) (!!((mem)->type & MEM_BOOTROW))
 #define mem_is_userrow(mem) (!!((mem)->type & MEM_USERROW))
-#define mem_is_sram(mem) (!!((mem)->type & MEM_SRAM))
+#define mem_is_data(mem) (!!((mem)->type & MEM_SRAM))
 #define mem_is_io(mem) (!!((mem)->type & MEM_IO))
 #define mem_is_sib(mem) (!!((mem)->type & MEM_SIB))
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -371,6 +371,57 @@ typedef struct {
 #define MEM_IN_SIGROW   (1<<30) // prodsig sigrow signature calibration sernum tempsense osccal16 osccal20 osc16err osc20err
 #define MEM_READONLY   (1U<<31) // sib prodsig sigrow signature sernum tempsense calibration osccal16 osccal20 osc16err osc20err
 
+// Marcos to locate a memory type or a fuse
+#define avr_locate_eeprom(p) avr_locate_mem_by_type((p), MEM_EEPROM)
+#define avr_locate_flash(p) avr_locate_mem_by_type((p), MEM_FLASH)
+#define avr_locate_application(p) avr_locate_mem_by_type((p), MEM_APPLICATION)
+#define avr_locate_apptable(p) avr_locate_mem_by_type((p), MEM_APPTABLE)
+#define avr_locate_boot(p) avr_locate_mem_by_type((p), MEM_BOOT)
+#define avr_locate_fuses(p) avr_locate_mem_by_type((p), MEM_FUSES)
+#define avr_locate_lock(p) avr_locate_mem_by_type((p), MEM_LOCK)
+#define avr_locate_lockbits(p) avr_locate_mem_by_type((p), MEM_LOCK)
+#define avr_locate_prodsig(p) avr_locate_mem_by_type((p), MEM_SIGROW)
+#define avr_locate_sigrow(p) avr_locate_mem_by_type((p), MEM_SIGROW)
+#define avr_locate_signature(p) avr_locate_mem_by_type((p), MEM_SIGNATURE)
+#define avr_locate_calibration(p) avr_locate_mem_by_type((p), MEM_CALIBRATION)
+#define avr_locate_tempsense(p) avr_locate_mem_by_type((p), MEM_TEMPSENSE)
+#define avr_locate_sernum(p) avr_locate_mem_by_type((p), MEM_SERNUM)
+#define avr_locate_osccal16(p) avr_locate_mem_by_type((p), MEM_OSCCAL16)
+#define avr_locate_osccal20(p) avr_locate_mem_by_type((p), MEM_OSCCAL20)
+#define avr_locate_osc16err(p) avr_locate_mem_by_type((p), MEM_OSC16ERR)
+#define avr_locate_osc20err(p) avr_locate_mem_by_type((p), MEM_OSC20ERR)
+#define avr_locate_bootrow(p) avr_locate_mem_by_type((p), MEM_BOOTROW)
+#define avr_locate_usersig(p) avr_locate_mem_by_type((p), MEM_USERROW)
+#define avr_locate_userrow(p) avr_locate_mem_by_type((p), MEM_USERROW)
+#define avr_locate_data(p) avr_locate_mem_by_type((p), MEM_SRAM)
+#define avr_locate_io(p) avr_locate_mem_by_type((p), MEM_IO)
+#define avr_locate_sib(p) avr_locate_mem_by_type((p), MEM_SIB)
+
+#define avr_locate_fuse(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE0)
+#define avr_locate_lfuse(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE0)
+#define avr_locate_hfuse(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE1)
+#define avr_locate_efuse(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE2)
+#define avr_locate_fuse0(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE0)
+#define avr_locate_wdtcfg(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE0)
+#define avr_locate_fuse1(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE1)
+#define avr_locate_bodcfg(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE1)
+#define avr_locate_fuse2(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE2)
+#define avr_locate_osccfg(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE2)
+#define avr_locate_fuse4(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE4)
+#define avr_locate_tcd0cfg(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE4)
+#define avr_locate_fuse5(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE5)
+#define avr_locate_syscfg0(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE5)
+#define avr_locate_fuse6(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE6)
+#define avr_locate_syscfg1(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE6)
+#define avr_locate_fuse7(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE7)
+#define avr_locate_append(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE7)
+#define avr_locate_codesize(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE7)
+#define avr_locate_fuse8(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE8)
+#define avr_locate_bootend(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE8)
+#define avr_locate_bootsize(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE8)
+#define avr_locate_fusea(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSEA)
+#define avr_locate_pdicfg(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSEA)
+
 // Fuse offset and memory type/attribute macros
 #define mem_is_eeprom(mem) (!!((mem)->type & MEM_EEPROM))
 #define mem_is_flash(mem) (!!((mem)->type & MEM_FLASH))
@@ -483,6 +534,8 @@ void     avr_free_memalias(AVRMEM_ALIAS * m);
 AVRMEM * avr_locate_mem(const AVRPART *p, const char *desc);
 AVRMEM * avr_locate_mem_noalias(const AVRPART *p, const char *desc);
 AVRMEM * avr_locate_fuse_by_offset(const AVRPART *p, unsigned int off);
+AVRMEM * avr_locate_mem_by_type(const AVRPART *p, memtype_t type);
+unsigned int avr_data_offset(const AVRPART *p);
 AVRMEM_ALIAS * avr_locate_memalias(const AVRPART *p, const char *desc);
 AVRMEM_ALIAS * avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig);
 void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -986,7 +986,7 @@ typedef struct programmer_t {
                           unsigned long addr, unsigned char *value);
   int  (*read_sig_bytes) (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m);
   int  (*read_sib)       (const struct programmer_t *pgm, const AVRPART *p, char *sib);
-  int  (*read_chip_rev)  (const struct programmer_t *pgm, const AVRPART *p, char *chip_rev);
+  int  (*read_chip_rev)  (const struct programmer_t *pgm, const AVRPART *p, unsigned char *chip_rev);
   int  (*term_keep_alive)(const struct programmer_t *pgm, const AVRPART *p);
   void (*print_parms)    (const struct programmer_t *pgm, FILE *fp);
   int  (*set_vtarget)    (const struct programmer_t *pgm, double v);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1145,8 +1145,7 @@ int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p);
 
 void report_progress(int completed, int total, const char *hdr);
 
-void trace_buffer(char *what, const unsigned char *buf, size_t buflen);
-void trace2_buffer(char *what, const unsigned char *buf, size_t buflen);
+void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen);
 
 int avr_has_paged_access(const PROGRAMMER *pgm, const AVRMEM *m);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1469,7 +1469,7 @@ skipopen:
       }
     }
 
-    sig = avr_locate_mem(p, "signature");
+    sig = avr_locate_signature(p);
     if (sig == NULL)
       pmsg_warning("signature memory not defined for device %s\n", p->desc);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1586,6 +1586,7 @@ skipopen:
 
   int wrmem = 0, terminal = 0;
   for (ln=lfirst(updates); ln; ln=lnext(ln)) {
+    const AVRMEM *m;
     upd = ldata(ln);
     if(upd->cmdline && wrmem) { // Invalidate cache if device was written to
       wrmem = 0;
@@ -1600,7 +1601,7 @@ skipopen:
     if (rc && rc != LIBAVRDUDE_SOFTFAIL) {
       exitrc = 1;
       break;
-    } else if(rc == 0 && upd->op == DEVICE_WRITE && avr_memstr_is_flash_type(upd->memstr))
+    } else if(rc == 0 && upd->op == DEVICE_WRITE && (m = avr_locate_mem(p, upd->memstr)) && mem_is_in_flash(m))
       ce_delayed = 0;           // Redeemed chip erase promise
   }
   pgm->flush_cache(pgm, p);

--- a/src/main.c
+++ b/src/main.c
@@ -244,7 +244,7 @@ static void usage(void)
     "  -O                     Perform RC oscillator calibration (see AVR053)\n"
     "  -t                     Run an interactive terminal when it is its turn\n"
     "  -T <terminal cmd line> Run terminal line when it is its turn\n"
-    "  -U <memtype>:r|w|v:<filename>[:format]\n"
+    "  -U <memstr>:r|w|v:<filename>[:format]\n"
     "                         Carry out memory operation when it is its turn\n"
     "                         Multiple -t, -T and -U options can be specified\n"
     "  -n                     Do not write to the device whilst processing -U\n"
@@ -1340,12 +1340,12 @@ skipopen:
   int doexit = 0;
   for (ln=lfirst(updates); ln; ln=lnext(ln)) {
     upd = ldata(ln);
-    if (upd->memtype == NULL && upd->cmdline == NULL) {
+    if (upd->memstr == NULL && upd->cmdline == NULL) {
       const char *mtype = p->prog_modes & PM_PDI? "application": "flash";
-      pmsg_notice2("defaulting memtype in -U %c:%s option to \"%s\"\n",
+      pmsg_notice2("defaulting memstr in -U %c:%s option to \"%s\"\n",
         (upd->op == DEVICE_READ)? 'r': (upd->op == DEVICE_WRITE)? 'w': 'v',
         upd->filename, mtype);
-      upd->memtype = cfg_strdup("main()", mtype);
+      upd->memstr = cfg_strdup("main()", mtype);
     }
     rc = update_dryrun(p, upd);
     if (rc && rc != LIBAVRDUDE_SOFTFAIL)
@@ -1544,9 +1544,9 @@ skipopen:
       uflags &= ~UF_AUTO_ERASE;
       for (ln=lfirst(updates); ln; ln=lnext(ln)) {
         upd = ldata(ln);
-        if(!upd->memtype)
+        if(!upd->memstr)
           continue;
-        m = avr_locate_mem(p, upd->memtype);
+        m = avr_locate_mem(p, upd->memstr);
         if (m == NULL)
           continue;
         if(str_eq(m->desc, memname) && upd->op == DEVICE_WRITE) {
@@ -1600,7 +1600,7 @@ skipopen:
     if (rc && rc != LIBAVRDUDE_SOFTFAIL) {
       exitrc = 1;
       break;
-    } else if(rc == 0 && upd->op == DEVICE_WRITE && avr_memtype_is_flash_type(upd->memtype))
+    } else if(rc == 0 && upd->op == DEVICE_WRITE && avr_memstr_is_flash_type(upd->memstr))
       ce_delayed = 0;           // Redeemed chip erase promise
   }
   pgm->flush_cache(pgm, p);

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -850,7 +850,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 {
     pmsg_debug("micronucleus_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
 
-    if (str_eq(mem->desc, "flash"))
+    if (mem_is_flash(mem))
     {
         pdata_t* pdata = PDATA(pgm);
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -814,10 +814,7 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
 {
     pmsg_debug("micronucleus_read_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
 
-    if (str_eq(mem->desc, "lfuse") ||
-        str_eq(mem->desc, "hfuse") ||
-        str_eq(mem->desc, "efuse") ||
-        str_eq(mem->desc, "lock"))
+    if (mem_is_a_fuse(mem) || mem_is_lock(mem))
     {
         *value = 0xFF;
         return 0;
@@ -897,7 +894,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     }
     else
     {
-        pmsg_error("unsupported memory type: %s\n", mem->desc);
+        pmsg_error("unsupported memory %s\n", mem->desc);
         return -1;
     }
 }

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -454,7 +454,7 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned int page_size, unsigned int addr, unsigned int n_bytes) {
 
     // only supporting flash & eeprom page reads
-    if ((!mem->paged || page_size <= 1) || (!str_eq(mem->desc, "flash") && !str_eq(mem->desc, "eeprom")))
+    if ((!mem->paged || page_size <= 1) || (!mem_is_flash(mem) && !mem_is_eeprom(mem)))
     {
         return -1;
     }
@@ -591,7 +591,7 @@ static int  pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
                          unsigned int page_size, unsigned int addr, unsigned int n_bytes)
 {
     // only paged write for flash implemented
-    if (!str_eq(mem->desc, "flash") && !str_eq(mem->desc, "eeprom"))
+    if (!mem_is_flash(mem) && !mem_is_eeprom(mem))
     {
         pmsg_error("part does not support %d paged write of %s\n", page_size, mem->desc);
         return -1;

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -440,7 +440,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char *buf, si
   int rc;
 
   if(verbose > 3)
-    trace_buffer("ser_send: ", buf, len);
+    trace_buffer(__func__, buf, len);
 
   while(len) {
     rc = write(fd->ifd, buf, len > 1024? 1024: len);
@@ -499,7 +499,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
   }
 
   if(verbose > 3)
-    trace_buffer("ser_recv: ", buf, len);
+    trace_buffer(__func__, buf, len);
 
   return 0;
 }

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -436,42 +436,19 @@ static void ser_rawclose(union filedescriptor *fd) {
   close(fd->ifd);
 }
 
-static int ser_send(const union filedescriptor *fd, const unsigned char * buf, size_t buflen) {
+static int ser_send(const union filedescriptor *fd, const unsigned char *buf, size_t len) {
   int rc;
-  const unsigned char * p = buf;
-  size_t len = buflen;
 
-  if (!len)
-    return 0;
+  if(verbose > 3)
+    trace_buffer("ser_send: ", buf, len);
 
-  if (verbose > 3)
-  {
-      pmsg_trace("send: ");
-
-      while (buflen) {
-        unsigned char c = *buf;
-        if (isprint(c)) {
-          msg_trace("%c ", c);
-        }
-        else {
-          msg_trace(". ");
-        }
-        msg_trace("[%02x] ", c);
-
-        buf++;
-        buflen--;
-      }
-
-      msg_trace("\n");
-  }
-
-  while (len) {
-    rc = write(fd->ifd, p, (len > 1024) ? 1024 : len);
+  while(len) {
+    rc = write(fd->ifd, buf, len > 1024? 1024: len);
     if (rc < 0) {
       pmsg_ext_error("unable to write: %s\n", strerror(errno));
       return -1;
     }
-    p += rc;
+    buf += rc;
     len -= rc;
   }
 
@@ -479,12 +456,12 @@ static int ser_send(const union filedescriptor *fd, const unsigned char * buf, s
 }
 
 
-static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t buflen) {
+static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t buflen) {
   struct timeval timeout, to2;
   fd_set rfds;
   int nfds;
   int rc;
-  unsigned char * p = buf;
+  unsigned char *p = buf;
   size_t len = 0;
 
   timeout.tv_sec  = serial_recv_timeout / 1000L;
@@ -512,7 +489,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
       }
     }
 
-    rc = read(fd->ifd, p, (buflen - len > 1024) ? 1024 : buflen - len);
+    rc = read(fd->ifd, p, buflen - len > 1024? 1024: buflen - len);
     if (rc < 0) {
       pmsg_ext_error("unable to read: %s\n", strerror(errno));
       return -1;
@@ -521,27 +498,8 @@ static int ser_recv(const union filedescriptor *fd, unsigned char * buf, size_t 
     len += rc;
   }
 
-  p = buf;
-
-  if (verbose > 3)
-  {
-      pmsg_trace("recv: ");
-
-      while (len) {
-        unsigned char c = *p;
-        if (isprint(c)) {
-          msg_trace("%c ", c);
-        }
-        else {
-          msg_trace(". ");
-        }
-        msg_trace("[%02x] ", c);
-
-        p++;
-        len--;
-      }
-      msg_trace("\n");
-  }
+  if(verbose > 3)
+    trace_buffer("ser_recv: ", buf, len);
 
   return 0;
 }

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -385,7 +385,6 @@ static int ser_send(const union filedescriptor *fd, const unsigned char *buf, si
 	if (serial_over_ethernet)
 		return net_send(fd, buf, len);
 
-	unsigned char c='\0';
 	DWORD written;
 
 	HANDLE hComPort=(HANDLE)fd->pfd;
@@ -497,7 +496,6 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
 	if (serial_over_ethernet)
 		return net_recv(fd, buf, buflen);
 
-	unsigned char c;
 	DWORD read;
 
 	HANDLE hComPort=(HANDLE)fd->pfd;

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -354,7 +354,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char *buf, si
 		return 0;
 
 	if (verbose > 3)
-		trace_buffer("net_send: ", buf, len);
+		trace_buffer(__func__, buf, len);
 
 	while (len) {
 		rc = send(fd->ifd, (const char *) buf, len > 1024? 1024: len, 0);
@@ -399,7 +399,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char *buf, si
 		return 0;
 
 	if (verbose > 3)
-		trace_buffer("ser_send: ", buf, len);
+		trace_buffer(__func__, buf, len);
 	
 	serial_w32SetTimeOut(hComPort,500);
 
@@ -488,7 +488,7 @@ reselect:
 	}
 
 	if (verbose > 3)
-		trace_buffer("net_recv: ", buf, len);
+		trace_buffer(__func__, buf, len);
 
 	return 0;
 }
@@ -533,7 +533,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
 	}
 
 	if (verbose > 3)
-		trace_buffer("ser_recv: ", buf, read);
+		trace_buffer(__func__, buf, read);
 
 	return 0;
 }

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -739,7 +739,7 @@ static int serialupdi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
     if(serialupdi_read_byte(pgm, p, mem, addr, &is) >= 0 && is == value)
       return 0;
 
-    Return("cannot write to read-only memory %s %s", p->desc, mem->desc);
+    Return("cannot write to read-only memory %s", mem->desc);
   }
 
   return updi_write_byte(pgm, mem->offset + addr, value);

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -734,11 +734,7 @@ static int serialupdi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
     return updi_nvm_write_flash(pgm, p, mem->offset + addr, buffer, 1);
   }
   // Read-only memories
-  if(mem_is_osc16err(mem) || mem_is_osccal16(mem) ||
-     mem_is_osc20err(mem) || mem_is_osccal20(mem) ||
-     str_eq(mem->desc, "prodsig") || mem_is_sernum(mem) ||
-     mem_is_signature(mem) || mem_is_sib(mem)) {
-
+  if(mem_is_readonly(mem)) {
     unsigned char is;
     if(serialupdi_read_byte(pgm, p, mem, addr, &is) >= 0 && is == value)
       return 0;
@@ -806,7 +802,7 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
       } else if (mem_is_flash(m)) {
         rc = updi_nvm_write_flash(pgm, p, m->offset + write_offset, m->buf + write_offset, 
                                   remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
-      } else if (str_eq(m->desc, "userrow")) {
+      } else if (mem_is_userrow(m)) {
         rc = serialupdi_write_userrow(pgm, p, m, page_size, write_offset, 
                                       remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
       } else if (mem_is_fuses(m)) {
@@ -832,7 +828,7 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
       rc = updi_nvm_write_eeprom(pgm, p, m->offset+addr, m->buf+addr, n_bytes);
     } else if (mem_is_flash(m)) {
       rc = updi_nvm_write_flash(pgm, p, m->offset+addr, m->buf+addr, n_bytes);
-    } else if (str_eq(m->desc, "userrow")) {
+    } else if (mem_is_userrow(m)) {
       rc = serialupdi_write_userrow(pgm, p, m, page_size, addr, n_bytes);
     } else if (mem_is_fuses(m)) {
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -693,7 +693,7 @@ static int serialupdi_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
     Return("cannot read byte from %s %s as address 0x%04lx outside range [0, 0x%04x]",
       p->desc, mem->desc, addr, mem->size-1);
 
-  if(str_eq(mem->desc, "sib")) {
+  if(mem_is_sib(mem)) {
     if(addr >= SIB_INFO_STRING_LENGTH)
       Return("cannot read byte from %s sib as address 0x%04lx outside range [0, 0x%04x]",
         p->desc, addr, SIB_INFO_STRING_LENGTH-1);
@@ -723,21 +723,21 @@ static int serialupdi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
   if (str_eq(mem->desc, "lock")) {
     return updi_nvm_write_fuse(pgm, p, mem->offset + addr, value);
   }
-  if (str_eq(mem->desc, "eeprom")) {
+  if (mem_is_eeprom(mem)) {
     unsigned char buffer[1];
     buffer[0]=value;
     return updi_nvm_write_eeprom(pgm, p, mem->offset + addr, buffer, 1);
   }
-  if (str_eq(mem->desc, "flash")) {
+  if (mem_is_flash(mem)) {
     unsigned char buffer[1];
     buffer[0]=value;
     return updi_nvm_write_flash(pgm, p, mem->offset + addr, buffer, 1);
   }
   // Read-only memories
-  if(str_eq(mem->desc, "osc16err") || str_eq(mem->desc, "osccal16") ||
-     str_eq(mem->desc, "osc20err") || str_eq(mem->desc, "osccal20") ||
-     str_eq(mem->desc, "prodsig") || str_eq(mem->desc, "sernum") ||
-     str_eq(mem->desc, "signature") || str_eq(mem->desc, "sib")) {
+  if(mem_is_osc16err(mem) || mem_is_osccal16(mem) ||
+     mem_is_osc20err(mem) || mem_is_osccal20(mem) ||
+     str_eq(mem->desc, "prodsig") || mem_is_sernum(mem) ||
+     mem_is_signature(mem) || mem_is_sib(mem)) {
 
     unsigned char is;
     if(serialupdi_read_byte(pgm, p, mem, addr, &is) >= 0 && is == value)
@@ -800,16 +800,16 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 
     while (remaining_bytes > 0) {
 
-      if (str_eq(m->desc, "eeprom")) {
+      if (mem_is_eeprom(m)) {
         rc = updi_nvm_write_eeprom(pgm, p, m->offset + write_offset, m->buf + write_offset, 
                                    remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
-      } else if (str_eq(m->desc, "flash")) {
+      } else if (mem_is_flash(m)) {
         rc = updi_nvm_write_flash(pgm, p, m->offset + write_offset, m->buf + write_offset, 
                                   remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
       } else if (str_eq(m->desc, "userrow")) {
         rc = serialupdi_write_userrow(pgm, p, m, page_size, write_offset, 
                                       remaining_bytes > m->page_size ? m->page_size : remaining_bytes);
-      } else if (str_eq(m->desc, "fuses")) {
+      } else if (mem_is_fuses(m)) {
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         return -1;
       } else {
@@ -828,13 +828,13 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
     }
     return write_bytes;
   } else {
-    if (str_eq(m->desc, "eeprom")) {
+    if (mem_is_eeprom(m)) {
       rc = updi_nvm_write_eeprom(pgm, p, m->offset+addr, m->buf+addr, n_bytes);
-    } else if (str_eq(m->desc, "flash")) {
+    } else if (mem_is_flash(m)) {
       rc = updi_nvm_write_flash(pgm, p, m->offset+addr, m->buf+addr, n_bytes);
     } else if (str_eq(m->desc, "userrow")) {
       rc = serialupdi_write_userrow(pgm, p, m, page_size, addr, n_bytes);
-    } else if (str_eq(m->desc, "fuses")) {
+    } else if (mem_is_fuses(m)) {
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         rc = -1;
     } else {

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -717,10 +717,10 @@ static int serialupdi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
     Return("cannot write byte to %s %s as address 0x%04lx outside range [0, 0x%04x]",
       p->desc, mem->desc, addr, mem->size-1);
 
-  if (str_contains(mem->desc, "fuse")) {
+  if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     return updi_nvm_write_fuse(pgm, p, mem->offset + addr, value);
   }
-  if (str_eq(mem->desc, "lock")) {
+  if (mem_is_lock(mem)) {
     return updi_nvm_write_fuse(pgm, p, mem->offset + addr, value);
   }
   if (mem_is_eeprom(mem)) {
@@ -809,7 +809,7 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         return -1;
       } else {
-        pmsg_error("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
+        pmsg_error("invalid memory <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
         rc = -1;
       }
 
@@ -834,7 +834,7 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         rc = -1;
     } else {
-      pmsg_error("invalid memory type: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
+      pmsg_error("invalid memory: <%s:%d>, 0x%06X, %d (0x%04X)\n", m->desc, page_size, addr, n_bytes, n_bytes);
       rc = -1;
     }
     return rc;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -950,7 +950,7 @@ static int stk500_loadaddr(const PROGRAMMER *pgm, const AVRMEM *mem, unsigned in
 
 
 static int set_memchr_a_div(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int *memchrp, int *a_divp) {
-  if(avr_mem_is_flash_type(m)) {
+  if(mem_is_in_flash(m)) {
     *memchrp = 'F';
     if(!(pgm->prog_modes & PM_SPM)) // Programmer *not* for bootloaders: original stk500v1 protocol
       *a_divp = m->op[AVR_OP_LOADPAGE_LO] || m->op[AVR_OP_READ_LO]? 2: 1;
@@ -961,7 +961,7 @@ static int set_memchr_a_div(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
     return 0;
   }
 
-  if(avr_mem_is_eeprom_type(m)) {
+  if(mem_is_eeprom(m)) {
     *memchrp = 'E';
     // Word addr for bootloaders or Arduino as ISP if part is a "classic" part, byte addr otherwise
     *a_divp = ((pgm->prog_modes & PM_SPM) || str_caseeq(pgmid, "arduino_as_isp")) \

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2318,7 +2318,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     buf[0] = mode == PPMODE? CMD_READ_OSCCAL_PP: CMD_READ_OSCCAL_HVSP;
   } else if (mem_is_signature(mem)) {
     buf[0] = mode == PPMODE? CMD_READ_SIGNATURE_PP: CMD_READ_SIGNATURE_HVSP;
-  } else if (str_eq(mem->desc, "prodsig")) {
+  } else if (mem_is_sigrow(mem)) {
     buf[0] = addr&1?
       (mode == PPMODE? CMD_READ_OSCCAL_PP: CMD_READ_OSCCAL_HVSP):
       (mode == PPMODE? CMD_READ_SIGNATURE_PP: CMD_READ_SIGNATURE_HVSP);
@@ -2452,7 +2452,7 @@ static int stk500isp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     buf[0] = CMD_READ_OSCCAL_ISP;
   } else if (mem_is_signature(mem)) {
     buf[0] = CMD_READ_SIGNATURE_ISP;
-  } else if (str_eq(mem->desc, "prodsig")) {
+  } else if (mem_is_sigrow(mem)) {
     buf[0] = addr&1? CMD_READ_OSCCAL_ISP: CMD_READ_SIGNATURE_ISP;
   }
 
@@ -4280,7 +4280,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
              * fuses.
              */
             need_erase = 1;
-    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
+    } else if (mem_is_userrow(mem)) {
         memcode = XPRG_MEM_TYPE_USERSIG;
     } else {
         pmsg_error("unknown memory %s\n", mem->desc);
@@ -4351,9 +4351,9 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
         b[1] = XPRG_MEM_TYPE_FUSE;
     } else if (str_starts(mem->desc, "lock")) {
         b[1] = XPRG_MEM_TYPE_LOCKBITS;
-    } else if (mem_is_calibration(mem) || str_eq(mem->desc, "prodsig")) {
+    } else if (mem_is_calibration(mem) || mem_is_sigrow(mem)) {
         b[1] = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
-    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
+    } else if (mem_is_userrow(mem)) {
         b[1] = XPRG_MEM_TYPE_USERSIG;
     } else {
         pmsg_error("unknown memory %s\n", mem->desc);
@@ -4426,9 +4426,9 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
         mtype = XPRG_MEM_TYPE_FUSE;
     } else if (str_starts(mem->desc, "lock")) {
         mtype = XPRG_MEM_TYPE_LOCKBITS;
-    } else if (mem_is_calibration(mem) || str_eq(mem->desc, "prodsig")) {
+    } else if (mem_is_calibration(mem) || mem_is_sigrow(mem)) {
         mtype = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
-    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
+    } else if (mem_is_userrow(mem)) {
         mtype = XPRG_MEM_TYPE_USERSIG;
     } else {
         pmsg_error("unknown paged memory %s\n", mem->desc);
@@ -4536,7 +4536,7 @@ static int stk600_xprog_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     } else if (mem_is_calibration(mem)) {
         mtype = XPRG_MEM_TYPE_FACTORY_CALIBRATION;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
-    } else if (str_eq(mem->desc, "usersig") || str_eq(mem->desc, "userrow")) {
+    } else if (mem_is_userrow(mem)) {
         mtype = XPRG_MEM_TYPE_USERSIG;
         writemode = (1 << XPRG_MEM_WRITE_WRITE);
     } else {
@@ -4685,7 +4685,7 @@ static int stk600_xprog_page_erase(const PROGRAMMER *pgm, const AVRPART *p, cons
       b[1] = XPRG_ERASE_BOOT_PAGE;
     } else if (mem_is_eeprom(m)) {
       b[1] = XPRG_ERASE_EEPROM_PAGE;
-    } else if (str_eq(m->desc, "usersig") || str_eq(m->desc, "userrow")) {
+    } else if (mem_is_userrow(m)) {
       b[1] = XPRG_ERASE_USERSIG;
     } else {
       pmsg_error("unknown paged memory %s\n", m->desc);

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -553,7 +553,7 @@ unsigned long long int str_ull(const char *str, char **endptr, int base) {
  * function, but is also used for generic string to integer conversions in str_int() below. Both
  * routines define the "character" of how avrdude understands strings in (most) of its dealings.
  * The granularity of type is an bitwise-or combination of bits making up STR_INTEGER; STR_FLOAT;
- * STR_DOUBLE or STR_STRING. The arguments part and memtype are only needed for input from files.
+ * STR_DOUBLE or STR_STRING. The arguments part and memstr are only needed for input from files.
  */
 
 #define Return(...) do { \
@@ -574,7 +574,7 @@ unsigned long long int str_ull(const char *str, char **endptr, int base) {
   (ll) < INT16_MIN || (ll) > INT16_MAX? 4: \
   (ll) < INT8_MIN  || (ll) > INT8_MAX? 2: 1)
 
-Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *memtype) {
+Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *memstr) {
   char *end_ptr;
   Str2data *sd = cfg_malloc(__func__, sizeof *sd);
   char *str = cfg_strdup(__func__, s);
@@ -766,7 +766,7 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
     }
   }
 
-  if(type & STR_FILE && part && memtype) { // File name containing data to be loaded
+  if(type & STR_FILE && part && memstr) { // File name containing data to be loaded
     int format = FMT_AUTO;
     FILE *f;
     char fmtstr[4] = { 0 };
@@ -790,12 +790,12 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
     }
     // Obtain a copy of the part incl all memories
     AVRPART *dp = avr_dup_part(part);
-    AVRMEM *mem = avr_locate_mem(dp, memtype);
+    AVRMEM *mem = avr_locate_mem(dp, memstr);
     if(!mem) {
       avr_free_part(dp);
-      Return("memory type %s not configured for device %s", memtype, part->desc);
+      Return("memory type %s not configured for device %s", memstr, part->desc);
     }
-    int rc = fileio(FIO_READ_FOR_VERIFY, str, format, dp, memtype, -1);
+    int rc = fileio(FIO_READ_FOR_VERIFY, str, format, dp, memstr, -1);
     if(rc < 0) {
       avr_free_part(dp);
       Return("unable to read the%s %s file", fmtstr, fileio_fmtstr(format));

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -793,7 +793,7 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
     AVRMEM *mem = avr_locate_mem(dp, memstr);
     if(!mem) {
       avr_free_part(dp);
-      Return("memory type %s not configured for device %s", memstr, part->desc);
+      Return("memory %s not configured for device %s", memstr, part->desc);
     }
     int rc = fileio(FIO_READ_FOR_VERIFY, str, format, dp, memstr, -1);
     if(rc < 0) {

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -129,7 +129,7 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
             // To use this workaround, the -F option is required.
             pmsg_error("cannot detect board type (HID usage is 0)\n");
 
-            AVRMEM* mem = avr_locate_mem(p, "flash");
+            AVRMEM* mem = avr_locate_flash(p);
             if (mem == NULL)
             {
                 pmsg_error("no flash memory defined for part %s\n", p->desc);

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -499,7 +499,7 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 {
     pmsg_debug("teensy_paged_write(page_size=0x%X, addr=0x%X, n_bytes=0x%X)\n", page_size, addr, n_bytes);
 
-    if (str_eq(mem->desc, "flash"))
+    if (mem_is_flash(mem))
     {
         pdata_t* pdata = PDATA(pgm);
 

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -463,17 +463,14 @@ static int teensy_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
 {
     pmsg_debug("teensy_read_byte(desc=%s, addr=0x%04lX)\n", mem->desc, addr);
 
-    if (str_eq(mem->desc, "lfuse") ||
-        str_eq(mem->desc, "hfuse") ||
-        str_eq(mem->desc, "efuse") ||
-        str_eq(mem->desc, "lock"))
+    if (mem_is_a_fuse(mem) || mem_is_lock(mem))
     {
         *value = 0xFF;
         return 0;
     }
     else
     {
-        pmsg_error("unsupported memory type: %s\n", mem->desc);
+        pmsg_error("unsupported memory %s\n", mem->desc);
         return -1;
     }
 }
@@ -544,7 +541,7 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     }
     else
     {
-        pmsg_error("unsupported memory type: %s\n", mem->desc);
+        pmsg_error("unsupported memory %s\n", mem->desc);
         return -1;
     }
 }

--- a/src/term.c
+++ b/src/term.c
@@ -231,14 +231,14 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
   }
 
   enum { read_size = 256 };
-  char *memtype;
+  char *memstr;
   if(argc > 1)
-    memtype = argv[1];
+    memstr = argv[1];
   else
-    memtype = (char*)read_mem[i].mem->desc;
-  const AVRMEM *mem = avr_locate_mem(p, memtype);
+    memstr = (char*)read_mem[i].mem->desc;
+  const AVRMEM *mem = avr_locate_mem(p, memstr);
   if (mem == NULL) {
-    pmsg_error("(%s) %s memory type not defined for part %s\n", cmd, memtype, p->desc);
+    pmsg_error("(%s) %s memory type not defined for part %s\n", cmd, memstr, p->desc);
     return -1;
   }
 
@@ -425,10 +425,10 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   int write_mode;               // Operation mode, standard or fill
   int start_offset;             // Which argc argument
   int len;                      // Number of bytes to write to memory
-  char *memtype = argv[1];      // Memory name string
-  const AVRMEM *mem = avr_locate_mem(p, memtype);
+  char *memstr = argv[1];       // Memory name string
+  const AVRMEM *mem = avr_locate_mem(p, memstr);
   if (mem == NULL) {
-    pmsg_error("(write) %s memory type not defined for part %s\n", memtype, p->desc);
+    pmsg_error("(write) %s memory type not defined for part %s\n", memstr, p->desc);
     return -1;
   }
   int maxsize = mem->size;
@@ -831,13 +831,13 @@ static int cmd_erase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   }
 
   if (argc > 1) {
-    char *memtype = argv[1];
-    const AVRMEM *mem = avr_locate_mem(p, memtype);
+    char *memstr = argv[1];
+    const AVRMEM *mem = avr_locate_mem(p, memstr);
     if (mem == NULL) {
       pmsg_error("(erase) %s memory type not defined for part %s\n", argv[1], p->desc);
       return -1;
     }
-    char *args[] = {"write", memtype, "", "", "0xff", "...", NULL};
+    char *args[] = {"write", memstr, "", "", "0xff", "...", NULL};
     // erase <mem>
     if (argc == 2) {
       args[2] = "0";
@@ -907,14 +907,14 @@ static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
     return -1;
   }
 
-  char *memtype = argv[1];
-  const AVRMEM *mem = avr_locate_mem(p, memtype);
+  char *memstr = argv[1];
+  const AVRMEM *mem = avr_locate_mem(p, memstr);
   if(!mem) {
-    pmsg_error("(pgerase) %s memory type not defined for part %s\n", memtype, p->desc);
+    pmsg_error("(pgerase) %s memory type not defined for part %s\n", memstr, p->desc);
     return -1;
   }
   if(!avr_has_paged_access(pgm, mem)) {
-    pmsg_error("(pgerase) %s memory cannot be paged addressed by %s\n", memtype, pgmid);
+    pmsg_error("(pgerase) %s memory cannot be paged addressed by %s\n", memstr, pgmid);
     return -1;
   }
 
@@ -1362,7 +1362,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *a
     locktype = "lockbits";
   for(int i=0; i<nc; i++) {
     cc[i].t = ct+i;
-    const char *mt = str_starts(ct[i].memtype, "lock")? locktype: ct[i].memtype;
+    const char *mt = str_starts(ct[i].memstr, "lock")? locktype: ct[i].memstr;
     cc[i].memstr = mt;
     const AVRMEM *mem = avr_locate_mem(p, mt);
     if(!mem) {

--- a/src/term.c
+++ b/src/term.c
@@ -238,7 +238,7 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
     memstr = (char*)read_mem[i].mem->desc;
   const AVRMEM *mem = avr_locate_mem(p, memstr);
   if (mem == NULL) {
-    pmsg_error("(%s) %s memory type not defined for part %s\n", cmd, memstr, p->desc);
+    pmsg_error("(%s) memory %s not defined for part %s\n", cmd, memstr, p->desc);
     return -1;
   }
 
@@ -337,7 +337,7 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
       report_progress(1, -1, NULL);
       pmsg_error("(%s) error reading %s address 0x%05lx of part %s\n", cmd, mem->desc, (long) read_mem[i].addr + j, p->desc);
       if (rc == -1)
-        imsg_error("%*sread operation not supported on memory type %s\n", 7, "", mem->desc);
+        imsg_error("%*sread operation not supported on memory %s\n", 7, "", mem->desc);
       free(buf);
       return -1;
     }
@@ -428,7 +428,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   char *memstr = argv[1];       // Memory name string
   const AVRMEM *mem = avr_locate_mem(p, memstr);
   if (mem == NULL) {
-    pmsg_error("(write) %s memory type not defined for part %s\n", memstr, p->desc);
+    pmsg_error("(write) memory %s not defined for part %s\n", memstr, p->desc);
     return -1;
   }
   int maxsize = mem->size;
@@ -610,7 +610,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
     } else if(rc) {
       pmsg_error("(write) error writing 0x%02x at 0x%05x, rc=%d\n", buf[i], addr+i, (int) rc);
       if (rc == -1)
-        imsg_error("%*swrite operation not supported on memory type %s\n", 8, "", mem->desc);
+        imsg_error("%*swrite operation not supported on memory %s\n", 8, "", mem->desc);
     } else if(pgm->read_byte_cached(pgm, p, mem, addr+i, &b) < 0) {
       imsg_error("%*sreadback from %s failed\n", 8, "", mem->desc);
     } else {                    // Read back byte b is now set
@@ -641,7 +641,7 @@ static int cmd_save(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 
   AVRMEM *mem, *omem;
   if(!(omem = avr_locate_mem(p, argv[1]))) {
-    pmsg_error("(save) %s memory type not defined for part %s\n", argv[1], p->desc);
+    pmsg_error("(save) memory %s not defined for part %s\n", argv[1], p->desc);
     return -1;
   }
 
@@ -834,7 +834,7 @@ static int cmd_erase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
     char *memstr = argv[1];
     const AVRMEM *mem = avr_locate_mem(p, memstr);
     if (mem == NULL) {
-      pmsg_error("(erase) %s memory type not defined for part %s\n", argv[1], p->desc);
+      pmsg_error("(erase) memory %s not defined for part %s\n", argv[1], p->desc);
       return -1;
     }
     char *args[] = {"write", memstr, "", "", "0xff", "...", NULL};
@@ -910,7 +910,7 @@ static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
   char *memstr = argv[1];
   const AVRMEM *mem = avr_locate_mem(p, memstr);
   if(!mem) {
-    pmsg_error("(pgerase) %s memory type not defined for part %s\n", memstr, p->desc);
+    pmsg_error("(pgerase) memory %s not defined for part %s\n", memstr, p->desc);
     return -1;
   }
   if(!avr_has_paged_access(pgm, mem)) {
@@ -999,7 +999,7 @@ static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const 
 
   const AVRMEM *mem = avr_locate_mem(p, cci->memstr);
   if(!mem) {
-    err = cache_string(tofree = str_sprintf("%s memory type not defined for part %s", cci->memstr, p->desc));
+    err = cache_string(tofree = str_sprintf("memory %s not defined for part %s", cci->memstr, p->desc));
     free(tofree);
     goto back;
   }
@@ -1528,7 +1528,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *a
   towrite.i = (fusel.current & ~ct[ci].mask) | (toassign<<ct[ci].lsh);
   const AVRMEM *mem = avr_locate_mem(p, cc[ci].memstr);
   if(!mem) {
-    pmsg_error("(config) %s memory type not defined for part %s\n", cc[ci].memstr, p->desc);
+    pmsg_error("(config) memory %s not defined for part %s\n", cc[ci].memstr, p->desc);
     ret = -1;
     goto finished;
   }
@@ -1793,7 +1793,7 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
     "Note that not all programmer derivatives support all commands. Flash and\n"
     "EEPROM type memories are normally read and written using a cache via paged\n"
     "read and write access; the cache is synchronised on quit or flush commands.\n"
-    "The part command displays valid memory types for use with dump and write.\n");
+    "The part command displays valid memories for use with dump and write.\n");
   return 0;
 }
 

--- a/src/update.c
+++ b/src/update.c
@@ -96,28 +96,18 @@ UPDATE *parse_op(const char *s) {
 
 
 UPDATE *dup_update(const UPDATE *upd) {
-  UPDATE * u;
-
-  u = (UPDATE *) cfg_malloc("dup_update()", sizeof(UPDATE));
-
-  memcpy(u, upd, sizeof(UPDATE));
-
-  if (upd->memstr != NULL)
-    u->memstr = cfg_strdup("dup_update()", upd->memstr);
-  else
-    u->memstr = NULL;
-  u->filename = cfg_strdup("dup_update()", upd->filename);
+  UPDATE *u = (UPDATE *) cfg_malloc(__func__, sizeof *u);
+  memcpy(u, upd, sizeof*u);
+  u->memstr = upd->memstr? cfg_strdup(__func__, upd->memstr): NULL;
+  u->filename = cfg_strdup(__func__, upd->filename);
 
   return u;
 }
 
 UPDATE *new_update(int op, const char *memstr, int filefmt, const char *fname) {
-  UPDATE * u;
-
-  u = (UPDATE *) cfg_malloc("new_update()", sizeof(UPDATE));
-
-  u->memstr = cfg_strdup("new_update()", memstr);
-  u->filename = cfg_strdup("new_update()", fname);
+  UPDATE *u = (UPDATE *) cfg_malloc(__func__, sizeof *u);
+  u->memstr = cfg_strdup(__func__, memstr);
+  u->filename = cfg_strdup(__func__, fname);
   u->op = op;
   u->format = filefmt;
 
@@ -127,22 +117,17 @@ UPDATE *new_update(int op, const char *memstr, int filefmt, const char *fname) {
 UPDATE *cmd_update(const char *cmd) {
   UPDATE *u = (UPDATE *) cfg_malloc(__func__, sizeof *u);
   u->cmdline = cmd;
+
   return u;
 }
 
-void free_update(UPDATE * u)
-{
-    if (u != NULL) {
-	if(u->memstr != NULL) {
-	    free(u->memstr);
-	    u->memstr = NULL;
-	}
-	if(u->filename != NULL) {
-	    free(u->filename);
-	    u->filename = NULL;
-	}
-	free(u);
-    }
+void free_update(UPDATE *u) {
+  if(u) {
+    free(u->memstr);
+    free(u->filename);
+    memset(u, 0, sizeof *u);
+    free(u);
+  }
 }
 
 char *update_str(const UPDATE *upd) {

--- a/src/update.c
+++ b/src/update.c
@@ -282,7 +282,7 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
    * but accept when the specific part does not have it (allow unifying i/faces)
    */
   if(!avr_mem_might_be_known(upd->memstr)) {
-    pmsg_error("unknown memory type %s\n", upd->memstr);
+    pmsg_error("unknown memory %s\n", upd->memstr);
     ret = LIBAVRDUDE_GENERAL_FAILURE;
   } else if(p && !avr_locate_mem(p, upd->memstr))
     ret = LIBAVRDUDE_SOFTFAIL;
@@ -485,7 +485,7 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd, enum updat
     }
     size = rc;
 
-    // Write the buffer contents to the selected memory type
+    // Write the buffer contents to the selected memory
     pmsg_info("writing %d byte%s %s%s ...\n", fs.nbytes,
       str_plural(fs.nbytes), mem->desc, alias_mem_desc);
 

--- a/src/update.c
+++ b/src/update.c
@@ -471,7 +471,7 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd, enum updat
     // Patch flash input, eg, for vector bootloaders
     if(pgm->flash_readhook) {
       AVRMEM *mem = avr_locate_mem(p, upd->memstr);
-      if(mem && str_eq(mem->desc, "flash")) {
+      if(mem && mem_is_flash(mem)) {
         rc = pgm->flash_readhook(pgm, p, mem, upd->filename, rc);
         if (rc < 0) {
           pmsg_notice("readhook for file %s failed\n", str_inname(upd->filename));

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -585,7 +585,7 @@ static int urclock_flash_readhook(const PROGRAMMER *pgm, const AVRPART *p, const
 
   // Check size of uploded application and protect bootloader from being overwritten
   if((ur.boothigh && size > maxsize) || (!ur.boothigh && firstbeg <= ur.blend))
-    Return("input [0x%04x, 0x%04x] overlaps bootloader [0x%04x, 0x%04x]",
+    Return("input [0x%04x, 0x%04x] overlaps bootloader [0x%04x, 0x%04x]; consider -xrestore",
       firstbeg, size-1, ur.blstart, ur.blend);
 
   if(size > maxsize)
@@ -2455,7 +2455,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
     {"vectornum", &ur.xvectornum, ARG,    "Treat bootloader as vector b/loader using this vector"},
     {"eepromrw", &ur.xeepromrw, NA,       "Assert bootloader EEPROM read/write capability"},
     {"emulate_ce", &ur.xemulate_ce, NA,   "Emulate chip erase"},
-    {"restore", &ur.restore, NA,          "Restore a flash backup as is trimming the bootloader"},
+    {"restore", &ur.restore, NA,          "Restore a flash backup and trim the bootloader"},
     {"initstore", &ur.initstore, NA,      "Fill store with 0xff on writing to flash"},
     //@@@  {"copystore", &ur.copystore, NA, "Copy over store on writing to flash"},
     {"nofilename", &ur.nofilename, NA,    "Do not store filename on writing to flash"},

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1867,7 +1867,7 @@ static int readUrclockID(const PROGRAMMER *pgm, const AVRPART *p, uint64_t *urcl
       mchr = 'F';
   }
 
-  const char *memtype = mchr == 'E'? "eeprom": "flash";
+  const char *memstr = mchr == 'E'? "eeprom": "flash";
 
   size = mchr == 'F'? ur.uP.flashsize: ur.uP.eepromsize;
 
@@ -1877,11 +1877,11 @@ static int readUrclockID(const PROGRAMMER *pgm, const AVRPART *p, uint64_t *urcl
 
     if(addr < 0 || addr >= size)
       Return("effective address %d of -xids=%s string out of %s range [0, 0x%04x]\n",
-        addr, ur.iddesc, memtype, size-1);
+        addr, ur.iddesc, memstr, size-1);
 
     if(addr+len > size)
       Return("memory range [0x%04x, 0x%04x] of -xid=%s out of %s range [0, 0x%04x]\n",
-        addr, addr+len-1, ur.iddesc, memtype, size-1);
+        addr, addr+len-1, ur.iddesc, memstr, size-1);
   }
 
   memset(spc, 0, sizeof spc);

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2358,7 +2358,7 @@ int urclock_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem
   // Bytewise read only valid for flash and eeprom
   int mchr = mem_is_in_flash(mem)? 'F': 'E';
   if(mchr == 'E' && !mem_is_eeprom(mem)) {
-    if(str_eq(mem->desc, "signature") && pgm->read_sig_bytes) {
+    if(mem_is_signature(mem) && pgm->read_sig_bytes) {
        if((int) addr < 0 || (int) addr >= mem->size) {
          return -1;
        }

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2269,8 +2269,8 @@ static int urclock_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   if(n_bytes) {
     // Paged writes only valid for flash and eeprom
-    mchr = avr_mem_is_flash_type(m)? 'F': 'E';
-    if(mchr == 'E' && !avr_mem_is_eeprom_type(m))
+    mchr = mem_is_in_flash(m)? 'F': 'E';
+    if(mchr == 'E' && !mem_is_eeprom(m))
       return -2;
 
     if(mchr == 'E' && !ur.bleepromrw && !ur.xeepromrw)
@@ -2301,8 +2301,8 @@ static int urclock_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   if(n_bytes) {
     // Paged reads only valid for flash and eeprom
-    mchr = avr_mem_is_flash_type(m)? 'F': 'E';
-    if(mchr == 'E' && !avr_mem_is_eeprom_type(m))
+    mchr = mem_is_in_flash(m)? 'F': 'E';
+    if(mchr == 'E' && !mem_is_eeprom(m))
       return -2;
 
     if(mchr == 'F' && ur.urprotocol && !(ur.urfeatures & UB_READ_FLASH))
@@ -2356,8 +2356,8 @@ int urclock_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem
   unsigned long addr, unsigned char *value) {
 
   // Bytewise read only valid for flash and eeprom
-  int mchr = avr_mem_is_flash_type(mem)? 'F': 'E';
-  if(mchr == 'E' && !avr_mem_is_eeprom_type(mem)) {
+  int mchr = mem_is_in_flash(mem)? 'F': 'E';
+  if(mchr == 'E' && !mem_is_eeprom(mem)) {
     if(str_eq(mem->desc, "signature") && pgm->read_sig_bytes) {
        if((int) addr < 0 || (int) addr >= mem->size) {
          return -1;
@@ -2405,7 +2405,7 @@ static void urclock_display(const PROGRAMMER *pgm, const char *p_unused) {
 static int urclock_readonly(const struct programmer_t *pgm, const AVRPART *p_unused,
   const AVRMEM *mem, unsigned int addr) {
 
-  if(avr_mem_is_flash_type(mem)) {
+  if(mem_is_in_flash(mem)) {
     if(addr > (unsigned int) ur.pfend)
       return 1;
     if(addr < (unsigned int) ur.pfstart)
@@ -2420,7 +2420,7 @@ static int urclock_readonly(const struct programmer_t *pgm, const AVRPART *p_unu
           return 1;
       }
     }
-  } else if(!avr_mem_is_eeprom_type(mem))
+  } else if(!mem_is_eeprom(mem))
     return 1;
 
   return 0;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1039,7 +1039,7 @@ static void set_uP(const PROGRAMMER *pgm, const AVRPART *p, int mcuid, int mcuid
       p->prog_modes & PM_TPI? F_AVR8L:
       p->prog_modes & (PM_ISP | PM_HVPP | PM_HVSP)? F_AVR8: 0;
     memcpy(ur.uP.sigs, p->signature, sizeof ur.uP.sigs);
-    if((mem = avr_locate_mem(p, "flash"))) {
+    if((mem = avr_locate_flash(p))) {
       ur.uP.flashoffset = mem->offset;
       ur.uP.flashsize = mem->size;
       ur.uP.pagesize = mem->page_size;
@@ -1050,7 +1050,7 @@ static void set_uP(const PROGRAMMER *pgm, const AVRPART *p, int mcuid, int mcuid
     }
     ur.uP.nboots = -1;
     ur.uP.bootsize = -1;
-    if((mem = avr_locate_mem(p, "eeprom"))) {
+    if((mem = avr_locate_eeprom(p))) {
       ur.uP.eepromoffset = mem->offset;
       ur.uP.eepromsize = mem->size;
       ur.uP.eeprompagesize = mem->page_size;
@@ -1260,7 +1260,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
   AVRMEM *flm;
   int rc;
 
-  if(!(flm = avr_locate_mem(p, "flash")))
+  if(!(flm = avr_locate_flash(p)))
     Return("cannot obtain flash memory for %s", p->desc);
 
   if(flm->page_size > (int) sizeof spc)
@@ -2152,7 +2152,7 @@ static int urclock_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
   if(!emulated) {               // Write jump to boot section to reset vector
     if(ur.boothigh && ur.blstart && ur.vbllevel==1) {
-      AVRMEM *flm = avr_locate_mem(p, "flash");
+      AVRMEM *flm = avr_locate_flash(p);
       int vecsz = ur.uP.flashsize <= 8192? 2: 4;
       if(flm && flm->page_size >= vecsz) {
         unsigned char *page = cfg_malloc(__func__, flm->page_size);

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -241,7 +241,7 @@ static int usbhid_send(const union filedescriptor *fd, const unsigned char *bp, 
     pmsg_error("short write to USB: %d bytes out of %d written\n", rv, tx_size + 1);
 
   if(verbose > 4)
-    trace2_buffer("usbhid_send: ", bp, tx_size);
+    trace_buffer(__func__, bp, tx_size);
 
   return 0;
 }
@@ -261,7 +261,7 @@ static int usbhid_recv(const union filedescriptor *fd, unsigned char *buf, size_
     pmsg_error("short read, read only %d out of %lu bytes\n", i, (unsigned long) nbytes);
 
   if (verbose > 4 && i > 0)
-    trace2_buffer("usbhid_recv: ", p, i);
+    trace_buffer(__func__, p, i);
 
   return rv;
 }

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -224,16 +224,12 @@ static void usbhid_close(union filedescriptor *fd) {
 static int usbhid_send(const union filedescriptor *fd, const unsigned char *bp, size_t mlen) {
   hid_device *udev = (hid_device *)fd->usb.handle;
   int rv;
-  int i = mlen;
-  const unsigned char * p = bp;
   unsigned char usbbuf[USBDEV_MAX_XFER_3 + 1];
-
-  int tx_size;
+  const int tx_size = mlen < USBDEV_MAX_XFER_3? mlen: USBDEV_MAX_XFER_3;
 
   if (udev == NULL)
     return -1;
 
-  tx_size = (mlen < USBDEV_MAX_XFER_3)? mlen: USBDEV_MAX_XFER_3;
   usbbuf[0] = 0; /* No report ID used */
   memcpy(usbbuf + 1, bp, tx_size);
   rv = hid_write(udev, usbbuf, tx_size + 1);
@@ -244,22 +240,9 @@ static int usbhid_send(const union filedescriptor *fd, const unsigned char *bp, 
   if (rv != tx_size + 1)
     pmsg_error("short write to USB: %d bytes out of %d written\n", rv, tx_size + 1);
 
-  if (verbose > 4) {
-    pmsg_trace2("sent: ");
+  if(verbose > 4)
+    trace2_buffer("usbhid_send: ", bp, tx_size);
 
-    while (i) {
-      unsigned char c = *p;
-      if (isprint(c))
-        msg_trace2("%c ", c);
-      else
-        msg_trace2(". ");
-      msg_trace2("[%02x] ", c);
-
-      p++;
-      i--;
-    }
-    msg_trace2("\n");
-  }
   return 0;
 }
 
@@ -277,22 +260,8 @@ static int usbhid_recv(const union filedescriptor *fd, unsigned char *buf, size_
   else if ((size_t) i != nbytes)
     pmsg_error("short read, read only %d out of %lu bytes\n", i, (unsigned long) nbytes);
 
-  if (verbose > 4) {
-    pmsg_trace2("recv: ");
-
-    while (i) {
-      unsigned char c = *p;
-      if (isprint(c))
-        msg_trace2("%c ", c);
-      else
-        msg_trace2(". ");
-      msg_trace2("[%02x] ", c);
-
-      p++;
-      i--;
-    }
-    msg_trace2("\n");
-  }
+  if (verbose > 4 && i > 0)
+    trace2_buffer("usbhid_recv: ", p, i);
 
   return rv;
 }

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -349,25 +349,8 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
     mlen -= tx_size;
   } while (mlen > 0);
 
-  if (verbose > 3)
-  {
-      pmsg_trace("sent: ");
-
-      while (i) {
-        unsigned char c = *p;
-        if (isprint(c)) {
-          msg_trace("%c ", c);
-        }
-        else {
-          msg_trace(". ");
-        }
-        msg_trace("[%02x] ", c);
-
-        p++;
-        i--;
-      }
-      msg_trace("\n");
-  }
+  if(verbose > 3)
+    trace_buffer("usbdev_send: ", p, i);
   return 0;
 }
 
@@ -424,25 +407,8 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
       i += amnt;
     }
 
-  if (verbose > 4)
-  {
-      pmsg_trace2("recv: ");
-
-      while (i) {
-        unsigned char c = *p;
-        if (isprint(c)) {
-          msg_trace2("%c ", c);
-        }
-        else {
-          msg_trace2(". ");
-        }
-        msg_trace2("[%02x] ", c);
-
-        p++;
-        i--;
-      }
-      msg_trace2("\n");
-  }
+  if(verbose > 4)
+    trace2_buffer("usbdev_recv: ", p, i);
 
   return 0;
 }
@@ -460,8 +426,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
 {
   usb_dev_handle *udev = (usb_dev_handle *)fd->usb.handle;
   int rv, n;
-  int i;
-  unsigned char * p = buf;
+  unsigned char *p = buf;
 
   if (udev == NULL)
     return -1;
@@ -532,26 +497,9 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
 */
 
   printout:
-  if (verbose > 3)
-  {
-      i = n & USB_RECV_LENGTH_MASK;
-      pmsg_trace("recv: ");
+  if(verbose > 3)
+    pmsg_trace("recv: ", p, n & USB_RECV_LENGTH_MASK);
 
-      while (i) {
-        unsigned char c = *p;
-        if (isprint(c)) {
-          msg_trace("%c ", c);
-        }
-        else {
-          msg_trace(". ");
-        }
-        msg_trace("[%02x] ", c);
-
-        p++;
-        i--;
-      }
-      msg_trace("\n");
-  }
   return n;
 }
 

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -350,7 +350,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
   } while (mlen > 0);
 
   if(verbose > 3)
-    trace_buffer("usbdev_send: ", p, i);
+    trace_buffer(__func__, p, i);
   return 0;
 }
 
@@ -408,7 +408,7 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
     }
 
   if(verbose > 4)
-    trace2_buffer("usbdev_recv: ", p, i);
+    trace_buffer(__func__, p, i);
 
   return 0;
 }
@@ -498,7 +498,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
 
   printout:
   if(verbose > 3)
-    trace_buffer("usbdev_recv_frame: ", p, n & USB_RECV_LENGTH_MASK);
+    trace_buffer(__func__, p, n & USB_RECV_LENGTH_MASK);
 
   return n;
 }

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -498,7 +498,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
 
   printout:
   if(verbose > 3)
-    pmsg_trace("recv: ", p, n & USB_RECV_LENGTH_MASK);
+    trace_buffer("usbdev_recv_frame: ", p, n & USB_RECV_LENGTH_MASK);
 
   return n;
 }

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -1171,8 +1171,8 @@ static int usbasp_tpi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
   pr = addr + m->offset;
   writed = 0;
 
-  /* must erase fuse first */
-  if(str_eq(m->desc, "fuse"))
+  /* must erase fuse first, TPI parts only have one fuse */
+  if(mem_is_a_fuse(m))
   {
     /* Set PR */
     usbasp_tpi_send_byte(pgm, TPI_OP_SSTPR(0));

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -771,9 +771,9 @@ static int usbasp_spi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 
   pmsg_debug("usbasp_program_paged_load(\"%s\", 0x%x, %d)\n", m->desc, address, n_bytes);
 
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     function = USBASP_FUNC_READFLASH;
-  } else if (str_eq(m->desc, "eeprom")) {
+  } else if (mem_is_eeprom(m)) {
     function = USBASP_FUNC_READEEPROM;
   } else {
     return -2;
@@ -836,9 +836,9 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 
   pmsg_debug("usbasp_program_paged_write(\"%s\", 0x%x, %d)\n", m->desc, address, n_bytes);
 
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     function = USBASP_FUNC_WRITEFLASH;
-  } else if (str_eq(m->desc, "eeprom")) {
+  } else if (mem_is_eeprom(m)) {
     function = USBASP_FUNC_WRITEEEPROM;
   } else {
     return -2;

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -604,7 +604,7 @@ static int usbtiny_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
 
   if(pgm->prog_modes & PM_SPM) { // Talking to bootloader directly
-    AVRMEM *fl = avr_locate_mem(p, "flash");
+    AVRMEM *fl = avr_locate_flash(p);
     // Estimated time it takes to erase all pages in bootloader
     usleep(p->chip_erase_delay * (fl? fl->num_pages: 999));
   } else

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -643,7 +643,7 @@ static int usbtiny_paged_load (const PROGRAMMER *pgm, const AVRPART *p, const AV
   unsigned char cmd[8];
 
   // First determine what we're doing
-  function = str_eq(m->desc, "eeprom")? USBTINY_EEPROM_READ: USBTINY_FLASH_READ;
+  function = mem_is_eeprom(m)? USBTINY_EEPROM_READ: USBTINY_FLASH_READ;
 
   // paged_load() only called for pages, so OK to set ext addr once at start
   if((lext = m->op[AVR_OP_LOAD_EXT_ADDR])) {
@@ -713,7 +713,7 @@ static int usbtiny_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   int delay;        // delay required between SPI commands
 
   // First determine what we're doing
-  if (str_eq(m->desc, "flash")) {
+  if (mem_is_flash(m)) {
     function = USBTINY_FLASH_WRITE;
   } else {
     function = USBTINY_EEPROM_WRITE;


### PR DESCRIPTION
Fixes #1330 

This PR introduces an integer memory component `type` that encodes the memory type and some of its attributes in bitfields allowing us to separate the name of a memory from its function. This means that instead of a string compare with the memory name, AVRDUDE now bases its programming strategy on testing bits in the type integer.

Nothing in the functionality has changed, and *actually* the type bits are still determined by the memory  name, albeit *once* when parsing the `avrdude.conf` file rather than 391 times in 30 source files. There is now only a small step left of *externalising* the `type` in `avrdude.conf` and fully separating name from function but this is not part of this PR.

This is one of the unthankful PRs that do not improve functionality but that attempt to bring clarity to the role and properties of the memories that AVRDUDE deals with. As such this needs a careful review (@MCUdude?) and good testing (@mcuee?) as virtually all programmers will have seen a code change.

The first thing to look at is how [memory types are modelled](https://github.com/stefanrueger/avrdude/blob/2be7f7e5279b006a7560957edfe14afd1e8f2136/src/avr.c#L1468-L1517) in avr.c. The other, perhaps, how the new type is accessed in `libavrdude.h` [macros](https://github.com/stefanrueger/avrdude/blob/2be7f7e5279b006a7560957edfe14afd1e8f2136/src/libavrdude.h#L374-L415).

Most of the string comparisons could be replaced automatically with bit tests, but the fuses were dealt with mostly by hand.
