### PR TITLE
Harmonize WIN32 implementation of serial time-outs with Posix

### DIFF
--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -88,8 +88,8 @@ static BOOL serial_w32SetTimeOut(HANDLE hComPort, DWORD timeout) // in ms
 {
 	COMMTIMEOUTS ctmo;
 	ZeroMemory (&ctmo, sizeof(COMMTIMEOUTS));
-	ctmo.ReadIntervalTimeout = timeout;
-	ctmo.ReadTotalTimeoutMultiplier = timeout;
+	ctmo.ReadIntervalTimeout = 0;
+	ctmo.ReadTotalTimeoutMultiplier = 0;
 	ctmo.ReadTotalTimeoutConstant = timeout;
 
 	return SetCommTimeouts(hComPort, &ctmo);


### PR DESCRIPTION
This is from @mariusgreuel in Issue #1249.
* https://github.com/avrdudes/avrdude/issues/1249

> The WIN32 time-out is specified as `ReadTotalTimeoutConstant + buflen * ReadTotalTimeoutMultiplier`, which makes it potentially much longer than the POSIX one (i.e. at least double). `ReadIntervalTimeout` is also set to timeout, which essentially renders the interval timeout ineffective, so IMHO, we should explicitly disable that feature.