### PR TITLE
Support for STK500 v1 devices with STK500_XTAL != 7372800

### DIFF
--- a/src/stk500.h
+++ b/src/stk500.h
@@ -57,6 +57,9 @@ struct pdata {
   bool fosc_get;
   bool fosc_set;
   double fosc_data;
+
+  // Set STK500 XTAL frequency
+  unsigned xtal;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))


### PR DESCRIPTION
As discussed in #1560 - please check

```
$ avrdude_Ho-Ro -pt85 -cstk500v1 -x xtal=16M -v

avrdude_Ho-Ro: Version 7.2-20231110 (9e41b00)

...
               Programmer Type : STK500
               Description     : Atmel STK500 version 1.x firmware
               Hardware Version: 2
               Firmware Version: 1.28
               Vtarget         : 4.8 V
               Varef           : 0.0 V
               Oscillator      : 1.000 MHz
               SCK period      : 0.5 us
               XTAL frequency  : 16.000 MHz
avrdude_Ho-Ro: AVR device initialized and ready to accept instructions
avrdude_Ho-Ro: device signature = 0x1e930b (probably t85)

avrdude_Ho-Ro done.  Thank you.
```