### PR TITLE
Add Avrdude version number to avrdude.conf using autoconf

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,6 +120,7 @@ add_custom_command(
     OUTPUT avrdude.conf
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/avrdude.conf.in" avrdude.conf.in
     COMMAND ${CMAKE_COMMAND}
+        -D "AVRDUDE_FULL_VERSION=${AVRDUDE_FULL_VERSION}"
         -D HAVE_PARPORT=$<BOOL:${HAVE_PARPORT}>
         -D HAVE_LINUXSPI=$<BOOL:${HAVE_LINUXSPI}>
         -D HAVE_LINUXGPIO=$<BOOL:${HAVE_LINUXGPIO}>

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1,6 +1,6 @@
 # $Id$ -*- text -*-
 #
-# AVRDUDE Configuration File
+# AVRDUDE @AVRDUDE_FULL_VERSION@ Configuration File
 #
 # This file contains configuration data used by AVRDUDE which describes
 # the programming hardware pinouts and also provides part definitions.
@@ -432,7 +432,7 @@
 # ATmega8       0x76
 # ATmega169     0x78
 
-# Buildtime configuration
+# Avrdude build version
 avrdude_version = "@AVRDUDE_FULL_VERSION@";
 
 #

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -432,6 +432,9 @@
 # ATmega8       0x76
 # ATmega169     0x78
 
+# Buildtime configuration
+avrdude_version = "@AVRDUDE_FULL_VERSION@";
+
 #
 # Overall avrdude defaults; suitable for ~/.config/avrdude/avrdude.rc
 #

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -433,7 +433,7 @@
 # ATmega169     0x78
 
 # Avrdude build version
-avrdude_version = "@AVRDUDE_FULL_VERSION@";
+#avrdude_version = "@AVRDUDE_FULL_VERSION@";
 
 #
 # Overall avrdude defaults; suitable for ~/.config/avrdude/avrdude.rc

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -543,8 +543,9 @@ AC_CONFIG_FILES([
        Makefile
 ])
 
-# Pass into avrdude.conf.in
-AVRDUDE_FULL_VERSION='$(VERSION)'
+# Pass version number into avrdude.conf
+AVRDUDE_FULL_VERSION=$PACKAGE_VERSION
+AC_SUBST(AVRDUDE_FULL_VERSION, $AVRDUDE_FULL_VERSION)
 
 # The procedure to create avrdude.conf involves two steps.  First,
 # normal autoconf substitution will be applied, resulting in

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -543,6 +543,9 @@ AC_CONFIG_FILES([
        Makefile
 ])
 
+# Pass into avrdude.conf.in
+AVRDUDE_FULL_VERSION='$(VERSION)'
+
 # The procedure to create avrdude.conf involves two steps.  First,
 # normal autoconf substitution will be applied, resulting in
 # avrdude.conf.tmp. Finally, a sed command will be applied to filter


### PR DESCRIPTION
Resolves #1475.

@stefanrueger I had to comment out `avrdude_version`, because the grammar complaints:

```
$ ./avrdude -cpkobn_updi -pavr16eb32
avrdude error: syntax error [/Users/hans/Downloads/avrdude/src/avrdude.conf:435]
avrdude error: unable to process system wide configuration file /Users/hans/Downloads/avrdude/src/avrdude.conf
```

It would be great if you could push a tiny grammar change to this PR so that this line doesn't have to be commented out. And maybe it can be utilized by Avrdude as well? Potentially warn the user that they're using an old/untested version of avrdude.conf?