### PR TITLE
Print warning when avrdude and avrdude.conf versions doesn't match

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -995,6 +995,11 @@ int main(int argc, char * argv [])
     }
   }
 
+  if(!str_starts(avrdude_conf_version, version)) {
+    pmsg_warning("System wide configuration file version (%s)\n", avrdude_conf_version);
+    imsg_warning("does not match Avrdude build version (%s)\n", version);
+  }
+
   if (lsize(additional_config_files) > 0) {
     LNODEID ln1;
     const char * p = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -995,7 +995,7 @@ int main(int argc, char * argv [])
     }
   }
 
-  if(!str_starts(avrdude_conf_version, version)) {
+  if(!str_eq(avrdude_conf_version, version)) {
     pmsg_warning("System wide configuration file version (%s)\n", avrdude_conf_version);
     imsg_warning("does not match Avrdude build version (%s)\n", version);
   }


### PR DESCRIPTION
With this PR Avrdude will print a warning if the avrdude.conf file version doesn't match the avrdude executable version.

```
$ cat avrdude.conf | grep avrdude_conf_version
avrdude_conf_version = "7.1";

$ ./avrdude -cdryrun -patmega328p -PUSB 
avrdude warning: System wide configuration file version (7.1)
        does not match Avrdude build version (7.2-20230720)
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e950f (probably m328p)

avrdude done.  Thank you.
```

Resolves issue #1562