### PR TITLE
To adopt PR #1264 approach of using Readline replacement for MinGW build (WIP, DNM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,8 @@ if(HAVE_LIBREADLINE)
     find_library(LIB_NCURSES NAMES ncurses)
 elseif(MSVC)
     set(HAVE_LIBREADLINE 1)
+elseif(MINGW)
+    set(HAVE_LIBREADLINE 1)
 endif()
 
 #-------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,14 +219,16 @@ endif()
 # -------------------------------------
 # Find libreadline
 
-find_library(HAVE_LIBREADLINE NAMES ${PREFERRED_LIBREADLINE})
-if(HAVE_LIBREADLINE)
-    set(LIB_LIBREADLINE ${HAVE_LIBREADLINE})
-    find_library(LIB_NCURSES NAMES ncurses)
-elseif(MSVC)
-    set(HAVE_LIBREADLINE 1)
+if(MSVC)
+    set(HAVE_LIBREADLINE "Embedded MSVC")
 elseif(MINGW)
-    set(HAVE_LIBREADLINE 1)
+    set(HAVE_LIBREADLINE "Embedded MINGW")
+else()
+    find_library(HAVE_LIBREADLINE NAMES ${PREFERRED_LIBREADLINE})
+    if(HAVE_LIBREADLINE)
+        set(LIB_LIBREADLINE ${HAVE_LIBREADLINE})
+        find_library(LIB_NCURSES NAMES ncurses)
+    endif()
 endif()
 
 #-------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,8 @@ if(MSVC)
         )
     list(APPEND EXTRA_WINDOWS_INCLUDES "msvc")
 elseif(MINGW)
