### PR TITLE
Support for STK500 v1 and v2 devices with STK500_XTAL != 7372800

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1516,7 +1516,7 @@ The generated on-board target voltage can be changed by specifying a new voltage
 The current set-voltage can be read by
 .Ar -xvtarg
 alone.
-.It Ar fosc=VALUE[MHz|M|kHz|k|Hz], fosc
+.It Ar fosc=VALUE[MHz|M|kHz|k|Hz|H], fosc
 Set the programmable oscillator frequency. The current frequency can be read by
 .Ar -xfosc
 alone.
@@ -1540,6 +1540,9 @@ alone.
 .sp 0.5
 Specify how many connection retry attemps to perform before exiting.
 Defaults to 10 if not specified.
+.It Ar xtal=VALUE[MHz|M|kHz|k|Hz|H]
+Defines the XTAL frequency of the programmer if it differs from 7.3728 MHz of the
+original STK500. Used by avrdude for the correct calculation of fosc and sck.
 .It Ar help
 Show help menu and exit.
 .El

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1157,7 +1157,7 @@ The STK500 and STK600 boards accept the following extended parameters:
 @item @samp{vtarg=VALUE, vtarg}
 The generated on-board target voltage can be changed by specifying a new voltage.
 The current set-voltage can be read by @samp{-xvtarg} alone.
-@item @samp{fosc=VALUE[MHz|M|kHz|k|Hz], fosc}
+@item @samp{fosc=VALUE[MHz|M|kHz|k|Hz|H], fosc}
 Set the programmable oscillator frequency in MHz, kHz or Hz.
 The current frequency can be read by @samp{-xfosc} alone.
 @item @samp{varef=VALUE, varef}
@@ -1176,6 +1176,9 @@ The current reference voltage can be read by @samp{-xvaref0} or
 @*
 Specify how many connection retry attemps to perform before exiting.
 Defaults to 10 if not specified.
+@item @samp{xtal=VALUE[MHz|M|kHz|k|Hz|H]}
+Defines the XTAL frequency of the programmer if it differs from 7.3728 MHz of the
+original STK500. Used by avrdude for the correct calculation of fosc and sck.
 @item @samp{help}
 Show help menu and exit.
 @end table

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -862,6 +862,11 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
   if (stk500_getsync(pgm) < 0)
     return -1;
 
+  if (pgm->bitclock != 0.0) {
+    if (pgm->set_sck_period(pgm, pgm->bitclock) != 0)
+      return -1;
+  }
+
   return 0;
 }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -46,10 +46,10 @@
 #define MAX_SYNC_ATTEMPTS 10
 
 static double f_to_kHz_MHz(double f, const char **unit) {
-  if (f > 1e6) {
+  if (f >= 1e6) {
     f /= 1e6;
     *unit = "MHz";
-  } else if (f > 1e3) {
+  } else if (f >= 1e3) {
     f /= 1000;
     *unit = "kHz";
   } else
@@ -590,7 +590,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     stk500_getparm(pgm, Parm_STK_OSC_CMATCH, &osc_cmatch);
     if(osc_pscale) {
       int prescale = 1;
-      f_get = STK500_XTAL / 2;
+      f_get = PDATA(pgm)->xtal / 2;
       switch (osc_pscale) {
         case 2: prescale = 8; break;
         case 3: prescale = 32; break;
@@ -713,6 +713,8 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
             PDATA(pgm)->fosc_data =  v * 1e6;
           else if (*endp == 'k' || *endp == 'K')
             PDATA(pgm)->fosc_data =  v * 1e3;
+          else if (*endp == 0 || *endp == 'h' || *endp == 'H')
+            PDATA(pgm)->fosc_data =  v;
           PDATA(pgm)->fosc_set = true;
           continue;
         }
@@ -721,6 +723,33 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
           PDATA(pgm)->fosc_get = true;
          continue;
         }
+      }
+    }
+
+    else if (str_starts(extended_param, "xtal")) {
+      // Set clock generator frequency
+      if (str_starts(extended_param, "xtal=")) {
+        char xtal_str[16] = {0};
+        int sscanf_success = sscanf(extended_param, "xtal=%10s", xtal_str);
+        if (sscanf_success < 1) {
+          pmsg_error("invalid xtal value '%s'\n", extended_param);
+          rv = -1;
+          break;
+        }
+        char *endp;
+        double v = strtod(xtal_str, &endp);
+        if (endp == xtal_str){
+          pmsg_error("cannot parse xtal value %s\n", xtal_str);
+          rv = -1;
+          break;
+        }
+        if (*endp == 'm' || *endp == 'M') // fits also e.g. "nnnnMHz"
+          PDATA(pgm)->xtal = v * 1e6;
+        else if (*endp == 'k' || *endp == 'K')
+          PDATA(pgm)->xtal = v * 1e3;
+        else if (*endp == 0 || *endp == 'h' || *endp == 'H') // "nnnn" or "nnnnHz"
+          PDATA(pgm)->xtal = v;
+        continue;
       }
     }
 
@@ -741,6 +770,7 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
         msg_error("  -xfosc                Read oscillator clock frequency\n");
         msg_error("  -xfosc=<arg>[M|k]|off Set oscillator clock frequency\n");
       }
+      msg_error("  -xxtal=<arg>[M|k]     Set programmer xtal frequency\n");
       msg_error("  -xhelp                Show this help menu and exit\n");
       exit(0);
     }
