### PR TITLE
Remove paged eeprom property from ATtiny43U

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -185,7 +185,7 @@ avrdude_conf_version = "@AVRDUDE_FULL_VERSION@";
 #       autobaud_sync    = <num> ;                # autobaud detection byte, default 0x30
 #
 #       memory <memstr>
-#           paged           = <yes/no> ;          # yes/no (flash only, do not use for EEPROM)
+#           paged           = <yes/no> ;          # yes/no (flash of classic parts only)
 #           offset          = <num> ;             # memory offset
 #           size            = <num> ;             # bytes
 #           page_size       = <num> ;             # bytes
@@ -14223,7 +14223,6 @@ part # t43u
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
     memory "eeprom"
-        paged              = yes;
         size               = 64;
         page_size          = 4;
         num_pages          = 16;

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -3120,7 +3120,7 @@ part
     autobaud_sync    = <num> ;                # autobaud detection byte, default 0x30
 
     memory <memstr>
-        paged           = <yes/no> ;          # yes/no (flash only, do not use for EEPROM)
+        paged           = <yes/no> ;          # yes/no (flash of classic parts only)
         offset          = <num> ;             # memory offset
         size            = <num> ;             # bytes
         page_size       = <num> ;             # bytes


### PR DESCRIPTION
The `paged` should only be used for flash of classic parts. It may lead to problems when used for `eeprom` memories.