### PR TITLE
Review write_byte() functions

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -656,6 +656,15 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     goto error;
   }
 
+  if(mem_is_readonly(mem)) {
+    unsigned char is;
+    if(pgm->read_byte(pgm, p, mem, addr, &is) >= 0 && is == data)
+      return 0;
+
+    pmsg_error("cannot write to read-only memory %s of %s\n", mem->desc, p->desc);
+    return -1;
+  }
+
   data = avr_bitmask_data(pgm, p, mem, addr, data);
 
   if (p->prog_modes & PM_TPI) {
@@ -891,6 +900,15 @@ rcerror:
 int avr_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr, unsigned char data)
 {
+
+  if(mem_is_readonly(mem)) {
+    unsigned char is;
+    if(pgm->read_byte(pgm, p, mem, addr, &is) >= 0 && is == data)
+      return 0;
+
+    pmsg_error("cannot write to read-only memory %s of %s\n", mem->desc, p->desc);
+    return -1;
+  }
 
   if(pgm->write_byte != avr_write_byte_default)
     if(!(p->prog_modes & (PM_UPDI | PM_aWire))) // Initialise unused bits in classic & XMEGA parts

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1671,6 +1671,13 @@ static int avrftdi_jtag_write_byte(const PROGRAMMER *pgm, const AVRPART *p,
 		while (!(avrftdi_jtag_dr_inout(pgm, 0x3300, 15) & 0x0200))
 			;
 
+	} else if(mem_is_readonly(m)) {
+		unsigned char is;
+		if(pgm->read_byte(pgm, p, m, addr, &is) >= 0 && is == value)
+			return 0;
+
+		pmsg_error("cannot write to read-only memory %s of %s\n", m->desc, p->desc);
+		return -1;
 	} else {
 		return -1;
 	}

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -459,6 +459,13 @@ static int butterfly_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const A
     cmd[0] = 'l';
     cmd[1] = value;
     size = 2;
+  } else if(mem_is_readonly(m)) {
+    unsigned char is;
+    if(pgm->read_byte(pgm, p, m, addr, &is) >= 0 && is == value)
+      return 0;
+
+    pmsg_error("cannot write to read-only memory %s of %s\n", m->desc, p->desc);
+    return -1;
   }
   else
     return -1;

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1154,7 +1154,7 @@ void dev_output_part_defs(char *partdesc) {
         for(LNODEID lnm=lfirst(p->mem); lnm; lnm=lnext(lnm)) {
           AVRMEM *m = ldata(lnm);
           // Write delays not needed for read-only calibration and signature memories
-          if(!mem_is_calibration(m) && !mem_is_signature(m)) {
+          if(!mem_is_readonly(m)) {
             if(p->prog_modes & PM_ISP) {
               if(m->min_write_delay == m->max_write_delay)
                  dev_info(".wd_%s %.3f ms %s\n", m->desc, m->min_write_delay/1000.0, p->desc);

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -401,6 +401,15 @@ int flip1_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
 {
   enum flip1_mem_unit mem_unit;
 
+  if(mem_is_readonly(mem)) {
+    unsigned char is;
+    if(pgm->read_byte(pgm, part, mem, addr, &is) >= 0 && is == value)
+      return 0;
+
+    pmsg_error("cannot write to read-only memory %s of %s\n", mem->desc, part->desc);
+    return -1;
+  }
+
   if (FLIP1(pgm)->dfu == NULL)
     return -1;
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -415,6 +415,15 @@ int flip2_write_byte(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *m
 {
   enum flip2_mem_unit mem_unit;
 
+  if(mem_is_readonly(mem)) {
+    unsigned char is;
+    if(pgm->read_byte(pgm, part, mem, addr, &is) >= 0 && is == value)
+      return 0;
+
+    pmsg_error("cannot write to read-only memory %s of %s\n", mem->desc, part->desc);
+    return -1;
+  }
+
   if (FLIP2(pgm)->dfu == NULL)
     return -1;
 

--- a/src/leds.c
+++ b/src/leds.c
@@ -196,6 +196,9 @@ int led_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 int led_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
   unsigned long addr, unsigned char value) {
 
+  if(mem_is_readonly(m))
+    return pgm->write_byte(pgm, p, m, addr, value);
+
   led_clr(pgm, LED_ERR);
   led_set(pgm, LED_PGM);
 

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -748,7 +748,7 @@ static int serialupdi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
     if(serialupdi_read_byte(pgm, p, mem, addr, &is) >= 0 && is == value)
       return 0;
 
-    Return("cannot write to read-only memory %s", mem->desc);
+    Return("cannot write to read-only memory %s of %s", mem->desc, p->desc);
   }
 
   return updi_write_byte(pgm, mem->offset + addr, value);

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -255,6 +255,15 @@ static int usbasp_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
 static int usbasp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
   unsigned long addr, unsigned char data) {
 
+  if(mem_is_readonly(m)) {
+    unsigned char is;
+    if(pgm->read_byte(pgm, p, m, addr, &is) >= 0 && is == data)
+      return 0;
+
+    pmsg_error("cannot write to read-only memory %s of %s\n", m->desc, p->desc);
+    return -1;
+  }
+
   return PDATA(pgm)->use_tpi?
     usbasp_tpi_write_byte(pgm, p, m, addr, data):
     avr_write_byte_default(pgm, p, m, addr, data);


### PR DESCRIPTION
Fixes #1527 

This PR allows read-only memories to appear written successfully provided the data to be written is already there. This is useful so that "writing" a backup to read-only memories works without generating an error and without actually trying to write to the part.

Trying to write a read-only memory with a byte that is different to the one in the memory will cause a write error. This is useful, if for example, one tries to write a backup of a part to another part with different signature. If the signature is written back first, this constitutes a sanity check that we are writing to the same type of part.