@@ -1166,31 +1196,31 @@ static int stk500_set_fosc(const PROGRAMMER *pgm, double v) {
 
   prescale = cmatch = 0;
   if (v > 0.0) {
-    if (v > STK500_XTAL / 2) {
+    if (v > PDATA(pgm)->xtal / 2) {
       const char *unit;
-      if (v > 1e6) {
+      if (v >= 1e6) {
         v /= 1e6;
         unit = "MHz";
-      } else if (v > 1e3) {
+      } else if (v >= 1e3) {
         v /= 1e3;
         unit = "kHz";
       } else
         unit = "Hz";
-      pmsg_warning("f = %.3f %s too high, using %.3f MHz\n", v, unit, STK500_XTAL/2e6);
-      fosc = STK500_XTAL / 2;
+      pmsg_warning("f = %.3f %s too high, using %.3f MHz\n", v, unit, PDATA(pgm)->xtal/2e6);
+      fosc = PDATA(pgm)->xtal / 2;
     } else
       fosc = (unsigned) v;
     
     for (idx = 0; idx < sizeof(ps) / sizeof(ps[0]); idx++) {
-      if (fosc >= STK500_XTAL / (256 * ps[idx] * 2)) {
+      if (fosc >= PDATA(pgm)->xtal / (256 * ps[idx] * 2)) {
         /* this prescaler value can handle our frequency */
         prescale = idx + 1;
-        cmatch = (unsigned)(STK500_XTAL / (2 * fosc * ps[idx])) - 1;
+        cmatch = (unsigned)(PDATA(pgm)->xtal / (2 * fosc * ps[idx])) - 1;
         break;
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
-      pmsg_warning("f = %u Hz too low, %u Hz min\n", fosc, STK500_XTAL / (256 * 1024 * 2));
+      pmsg_warning("f = %u Hz too low, %u Hz min\n", fosc, PDATA(pgm)->xtal / (256 * 1024 * 2));
       return -1;
     }
   }
@@ -1214,7 +1244,7 @@ static int stk500_set_sck_period(const PROGRAMMER *pgm, double v) {
   int dur;
   double min, max;
 
-  min = 8.0 / STK500_XTAL;
+  min = 8.0 / PDATA(pgm)->xtal;
   max = 255 * min;
   dur = v / min + 0.5;
   
@@ -1388,7 +1418,7 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) 
       fmsg_out(fp, "Off\n");
     else {
       int prescale = 1;
-      double f = STK500_XTAL / 2;
+      double f = PDATA(pgm)->xtal / 2;
       const char *unit;
 
       switch (osc_pscale) {
@@ -1401,10 +1431,10 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) 
       }
       f /= prescale;
       f /= (osc_cmatch + 1);
-      if (f > 1e6) {
+      if (f >= 1e6) {
         f /= 1e6;
         unit = "MHz";
-      } else if (f > 1e3) {
+      } else if (f >= 1e3) {
         f /= 1000;
         unit = "kHz";
       } else
@@ -1414,7 +1444,19 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) 
   }
 
   stk500_getparm(pgm, Parm_STK_SCK_DURATION, &sck_duration);
-  fmsg_out(fp, "%sSCK period      : %.1f us\n", p, sck_duration * 8.0e6 / STK500_XTAL + 0.05);
+  fmsg_out(fp, "%sSCK period      : %.1f us\n", p, sck_duration * 8.0e6 / PDATA(pgm)->xtal + 0.0499);
+
+  const char *unit;
+  double f = PDATA(pgm)->xtal;
+  if (f >= 1e6) {
+    f /= 1e6;
+    unit = "MHz";
+  } else if (f >= 1e3) {
+    f /= 1000;
+    unit = "kHz";
+  } else
+    unit = "Hz";
+  fmsg_out(fp, "%sXTAL frequency  : %.3f %s\n", p, f, unit);
 
   return;
 }
@@ -1433,6 +1475,11 @@ static void stk500_setup(PROGRAMMER * pgm)
   memset(pgm->cookie, 0, sizeof(struct pdata));
   PDATA(pgm)->ext_addr_byte = 0xff;
   PDATA(pgm)->xbeeResetPin = XBEE_DEFAULT_RESET_PIN;
+  // nanoSTK (Arduino Nano HW) uses 16 MHz
+  if (str_starts(pgmid, "nanoSTK"))
+    PDATA(pgm)->xtal = 16000000U;
+  else
+    PDATA(pgm)->xtal = STK500_XTAL;
 }
 
 static void stk500_teardown(PROGRAMMER * pgm)

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -57,6 +57,9 @@ struct pdata {
   bool fosc_get;
   bool fosc_set;
   double fosc_data;
+
+  // Set STK500 XTAL frequency
+  unsigned xtal;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -58,8 +58,7 @@ struct pdata {
   bool fosc_set;
   double fosc_data;
 
-  // Set STK500 XTAL frequency
-  unsigned xtal;
+  unsigned xtal;                // Set STK500 XTAL frequency
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -50,7 +50,6 @@
 #include "avrdude.h"
 #include "libavrdude.h"
 
-#include "stk500_private.h"	// temp until all code converted
 #include "stk500v2.h"
 #include "stk500v2_private.h"
 #include "usbdevs.h"
@@ -295,6 +294,7 @@ void stk500v2_setup(PROGRAMMER * pgm)
   memset(pgm->cookie, 0, sizeof(struct pdata));
   PDATA(pgm)->command_sequence = 1;
   PDATA(pgm)->boot_start = ULONG_MAX;
+  PDATA(pgm)->xtal = STK500V2_XTAL;
 }
 
 static void stk500v2_jtagmkII_setup(PROGRAMMER * pgm)
@@ -393,10 +393,10 @@ u16_to_b2(unsigned char *b, unsigned short l)
 static double
 f_to_kHz_MHz(double f, const char **unit)
 {
-  if (f > 1e6) {
+  if (f >= 1e6) {
     f /= 1e6;
     *unit = "MHz";
-  } else if (f > 1e3) {
+  } else if (f >= 1e3) {
     f /= 1000;
     *unit = "kHz";
   } else
@@ -1254,10 +1254,10 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     unsigned char vtarg_read;
     stk500v2_getparm(pgm, PARAM_VTARGET, &vtarg_read);
     if (PDATA(pgm)->vtarg_get)
-      msg_info("Target voltage value read as %.2fV\n", (vtarg_read / 10.0));
+      msg_info("Target voltage value read as %.2f V\n", (vtarg_read / 10.0));
     // Write target voltage value
     else {
-      msg_info("Changing target voltage from %.2f to %.2fV\n", (vtarg_read / 10.0), PDATA(pgm)->vtarg_data);
+      msg_info("Changing target voltage from %.2f V to %.2f V\n", (vtarg_read / 10.0), PDATA(pgm)->vtarg_data);
       if(pgm->set_vtarget(pgm, PDATA(pgm)->vtarg_data) < 0)
         return -1;
     }
@@ -1270,10 +1270,10 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       unsigned char varef_read;
       stk500v2_getparm(pgm, PARAM_VADJUST, &varef_read);
       if (PDATA(pgm)->varef_get)
-        msg_info("Analog reference voltage value read as %.2fV\n", (varef_read / 10.0));
+        msg_info("Analog reference voltage value read as %.2f V\n", (varef_read / 10.0));
       // STK500: Write analog reference voltage
       else {
-        msg_info("Changing analog reference voltage from %.2f to %.2fV\n",
+        msg_info("Changing analog reference voltage from %.2f V to %.2f V\n",
           (varef_read / 10.0), PDATA(pgm)->varef_data);
         if(pgm->set_varef(pgm, 0, PDATA(pgm)->varef_data) < 0)
           return -1;
@@ -1283,10 +1283,10 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       unsigned int varef_read;
       stk500v2_getparm2(pgm, PDATA(pgm)->varef_channel == 0 ? PARAM2_AREF0 : PARAM2_AREF1, &varef_read);
       if (PDATA(pgm)->varef_get)
-        msg_info("Analog reference channel %d voltage read as %.2fV\n", PDATA(pgm)->varef_channel, (varef_read / 100.0));
+        msg_info("Analog reference channel %d voltage read as %.2f V\n", PDATA(pgm)->varef_channel, (varef_read / 100.0));
       // STK600: Write target voltage value for channel n
       else {
-        msg_info("Changing analog reference channel %d voltage from %.2f to %.2fV\n",
+        msg_info("Changing analog reference channel %d voltage from %.2f V to %.2f V\n",
           PDATA(pgm)->varef_channel, (varef_read / 100.0), PDATA(pgm)->varef_data);
         if(pgm->set_varef(pgm, PDATA(pgm)->varef_channel, PDATA(pgm)->varef_data) < 0)
           return -1;
@@ -1306,7 +1306,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
       if(osc_pscale) {
         int prescale = 1;
-        f_get = STK500V2_XTAL / 2;
+        f_get = PDATA(pgm)->xtal / 2;
         switch (osc_pscale) {
           case 2: prescale = 8; break;
           case 3: prescale = 32; break;
@@ -1485,13 +1485,13 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       return -1;
     double vtarg_read = b2_to_u16(buf) / 1000.0;
     if (PDATA(pgm)->vtarg_get)
-      msg_info("Target voltage value read as %.2fV\n", vtarg_read);
+      msg_info("Target voltage value read as %.2f V\n", vtarg_read);
     // Write target voltage value
     else {
       u16_to_b2(buf, (unsigned)(PDATA(pgm)->vtarg_data * 1000));
-      msg_info("Changing target voltage from %.2f to %.2fV\n", vtarg_read, PDATA(pgm)->vtarg_data);
+      msg_info("Changing target voltage from %.2f V to %.2f V\n", vtarg_read, PDATA(pgm)->vtarg_data);
       if (jtag3_setparm(pgmcp, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, sizeof(buf)) < 0) {
-        msg_warning("Cannot set target voltage %.2fV\n", PDATA(pgm)->vtarg_data);
+        msg_warning("Cannot set target voltage %.2f V\n", PDATA(pgm)->vtarg_data);
         return -1;
       }
     }
@@ -1568,10 +1568,10 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
     unsigned char vtarg_read;
     stk500v2_getparm(pgm, PARAM_VTARGET, &vtarg_read);
     if (PDATA(pgm)->vtarg_get)
-      msg_info("Target voltage value read as %.2fV\n", (vtarg_read / 10.0));
+      msg_info("Target voltage value read as %.2f V\n", (vtarg_read / 10.0));
     // Write target voltage value
     else {
-      msg_info("Changing target voltage from %.2f to %.2fV\n", (vtarg_read / 10.0), PDATA(pgm)->vtarg_data);
+      msg_info("Changing target voltage from %.2f V to %.2f V\n", (vtarg_read / 10.0), PDATA(pgm)->vtarg_data);
       if(pgm->set_vtarget(pgm, PDATA(pgm)->vtarg_data) < 0)
         return -1;
     }
@@ -1584,10 +1584,10 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       unsigned char varef_read;
       stk500v2_getparm(pgm, PARAM_VADJUST, &varef_read);
       if (PDATA(pgm)->varef_get)
-        msg_info("Analog reference voltage value read as %.2fV\n", (varef_read / 10.0));
+        msg_info("Analog reference voltage value read as %.2f V\n", (varef_read / 10.0));
       // STK500: Write analog reference voltage
       else {
-        msg_info("Changing analog reference voltage from %.2f to %.2fV\n",
+        msg_info("Changing analog reference voltage from %.2f V to %.2f V\n",
           (varef_read / 10.0), PDATA(pgm)->varef_data);
         if(pgm->set_varef(pgm, 0, PDATA(pgm)->varef_data) < 0)
           return -1;
@@ -1597,10 +1597,10 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       unsigned int varef_read;
       stk500v2_getparm2(pgm, PDATA(pgm)->varef_channel == 0 ? PARAM2_AREF0 : PARAM2_AREF1, &varef_read);
       if (PDATA(pgm)->varef_get)
-        msg_info("Analog reference channel %d voltage read as %.2fV\n", PDATA(pgm)->varef_channel, (varef_read / 100.0));
+        msg_info("Analog reference channel %d voltage read as %.2f V\n", PDATA(pgm)->varef_channel, (varef_read / 100.0));
       // STK600: Write target voltage value for channel n
       else {
-        msg_info("Changing analog reference channel %d voltage from %.2f to %.2fV\n",
+        msg_info("Changing analog reference channel %d voltage from %.2f V to %.2f V\n",
           PDATA(pgm)->varef_channel, (varef_read / 100.0), PDATA(pgm)->varef_data);
         if(pgm->set_varef(pgm, PDATA(pgm)->varef_channel, PDATA(pgm)->varef_data) < 0)
           return -1;
@@ -1620,7 +1620,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
       if(osc_pscale) {
         int prescale = 1;
-        f_get = STK500V2_XTAL / 2;
+        f_get = PDATA(pgm)->xtal / 2;
         switch (osc_pscale) {
           case 2: prescale = 8; break;
           case 3: prescale = 32; break;
@@ -1829,7 +1829,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       if (pgm->extra_features & HAS_VTARG_ADJ) {
         // Set target voltage
         if (str_starts(extended_param, "vtarg=") ) {
-          double vtarg_set_val = 0;
+          double vtarg_set_val = -1; // default = invalid value
           int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
           PDATA(pgm)->vtarg_data = (double)((int)(vtarg_set_val * 100 + .5)) / 100;
           if (sscanf_success < 1 || vtarg_set_val < 0) {
@@ -1851,7 +1851,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     else if (str_starts(extended_param, "varef")) {
       if (pgm->extra_features & HAS_VAREF_ADJ) {
         int sscanf_success = 0;
-        double varef_set_val = 0;
+        double varef_set_val = -1;
         // Get new analog reference voltage for channel 0
         if (str_starts(extended_param, "varef=")) {
           sscanf_success = sscanf(extended_param, "varef=%lf", &varef_set_val);
@@ -1897,7 +1897,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     }
 
     else if (str_starts(extended_param, "fosc")) {
-      if (pgm->extra_features & HAS_VAREF_ADJ) {
+      if (pgm->extra_features & HAS_FOSC_ADJ) {
         // Set clock generator frequency
         if (str_starts(extended_param, "fosc=")) {
           char fosc_str[16] = {0};
@@ -1913,7 +1913,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
             if (str_eq(fosc_str, "off"))
               PDATA(pgm)->fosc_data = 0.0;
             else {
-              pmsg_error("cannot parse fosc value %s\n", fosc_str);
+              pmsg_error("invalid fosc value '%s'\n", fosc_str);
               rv = -1;
               break;
             }
@@ -1922,6 +1922,13 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
             PDATA(pgm)->fosc_data =  v * 1e6;
           else if (*endp == 'k' || *endp == 'K')
             PDATA(pgm)->fosc_data =  v * 1e3;
+          else if (*endp == 'h' || *endp == 'H' || *endp == 0)
+            PDATA(pgm)->fosc_data =  v;
+          else {
+            pmsg_error("invalid fosc value '%s'\n", fosc_str);
+            rv = -1;
+            break;
+          }
           PDATA(pgm)->fosc_set = true;
           continue;
         }
@@ -1930,6 +1937,38 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           PDATA(pgm)->fosc_get = true;
          continue;
         }
+      }
+    }
+
+    else if (str_starts(extended_param, "xtal")) {
+      // Set clock generator frequency
+      if (str_starts(extended_param, "xtal=")) {
+        char xtal_str[16] = {0};
+        int sscanf_success = sscanf(extended_param, "xtal=%10s", xtal_str);
+        if (sscanf_success < 1) {
+          pmsg_error("invalid xtal value '%s'\n", extended_param);
+          rv = -1;
+          break;
+        }
+        char *endp;
+        double v = strtod(xtal_str, &endp);
+        if (endp == xtal_str){
+          pmsg_error("invalid xtal value '%s'\n", xtal_str);
+          rv = -1;
+          break;
+        }
+        if (*endp == 'm' || *endp == 'M') // fits also e.g. "nnnnMHz"
+          PDATA(pgm)->xtal = v * 1e6;
+        else if (*endp == 'k' || *endp == 'K')
+          PDATA(pgm)->xtal = v * 1e3;
+        else if (*endp == 0 || *endp == 'h' || *endp == 'H') // "nnnn" or "nnnnHz"
+          PDATA(pgm)->xtal = (unsigned)v;
+        else {
+          pmsg_error("invalid xtal value '%s'\n", xtal_str);
+          rv = -1;
+          break;
+        }
+        continue;
       }
     }
 
@@ -1957,6 +1996,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         msg_error("  -xfosc                Read oscillator clock frequency\n");
         msg_error("  -xfosc=<arg>[M|k]|off Set oscillator clock frequency\n");
       }
+      msg_error("  -xxtal=<arg>[M|k]     Set programmer xtal frequency\n");
       msg_error("  -xhelp                Show this help menu and exit\n");
       exit(0);
     }
@@ -3215,33 +3255,33 @@ static int stk500v2_set_fosc(const PROGRAMMER *pgm, double v) {
 
   prescale = cmatch = 0;
   if (v > 0.0) {
-    if (v > STK500V2_XTAL / 2) {
+    if (v > PDATA(pgm)->xtal / 2) {
       const char *unit;
-      if (v > 1e6) {
+      if (v >= 1e6) {
         v /= 1e6;
         unit = "MHz";
-      } else if (v > 1e3) {
+      } else if (v >= 1e3) {
         v /= 1e3;
         unit = "kHz";
       } else
         unit = "Hz";
       pmsg_warning("f = %.3f %s too high, using %.3f MHz\n",
-        v, unit, STK500V2_XTAL / 2e6);
-      fosc = STK500V2_XTAL / 2;
+        v, unit, PDATA(pgm)->xtal / 2e6);
+      fosc = PDATA(pgm)->xtal / 2;
     } else
       fosc = (unsigned)v;
 
     for (idx = 0; idx < sizeof(ps) / sizeof(ps[0]); idx++) {
-      if ((unsigned) fosc >= STK500V2_XTAL / (256 * ps[idx] * 2)) {
+      if ((unsigned) fosc >= PDATA(pgm)->xtal / (256 * ps[idx] * 2)) {
         /* this prescaler value can handle our frequency */
         prescale = idx + 1;
-        cmatch = (unsigned)(STK500V2_XTAL / (2 * fosc * ps[idx])) - 1;
+        cmatch = (unsigned)(PDATA(pgm)->xtal / (2 * fosc * ps[idx])) - 1;
         break;
       }
     }
     if (idx == sizeof(ps) / sizeof(ps[0])) {
       pmsg_warning("f = %u Hz too low, %u Hz min\n",
-        fosc, STK500V2_XTAL / (256 * 1024 * 2));
+        fosc, PDATA(pgm)->xtal / (256 * 1024 * 2));
       return -1;
     }
   }
@@ -3327,22 +3367,24 @@ static unsigned int stk500v2_mode_for_pagesize(unsigned int pagesize)
  * AVRISP devices are virtually no longer around (and the AVRISPmkII
  * uses a different algorithm below), it's probably not worth the
  * hassle.
+ * Originally, magic constants based on the XTAL frequency
+ * 7.3728 MHz of the original STK500 HW were used here.
  */
 static int stk500v2_set_sck_period(const PROGRAMMER *pgm, double v) {
   unsigned int d;
   unsigned char dur;
   double f = 1 / v;
 
-  if (f >= 1.8432E6)
+  if (f >= PDATA(pgm)->xtal / 4)       // 1.8432E6
     d = 0;
-  else if (f > 460.8E3)
+  else if (f > PDATA(pgm)->xtal / 16)  // 460.8E3
     d = 1;
-  else if (f > 115.2E3)
+  else if (f > PDATA(pgm)->xtal / 64)  // 115.2E3
     d = 2;
-  else if (f > 57.6E3)
+  else if (f > PDATA(pgm)->xtal / 128) // 57.6E3
     d = 3;
   else
-    d = (unsigned int)ceil(1 / (24 * f / (double)STK500V2_XTAL) - 10.0 / 12.0);
+    d = (unsigned int)ceil(1 / (24 * f / (double)PDATA(pgm)->xtal) - 10.0 / 12.0);
   if (d >= 255)
     d = 254;
   dur = d;
@@ -3354,18 +3396,18 @@ static double stk500v2_sck_to_us(const PROGRAMMER *pgm, unsigned char dur) {
   double x;
 
   if (dur == 0)
-    return 0.5425;
+    return  4E6 / PDATA(pgm)->xtal;  // 0.5425;
   if (dur == 1)
-    return 2.17;
+    return 16E6 / PDATA(pgm)->xtal;  // 2.17;
   if (dur == 2)
-    return 8.68;
+    return 64E6 / PDATA(pgm)->xtal;  // 8.68;
   if (dur == 3)
-    return 17.36;
+    return 128E6 / PDATA(pgm)->xtal; // 17.36;
 
   x = (double)dur + 10.0 / 12.0;
   x = 1.0 / x;
   x /= 24.0;
-  x *= (double)STK500V2_XTAL;
+  x *= (double)PDATA(pgm)->xtal;
   return 1E6 / x;
 }
 
@@ -3382,7 +3424,7 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    pmsg_warning("reducing V[aref][0] from %.2f to %.1f\n", uaref/100.0, v);
+    pmsg_warning("reducing V[aref][0] from %.2f V to %.1f\n", uaref/100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF0, uaref) != 0)
       return -1;
@@ -3394,7 +3436,7 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
   }
 
   if (uaref > (unsigned)utarg * 10) {
-    pmsg_warning("reducing V[aref][1] from %.2f to %.1f\n", uaref/100.0, v);
+    pmsg_warning("reducing V[aref][1] from %.2f V to %.1f\n", uaref/100.0, v);
     uaref = 10 * (unsigned)utarg;
     if (stk500v2_setparm2(pgm, PARAM2_AREF1, uaref)
 	!= 0)
@@ -3680,8 +3722,6 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
   switch (PDATA(pgm)->pgmtype) {
   case PGMTYPE_STK500:
     stk500v2_getparm(pgm, PARAM_SCK_DURATION, &sck_duration);
-    fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
-	    stk500v2_sck_to_us(pgm, sck_duration));
     if (pgm->extra_features & HAS_VAREF_ADJ) {
       stk500v2_getparm(pgm, PARAM_VADJUST, &vadjust);
       fmsg_out(fp, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
@@ -3694,7 +3734,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
         fmsg_out(fp, "Off\n");
       else {
         prescale = 1;
-        f = STK500V2_XTAL / 2;
+        f = PDATA(pgm)->xtal / 2;
 
         switch (osc_pscale) {
           case 2: prescale = 8; break;
@@ -3710,6 +3750,20 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
         fmsg_out(fp, "%.3f %s\n", f, unit);
       }
     }
+    fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
+	    stk500v2_sck_to_us(pgm, sck_duration));
+
+  const char *unit;
+  double f = PDATA(pgm)->xtal;
+  if (f >= 1e6) {
+    f /= 1e6;
+    unit = "MHz";
+  } else if (f >= 1e3) {
+    f /= 1000;
+    unit = "kHz";
+  } else
+    unit = "Hz";
+  fmsg_out(fp, "%sXTAL frequency  : %.3f %s\n", p, f, unit);
     break;
 
   case PGMTYPE_AVRISP_MKII:
@@ -3759,7 +3813,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
 
   default:
     fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
-	  sck_duration * 8.0e6 / STK500V2_XTAL + 0.05);
+	  sck_duration * 8.0e6 / PDATA(pgm)->xtal + 0.0499);
     break;
   }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1919,7 +1919,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         // Set clock generator frequency
         if (str_starts(extended_param, "fosc=")) {
           char fosc_str[16] = {0};
-          int sscanf_success = sscanf(extended_param, "fosc=%10s", fosc_str);
+          int sscanf_success = sscanf(extended_param, "fosc=%15[0-9.eE MmKkHhZzof]", fosc_str);
           if (sscanf_success < 1) {
             pmsg_error("invalid fosc value %s\n", extended_param);
             rv = -1;
@@ -1927,26 +1927,25 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           }
           char *endp;
           double v = strtod(fosc_str, &endp);
-          if (endp == fosc_str){
-            if (str_eq(fosc_str, "off"))
+          if (endp == fosc_str){ // no number
+            while ( *endp == ' ' ) // remove leading spaces
+              ++endp;
+            if (str_starts(endp, "off"))
               PDATA(pgm)->fosc_data = 0.0;
             else {
-              pmsg_error("invalid fosc value %s\n", fosc_str);
+              pmsg_error("invalid fosc value %s\n", endp);
               rv = -1;
               break;
             }
           }
+          while ( *endp == ' ' ) // remove leading spaces before unit
+            ++endp;
           if (*endp == 'm' || *endp == 'M')
             PDATA(pgm)->fosc_data =  v * 1e6;
           else if (*endp == 'k' || *endp == 'K')
             PDATA(pgm)->fosc_data =  v * 1e3;
-          else if (*endp == 'h' || *endp == 'H' || *endp == 0)
+          else if (*endp == 0 || *endp == 'h' || *endp == 'H' || *endp == 0)
             PDATA(pgm)->fosc_data =  v;
-          else {
-            pmsg_error("invalid fosc value %s\n", fosc_str);
-            rv = -1;
-            break;
-          }
           PDATA(pgm)->fosc_set = true;
           continue;
         }
@@ -1962,7 +1961,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       // Set clock generator frequency
       if (str_starts(extended_param, "xtal=")) {
         char xtal_str[16] = {0};
-        int sscanf_success = sscanf(extended_param, "xtal=%10s", xtal_str);
+        int sscanf_success = sscanf(extended_param, "xtal=%15[0-9.eE MmKkHhZz]", xtal_str);
         if (sscanf_success < 1) {
           pmsg_error("invalid xtal value %s\n", extended_param);
           rv = -1;
@@ -1975,17 +1974,14 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           rv = -1;
           break;
         }
+        while ( *endp == ' ' ) // remove leading spaces before unit
+          ++endp;
         if (*endp == 'm' || *endp == 'M') // fits also e.g. "nnnnMHz"
           PDATA(pgm)->xtal = v * 1e6;
         else if (*endp == 'k' || *endp == 'K')
           PDATA(pgm)->xtal = v * 1e3;
         else if (*endp == 0 || *endp == 'h' || *endp == 'H') // "nnnn" or "nnnnHz"
           PDATA(pgm)->xtal = (unsigned)v;
-        else {
-          pmsg_error("invalid xtal value %s\n", xtal_str);
-          rv = -1;
-          break;
-        }
         continue;
       }
     }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1259,8 +1259,9 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   // Read or write target voltage
   if (PDATA(pgm)->vtarg_get || PDATA(pgm)->vtarg_set) {
     // Read current target voltage set value
-    unsigned char vtarg_read;
-    stk500v2_getparm(pgm, PARAM_VTARGET, &vtarg_read);
+    unsigned char vtarg_read = 0;
+    if (stk500v2_getparm(pgm, PARAM_VTARGET, &vtarg_read) < 0)
+      return -1;
     if (PDATA(pgm)->vtarg_get)
       msg_info("Target voltage value read as %.2f V\n", (vtarg_read / 10.0));
     // Write target voltage value
@@ -1275,8 +1276,9 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (PDATA(pgm)->varef_get || PDATA(pgm)->varef_set) {
     if(PDATA(pgm)->pgmtype == PGMTYPE_STK500) {
       // STK500: Read current analog reference voltage
-      unsigned char varef_read;
-      stk500v2_getparm(pgm, PARAM_VADJUST, &varef_read);
+      unsigned char varef_read = 0;
+      if (stk500v2_getparm(pgm, PARAM_VADJUST, &varef_read) < 0 )
+        return -1;
       if (PDATA(pgm)->varef_get)
         msg_info("Analog reference voltage value read as %.2f V\n", (varef_read / 10.0));
       // STK500: Write analog reference voltage
@@ -1288,8 +1290,9 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       }
     } else if(PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
       // STK600: Read current target voltage set value
-      unsigned int varef_read;
-      stk500v2_getparm2(pgm, PDATA(pgm)->varef_channel == 0 ? PARAM2_AREF0 : PARAM2_AREF1, &varef_read);
+      unsigned int varef_read = 0;
+      if (stk500v2_getparm2(pgm, PDATA(pgm)->varef_channel == 0 ? PARAM2_AREF0 : PARAM2_AREF1, &varef_read) < 0)
+        return -1;
       if (PDATA(pgm)->varef_get)
         msg_info("Analog reference channel %d voltage read as %.2f V\n", PDATA(pgm)->varef_channel, (varef_read / 100.0));
       // STK600: Write target voltage value for channel n
@@ -1306,12 +1309,14 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (PDATA(pgm)->fosc_get || PDATA(pgm)->fosc_set) {
     if(PDATA(pgm)->pgmtype == PGMTYPE_STK500) {
       // Read current target voltage set value
-      unsigned char osc_pscale;
-      unsigned char osc_cmatch;
+      unsigned char osc_pscale = 0;
+      unsigned char osc_cmatch = 0;
       const char *unit_get = {"Hz"};
       double f_get = 0.0;
-      stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
-      stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
+      int rv = 0;
+      if ((rv = stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale)) < 0
+        || (rv = stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch)) < 0)
+        return rv;
       if(osc_pscale) {
         int prescale = 1;
         f_get = PDATA(pgm)->xtal / 2;
@@ -1339,7 +1344,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       }
     } else if(PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
       // Read current target voltage set value
-      unsigned int clock_conf;
+      unsigned int clock_conf = 0;
       stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf);
       unsigned int oct = (clock_conf & 0xf000) >> 12u;
       unsigned int dac = (clock_conf & 0x0ffc) >> 2u;
@@ -1573,8 +1578,9 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   // Read or write target voltage
   if (PDATA(pgm)->vtarg_get || PDATA(pgm)->vtarg_set) {
     // Read current target voltage set value
-    unsigned char vtarg_read;
-    stk500v2_getparm(pgm, PARAM_VTARGET, &vtarg_read);
+    unsigned char vtarg_read = 0;
+    if (stk500v2_getparm(pgm, PARAM_VTARGET, &vtarg_read) < 0)
+      return -1;
     if (PDATA(pgm)->vtarg_get)
       msg_info("Target voltage value read as %.2f V\n", (vtarg_read / 10.0));
     // Write target voltage value
@@ -1589,8 +1595,9 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   if (PDATA(pgm)->varef_get || PDATA(pgm)->varef_set) {
     if(PDATA(pgm)->pgmtype == PGMTYPE_STK500) {
       // STK500: Read current analog reference voltage
-      unsigned char varef_read;
-      stk500v2_getparm(pgm, PARAM_VADJUST, &varef_read);
+      unsigned char varef_read = 0;
+      if (stk500v2_getparm(pgm, PARAM_VADJUST, &varef_read) < 0)
+        return -1;
       if (PDATA(pgm)->varef_get)
         msg_info("Analog reference voltage value read as %.2f V\n", (varef_read / 10.0));
       // STK500: Write analog reference voltage
@@ -1602,8 +1609,9 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       }
     } else if(PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
       // STK600: Read current target voltage set value
-      unsigned int varef_read;
-      stk500v2_getparm2(pgm, PDATA(pgm)->varef_channel == 0 ? PARAM2_AREF0 : PARAM2_AREF1, &varef_read);
+      unsigned int varef_read = 0;
+      if (stk500v2_getparm2(pgm, PDATA(pgm)->varef_channel == 0 ? PARAM2_AREF0 : PARAM2_AREF1, &varef_read) < 0)
+        return -1;
       if (PDATA(pgm)->varef_get)
         msg_info("Analog reference channel %d voltage read as %.2f V\n", PDATA(pgm)->varef_channel, (varef_read / 100.0));
       // STK600: Write target voltage value for channel n
@@ -1620,12 +1628,13 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   if (PDATA(pgm)->fosc_get || PDATA(pgm)->fosc_set) {
     if(PDATA(pgm)->pgmtype == PGMTYPE_STK500) {
       // Read current target voltage set value
-      unsigned char osc_pscale;
-      unsigned char osc_cmatch;
+      unsigned char osc_pscale = 0;
+      unsigned char osc_cmatch = 0;
       const char *unit_get = {"Hz"};
       double f_get = 0.0;
-      stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
-      stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
+      if (stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale) < 0
+        || stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch) < 0)
+        return -1;
       if(osc_pscale) {
         int prescale = 1;
         f_get = PDATA(pgm)->xtal / 2;
@@ -1653,8 +1662,9 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       }
     } else if(PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
       // Read current target voltage set value
-      unsigned int clock_conf;
-      stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf);
+      unsigned int clock_conf = 0;
+      if (stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf) < 0)
+        return -1;
       unsigned int oct = (clock_conf & 0xf000) >> 12u;
       unsigned int dac = (clock_conf & 0x0ffc) >> 2u;
       double f_get = pow(2, (double)oct) * 2078.0 / (2 - (double)dac / 1024.0);
@@ -3213,9 +3223,8 @@ static int stk500hvsp_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 
 
 static int stk500v2_set_vtarget(const PROGRAMMER *pgm, double v) {
-  unsigned char uaref, utarg;
-
-  utarg = (unsigned)((v + 0.049) * 10);
+  unsigned char uaref = 0;
+  unsigned char utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VADJUST, &uaref) != 0) {
     pmsg_error("cannot obtain V[aref]\n");
@@ -3234,9 +3243,8 @@ static int stk500v2_set_vtarget(const PROGRAMMER *pgm, double v) {
 static int stk500v2_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused */,
                               double v)
 {
-  unsigned char uaref, utarg;
-
-  uaref = (unsigned)((v + 0.049) * 10);
+  unsigned char utarg = 0;
+  unsigned char uaref = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
     pmsg_error("cannot obtain V[target]\n");
@@ -3421,10 +3429,9 @@ static double stk500v2_sck_to_us(const PROGRAMMER *pgm, unsigned char dur) {
 
 
 static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
-  unsigned char utarg;
-  unsigned int uaref;
+  unsigned int uaref = 0;
+  unsigned char utarg = (unsigned)((v + 0.049) * 10);
   int rv;
-  utarg = (unsigned)((v + 0.049) * 10);
 
   if (stk500v2_getparm2(pgm, PARAM2_AREF0, &uaref) != 0) {
     pmsg_error("cannot obtain V[aref][0]\n");
@@ -3466,10 +3473,8 @@ static int stk600_set_vtarget(const PROGRAMMER *pgm, double v) {
 
 
 static int stk600_set_varef(const PROGRAMMER *pgm, unsigned int chan, double v) {
-  unsigned char utarg;
-  unsigned int uaref;
-
-  uaref = (unsigned)((v + 0.0049) * 100);
+  unsigned char utarg = 0;
+  unsigned int uaref = (unsigned)((v + 0.0049) * 100);
 
   if (stk500v2_getparm(pgm, PARAM_VTARGET, &utarg) != 0) {
     pmsg_error("cannot obtain V[target]\n");
@@ -3562,7 +3567,7 @@ static int stk500v2_setparm_real(const PROGRAMMER *pgm, unsigned char parm, unsi
   buf[2] = value;
 
   if (stk500v2_command(pgm, buf, 3, sizeof(buf)) < 0) {
-    pmsg_error("\n%s: stk500v2_setparm(): unable to set parameter 0x%02x\n",
+    pmsg_error("\n%s stk500v2_setparm(): unable to set parameter 0x%02x\n",
       progname, parm);
     return -1;
   }
@@ -3614,7 +3619,7 @@ static int stk500v2_setparm2(const PROGRAMMER *pgm, unsigned char parm, unsigned
   buf[3] = value;
 
   if (stk500v2_command(pgm, buf, 4, sizeof(buf)) < 0) {
-    pmsg_error("\n%s: stk500v2_setparm2(): unable to set parameter 0x%02x\n",
+    pmsg_error("\n%s stk500v2_setparm2(): unable to set parameter 0x%02x\n",
       progname, parm);
     return -1;
   }
@@ -3757,7 +3762,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
         f /= (osc_cmatch + 1);
         decimals = get_decimals(f);
         f = f_to_kHz_MHz(f, &unit);
-        fmsg_out(fp, "%.*f %s\n", f, decimals, unit);
+        fmsg_out(fp, "%.*f %s\n", decimals, f, unit);
       }
     }
     fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
@@ -3767,7 +3772,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
     double f = PDATA(pgm)->xtal;
     decimals = get_decimals(f);
     f = f_to_kHz_MHz(f, &unit);
-    fmsg_out(fp, "%sXTAL frequency  : %.*f %s\n", p, f, decimals, unit);
+    fmsg_out(fp, "%sXTAL frequency  : %.*f %s\n", p, decimals, f, unit);
       break;
 
   case PGMTYPE_AVRISP_MKII:

--- a/src/stk500v2_private.h
+++ b/src/stk500v2_private.h
@@ -298,6 +298,9 @@ struct pdata
   bool fosc_set;
   double fosc_data;
 
+  // Set STK500 XTAL frequency
+  unsigned xtal;
+
   const AVRPART *lastpart;
 
   /* Start address of Xmega boot area */


### PR DESCRIPTION
This PR replaces #1565 because it introduced a lot of whitespace-only changes. Sorry for the confusion.
1st part fixed some errors while 2nd commit does the real work.