+    enable_language(CXX)
+
     set(LIB_MATH m)
     add_compile_options(-Wall -Wextra -Wno-unused-parameter)
     list(APPEND EXTRA_WINDOWS_SOURCES "mingw/readline.cpp")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,9 +50,15 @@ endif()
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 add_compile_definitions(CONFIG_DIR=\"${CONFIG_DIR}\")
 
+
+set(EXTRA_WINDOWS_SOURCES)
+set(EXTRA_WINDOWS_INCLUDES)
+set(EXTRA_WINDOWS_RESOURCES)
+set(EXTRA_WINDOWS_LIBRARIES)
+
 if(WIN32 OR MINGW)
-    set(EXTRA_WINDOWS_RESOURCES "${PROJECT_BINARY_DIR}/src/windows.rc")
-    set(EXTRA_WINDOWS_LIBRARIES setupapi hid ws2_32)
+    list(APPEND EXTRA_WINDOWS_RESOURCES "${PROJECT_BINARY_DIR}/src/windows.rc")
+    list(APPEND EXTRA_WINDOWS_LIBRARIES setupapi hid ws2_32)
 endif()
 
 if(MSVC)
@@ -66,24 +72,18 @@ if(MSVC)
     add_compile_options(/wd4244) # warning C4244: conversion from '...' to '...', possible loss of data
     add_compile_options(/wd4267) # warning C4267: conversion from '...' to '...', possible loss of data
 
-    set(EXTRA_WINDOWS_SOURCES ${EXTRA_WINDOWS_SOURCES}
+    list(APPEND EXTRA_WINDOWS_SOURCES
         "msvc/getopt.c"
         "msvc/gettimeofday.c"
         "msvc/usleep.cpp"
         "msvc/readline.cpp"
         )
-    set(EXTRA_WINDOWS_INCLUDES ${EXTRA_WINDOWS_INCLUDES}
-        "msvc"
-        )
+    list(APPEND EXTRA_WINDOWS_INCLUDES "msvc")
 elseif(MINGW)
     set(LIB_MATH m)
     add_compile_options(-Wall -Wextra -Wno-unused-parameter)
-    set(EXTRA_WINDOWS_SOURCES ${EXTRA_WINDOWS_SOURCES}
-        "mingw/readline.cpp"
-        )
-    set(EXTRA_WINDOWS_INCLUDES ${EXTRA_WINDOWS_INCLUDES}
-        "mingw"
-        )
+    list(APPEND EXTRA_WINDOWS_SOURCES "mingw/readline.cpp")
+    list(APPEND EXTRA_WINDOWS_INCLUDES "mingw")
 else()
     set(LIB_MATH m)
     add_compile_options(-Wall -Wextra -Wno-unused-parameter)
@@ -269,7 +269,7 @@ add_library(libavrdude
     xbee.c
     ${FLEX_Parser_OUTPUTS}
     ${BISON_Parser_OUTPUTS}
-    "${EXTRA_WINDOWS_SOURCES}"
+    ${EXTRA_WINDOWS_SOURCES}
     )
 
 set_target_properties(libavrdude PROPERTIES
@@ -283,8 +283,9 @@ target_include_directories(libavrdude
     PUBLIC
     "${PROJECT_SOURCE_DIR}"
     "${PROJECT_BINARY_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
     "${LIBUSB_COMPAT_DIR}"
-    "${EXTRA_WINDOWS_INCLUDES}"
+    ${EXTRA_WINDOWS_INCLUDES}
     )
 
 target_link_libraries(libavrdude
@@ -311,7 +312,7 @@ add_executable(avrdude
     developer_opts_private.h
     whereami.c
     whereami.h
-    "${EXTRA_WINDOWS_RESOURCES}"
+    ${EXTRA_WINDOWS_RESOURCES}
     )
 
 target_link_libraries(avrdude PUBLIC libavrdude)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,6 +319,10 @@ add_executable(avrdude
 
 target_link_libraries(avrdude PUBLIC libavrdude)
 
+if(MINGW)
+    target_link_options(avrdude PRIVATE -static)
+endif()
+
 # =====================================
 # Install
 # =====================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,15 @@ if(MSVC)
     set(EXTRA_WINDOWS_INCLUDES ${EXTRA_WINDOWS_INCLUDES}
         "msvc"
         )
+elseif(MINGW)
+    set(LIB_MATH m)
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter)
+    set(EXTRA_WINDOWS_SOURCES ${EXTRA_WINDOWS_SOURCES}
+        "mingw/readline.cpp"
+        )
+    set(EXTRA_WINDOWS_INCLUDES ${EXTRA_WINDOWS_INCLUDES}
+        "mingw"
+        )
 else()
     set(LIB_MATH m)
     add_compile_options(-Wall -Wextra -Wno-unused-parameter)

--- a/src/mingw/readline.cpp
+++ b/src/mingw/readline.cpp
@@ -1,0 +1,95 @@
+//
+// readline.cpp
+// Copyright (C) 2022 Marius Greuel
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+
+#include <string.h>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include "readline/readline.h"
+#include "readline/history.h"
+
+int rl_readline_version = 0x0502;
+
+static rl_vcpfunc_t* rl_handler;
+static std::unique_ptr<std::thread> rl_thread;
+static std::mutex rl_mutex;
+static std::string rl_line;
+static bool rl_has_line = false;
+
+static void get_line_thread()
+{
+    std::string line;
+    std::getline(std::cin, line);
+
+    const std::lock_guard<std::mutex> lock(rl_mutex);
+    rl_line = line;
+    rl_has_line = true;
+}
+
+static void call_handler(const char* string)
+{
+    if (rl_thread)
+    {
+        rl_thread->join();
+        rl_thread = nullptr;
+    }
+
+    if (rl_handler != nullptr)
+    {
+        if (string == nullptr)
+        {
+            rl_handler(nullptr);
+        }
+        else
+        {
+            rl_handler(_strdup(string));
+        }
+    }
+}
+
+int rl_input_available(void)
+{
+    return 1;
+}
+
+void rl_callback_read_char(void)
+{
+    if (std::cin.eof())
+    {
+        call_handler(nullptr);
+    }
+    else if (!rl_thread)
+    {
+        rl_thread = std::make_unique<std::thread>(get_line_thread);
+    }
+    else
+    {
+        const std::lock_guard<std::mutex> lock(rl_mutex);
+        if (rl_has_line)
+        {
+            rl_has_line = false;
+            call_handler(rl_line.c_str());
+        }
+    }
+}
+
+void rl_callback_handler_install(char* prompt, rl_vcpfunc_t* handler)
+{
+    rl_handler = handler;
+
+    std::cout << prompt;
+}
+
+void rl_callback_handler_remove(void)
+{
+    rl_handler = nullptr;
+}
+
+void add_history(const char*)
+{
+}

--- a/src/mingw/readline/history.h
+++ b/src/mingw/readline/history.h
@@ -1,0 +1,17 @@
+//
+// history.h
+// Copyright (C) 2022 Marius Greuel
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+void add_history(const char* string);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/mingw/readline/readline.h
+++ b/src/mingw/readline/readline.h
@@ -1,0 +1,24 @@
+//
+// readline.h
+// Copyright (C) 2022 Marius Greuel
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (rl_vcpfunc_t)(char* line);
+
+extern int rl_readline_version;
+
+int rl_input_available(void);
+void rl_callback_read_char(void);
+void rl_callback_handler_install(char* prompt, rl_vcpfunc_t* handler);
+void rl_callback_handler_remove(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/term.c
+++ b/src/term.c
@@ -2089,7 +2089,7 @@ static int term_running;
 
 // Any character in standard input available (without sleeping)?
 static int readytoread() {
-#ifdef _MSC_VER
+#ifdef _MSC_VER || MINGW
     return rl_input_available();
 #elif defined(WIN32)
   HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);

--- a/src/term.c
+++ b/src/term.c
@@ -2089,7 +2089,7 @@ static int term_running;
 
 // Any character in standard input available (without sleeping)?
 static int readytoread() {
-#ifdef _MSC_VER || MINGW
+#if defined(_MSC_VER) || defined(MINGW)
     return rl_input_available();
 #elif defined(WIN32)
   HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);


### PR DESCRIPTION
PR https://github.com/avrdudes/avrdude/pull/1264 has been merged and it performs much better than using GNU Readline under Windows. It is good to adopt the same approach for MinGW.

This PR will fix Issue #1271.

This PR was initially developed by Xiaofan Chen based on PR #1264 but it does not work.
@Youw (Ihor Dutchak) helps to sort out the remaining issues.