### PR TITLE
Update `part` cmd

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1257,9 +1257,12 @@ on a non-zero verbosity level the line numbers are printed, too.
 .It Ar sig
 Display the device signature bytes.
 .It Ar part
-Display the current part settings and parameters.  Includes chip
-specific information including all memories supported by the
-device, read/write timing, etc.
+Display the current part information. Includes chip specific information
+including supported programming modes, memory and variants tables. Use
+.Ar -m
+to only print the memory table, and
+.Ar -v
+to only print the variants table.
 .It Ar verbose Op Ar level
 Change (when
 .Ar level

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1257,8 +1257,8 @@ on a non-zero verbosity level the line numbers are printed, too.
 .It Ar sig
 Display the device signature bytes.
 .It Ar part
-Display the current part information. Includes chip specific information
-including supported programming modes, memory and variants tables. Use
+Display the current part information, including supported programming modes,
+memory and variants tables. Use
 .Ar -m
 to only print the memory table, and
 .Ar -v

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -916,7 +916,7 @@ static int avrftdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
 static void avrftdi_display(const PROGRAMMER *pgm, const char *p)
 {
-	msg_info("%sPin assignment  : 0..7 = DBUS0..7, 8..15 = CBUS0..7\n", p);
+	msg_info("%sPin assignment        : 0..7 = DBUS0..7, 8..15 = CBUS0..7\n", p);
 	if (pgm->flag & PGM_FL_IS_JTAG) {
 		pgm_display_generic_mask(pgm, p, SHOW_ALL_PINS & ~SHOW_AVR_PINS);
 	} else {

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -504,7 +504,6 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
   const char *table_padding = "-------------------------------";
   static int m_char_max[4] = {0};
 
-
   if (m == NULL) {
     for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
       m = ldata(ln);
@@ -534,6 +533,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
     }
     m_char_max[3] += strlen("0x");
 
+    // Print memory table header
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
       fprintf(f,
         "\n%s| %-*s  %-*s  %-*s  %*s |\n"
@@ -569,11 +569,10 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       prev_mem_offset = m->offset;
       prev_mem_size = m->size;
 
+      // Workaround to get the 0x prefix where it should be
       int m_offset = m->offset;
       int m_offset_cnt = 0;
       int m_offset_digits = 0;
-
-      // Workaround to get the 0x prefix where it should be
       do {
         m_offset /= 16;
         ++m_offset_cnt;
@@ -587,6 +586,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       char d[256];
       sprintf(d,"%s%s%s", m->desc, a? "/": "", m_desc_a);
 
+      // Print memory table content
       if(p->prog_modes & (PM_PDI | PM_UPDI)) {
         fprintf(f, "%s| %-*s  %*d  %*d  %*s0x%x |\n",
           prefix,
@@ -612,6 +612,7 @@ static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
   int var_tok_len[5] = {0};
 
   if(lsize(p->variants)) {
+    // Split variants strings into tokens and find their strlen
     for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln)) {
       sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
         var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]);
@@ -623,6 +624,7 @@ static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
       }
     }
 
+    // Print variants table header
     fprintf(f,
       "\n%s| %-*s  %-*s  %-*s  %-*s  %-*s |\n"
         "%s|-%*.*s--%*.*s--%*.*s--%*.*s--%*.*s-|\n",
@@ -639,6 +641,7 @@ static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
       var_tok_len[3]+2, var_tok_len[3]+2, table_padding,
       var_tok_len[4]+2, var_tok_len[4]+2, table_padding);
 
+    // Print variants table content
     for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln)) {
       sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
         var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]);

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -605,7 +605,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
   }
 }
 
-static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
+int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix) {
   const char *table_padding = "-------------------------------";
   const char *var_table_column[] = {"Variants", "Package", "F max", "T range", "V range"};
   char var_tok[5][50];
@@ -869,7 +869,7 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sProgramming modes       : %s\n", prefix, prog_modes_str(p->prog_modes));
 
   // Print variants table
-  avr_variants_display(prefix, f, p);
+  avr_variants_display(f, p, prefix);
 
   // Print memory table
   avr_mem_display(prefix, f, NULL, p, verbose);

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -536,7 +536,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
     // Print memory table header
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
       fprintf(f,
-        "\n%s %-*s  %-*s  %-*s  %*s \n"
+        "\n%s %-*s  %*s  %-*s  %*s \n"
         "%s-%*.*s--%*.*s--%*.*s--%*.*s-\n",
         prefix,
         m_char_max[0], table_colum[0],
@@ -550,7 +550,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
         m_char_max[3], m_char_max[3], table_padding);
     } else {
       fprintf(f,
-        "\n%s %-*s  %-*s  %-*s \n"
+        "\n%s %-*s  %*s  %-*s \n"
         "%s-%*.*s--%*.*s--%*.*s-\n",
         prefix,
         m_char_max[0], table_colum[0],

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -784,8 +784,6 @@ static char * reset_disp_str(int r)
 
 
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
-  char * buf;
-  const char * px;
   LNODEID ln;
   AVRMEM * m;
 
@@ -817,21 +815,12 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
     fprintf(f, "%sPollValue                     : 0x%02x\n", prefix, p->pollvalue);
   fprintf(  f, "%sMemory Detail                 :\n\n", prefix);
 
-  px = prefix;
-  buf = (char *) cfg_malloc("avr_display()", strlen(prefix) + 5);
-  strcpy(buf, prefix);
-  strcat(buf, "  ");
-  px = buf;
-
   avr_mem_display(prefix, f, NULL, p, verbose);
 
   for (ln=lfirst(p->mem); ln; ln=lnext(ln)) {
     m = ldata(ln);
     avr_mem_display(prefix, f, m, p, verbose);
   }
-
-  if (buf)
-    free(buf);
 }
 
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -599,13 +599,13 @@ int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix) {
     var_tok_len[i] = strlen(var_table_column[i]);
 
   if(lsize(p->variants)) {
-    // Split variants strings into tokens and find their strlen
+    // Split, eg, "ATtiny841-SSU:  SOIC14, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.7 V, 5.5 V]"
     for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln))
-      if(5 == sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
+      if(5 == sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=%48[^]]], Vcc=%48[^]]]",
         var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]))
         for(int i = 0; i < 5; i++)
-          if(var_tok_len[i] < (int)strlen(var_tok[i]))
-            var_tok_len[i] = strlen(var_tok[i]);
+          if(var_tok_len[i] < (int) strlen(var_tok[i]))
+            var_tok_len[i] = strlen(var_tok[i]) + (i>2); // Add 1 for closing interval bracket
 
     // Print variants table header
     fprintf(f,
@@ -615,27 +615,30 @@ int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix) {
       var_tok_len[0], var_table_column[0],
       var_tok_len[1], var_table_column[1],
       var_tok_len[2], var_table_column[2],
-      var_tok_len[3]+2, var_table_column[3],
-      var_tok_len[4]+2, var_table_column[4],
+      var_tok_len[3], var_table_column[3],
+      var_tok_len[4], var_table_column[4],
       prefix,
       var_tok_len[0], table_padding,
       var_tok_len[1], table_padding,
       var_tok_len[2], table_padding,
-      var_tok_len[3]+2, table_padding,
-      var_tok_len[4]+2, table_padding);
+      var_tok_len[3], table_padding,
+      var_tok_len[4], table_padding);
 
     // Print variants table content
     for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln))
-      if(5 == sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
-        var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]))
+      if(5 == sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=%48[^]]], Vcc=%48[^]]]",
+        var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4])) {
+        strcat(var_tok[3], "]");
+        strcat(var_tok[4], "]");
         fprintf(f,
-          "%s%-*s  %-*s  %-*s  [%-*s]  [%-*s]\n",
+          "%s%-*s  %-*s  %-*s  %-*s  %-*s\n",
           prefix,
           var_tok_len[0], var_tok[0],
           var_tok_len[1], var_tok[1],
           var_tok_len[2], var_tok[2],
           var_tok_len[3], var_tok[3],
           var_tok_len[4], var_tok[4]);
+      }
 
     return 0;
   }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -868,9 +868,6 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part                : %s\n", prefix, p->desc);
   fprintf(f, "%sProgramming modes       : %s\n", prefix, prog_modes_str(p->prog_modes));
 
-  // Print variants table
-  avr_variants_display(f, p, prefix);
-
   // Print memory table
   avr_mem_display(prefix, f, NULL, p, verbose);
   for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -863,8 +863,8 @@ static char *prog_modes_str(int pm) {
 
 
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
-  fprintf(f, "%sAVR Part                : %s\n", prefix, p->desc);
-  fprintf(f, "%sProgramming modes       : %s\n", prefix, prog_modes_str(p->prog_modes));
+  fprintf(f, "%sAVR Part              : %s\n", prefix, p->desc);
+  fprintf(f, "%sProgramming modes     : %s\n", prefix, prog_modes_str(p->prog_modes));
 
   if(verbose > 1) {
     avr_mem_display(f, p, prefix);

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -583,21 +583,21 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
 
       AVRMEM_ALIAS *a = avr_find_memalias(p, m);
       const char *m_desc_a = a? a->desc: "";
-      char d[256];
-      sprintf(d,"%s%s%s", m->desc, a? "/": "", m_desc_a);
+      char m_desc_str[256];
+      sprintf(m_desc_str,"%s%s%s", m->desc, a? "/": "", m_desc_a);
 
       // Print memory table content
       if(p->prog_modes & (PM_PDI | PM_UPDI)) {
         fprintf(f, "%s %-*s  %*d  %*d  %*s0x%x \n",
           prefix,
-          m_char_max[0], d,
+          m_char_max[0], m_desc_str,
           m_char_max[1] < 4? 4: m_char_max[1], m->size,
           m_char_max[2], m->page_size,
           m_char_max[3]-m_offset_digits, "", m->offset);
       } else {
         fprintf(f, "%s%-*s  %*d  %*d\n",
           prefix,
-          m_char_max[0], d,
+          m_char_max[0], m_desc_str,
           m_char_max[1] < 4? 4: m_char_max[1], m->size,
           m_char_max[2], m->page_size);
       }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -866,7 +866,10 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part                : %s\n", prefix, p->desc);
   fprintf(f, "%sProgramming modes       : %s\n", prefix, prog_modes_str(p->prog_modes));
 
-  avr_mem_display(f, p, prefix);
+  if(strlen(prefix) == 0 || verbose > 1) {
+    avr_mem_display(f, p, prefix);
+    avr_variants_display(f, p, prefix);
+  }
 }
 
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -537,27 +537,29 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
     }
 
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
-    fprintf(f,
-      "\n%s| %-*s | %-*s | Pg size | %-*s |\n"
-      "%s|-%*.*s-|-%*.*s-|---------|-%*.*s-|\n",
-      prefix,
-      m_desc_digits_max+1, "Memory",
-      m_size_digits_max, "Size",
-      m_offset_digits_max+2, "Offset",
-      prefix,
-      m_desc_digits_max+1, m_desc_digits_max+1, table_padding,
-      m_size_digits_max, m_size_digits_max, table_padding,
-      m_offset_digits_max+2, m_offset_digits_max+2, table_padding);
+      fprintf(f,
+        "\n%s| %-*s | %-*s | Pg size | %-*s |\n"
+        "%s|-%*.*s-|-%*.*s-|---------|-%*.*s-|\n",
+        prefix,
+        m_desc_digits_max+1, "Memory",
+        m_size_digits_max, "Size",
+        m_offset_digits_max+2, "Offset",
+        prefix,
+        m_desc_digits_max+1, m_desc_digits_max+1, table_padding,
+        m_size_digits_max, m_size_digits_max, table_padding,
+        m_offset_digits_max+2, m_offset_digits_max+2, table_padding);
     } else {
-    fprintf(f,
-      "\n%s| %-*s | %-*s | Pg size |\n"
-      "%s|-%*.*s-|-%*.*s-|---------|\n",
-      prefix,
-      m_desc_digits_max+1, "Memory",
-      m_size_digits_max, "Size",
-      prefix,
-      m_desc_digits_max+1, m_desc_digits_max+1, table_padding,
-      m_size_digits_max, m_size_digits_max, table_padding);
+      if(m_size_digits_max < 4)
+        m_size_digits_max = 4;
+      fprintf(f,
+        "\n%s| %-*s | %-*s | Pg size |\n"
+        "%s|-%*.*s-|-%*.*s-|---------|\n",
+        prefix,
+        m_desc_digits_max+1, "Memory",
+        m_size_digits_max, "Size",
+        prefix,
+        m_desc_digits_max+1, m_desc_digits_max+1, table_padding,
+        m_size_digits_max, m_size_digits_max, table_padding);
     }
   }
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -570,12 +570,14 @@ void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
 
     // Print memory table content
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
+      char *m_offset = print_num("0x%04x", m->offset);
       fprintf(f, "%s%-*s  %*d  %*d  %*s \n",
         prefix,
         m_char_max[0], m_desc_str,
         m_char_max[1], m->size,
         m_char_max[2], m->page_size,
-        m_char_max[3], print_num("0x%04x", m->offset));
+        m_char_max[3], m_offset);
+      free(m_offset);
     } else {
       fprintf(f, "%s%-*s  %*d  %*d\n",
         prefix,

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -501,7 +501,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
   static unsigned int prev_mem_offset;
   static int prev_mem_size;
   const char *table_padding = "-------------------------------";
-  static int m_desc_digits_max = strlen("Memory");
+  static int m_desc_digits_max;
   static int m_size_digits_max;
   static int m_offset_digits_max;
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -833,8 +833,6 @@ static char *prog_modes_str(int pm) {
   static char type[1024];
 
   strcpy(type, "0");
-  if(pm & PM_SPM)
-    strcat(type, ", SPM");
   if(pm & PM_TPI)
     strcat(type, ", TPI");
   if(pm & PM_ISP)
@@ -859,6 +857,8 @@ static char *prog_modes_str(int pm) {
     strcat(type, ", AVR32JTAG");
   if(pm & PM_aWire)
     strcat(type, ", aWire");
+  if(pm & PM_SPM)
+    strcat(type, ", SPM");
 
   return type + (type[1] == 0? 0: 3);
 }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -866,7 +866,7 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part              : %s\n", prefix, p->desc);
   fprintf(f, "%sProgramming modes     : %s\n", prefix, avr_prog_modes_str(p->prog_modes));
 
-  if(strlen(prefix) == 0 || verbose > 1) {
+  if(verbose > 1) {
     avr_mem_display(f, p, prefix);
     avr_variants_display(f, p, prefix);
   }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -510,7 +510,6 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       m = ldata(ln);
       int m_size[] = {0, m->size, m->page_size, m->offset};
       const int m_base[] = {0, 10, 10, 16};
-      int m_char_cnt[4] = {0};
 
       // Mem desc charcter length
       AVRMEM_ALIAS *a = avr_find_memalias(p, m);
@@ -532,34 +531,6 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
         if(m_char_max[i] < (int)strlen(table_colum[i]))
           m_char_max[i] = strlen(table_colum[i]);
       }
-/*
-      cnt = 0;
-      do {
-        m_size /= 10;
-        ++m_size_cnt;
-      } while (m_size != 0);
-      if(m_size_digits_max < m_size_cnt)
-        m_size_digits_max = m_size_cnt;
-      if(m_size_digits_max < (int)strlen(table_colum[1]))
-        m_size_digits_max = strlen(table_colum[1]);
-      // Mem pg size digits
-      do {
-        m_pgsize /= 10;
-        ++m_pgsize_cnt;
-      } while (m_pgsize != 0);
-      if(m_pgsize_digits_max < m_pgsize_cnt)
-        m_pgsize_digits_max = m_pgsize_cnt;
-      if(m_pgsize_digits_max < (int)strlen(table_colum[2]))
-        m_pgsize_digits_max = strlen(table_colum[2]);
-      // Mem offset digits
-      do {
-        m_offset /= 16;
-        ++m_offset_cnt;
-      } while (m_offset != 0);
-      if(m_offset_digits_max < m_offset_cnt)
-        m_offset_digits_max = m_offset_cnt;
-      if(m_offset_digits_max < (int)strlen(table_colum[3]))
-        m_offset_digits_max = strlen(table_colum[3]);*/
     }
     m_char_max[3] += strlen("0x");
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -538,7 +538,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
 
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
     fprintf(f,
-      "%s| %-*s | %-*s | Pg size | %-*s |\n"
+      "\n%s| %-*s | %-*s | Pg size | %-*s |\n"
       "%s|-%*.*s-|-%*.*s-|---------|-%*.*s-|\n",
       prefix,
       m_desc_digits_max+1, "Memory",
@@ -550,7 +550,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       m_offset_digits_max+2, m_offset_digits_max+2, table_padding);
     } else {
     fprintf(f,
-      "%s| %-*s | %-*s | Pg size |\n"
+      "\n%s| %-*s | %-*s | Pg size |\n"
       "%s|-%*.*s-|-%*.*s-|---------|\n",
       prefix,
       m_desc_digits_max+1, "Memory",
@@ -772,48 +772,46 @@ void sort_avrparts(LISTID avrparts)
   lsort(avrparts,(int (*)(void*, void*)) sort_avrparts_compare);
 }
 
+static char *prog_modes_str(int pm) {
+  static char type[1024];
 
-static char * reset_disp_str(int r)
-{
-  switch (r) {
-    case RESET_DEDICATED : return "dedicated";
-    case RESET_IO        : return "possible i/o";
-    default              : return "<invalid>";
-  }
+  strcpy(type, "0");
+  if(pm & PM_SPM)
+    strcat(type, " | PM_SPM");
+  if(pm & PM_TPI)
+    strcat(type, " | PM_TPI");
+  if(pm & PM_ISP)
+    strcat(type, " | PM_ISP");
+  if(pm & PM_PDI)
+    strcat(type, " | PM_PDI");
+  if(pm & PM_UPDI)
+    strcat(type, " | PM_UPDI");
+  if(pm & PM_HVSP)
+    strcat(type, " | PM_HVSP");
+  if(pm & PM_HVPP)
+    strcat(type, " | PM_HVPP");
+  if(pm & PM_debugWIRE)
+    strcat(type, " | PM_debugWIRE");
+  if(pm & PM_JTAG)
+    strcat(type, " | PM_JTAG");
+  if(pm & PM_JTAGmkI)
+    strcat(type, " | PM_JTAGmkI");
+  if(pm & PM_XMEGAJTAG)
+    strcat(type, " | PM_XMEGAJTAG");
+  if(pm & PM_AVR32JTAG)
+    strcat(type, " | PM_AVR32JTAG");
+  if(pm & PM_aWire)
+    strcat(type, " | PM_aWire");
+
+  return type + (type[1] == 0? 0: 4);
 }
-
 
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   LNODEID ln;
   AVRMEM * m;
 
-  fprintf(  f, "%sAVR Part                      : %s\n", prefix, p->desc);
-  if (p->chip_erase_delay)
-    fprintf(f, "%sChip Erase delay              : %d us\n", prefix, p->chip_erase_delay);
-  if (p->pagel)
-    fprintf(f, "%sPAGEL                         : P%02X\n", prefix, p->pagel);
-  if (p->bs2)
-    fprintf(f, "%sBS2                           : P%02X\n", prefix, p->bs2);
-  fprintf(  f, "%sRESET disposition             : %s\n", prefix, reset_disp_str(p->reset_disposition));
-  fprintf(  f, "%sRETRY pulse                   : %s\n", prefix, avr_pin_name(p->retry_pulse));
-  fprintf(  f, "%sSerial program mode           : %s\n", prefix, (p->flags & AVRPART_SERIALOK) ? "yes" : "no");
-  fprintf(  f, "%sParallel program mode         : %s\n", prefix, (p->flags & AVRPART_PARALLELOK) ?
-         ((p->flags & AVRPART_PSEUDOPARALLEL) ? "pseudo" : "yes") : "no");
-  if(p->timeout)
-    fprintf(f, "%sTimeout                       : %d\n", prefix, p->timeout);
-  if(p->stabdelay)
-    fprintf(f, "%sStabDelay                     : %d\n", prefix, p->stabdelay);
-  if(p->cmdexedelay)
-    fprintf(f, "%sCmdexeDelay                   : %d\n", prefix, p->cmdexedelay);
-  if(p->synchloops)
-    fprintf(f, "%sSyncLoops                     : %d\n", prefix, p->synchloops);
-  if(p->bytedelay)
-    fprintf(f, "%sByteDelay                     : %d\n", prefix, p->bytedelay);
-  if(p->pollindex)
-    fprintf(f, "%sPollIndex                     : %d\n", prefix, p->pollindex);
-  if(p->pollvalue)
-    fprintf(f, "%sPollValue                     : 0x%02x\n", prefix, p->pollvalue);
-  fprintf(  f, "%sMemory Detail                 :\n\n", prefix);
+  fprintf(f, "%sAVR Part                : %s\n", prefix, p->desc);
+  fprintf(f, "%sProgramming modes       : %s\n", prefix, prog_modes_str(p->prog_modes));
 
   avr_mem_display(prefix, f, NULL, p, verbose);
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -866,7 +866,7 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part                : %s\n", prefix, p->desc);
   fprintf(f, "%sProgramming modes       : %s\n", prefix, prog_modes_str(p->prog_modes));
 
-  if(strlen(prefix) == 0 || verbose > 1) {
+  if(verbose > 1) {
     avr_mem_display(f, p, prefix);
     avr_variants_display(f, p, prefix);
   }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -536,8 +536,8 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
     // Print memory table header
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
       fprintf(f,
-        "\n%s| %-*s  %-*s  %-*s  %*s |\n"
-        "%s|-%*.*s--%*.*s--%*.*s--%*.*s-|\n",
+        "\n%s %-*s  %-*s  %-*s  %*s \n"
+        "%s-%*.*s--%*.*s--%*.*s--%*.*s-\n",
         prefix,
         m_char_max[0], table_colum[0],
         m_char_max[1], table_colum[1],
@@ -550,8 +550,8 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
         m_char_max[3], m_char_max[3], table_padding);
     } else {
       fprintf(f,
-        "\n%s| %-*s  %-*s  %-*s |\n"
-        "%s|-%*.*s--%*.*s--%*.*s-|\n",
+        "\n%s %-*s  %-*s  %-*s \n"
+        "%s-%*.*s--%*.*s--%*.*s-\n",
         prefix,
         m_char_max[0], table_colum[0],
         m_char_max[1], table_colum[1],
@@ -588,14 +588,14 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
 
       // Print memory table content
       if(p->prog_modes & (PM_PDI | PM_UPDI)) {
-        fprintf(f, "%s| %-*s  %*d  %*d  %*s0x%x |\n",
+        fprintf(f, "%s %-*s  %*d  %*d  %*s0x%x \n",
           prefix,
           m_char_max[0], d,
           m_char_max[1] < 4? 4: m_char_max[1], m->size,
           m_char_max[2], m->page_size,
           m_char_max[3]-m_offset_digits, "", m->offset);
       } else {
-        fprintf(f, "%s| %-*s  %*d  %*d |\n",
+        fprintf(f, "%s %-*s  %*d  %*d \n",
           prefix,
           m_char_max[0], d,
           m_char_max[1] < 4? 4: m_char_max[1], m->size,
@@ -626,8 +626,8 @@ static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
 
     // Print variants table header
     fprintf(f,
-      "\n%s| %-*s  %-*s  %-*s  %-*s  %-*s |\n"
-        "%s|-%*.*s--%*.*s--%*.*s--%*.*s--%*.*s-|\n",
+      "\n%s %-*s  %-*s  %-*s  %-*s  %-*s \n"
+        "%s-%*.*s--%*.*s--%*.*s--%*.*s--%*.*s-\n",
       prefix,
       var_tok_len[0], var_table_column[0],
       var_tok_len[1], var_table_column[1],
@@ -646,7 +646,7 @@ static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
       sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
         var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]);
       fprintf(f,
-        "%s| %-*s  %-*s  %-*s  [%-*s]  [%-*s] |\n",
+        "%s %-*s  %-*s  %-*s  [%-*s]  [%-*s] \n",
         prefix,
         var_tok_len[0], var_tok[0],
         var_tok_len[1], var_tok[1],

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -496,74 +496,72 @@ AVRMEM_ALIAS *avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig) {
   return NULL;
 }
 
-void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
-                     const AVRPART *p, int verbose) {
-  static unsigned int prev_mem_offset;
-  static int prev_mem_size;
+void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
+  unsigned int prev_mem_offset = 0;
+  int prev_mem_size = 0;
   const char *table_colum[] = {"Memory", "Size", "Pg size", "Offset"};
   const char *table_padding = "-------------------------------";
-  static int m_char_max[4] = {0};
+  int m_char_max[4] = {0};
 
-  if (m == NULL) {
-    for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
-      m = ldata(ln);
-      int m_size[] = {0, m->size, m->page_size, m->offset};
-      const int m_base[] = {0, 10, 10, 16};
+  for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
+    AVRMEM *m = ldata(ln);
+    int m_size[] = {0, m->size, m->page_size, m->offset};
+    const int m_base[] = {0, 10, 10, 16};
 
-      // Mem desc charcter length
-      AVRMEM_ALIAS *a = avr_find_memalias(p, m);
-      const char *m_desc_a = a? a->desc: "";
-      int cnt = strlen(m->desc) + strlen(a? "/": "") + strlen(m_desc_a);
-      if(m_char_max[0] < cnt)
-        m_char_max[0] = cnt;
-      if(m_char_max[0] < (int)strlen(table_colum[0]))
-        m_char_max[0] = strlen(table_colum[0]);
-      // Mem size/pgsize/offset character length
-      for(int i = 1; i < 4; i++) {
-        cnt = 0;
-        do {
-          m_size[i] /= m_base[i];
-          ++cnt;
-        } while (m_size[i] != 0);
-        if(m_char_max[i] < cnt)
-          m_char_max[i] = cnt;
-        if(m_char_max[i] < (int)strlen(table_colum[i]))
-          m_char_max[i] = strlen(table_colum[i]);
-      }
-    }
-    m_char_max[3] += strlen("0x");
-
-    // Print memory table header
-    if(p->prog_modes & (PM_PDI | PM_UPDI)) {
-      fprintf(f,
-        "\n%s%-*s  %*s  %-*s  %*s\n"
-        "%s%*.*s--%*.*s--%*.*s--%*.*s\n",
-        prefix,
-        m_char_max[0], table_colum[0],
-        m_char_max[1], table_colum[1],
-        m_char_max[2], table_colum[2],
-        m_char_max[3], table_colum[3],
-        prefix,
-        m_char_max[0], m_char_max[0], table_padding,
-        m_char_max[1], m_char_max[1], table_padding,
-        m_char_max[2], m_char_max[2], table_padding,
-        m_char_max[3], m_char_max[3], table_padding);
-    } else {
-      fprintf(f,
-        "\n%s%-*s  %*s  %-*s\n"
-        "%s%*.*s--%*.*s--%*.*s\n",
-        prefix,
-        m_char_max[0], table_colum[0],
-        m_char_max[1], table_colum[1],
-        m_char_max[2], table_colum[2],
-        prefix,
-        m_char_max[0], m_char_max[0], table_padding,
-        m_char_max[1], m_char_max[1], table_padding,
-        m_char_max[2], m_char_max[2], table_padding);
+    // Mem desc charcter length
+    AVRMEM_ALIAS *a = avr_find_memalias(p, m);
+    const char *m_desc_a = a? a->desc: "";
+    int cnt = strlen(m->desc) + strlen(a? "/": "") + strlen(m_desc_a);
+    if(m_char_max[0] < cnt)
+      m_char_max[0] = cnt;
+    if(m_char_max[0] < (int)strlen(table_colum[0]))
+      m_char_max[0] = strlen(table_colum[0]);
+    // Mem size/pgsize/offset character length
+    for(int i = 1; i < 4; i++) {
+      cnt = 0;
+      do {
+        m_size[i] /= m_base[i];
+        ++cnt;
+      } while (m_size[i] != 0);
+      if(m_char_max[i] < cnt)
+        m_char_max[i] = cnt;
+      if(m_char_max[i] < (int)strlen(table_colum[i]))
+        m_char_max[i] = strlen(table_colum[i]);
     }
   }
+  m_char_max[3] += strlen("0x");
 
-  else {
+  // Print memory table header
+  if(p->prog_modes & (PM_PDI | PM_UPDI)) {
+    fprintf(f,
+      "\n%s%-*s  %*s  %-*s  %*s\n"
+      "%s%*.*s--%*.*s--%*.*s--%*.*s\n",
+      prefix,
+      m_char_max[0], table_colum[0],
+      m_char_max[1], table_colum[1],
+      m_char_max[2], table_colum[2],
+      m_char_max[3], table_colum[3],
+      prefix,
+      m_char_max[0], m_char_max[0], table_padding,
+      m_char_max[1], m_char_max[1], table_padding,
+      m_char_max[2], m_char_max[2], table_padding,
+      m_char_max[3], m_char_max[3], table_padding);
+  } else {
+    fprintf(f,
+      "\n%s%-*s  %*s  %-*s\n"
+      "%s%*.*s--%*.*s--%*.*s\n",
+      prefix,
+      m_char_max[0], table_colum[0],
+      m_char_max[1], table_colum[1],
+      m_char_max[2], table_colum[2],
+      prefix,
+      m_char_max[0], m_char_max[0], table_padding,
+      m_char_max[1], m_char_max[1], table_padding,
+      m_char_max[2], m_char_max[2], table_padding);
+  }
+
+  for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
+    AVRMEM *m = ldata(ln);
     // Only print memory section if the previous section printed isn't identical
     if(prev_mem_offset != m->offset || prev_mem_size != m->size || str_eq(p->family_id, "")) {
       prev_mem_offset = m->offset;
@@ -868,12 +866,7 @@ void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part                : %s\n", prefix, p->desc);
   fprintf(f, "%sProgramming modes       : %s\n", prefix, prog_modes_str(p->prog_modes));
 
-  // Print memory table
-  avr_mem_display(prefix, f, NULL, p, verbose);
-  for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
-    AVRMEM *m = ldata(ln);
-    avr_mem_display(prefix, f, m, p, verbose);
-  }
+  avr_mem_display(f, p, prefix);
 }
 
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -497,8 +497,6 @@ AVRMEM_ALIAS *avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig) {
 }
 
 void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
-  unsigned int prev_mem_offset = 0;
-  int prev_mem_size = 0;
   const char *table_colum[] = {"Memory", "Size", "Pg size", "Offset"};
   const char *table_padding = "-------------------------------";
   int m_char_max[4] = {0};
@@ -562,43 +560,38 @@ void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
 
   for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
     AVRMEM *m = ldata(ln);
-    // Only print memory section if the previous section printed isn't identical
-    if(prev_mem_offset != m->offset || prev_mem_size != m->size || str_eq(p->family_id, "")) {
-      prev_mem_offset = m->offset;
-      prev_mem_size = m->size;
 
-      // Workaround to get the 0x prefix where it should be
-      int m_offset = m->offset;
-      int m_offset_cnt = 0;
-      int m_offset_digits = 0;
-      do {
-        m_offset /= 16;
-        ++m_offset_cnt;
-      } while (m_offset != 0);
-      if(m_offset_digits < m_offset_cnt)
-        m_offset_digits = m_offset_cnt;
-      m_offset_digits += strlen("0x");
+    // Workaround to get the 0x prefix where it should be
+    int m_offset = m->offset;
+    int m_offset_cnt = 0;
+    int m_offset_digits = 0;
+    do {
+      m_offset /= 16;
+      ++m_offset_cnt;
+    } while (m_offset != 0);
+    if(m_offset_digits < m_offset_cnt)
+      m_offset_digits = m_offset_cnt;
+    m_offset_digits += strlen("0x");
 
-      AVRMEM_ALIAS *a = avr_find_memalias(p, m);
-      const char *m_desc_a = a? a->desc: "";
-      char m_desc_str[256];
-      sprintf(m_desc_str,"%s%s%s", m->desc, a? "/": "", m_desc_a);
+    AVRMEM_ALIAS *a = avr_find_memalias(p, m);
+    const char *m_desc_a = a? a->desc: "";
+    char m_desc_str[256];
+    sprintf(m_desc_str,"%s%s%s", m->desc, a? "/": "", m_desc_a);
 
-      // Print memory table content
-      if(p->prog_modes & (PM_PDI | PM_UPDI)) {
-        fprintf(f, "%s%-*s  %*d  %*d  %*s0x%x \n",
-          prefix,
-          m_char_max[0], m_desc_str,
-          m_char_max[1] < 4? 4: m_char_max[1], m->size,
-          m_char_max[2], m->page_size,
-          m_char_max[3]-m_offset_digits, "", m->offset);
-      } else {
-        fprintf(f, "%s%-*s  %*d  %*d\n",
-          prefix,
-          m_char_max[0], m_desc_str,
-          m_char_max[1] < 4? 4: m_char_max[1], m->size,
-          m_char_max[2], m->page_size);
-      }
+    // Print memory table content
+    if(p->prog_modes & (PM_PDI | PM_UPDI)) {
+      fprintf(f, "%s%-*s  %*d  %*d  %*s0x%x \n",
+        prefix,
+        m_char_max[0], m_desc_str,
+        m_char_max[1] < 4? 4: m_char_max[1], m->size,
+        m_char_max[2], m->page_size,
+        m_char_max[3]-m_offset_digits, "", m->offset);
+    } else {
+      fprintf(f, "%s%-*s  %*d  %*d\n",
+        prefix,
+        m_char_max[0], m_desc_str,
+        m_char_max[1] < 4? 4: m_char_max[1], m->size,
+        m_char_max[2], m->page_size);
     }
   }
 }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -511,7 +511,11 @@ static int num_len(const char *fmt, int n) {
 void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
   const char *table_colum[] = {"Memory", "Size", "Pg size", "Offset"};
   const char *table_padding = "-------------------------------";
-  int m_char_max[4] = {0};
+  const int memory_col = 0, offset_col = 3;
+  int m_char_max[4];
+
+  for(int i = 0; i < 4; i++)
+    m_char_max[i] = strlen(table_colum[i]);
 
   for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
     AVRMEM *m = ldata(ln);
@@ -521,14 +525,11 @@ void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
     AVRMEM_ALIAS *a = avr_find_memalias(p, m);
     int len;
     for(int i = 0; i < 4; i++) {
-      if(!m_size[i])
-        len = strlen(m->desc) + strlen(a? "/": "") + strlen(a? a->desc: ""); // desc
-      else
-        len = num_len(str_eq(table_colum[i], "Offset")? "0x%04x": "%d", m_size[i]); // size/pgsize/offset
+      len = i == memory_col?
+        (int) (strlen(m->desc) + strlen(a? "/": "") + strlen(a? a->desc: "")): // desc
+        num_len(i == offset_col? "0x%04x": "%d", m_size[i]); // size/pgsize/offset
       if(m_char_max[i] < len)
         m_char_max[i] = len;
-      if(m_char_max[i] < (int)strlen(table_colum[i]))
-        m_char_max[i] = strlen(table_colum[i]);
     }
   }
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -500,6 +500,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
                      const AVRPART *p, int verbose) {
   static unsigned int prev_mem_offset;
   static int prev_mem_size;
+  const char *table_colum[] = {"Memory", "Size", "Pg size", "Offset"};
   const char *table_padding = "-------------------------------";
   static int m_desc_digits_max;
   static int m_size_digits_max;
@@ -520,6 +521,8 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       m_desc_cnt = strlen(m->desc) + strlen(m_desc_a);
       if(m_desc_digits_max < m_desc_cnt)
         m_desc_digits_max = m_desc_cnt;
+      if(m_desc_digits_max < (int)strlen(table_colum[0]))
+        m_desc_digits_max = strlen(table_colum[0]);
       // Mem size digits
       do {
         m_size /= 10;
@@ -527,6 +530,8 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       } while (m_size != 0);
       if(m_size_digits_max < m_size_cnt)
         m_size_digits_max = m_size_cnt;
+      if(m_size_digits_max < (int)strlen(table_colum[1]))
+        m_size_digits_max = strlen(table_colum[1]);
       // Mem offset digits
       do {
         m_offset /= 16;
@@ -534,29 +539,31 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       } while (m_offset != 0);
       if(m_offset_digits_max < m_offset_cnt)
         m_offset_digits_max = m_offset_cnt;
+      if(m_offset_digits_max < (int)strlen(table_colum[3]))
+        m_offset_digits_max = strlen(table_colum[3]);
     }
 
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
       fprintf(f,
-        "\n%s| %-*s | %-*s | Pg size | %-*s |\n"
+        "\n%s| %-*s | %-*s | %s | %-*s |\n"
         "%s|-%*.*s-|-%*.*s-|---------|-%*.*s-|\n",
         prefix,
-        m_desc_digits_max+1, "Memory",
-        m_size_digits_max, "Size",
-        m_offset_digits_max+2, "Offset",
+        m_desc_digits_max+1, table_colum[0],
+        m_size_digits_max, table_colum[1],
+        table_colum[2],
+        m_offset_digits_max+2, table_colum[3],
         prefix,
         m_desc_digits_max+1, m_desc_digits_max+1, table_padding,
         m_size_digits_max, m_size_digits_max, table_padding,
         m_offset_digits_max+2, m_offset_digits_max+2, table_padding);
     } else {
-      if(m_size_digits_max < 4)
-        m_size_digits_max = 4;
       fprintf(f,
-        "\n%s| %-*s | %-*s | Pg size |\n"
+        "\n%s| %-*s | %-*s | %s |\n"
         "%s|-%*.*s-|-%*.*s-|---------|\n",
         prefix,
-        m_desc_digits_max+1, "Memory",
-        m_size_digits_max, "Size",
+        m_desc_digits_max+1, table_colum[0],
+        m_size_digits_max, table_colum[1],
+        table_colum[2],
         prefix,
         m_desc_digits_max+1, m_desc_digits_max+1, table_padding,
         m_size_digits_max, m_size_digits_max, table_padding);

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -536,8 +536,8 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
     // Print memory table header
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
       fprintf(f,
-        "\n%s %-*s  %*s  %-*s  %*s \n"
-        "%s-%*.*s--%*.*s--%*.*s--%*.*s-\n",
+        "\n%s%-*s  %*s  %-*s  %*s\n"
+        "%s%*.*s--%*.*s--%*.*s--%*.*s\n",
         prefix,
         m_char_max[0], table_colum[0],
         m_char_max[1], table_colum[1],
@@ -550,8 +550,8 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
         m_char_max[3], m_char_max[3], table_padding);
     } else {
       fprintf(f,
-        "\n%s %-*s  %*s  %-*s \n"
-        "%s-%*.*s--%*.*s--%*.*s-\n",
+        "\n%s%-*s  %*s  %-*s\n"
+        "%s%*.*s--%*.*s--%*.*s\n",
         prefix,
         m_char_max[0], table_colum[0],
         m_char_max[1], table_colum[1],
@@ -595,7 +595,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
           m_char_max[2], m->page_size,
           m_char_max[3]-m_offset_digits, "", m->offset);
       } else {
-        fprintf(f, "%s %-*s  %*d  %*d \n",
+        fprintf(f, "%s%-*s  %*d  %*d\n",
           prefix,
           m_char_max[0], d,
           m_char_max[1] < 4? 4: m_char_max[1], m->size,
@@ -626,8 +626,8 @@ static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
 
     // Print variants table header
     fprintf(f,
-      "\n%s %-*s  %-*s  %-*s  %-*s  %-*s \n"
-        "%s-%*.*s--%*.*s--%*.*s--%*.*s--%*.*s-\n",
+      "\n%s%-*s  %-*s  %-*s  %-*s  %-*s\n"
+        "%s%*.*s--%*.*s--%*.*s--%*.*s--%*.*s\n",
       prefix,
       var_tok_len[0], var_table_column[0],
       var_tok_len[1], var_table_column[1],
@@ -646,7 +646,7 @@ static int avr_variants_display(const char *prefix, FILE *f, const AVRPART *p) {
       sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
         var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]);
       fprintf(f,
-        "%s %-*s  %-*s  %-*s  [%-*s]  [%-*s] \n",
+        "%s%-*s  %-*s  %-*s  [%-*s]  [%-*s]\n",
         prefix,
         var_tok_len[0], var_tok[0],
         var_tok_len[1], var_tok[1],

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -588,7 +588,7 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
 
       // Print memory table content
       if(p->prog_modes & (PM_PDI | PM_UPDI)) {
-        fprintf(f, "%s %-*s  %*d  %*d  %*s0x%x \n",
+        fprintf(f, "%s%-*s  %*d  %*d  %*s0x%x \n",
           prefix,
           m_char_max[0], m_desc_str,
           m_char_max[1] < 4? 4: m_char_max[1], m->size,

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -523,9 +523,8 @@ void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
 
     // Mem desc/size/pgsize/offset string length
     AVRMEM_ALIAS *a = avr_find_memalias(p, m);
-    int len;
     for(int i = 0; i < 4; i++) {
-      len = i == memory_col?
+      int len = i == memory_col?
         (int) (strlen(m->desc) + strlen(a? "/": "") + strlen(a? a->desc: "")): // desc
         num_len(i == offset_col? "0x%04x": "%d", m_size[i]); // size/pgsize/offset
       if(m_char_max[i] < len)
@@ -537,29 +536,29 @@ void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
   if(p->prog_modes & (PM_PDI | PM_UPDI)) {
     fprintf(f,
       "\n%s%-*s  %*s  %-*s  %*s\n"
-      "%s%*.*s--%*.*s--%*.*s--%*.*s\n",
+      "%s%.*s--%.*s--%.*s--%.*s\n",
       prefix,
       m_char_max[0], table_colum[0],
       m_char_max[1], table_colum[1],
       m_char_max[2], table_colum[2],
       m_char_max[3], table_colum[3],
       prefix,
-      m_char_max[0], m_char_max[0], table_padding,
-      m_char_max[1], m_char_max[1], table_padding,
-      m_char_max[2], m_char_max[2], table_padding,
-      m_char_max[3], m_char_max[3], table_padding);
+      m_char_max[0], table_padding,
+      m_char_max[1], table_padding,
+      m_char_max[2], table_padding,
+      m_char_max[3], table_padding);
   } else {
     fprintf(f,
       "\n%s%-*s  %*s  %-*s\n"
-      "%s%*.*s--%*.*s--%*.*s\n",
+      "%s%.*s--%.*s--%.*s\n",
       prefix,
       m_char_max[0], table_colum[0],
       m_char_max[1], table_colum[1],
       m_char_max[2], table_colum[2],
       prefix,
-      m_char_max[0], m_char_max[0], table_padding,
-      m_char_max[1], m_char_max[1], table_padding,
-      m_char_max[2], m_char_max[2], table_padding);
+      m_char_max[0], table_padding,
+      m_char_max[1], table_padding,
+      m_char_max[2], table_padding);
   }
 
   for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
@@ -594,25 +593,24 @@ int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix) {
   const char *table_padding = "-------------------------------";
   const char *var_table_column[] = {"Variants", "Package", "F max", "T range", "V range"};
   char var_tok[5][50];
-  int var_tok_len[5] = {0};
+  int var_tok_len[5];
+
+  for(int i = 0; i < 5; i++)
+    var_tok_len[i] = strlen(var_table_column[i]);
 
   if(lsize(p->variants)) {
     // Split variants strings into tokens and find their strlen
-    for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln)) {
-      sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
-        var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]);
-      for(int i = 0; i < 5; i++) {
-        if(var_tok_len[i] < (int)strlen(var_tok[i]))
-          var_tok_len[i] = strlen(var_tok[i]);
-        if(var_tok_len[i] < (int)strlen(var_table_column[i]))
-          var_tok_len[i] = strlen(var_table_column[i]);
-      }
-    }
+    for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln))
+      if(5 == sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
+        var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]))
+        for(int i = 0; i < 5; i++)
+          if(var_tok_len[i] < (int)strlen(var_tok[i]))
+            var_tok_len[i] = strlen(var_tok[i]);
 
     // Print variants table header
     fprintf(f,
       "\n%s%-*s  %-*s  %-*s  %-*s  %-*s\n"
-        "%s%*.*s--%*.*s--%*.*s--%*.*s--%*.*s\n",
+        "%s%.*s--%.*s--%.*s--%.*s--%.*s\n",
       prefix,
       var_tok_len[0], var_table_column[0],
       var_tok_len[1], var_table_column[1],
@@ -620,25 +618,25 @@ int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix) {
       var_tok_len[3]+2, var_table_column[3],
       var_tok_len[4]+2, var_table_column[4],
       prefix,
-      var_tok_len[0], var_tok_len[0], table_padding,
-      var_tok_len[1], var_tok_len[1], table_padding,
-      var_tok_len[2], var_tok_len[2], table_padding,
-      var_tok_len[3]+2, var_tok_len[3]+2, table_padding,
-      var_tok_len[4]+2, var_tok_len[4]+2, table_padding);
+      var_tok_len[0], table_padding,
+      var_tok_len[1], table_padding,
+      var_tok_len[2], table_padding,
+      var_tok_len[3]+2, table_padding,
+      var_tok_len[4]+2, table_padding);
 
     // Print variants table content
-    for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln)) {
-      sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
-        var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]);
-      fprintf(f,
-        "%s%-*s  %-*s  %-*s  [%-*s]  [%-*s]\n",
-        prefix,
-        var_tok_len[0], var_tok[0],
-        var_tok_len[1], var_tok[1],
-        var_tok_len[2], var_tok[2],
-        var_tok_len[3], var_tok[3],
-        var_tok_len[4], var_tok[4]);
-    }
+    for(LNODEID ln=lfirst(p->variants); ln; ln=lnext(ln))
+      if(5 == sscanf(ldata(ln), "%49[^:]: %49[^,], Fmax=%49[^,], T=[%49[^]]], Vcc=[%49[^]]]",
+        var_tok[0], var_tok[1], var_tok[2], var_tok[3], var_tok[4]))
+        fprintf(f,
+          "%s%-*s  %-*s  %-*s  [%-*s]  [%-*s]\n",
+          prefix,
+          var_tok_len[0], var_tok[0],
+          var_tok_len[1], var_tok[1],
+          var_tok_len[2], var_tok[2],
+          var_tok_len[3], var_tok[3],
+          var_tok_len[4], var_tok[4]);
+
     return 0;
   }
   return -1;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -837,33 +837,33 @@ static char *prog_modes_str(int pm) {
 
   strcpy(type, "0");
   if(pm & PM_SPM)
-    strcat(type, " | PM_SPM");
+    strcat(type, ", SPM");
   if(pm & PM_TPI)
-    strcat(type, " | PM_TPI");
+    strcat(type, ", TPI");
   if(pm & PM_ISP)
-    strcat(type, " | PM_ISP");
+    strcat(type, ", ISP");
   if(pm & PM_PDI)
-    strcat(type, " | PM_PDI");
+    strcat(type, ", PDI");
   if(pm & PM_UPDI)
-    strcat(type, " | PM_UPDI");
+    strcat(type, ", UPDI");
   if(pm & PM_HVSP)
-    strcat(type, " | PM_HVSP");
+    strcat(type, ", HVSP");
   if(pm & PM_HVPP)
-    strcat(type, " | PM_HVPP");
+    strcat(type, ", HVPP");
   if(pm & PM_debugWIRE)
-    strcat(type, " | PM_debugWIRE");
+    strcat(type, ", debugWIRE");
   if(pm & PM_JTAG)
-    strcat(type, " | PM_JTAG");
+    strcat(type, ", JTAG");
   if(pm & PM_JTAGmkI)
-    strcat(type, " | PM_JTAGmkI");
+    strcat(type, ", JTAGmkI");
   if(pm & PM_XMEGAJTAG)
-    strcat(type, " | PM_XMEGAJTAG");
+    strcat(type, ", XMEGAJTAG");
   if(pm & PM_AVR32JTAG)
-    strcat(type, " | PM_AVR32JTAG");
+    strcat(type, ", AVR32JTAG");
   if(pm & PM_aWire)
-    strcat(type, " | PM_aWire");
+    strcat(type, ", aWire");
 
-  return type + (type[1] == 0? 0: 4);
+  return type + (type[1] == 0? 0: 3);
 }
 
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -502,31 +502,38 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
   static int prev_mem_size;
   const char *table_colum[] = {"Memory", "Size", "Pg size", "Offset"};
   const char *table_padding = "-------------------------------";
-  static int m_desc_digits_max;
-  static int m_size_digits_max;
-  static int m_pgsize_digits_max;
-  static int m_offset_digits_max;
+  static int m_char_max[4] = {0};
+
 
   if (m == NULL) {
     for (LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
       m = ldata(ln);
-      int m_size = m->size;
-      int m_pg_size = m->page_size;
-      int m_offset = m->offset;
-      int m_desc_cnt = 0;
-      int m_size_cnt = 0;
-      int m_pg_size_cnt = 0;
-      int m_offset_cnt = 0;
+      int m_size[] = {0, m->size, m->page_size, m->offset};
+      const int m_base[] = {0, 10, 10, 16};
+      int m_char_cnt[4] = {0};
 
-      // Mem desc digits
+      // Mem desc charcter length
       AVRMEM_ALIAS *a = avr_find_memalias(p, m);
       const char *m_desc_a = a? a->desc: "";
-      m_desc_cnt = strlen(m->desc) + strlen(a? "/": "") + strlen(m_desc_a);
-      if(m_desc_digits_max < m_desc_cnt)
-        m_desc_digits_max = m_desc_cnt;
-      if(m_desc_digits_max < (int)strlen(table_colum[0]))
-        m_desc_digits_max = strlen(table_colum[0]);
-      // Mem size digits
+      int cnt = strlen(m->desc) + strlen(a? "/": "") + strlen(m_desc_a);
+      if(m_char_max[0] < cnt)
+        m_char_max[0] = cnt;
+      if(m_char_max[0] < (int)strlen(table_colum[0]))
+        m_char_max[0] = strlen(table_colum[0]);
+      // Mem size/pgsize/offset character length
+      for(int i = 1; i < 4; i++) {
+        cnt = 0;
+        do {
+          m_size[i] /= m_base[i];
+          ++cnt;
+        } while (m_size[i] != 0);
+        if(m_char_max[i] < cnt)
+          m_char_max[i] = cnt;
+        if(m_char_max[i] < (int)strlen(table_colum[i]))
+          m_char_max[i] = strlen(table_colum[i]);
+      }
+/*
+      cnt = 0;
       do {
         m_size /= 10;
         ++m_size_cnt;
@@ -537,11 +544,11 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
         m_size_digits_max = strlen(table_colum[1]);
       // Mem pg size digits
       do {
-        m_pg_size /= 10;
-        ++m_pg_size_cnt;
-      } while (m_pg_size != 0);
-      if(m_pgsize_digits_max < m_pg_size_cnt)
-        m_pgsize_digits_max = m_pg_size_cnt;
+        m_pgsize /= 10;
+        ++m_pgsize_cnt;
+      } while (m_pgsize != 0);
+      if(m_pgsize_digits_max < m_pgsize_cnt)
+        m_pgsize_digits_max = m_pgsize_cnt;
       if(m_pgsize_digits_max < (int)strlen(table_colum[2]))
         m_pgsize_digits_max = strlen(table_colum[2]);
       // Mem offset digits
@@ -552,36 +559,36 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       if(m_offset_digits_max < m_offset_cnt)
         m_offset_digits_max = m_offset_cnt;
       if(m_offset_digits_max < (int)strlen(table_colum[3]))
-        m_offset_digits_max = strlen(table_colum[3]);
+        m_offset_digits_max = strlen(table_colum[3]);*/
     }
-    m_offset_digits_max += strlen("0x");
+    m_char_max[3] += strlen("0x");
 
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {
       fprintf(f,
         "\n%s| %-*s  %-*s  %-*s  %*s |\n"
         "%s|-%*.*s--%*.*s--%*.*s--%*.*s-|\n",
         prefix,
-        m_desc_digits_max, table_colum[0],
-        m_size_digits_max, table_colum[1],
-        m_pgsize_digits_max, table_colum[2],
-        m_offset_digits_max, table_colum[3],
+        m_char_max[0], table_colum[0],
+        m_char_max[1], table_colum[1],
+        m_char_max[2], table_colum[2],
+        m_char_max[3], table_colum[3],
         prefix,
-        m_desc_digits_max, m_desc_digits_max, table_padding,
-        m_size_digits_max, m_size_digits_max, table_padding,
-        m_pgsize_digits_max, m_pgsize_digits_max, table_padding,
-        m_offset_digits_max, m_offset_digits_max, table_padding);
+        m_char_max[0], m_char_max[0], table_padding,
+        m_char_max[1], m_char_max[1], table_padding,
+        m_char_max[2], m_char_max[2], table_padding,
+        m_char_max[3], m_char_max[3], table_padding);
     } else {
       fprintf(f,
         "\n%s| %-*s  %-*s  %-*s |\n"
         "%s|-%*.*s--%*.*s--%*.*s-|\n",
         prefix,
-        m_desc_digits_max, table_colum[0],
-        m_size_digits_max, table_colum[1],
-        m_pgsize_digits_max, table_colum[2],
+        m_char_max[0], table_colum[0],
+        m_char_max[1], table_colum[1],
+        m_char_max[2], table_colum[2],
         prefix,
-        m_desc_digits_max, m_desc_digits_max, table_padding,
-        m_size_digits_max, m_size_digits_max, table_padding,
-        m_pgsize_digits_max, m_pgsize_digits_max, table_padding);
+        m_char_max[0], m_char_max[0], table_padding,
+        m_char_max[1], m_char_max[1], table_padding,
+        m_char_max[2], m_char_max[2], table_padding);
     }
   }
 
@@ -612,16 +619,16 @@ void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
       if(p->prog_modes & (PM_PDI | PM_UPDI)) {
         fprintf(f, "%s| %-*s  %*d  %*d  %*s0x%x |\n",
           prefix,
-          m_desc_digits_max, d,
-          m_size_digits_max < 4? 4: m_size_digits_max, m->size,
-          m_pgsize_digits_max, m->page_size,
-          m_offset_digits_max-m_offset_digits, "", m->offset);
+          m_char_max[0], d,
+          m_char_max[1] < 4? 4: m_char_max[1], m->size,
+          m_char_max[2], m->page_size,
+          m_char_max[3]-m_offset_digits, "", m->offset);
       } else {
         fprintf(f, "%s| %-*s  %*d  %*d |\n",
           prefix,
-          m_desc_digits_max, d,
-          m_size_digits_max < 4? 4: m_size_digits_max, m->size,
-          m_pgsize_digits_max, m->page_size);
+          m_char_max[0], d,
+          m_char_max[1] < 4? 4: m_char_max[1], m->size,
+          m_char_max[2], m->page_size);
       }
     }
   }

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -827,7 +827,7 @@ void sort_avrparts(LISTID avrparts)
   lsort(avrparts,(int (*)(void*, void*)) sort_avrparts_compare);
 }
 
-static char *prog_modes_str(int pm) {
+const char *avr_prog_modes_str(int pm) {
   static char type[1024];
 
   strcpy(type, "0");
@@ -864,9 +864,9 @@ static char *prog_modes_str(int pm) {
 
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part              : %s\n", prefix, p->desc);
-  fprintf(f, "%sProgramming modes     : %s\n", prefix, prog_modes_str(p->prog_modes));
+  fprintf(f, "%sProgramming modes     : %s\n", prefix, avr_prog_modes_str(p->prog_modes));
 
-  if(verbose > 1) {
+  if(strlen(prefix) == 0 || verbose > 1) {
     avr_mem_display(f, p, prefix);
     avr_variants_display(f, p, prefix);
   }

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2412,9 +2412,9 @@ printed, too.
 Display the device signature bytes.
 
 @item part
-Display the current part information. Includes chip specific information
-including supported programming modes, memory and variants tables. Use @var{-m}
-to only print the memory table, and @var{-v} to only print the variants table.
+Display the current part information, including supported programming modes,
+memory and variants tables. Use @var{-m} to only print the memory table,
+and @var{-v} to only print the variants table.
 
 @item verbose [@var{level}]
 Change (when @var{level} is provided), or display the verbosity

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2412,9 +2412,9 @@ printed, too.
 Display the device signature bytes.
 
 @item part
-Display the current part settings and parameters.  Includes chip
-specific information including all memories supported by the
-device, read/write timing, etc.
+Display the current part information. Includes chip specific information
+including supported programming modes, memory and variants tables. Use @var{-m}
+to only print the memory table, and @var{-v} to only print the variants table.
 
 @item verbose [@var{level}]
 Change (when @var{level} is provided), or display the verbosity

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -953,7 +953,7 @@ static void ft245r_close(PROGRAMMER * pgm) {
 }
 
 static void ft245r_display(const PROGRAMMER *pgm, const char *p) {
-    msg_info("%sPin assignment  : 0..7 = DBUS0..7\n", p); // , 8..11 = GPIO0..3\n",p);
+    msg_info("%sPin assignment        : 0..7 = DBUS0..7\n", p); // , 8..11 = GPIO0..3\n",p);
     pgm_display_generic_mask(pgm, p, SHOW_ALL_PINS);
 }
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1742,7 +1742,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port) {
     /* The event EP has been deleted by usb_open(), so we are
        running on a CMSIS-DAP device, using EDBG protocol */
     pgm->flag |= PGM_FL_IS_EDBG;
-    pmsg_notice("found CMSIS-DAP compliant device, using EDBG protocol\n");
+    pmsg_notice2("found CMSIS-DAP compliant device, using EDBG protocol\n");
   }
 
   // Make USB serial number available to programmer
@@ -2595,11 +2595,10 @@ void jtag3_display(const PROGRAMMER *pgm, const char *p) {
     resp[status - 3] = 0;
     sn = (const char*)resp;
   }
-
-  msg_info("%sICE HW version  : %d\n", p, parms[0]);
-  msg_info("%sICE FW version  : %d.%02d (rel. %d)\n", p, parms[1], parms[2],
-           (parms[3] | (parms[4] << 8)));
-  msg_info("%sSerial number   : %s\n", p, sn);
+  msg_info("%sICE HW version        : %d\n", p, parms[0]);
+  msg_info("%sICE FW version        : %d.%02d (rel. %d)\n",
+    p, parms[1], parms[2], (parms[3] | (parms[4] << 8)));
+  msg_info("%sSerial number         : %s\n", p, sn);
   free(resp);
 }
 
@@ -2611,7 +2610,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
   if (pgm->extra_features & HAS_VTARG_READ) {
     if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
       return;
-    msg_info("%sVtarget         : %.2f V\n", p, b2_to_u16(buf)/1000.0);
+    msg_info("%sVtarget               : %.2f V\n", p, b2_to_u16(buf)/1000.0);
   }
 
   // Print clocks if programmer type is not TPI
@@ -2626,24 +2625,24 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
         if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_JTAG, buf, 2) < 0)
           return;
         if (b2_to_u16(buf) > 0)
-          fmsg_out(fp, "%sJTAG clk Xmega  : %u kHz\n", p, b2_to_u16(buf));
+          fmsg_out(fp, "%sJTAG clk Xmega        : %u kHz\n", p, b2_to_u16(buf));
       } else {
         if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_PROG, buf, 2) < 0)
           return;
         if (b2_to_u16(buf) > 0)
-          fmsg_out(fp, "%sJTAG clk prog.  : %u kHz\n", p, b2_to_u16(buf));
+          fmsg_out(fp, "%sJTAG clk prog.        : %u kHz\n", p, b2_to_u16(buf));
 
         if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_DEBUG, buf, 2) < 0)
           return;
         if (b2_to_u16(buf) > 0)
-          fmsg_out(fp, "%sJTAG clk debug  : %u kHz\n", p, b2_to_u16(buf));
+          fmsg_out(fp, "%sJTAG clk debug        : %u kHz\n", p, b2_to_u16(buf));
       }
     }
     else if (prog_mode[0] == PARM3_CONN_PDI || prog_mode[0] == PARM3_CONN_UPDI) {
       if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_PDI, buf, 2) < 0)
         return;
       if (b2_to_u16(buf) > 0)
-        fmsg_out(fp, "%sPDI/UPDI clk    : %u kHz\n", p, b2_to_u16(buf));
+        fmsg_out(fp, "%sPDI/UPDI clk          : %u kHz\n", p, b2_to_u16(buf));
     }
   }
 
@@ -2656,7 +2655,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
         return;
       analog_raw_data = b2_to_u16(buf);
-      fmsg_out(fp, "%sVout set        : %.2f V\n", p, analog_raw_data / 1000.0);
+      fmsg_out(fp, "%sVout set              : %.2f V\n", p, analog_raw_data / 1000.0);
 
       // Read measured generator voltage value (VOUT)
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_TSUP_VOLTAGE_MEAS, buf, 2) < 0)
@@ -2667,7 +2666,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sVout measured   : %.02f V\n", p, analog_raw_data / -200.0);
+        fmsg_out(fp, "%sVout measured         : %.02f V\n", p, analog_raw_data / -200.0);
       }
 
       // Read channel A voltage
@@ -2679,7 +2678,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh A voltage    : %.03f V\n", p, analog_raw_data / -200.0);
+        fmsg_out(fp, "%sCh A voltage          : %.03f V\n", p, analog_raw_data / -200.0);
       }
 
       // Read channel A current
@@ -2689,7 +2688,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       if (buf[0] != 0x90)
         pmsg_error("invalid PARM3_ANALOG_A_CURRENT data packet format\n");
       else
-        fmsg_out(fp, "%sCh A current    : %.3f mA\n", p, analog_raw_data * 0.003472);
+        fmsg_out(fp, "%sCh A current          : %.3f mA\n", p, analog_raw_data * 0.003472);
 
       // Read channel B voltage
       if (jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_ANALOG_B_VOLTAGE, buf, 2) < 0)
@@ -2700,7 +2699,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh B voltage    : %.03f V\n", p, analog_raw_data / -200.0);
+        fmsg_out(fp, "%sCh B voltage          : %.03f V\n", p, analog_raw_data / -200.0);
       }
 
       // Read channel B current
@@ -2712,7 +2711,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
       else {
         if (analog_raw_data & 0x0800)
           analog_raw_data |= 0xF000;
-        fmsg_out(fp, "%sCh B current    : %.3f mA\n", p, analog_raw_data * 0.555556);
+        fmsg_out(fp, "%sCh B current          : %.3f mA\n", p, analog_raw_data * 0.555556);
       }
       break;
     }

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -1162,9 +1162,8 @@ static void jtagmkI_display(const PROGRAMMER *pgm, const char *p) {
   if (jtagmkI_getparm(pgm, PARM_HW_VERSION, &hw) < 0 ||
       jtagmkI_getparm(pgm, PARM_SW_VERSION, &fw) < 0)
     return;
-
-  msg_info("%sICE HW version: 0x%02x\n", p, hw);
-  msg_info("%sICE FW version: 0x%02x\n", p, fw);
+  msg_info("%sICE HW version          : 0x%02x\n", p, hw);
+  msg_info("%sICE FW version          : 0x%02x\n", p, fw);
 
   jtagmkI_print_parms1(pgm, p, stderr);
 
@@ -1209,9 +1208,9 @@ static void jtagmkI_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp)
   if (pgm->extra_features & HAS_VTARG_READ) {
     if (jtagmkI_getparm(pgm, PARM_OCD_VTARGET, &vtarget) < 0)
       return;
-    fmsg_out(fp, "%sVtarget       : %.1f V\n", p, 6.25 * (unsigned)vtarget / 255.0);
+    fmsg_out(fp, "%sVtarget               : %.1f V\n", p, 6.25 * (unsigned)vtarget / 255.0);
   }
-  fmsg_out(fp, "%sJTAG clock    : %s (%.1f us)\n", p, clkstr, 1.0e6 / clk);
+  fmsg_out(fp, "%sJTAG clock            : %s (%.1f us)\n", p, clkstr, 1.0e6 / clk);
 
   return;
 }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -679,28 +679,28 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
 	hwver = (unsigned)resp[9];
 	memcpy(PDATA(pgm)->serno, resp + 10, 6);
 	if (status > 17) {
-	  msg_notice("JTAG ICE mkII sign-on message:\n");
-	  msg_notice("Communications protocol version: %u\n",
+	  imsg_notice2("JTAG ICE mkII sign-on message:\n");
+	  imsg_notice2("Communications protocol version: %u\n",
 		  (unsigned)resp[1]);
-	  msg_notice("M_MCU:\n");
-	  msg_notice("  boot-loader FW version:        %u\n",
+	  imsg_notice2("M_MCU:\n");
+	  imsg_notice2("  boot-loader FW version:        %u\n",
 		  (unsigned)resp[2]);
-	  msg_notice("  firmware version:              %u.%02u\n",
+	  imsg_notice2("  firmware version:              %u.%02u\n",
 		  (unsigned)resp[4], (unsigned)resp[3]);
-	  msg_notice("  hardware version:              %u\n",
+	  imsg_notice2("  hardware version:              %u\n",
 		  (unsigned)resp[5]);
-	  msg_notice("S_MCU:\n");
-	  msg_notice("  boot-loader FW version:        %u\n",
+	  imsg_notice2("S_MCU:\n");
+	  imsg_notice2("  boot-loader FW version:        %u\n",
 		  (unsigned)resp[6]);
-	  msg_notice("  firmware version:              %u.%02u\n",
+	  imsg_notice2("  firmware version:              %u.%02u\n",
 		  (unsigned)resp[8], (unsigned)resp[7]);
-	  msg_notice("  hardware version:              %u\n",
+	  imsg_notice2("  hardware version:              %u\n",
 		  (unsigned)resp[9]);
-	  msg_notice("Serial number:                   "
+	  imsg_notice2("Serial number:                   "
 		  "%02x:%02x:%02x:%02x:%02x:%02x\n",
 		  PDATA(pgm)->serno[0], PDATA(pgm)->serno[1], PDATA(pgm)->serno[2], PDATA(pgm)->serno[3], PDATA(pgm)->serno[4], PDATA(pgm)->serno[5]);
 	  resp[status - 1] = '\0';
-	  msg_notice("Device ID:                       %s\n",
+	  imsg_notice2("Device ID:                       %s\n",
 		  resp + 16);
 	}
 	free(resp);
@@ -2551,12 +2551,11 @@ static void jtagmkII_display(const PROGRAMMER *pgm, const char *p) {
   if (jtagmkII_getparm(pgm, PAR_HW_VERSION, hw) < 0 ||
       jtagmkII_getparm(pgm, PAR_FW_VERSION, fw) < 0)
     return;
-
-  msg_info("%sM_MCU HW version: %d\n", p, hw[0]);
-  msg_info("%sM_MCU FW version: %d.%02d\n", p, fw[1], fw[0]);
-  msg_info("%sS_MCU HW version: %d\n", p, hw[1]);
-  msg_info("%sS_MCU FW version: %d.%02d\n", p, fw[3], fw[2]);
-  msg_info("%sSerial number   : %02x:%02x:%02x:%02x:%02x:%02x\n", p,
+  msg_info("%sMain MCU HW version   : %d\n", p, hw[0]);
+  msg_info("%sMain MCU FW version   : %d.%02d\n", p, fw[1], fw[0]);
+  msg_info("%sSec. MCU HW version   : %d\n", p, hw[1]);
+  msg_info("%sSec. MCU FW version   : %d.%02d\n", p, fw[3], fw[2]);
+  msg_info("%sSerial number         : %02x:%02x:%02x:%02x:%02x:%02x\n", p,
     PDATA(pgm)->serno[0], PDATA(pgm)->serno[1], PDATA(pgm)->serno[2],
     PDATA(pgm)->serno[3], PDATA(pgm)->serno[4], PDATA(pgm)->serno[5]);
 
@@ -2574,7 +2573,7 @@ static void jtagmkII_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
   if (pgm->extra_features & HAS_VTARG_READ) {
     if (jtagmkII_getparm(pgm, PAR_OCD_VTARGET, vtarget) < 0)
       return;
-    fmsg_out(fp, "%sVtarget         : %.1f V\n", p, b2_to_u16(vtarget) / 1000.0);
+    fmsg_out(fp, "%sVtarget               : %.1f V\n", p, b2_to_u16(vtarget) / 1000.0);
   }
 
   if ((pgm->flag & PGM_FL_IS_JTAG)) {
@@ -2593,8 +2592,7 @@ static void jtagmkII_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
     } else {
       sprintf(clkbuf, "%.1f kHz", 5.35e3 / (double)jtag_clock[0]);
       clk = 5.35e6 / (double)jtag_clock[0];
-
-      fmsg_out(fp, "%sJTAG clock      : %s (%.1f us)\n", p, clkbuf, 1.0e6 / clk);
+      fmsg_out(fp, "%sJTAG clock            : %s (%.1f us)\n", p, clkbuf, 1.0e6 / clk);
     }
   }
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -549,6 +549,7 @@ AVRPART * locate_part(const LISTID parts, const char *partdesc);
 AVRPART * locate_part_by_avr910_devcode(const LISTID parts, int devcode);
 AVRPART * locate_part_by_signature(const LISTID parts, unsigned char *sig, int sigsize);
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose);
+int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix);
 
 typedef void (*walk_avrparts_cb)(const char *name, const char *desc,
                                  const char *cfgname, int cfglineno,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -547,6 +547,7 @@ void      avr_free_part(AVRPART * d);
 AVRPART * locate_part(const LISTID parts, const char *partdesc);
 AVRPART * locate_part_by_avr910_devcode(const LISTID parts, int devcode);
 AVRPART * locate_part_by_signature(const LISTID parts, unsigned char *sig, int sigsize);
+const char *avr_prog_modes_str(int pm);
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose);
 int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -538,8 +538,7 @@ AVRMEM * avr_locate_mem_by_type(const AVRPART *p, memtype_t type);
 unsigned int avr_data_offset(const AVRPART *p);
 AVRMEM_ALIAS * avr_locate_memalias(const AVRPART *p, const char *desc);
 AVRMEM_ALIAS * avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig);
-void avr_mem_display(const char *prefix, FILE *f, const AVRMEM *m,
-                     const AVRPART *p, int verbose);
+void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix);
 
 /* Functions for AVRPART structures */
 AVRPART * avr_new_part(void);

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -213,7 +213,7 @@ static int linuxgpio_sysfs_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
 
 
 static void linuxgpio_sysfs_display(const PROGRAMMER *pgm, const char *p) {
-    msg_info("%sPin assignment  : /sys/class/gpio/gpio{n}\n",p);
+    msg_info("%sPin assignment          : /sys/class/gpio/gpio{n}\n",p);
     pgm_display_generic_mask(pgm, p, SHOW_AVR_PINS);
 }
 
@@ -356,7 +356,7 @@ static int libgpiod_is_working(void) {
 
 
 static void linuxgpio_libgpiod_display(const PROGRAMMER *pgm, const char *p) {
-  msg_info("Pin assignment  : libgpiod\n");
+  msg_info("%sPin assignment        : libgpiod\n", %s);
   pgm_display_generic_mask(pgm, p, SHOW_AVR_PINS);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1402,7 +1402,8 @@ skipopen:
 
   if (verbose > 0 && quell_progress < 2) {
     avr_display(stderr, p, progbuf, verbose);
-    msg_notice("\n");
+    if (verbose > 1)
+      msg_notice("\n");
     programmer_display(pgm, progbuf);
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1253,25 +1253,25 @@ int main(int argc, char * argv [])
 
   // Open the programmer
   if (verbose > 0) {
-    imsg_notice("Using Port                    : %s\n", port);
-    imsg_notice("Using Programmer              : %s\n", pgmid);
+    imsg_notice("Using Port              : %s\n", port);
+    imsg_notice("Using Programmer        : %s\n", pgmid);
   }
 
   if (baudrate != 0) {
-    imsg_notice("Overriding Baud Rate          : %d\n", baudrate);
+    imsg_notice("Overriding Baud Rate    : %d\n", baudrate);
     pgm->baudrate = baudrate;
   }
   else if (ser && ser->baudrate) {
-    imsg_notice("Default Baud Rate             : %d\n", ser->baudrate);
+    imsg_notice("Default Baud Rate       : %d\n", ser->baudrate);
     pgm->baudrate = ser->baudrate;
   }
   if (bitclock != 0.0) {
-    imsg_notice("Setting bit clk period        : %.1f\n", bitclock);
+    imsg_notice("Setting bit clk period  : %.1f\n", bitclock);
     pgm->bitclock = bitclock * 1e-6;
   }
 
   if (ispdelay != 0) {
-    imsg_notice("Setting isp clock delay       : %3i\n", ispdelay);
+    imsg_notice("Setting isp clock delay : %3i\n", ispdelay);
     pgm->ispdelay = ispdelay;
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1278,25 +1278,25 @@ int main(int argc, char * argv [])
 
   // Open the programmer
   if (verbose > 0) {
-    imsg_notice("Using Port              : %s\n", port);
-    imsg_notice("Using Programmer        : %s\n", pgmid);
+    imsg_notice("Using port            : %s\n", port);
+    imsg_notice("Using programmer      : %s\n", pgmid);
   }
 
   if (baudrate != 0) {
-    imsg_notice("Overriding Baud Rate    : %d\n", baudrate);
+    imsg_notice("Setting baud rate     : %d\n", baudrate);
     pgm->baudrate = baudrate;
   }
   else if (ser && ser->baudrate) {
-    imsg_notice("Default Baud Rate       : %d\n", ser->baudrate);
+    imsg_notice("Default baud rate     : %d\n", ser->baudrate);
     pgm->baudrate = ser->baudrate;
   }
   if (bitclock != 0.0) {
-    imsg_notice("Setting bit clk period  : %.1f\n", bitclock);
+    imsg_notice("Setting bit clk period: %.1f us\n", bitclock);
     pgm->bitclock = bitclock * 1e-6;
   }
 
   if (ispdelay != 0) {
-    imsg_notice("Setting isp clock delay : %3i\n", ispdelay);
+    imsg_notice("Setting ISP clk delay : %3i us\n", ispdelay);
     pgm->ispdelay = ispdelay;
   }
 

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -266,8 +266,8 @@ static void pgm_default_6 (const PROGRAMMER *pgm, const char *p) {
 
 
 void programmer_display(PROGRAMMER *pgm, const char * p) {
-  msg_info("%sProgrammer Type         : %s\n", p, pgm->type);
-  msg_info("%sDescription             : %s\n", p, pgm->desc);
+  msg_info("%sProgrammer Type       : %s\n", p, pgm->type);
+  msg_info("%sDescription           : %s\n", p, pgm->desc);
 
   pgm->display(pgm, p);
 }

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -266,8 +266,8 @@ static void pgm_default_6 (const PROGRAMMER *pgm, const char *p) {
 
 
 void programmer_display(PROGRAMMER *pgm, const char * p) {
-  msg_info("%sProgrammer Type : %s\n", p, pgm->type);
-  msg_info("%sDescription     : %s\n", p, pgm->desc);
+  msg_info("%sProgrammer Type         : %s\n", p, pgm->type);
+  msg_info("%sDescription             : %s\n", p, pgm->desc);
 
   pgm->display(pgm, p);
 }

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -139,7 +139,7 @@ static speed_t serial_baud_lookup(long baud, bool *nonstandard) {
    * If a non-standard BAUD rate is used, issue
    * a warning (if we are verbose) and return the raw rate
    */
-  pmsg_notice("serial_baud_lookup(): using non-standard baud rate: %ld\n", baud);
+  pmsg_notice2("serial_baud_lookup(): using non-standard baud rate: %ld\n", baud);
 
   *nonstandard = true;
 

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -78,7 +78,7 @@ static DWORD serial_baud_lookup(long baud)
    * If a non-standard BAUD rate is used, issue
    * a warning (if we are verbose) and return the raw rate
    */
-  pmsg_notice("serial_baud_lookup(): using non-standard baud rate: %ld", baud);
+  pmsg_notice2("serial_baud_lookup(): using non-standard baud rate: %ld", baud);
 
   return baud;
 }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1478,7 +1478,6 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) 
   f = f_to_kHz_MHz(f, &unit);
   fmsg_out(fp, "%sXTAL frequency        : %.*f %s\n", p, decimals, f, unit);
 
-
   return;
 }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1346,9 +1346,8 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
   stk500_getparm(pgm, Parm_STK_SW_MAJOR, &maj);
   stk500_getparm(pgm, Parm_STK_SW_MINOR, &min);
   stk500_getparm(pgm, Param_STK500_TOPCARD_DETECT, &topcard);
-
-  msg_info("%sHardware Version: %d\n", p, hdw);
-  msg_info("%sFirmware Version: %d.%d\n", p, maj, min);
+  msg_info("%sHW Version            : %d\n", p, hdw);
+  msg_info("%sFW Version            : %d.%d\n", p, maj, min);
   if (topcard < 3) {
     const char *n = "Unknown";
 
@@ -1361,7 +1360,7 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
         n = "STK501";
         break;
     }
-    msg_info("%sTopcard         : %s\n", p, n);
+    msg_info("%sTopcard               : %s\n", p, n);
   }
   if(!str_eq(pgm->type, "Arduino"))
     stk500_print_parms1(pgm, p, stderr);
@@ -1375,16 +1374,16 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) 
 
   if (pgm->extra_features & HAS_VTARG_READ) {
     stk500_getparm(pgm, Parm_STK_VTARGET, &vtarget);
-    fmsg_out(fp, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
+    fmsg_out(fp, "%sVtarget               : %.1f V\n", p, vtarget / 10.0);
   }
   if (pgm->extra_features & HAS_VAREF_ADJ) {
     stk500_getparm(pgm, Parm_STK_VADJUST, &vadjust);
-    fmsg_out(fp, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
+    fmsg_out(fp, "%sVaref                 : %.1f V\n", p, vadjust / 10.0);
   }
   if (pgm->extra_features & HAS_FOSC_ADJ) {
     stk500_getparm(pgm, Parm_STK_OSC_PSCALE, &osc_pscale);
     stk500_getparm(pgm, Parm_STK_OSC_CMATCH, &osc_cmatch);
-    fmsg_out(fp, "%sOscillator      : ", p);
+    fmsg_out(fp, "%sOscillator            : ", p);
     if (osc_pscale == 0)
       fmsg_out(fp, "Off\n");
     else {
@@ -1415,7 +1414,7 @@ static void stk500_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) 
   }
 
   stk500_getparm(pgm, Parm_STK_SCK_DURATION, &sck_duration);
-  fmsg_out(fp, "%sSCK period      : %.1f us\n", p, sck_duration * 8.0e6 / STK500_XTAL + 0.05);
+  fmsg_out(fp, "%sSCK period            : %.1f us\n", p, sck_duration * 8.0e6 / STK500_XTAL + 0.05);
 
   return;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3604,21 +3604,21 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
 
   if (PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE_MKII &&
       PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE3) {
-    msg_info("%sProgrammer Model: %s\n", p, pgmname(pgm));
+    msg_info("%sProgrammer model      : %s\n", p, pgmname(pgm));
     stk500v2_getparm(pgm, PARAM_HW_VER, &hdw);
     stk500v2_getparm(pgm, PARAM_SW_MAJOR, &maj);
     stk500v2_getparm(pgm, PARAM_SW_MINOR, &min);
-    msg_info("%sHardware Version: %d\n", p, hdw);
+    msg_info("%sHW version            : %d\n", p, hdw);
     if (pgm->usbsn && *pgm->usbsn)
-      msg_info("%sSerial number   : %s\n", p, pgm->usbsn);
-    msg_info("%sFirmware Version Controller : %d.%02d\n", p, maj, min);
+      msg_info("%sSerial number         : %s\n", p, pgm->usbsn);
+    msg_info("%sFW Version Controller : %d.%02d\n", p, maj, min);
     if (PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
       stk500v2_getparm(pgm, PARAM_SW_MAJOR_PERIPHERY1, &maj_s1);
       stk500v2_getparm(pgm, PARAM_SW_MINOR_PERIPHERY1, &min_s1);
       stk500v2_getparm(pgm, PARAM_SW_MAJOR_PERIPHERY2, &maj_s2);
       stk500v2_getparm(pgm, PARAM_SW_MINOR_PERIPHERY2, &min_s2);
-      msg_info("%sFirmware Version Periphery 1: %d.%02d\n", p, maj_s1, min_s1);
-      msg_info("%sFirmware Version Periphery 2: %d.%02d\n", p, maj_s2, min_s2);
+      msg_info("%sFW Version Periphery 1: %d.%02d\n", p, maj_s1, min_s1);
+      msg_info("%sFW Version Periphery 2: %d.%02d\n", p, maj_s2, min_s2);
     }
   }
 
@@ -3633,22 +3633,22 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
       case 0xDD: topcard_name = "STK520"; break;
       default: topcard_name = "Unknown"; break;
     }
-    msg_info("%sTopcard         : %s\n", p, topcard_name);
+    msg_info("%sTopcard               : %s\n", p, topcard_name);
   } else if (PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
     stk500v2_getparm(pgm, PARAM_ROUTINGCARD_ID, &topcard);
-    msg_info("%sRouting card    : %s\n", p,
+    msg_info("%sRouting card          : %s\n", p,
 	    stk600_get_cardname(routing_cards,
 				sizeof routing_cards / sizeof routing_cards[0],
 				topcard));
     stk500v2_getparm(pgm, PARAM_SOCKETCARD_ID, &topcard);
-    msg_info("%sSocket card     : %s\n", p,
+    msg_info("%sSocket card           : %s\n", p,
 	    stk600_get_cardname(socket_cards,
 				sizeof socket_cards / sizeof socket_cards[0],
 				topcard));
     stk500v2_getparm2(pgm, PARAM2_RC_ID_TABLE_REV, &rev);
-    msg_info("%sRC_ID table rev : %d\n", p, rev);
+    msg_info("%sRC_ID table rev       : %d\n", p, rev);
     stk500v2_getparm2(pgm, PARAM2_EC_ID_TABLE_REV, &rev);
-    msg_info("%sEC_ID table rev : %d\n", p, rev);
+    msg_info("%sEC_ID table rev       : %d\n", p, rev);
   } else if (PDATA(pgm)->pgmtype == PGMTYPE_JTAGICE3) {
     PROGRAMMER *pgmcp = pgm_dup(pgm);
     pgmcp->cookie = PDATA(pgm)->chained_pdata;
@@ -3677,26 +3677,26 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
       pgmcp->cookie = PDATA(pgm)->chained_pdata;
       jtagmkII_getparm(pgmcp, PAR_OCD_VTARGET, vtarget_jtag);
       pgm_free(pgmcp);
-      fmsg_out(fp, "%sVtarget         : %.1f V\n", p, b2_to_u16(vtarget_jtag) / 1000.0);
+      fmsg_out(fp, "%sVtarget               : %.1f V\n", p, b2_to_u16(vtarget_jtag) / 1000.0);
     } else if (PDATA(pgm)->pgmtype != PGMTYPE_JTAGICE3) {
       stk500v2_getparm(pgm, PARAM_VTARGET, &vtarget);
-      fmsg_out(fp, "%sVtarget         : %.1f V\n", p, vtarget / 10.0);
+      fmsg_out(fp, "%sVtarget               : %.1f V\n", p, vtarget / 10.0);
     }
   }
 
   switch (PDATA(pgm)->pgmtype) {
   case PGMTYPE_STK500:
     stk500v2_getparm(pgm, PARAM_SCK_DURATION, &sck_duration);
-    fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
+    fmsg_out(fp, "%sSCK period            : %.1f us\n", p,
 	    stk500v2_sck_to_us(pgm, sck_duration));
     if (pgm->extra_features & HAS_VAREF_ADJ) {
       stk500v2_getparm(pgm, PARAM_VADJUST, &vadjust);
-      fmsg_out(fp, "%sVaref           : %.1f V\n", p, vadjust / 10.0);
+      fmsg_out(fp, "%sVaref                 : %.1f V\n", p, vadjust / 10.0);
     }
     if (pgm->extra_features & HAS_FOSC_ADJ) {
       stk500v2_getparm(pgm, PARAM_OSC_PSCALE, &osc_pscale);
       stk500v2_getparm(pgm, PARAM_OSC_CMATCH, &osc_cmatch);
-      fmsg_out(fp, "%sOscillator      : ", p);
+      fmsg_out(fp, "%sOscillator            : ", p);
       if (osc_pscale == 0)
         fmsg_out(fp, "Off\n");
       else {
@@ -3722,7 +3722,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
   case PGMTYPE_AVRISP_MKII:
   case PGMTYPE_JTAGICE_MKII:
     stk500v2_getparm(pgm, PARAM_SCK_DURATION, &sck_duration);
-    fmsg_out(fp, "%sSCK period      : %.2f us\n", p,
+    fmsg_out(fp, "%sSCK period            : %.2f us\n", p,
 	    1000000 / avrispmkIIfreqs[sck_duration]);
     break;
 
@@ -3732,7 +3732,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
       cmd[0] = CMD_GET_SCK;
       if (stk500v2_jtag3_send(pgm, cmd, 1) >= 0 && stk500v2_jtag3_recv(pgm, cmd, 4) >= 2) {
 	      unsigned int sck = cmd[1] | (cmd[2] << 8);
-	      fmsg_out(fp, "%sSCK period      : %.2f us\n", p, (1E6 / (1000.0 * sck)));
+	      fmsg_out(fp, "%sSCK period            : %.2f us\n", p, (1E6 / (1000.0 * sck)));
       }
       PROGRAMMER *pgmcp = pgm_dup(pgm);
       pgmcp->cookie = PDATA(pgm)->chained_pdata;
@@ -3748,24 +3748,24 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
   case PGMTYPE_STK600:
     if (pgm->extra_features & HAS_VAREF_ADJ) {
       stk500v2_getparm2(pgm, PARAM2_AREF0, &varef);
-      fmsg_out(fp, "%sVaref 0         : %.2f V\n", p, varef / 100.0);
+      fmsg_out(fp, "%sVaref 0               : %.2f V\n", p, varef / 100.0);
       stk500v2_getparm2(pgm, PARAM2_AREF1, &varef);
-      fmsg_out(fp, "%sVaref 1         : %.2f V\n", p, varef / 100.0);
+      fmsg_out(fp, "%sVaref 1               : %.2f V\n", p, varef / 100.0);
     }
     stk500v2_getparm2(pgm, PARAM2_SCK_DURATION, &sck_stk600);
-    fmsg_out(fp, "%sSCK period      : %.2f us\n", p, (sck_stk600 + 1) / 8.0);
+    fmsg_out(fp, "%sSCK period            : %.2f us\n", p, (sck_stk600 + 1) / 8.0);
     if (pgm->extra_features & HAS_FOSC_ADJ) {
       stk500v2_getparm2(pgm, PARAM2_CLOCK_CONF, &clock_conf);
       oct = (clock_conf & 0xf000) >> 12u;
       dac = (clock_conf & 0x0ffc) >> 2u;
       f = pow(2, (double)oct) * 2078.0 / (2 - (double)dac / 1024.0);
       f = f_to_kHz_MHz(f, &unit);
-      fmsg_out(fp, "%sOscillator      : %.3f %s\n", p, f, unit);
+      fmsg_out(fp, "%sOscillator            : %.3f %s\n", p, f, unit);
     }
     break;
 
   default:
-    fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
+    fmsg_out(fp, "%sSCK period            : %.1f us\n", p,
 	  sck_duration * 8.0e6 / STK500V2_XTAL + 0.05);
     break;
   }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3768,14 +3768,14 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
         fmsg_out(fp, "%.*f %s\n", decimals, f, unit);
       }
     }
-    fmsg_out(fp, "%sSCK period      : %.1f us\n", p,
+    fmsg_out(fp, "%sSCK period            : %.1f us\n", p,
 	    stk500v2_sck_to_us(pgm, sck_duration));
 
     //const char *unit;
     double f = PDATA(pgm)->xtal;
     decimals = get_decimals(f);
     f = f_to_kHz_MHz(f, &unit);
-    fmsg_out(fp, "%sXTAL frequency  : %.*f %s\n", p, decimals, f, unit);
+    fmsg_out(fp, "%sXTAL frequency        : %.*f %s\n", p, decimals, f, unit);
       break;
 
   case PGMTYPE_AVRISP_MKII:

--- a/src/term.c
+++ b/src/term.c
@@ -76,6 +76,7 @@ static int cmd_config (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
 static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_sig    (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_part   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
+static int cmd_variants(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_help   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_quit   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_send   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
@@ -104,6 +105,7 @@ struct command cmd[] = {
   { "include", cmd_include, _fo(open),          "include contents of named file as if it was typed" },
   { "sig",   cmd_sig,   _fo(open),              "display device signature bytes" },
   { "part",  cmd_part,  _fo(open),              "display the current part information" },
+  { "variants", cmd_variants, _fo(open),        "display all chip variants known to Avrdude"},
   { "send",  cmd_send,  _fo(cmd),               "send a raw command to the programmer" },
   { "parms", cmd_parms, _fo(print_parms),       "display useful parameters" },
   { "vtarg", cmd_vtarg, _fo(set_vtarget),       "set the target voltage" },
@@ -1576,6 +1578,23 @@ static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 }
 
 
+static int cmd_variants(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+  if(argc > 1) {
+    msg_error(
+      "Syntax: variants\n"
+      "Function: display all variants of %s known to Avrdude\n", p->desc
+    );
+    return -1;
+  }
+
+  term_out("\v");
+  avr_variants_display(stdout, p, "");
+  term_out("\v");
+
+  return 0;
+}
+
+
 static int cmd_sig(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
   int i;
   int rc;
@@ -1778,15 +1797,15 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
   for(int i=0; i<NCMDS; i++) {
     if(!*(void (**)(void)) ((char *) pgm + cmd[i].fnoff))
       continue;
-    term_out("  %-7s : ", cmd[i].name);
+    term_out("  %-8s : ", cmd[i].name);
     term_out(cmd[i].desc, cmd[i].name);
     term_out("\n");
   }
   term_out(
     "\nFor more details about a terminal command cmd type cmd -?\n\n"
     "Other:\n"
-    "  !<line> : run the shell <line> in a subshell, eg, !ls *.hex\n"
-    "  # ...   : ignore rest of line (eg, used as comments in scripts)\n\n"
+    "  !<line>  : run the shell <line> in a subshell, eg, !ls *.hex\n"
+    "  # ...    : ignore rest of line (eg, used as comments in scripts)\n\n"
     "Note that not all programmer derivatives support all commands. Flash and\n"
     "EEPROM type memories are normally read and written using a cache via paged\n"
     "read and write access; the cache is synchronised on quit or flush commands.\n"

--- a/src/term.c
+++ b/src/term.c
@@ -1570,6 +1570,9 @@ static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 
   term_out("\v");
   avr_display(stdout, p, "", 0);
+  avr_mem_display(stdout, p, "");
+  if(verbose)
+    avr_variants_display(stdout, p, "");
   term_out("\v");
 
   return 0;

--- a/src/term.c
+++ b/src/term.c
@@ -1819,15 +1819,15 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
   for(int i=0; i<NCMDS; i++) {
     if(!*(void (**)(void)) ((char *) pgm + cmd[i].fnoff))
       continue;
-    term_out("  %-8s : ", cmd[i].name);
+    term_out("  %-7s : ", cmd[i].name);
     term_out(cmd[i].desc, cmd[i].name);
     term_out("\n");
   }
   term_out(
     "\nFor more details about a terminal command cmd type cmd -?\n\n"
     "Other:\n"
-    "  !<line>  : run the shell <line> in a subshell, eg, !ls *.hex\n"
-    "  # ...    : ignore rest of line (eg, used as comments in scripts)\n\n"
+    "  !<line> : run the shell <line> in a subshell, eg, !ls *.hex\n"
+    "  # ...   : ignore rest of line (eg, used as comments in scripts)\n\n"
     "Note that not all programmer derivatives support all commands. Flash and\n"
     "EEPROM type memories are normally read and written using a cache via paged\n"
     "read and write access; the cache is synchronised on quit or flush commands.\n"

--- a/src/term.c
+++ b/src/term.c
@@ -76,7 +76,6 @@ static int cmd_config (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
 static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_sig    (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_part   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_variants(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_help   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_quit   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
 static int cmd_send   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
@@ -105,7 +104,6 @@ struct command cmd[] = {
   { "include", cmd_include, _fo(open),          "include contents of named file as if it was typed" },
   { "sig",   cmd_sig,   _fo(open),              "display device signature bytes" },
   { "part",  cmd_part,  _fo(open),              "display the current part information" },
-  { "variants", cmd_variants, _fo(open),        "display all target chip variants known to Avrdude"},
   { "send",  cmd_send,  _fo(cmd),               "send a raw command to the programmer" },
   { "parms", cmd_parms, _fo(print_parms),       "display useful parameters" },
   { "vtarg", cmd_vtarg, _fo(set_vtarget),       "set the target voltage" },
@@ -1572,23 +1570,6 @@ static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 
   term_out("\v");
   avr_display(stdout, p, "", 0);
-  term_out("\v");
-
-  return 0;
-}
-
-
-static int cmd_variants(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
-  if(argc > 1) {
-    msg_error(
-      "Syntax: variants\n"
-      "Function: display all variants of %s known to Avrdude\n", p->desc
-    );
-    return -1;
-  }
-
-  term_out("\v");
-  avr_variants_display(stdout, p, "");
   term_out("\v");
 
   return 0;

--- a/src/term.c
+++ b/src/term.c
@@ -105,7 +105,7 @@ struct command cmd[] = {
   { "include", cmd_include, _fo(open),          "include contents of named file as if it was typed" },
   { "sig",   cmd_sig,   _fo(open),              "display device signature bytes" },
   { "part",  cmd_part,  _fo(open),              "display the current part information" },
-  { "variants", cmd_variants, _fo(open),        "display all chip variants known to Avrdude"},
+  { "variants", cmd_variants, _fo(open),        "display all target chip variants known to Avrdude"},
   { "send",  cmd_send,  _fo(cmd),               "send a raw command to the programmer" },
   { "parms", cmd_parms, _fo(print_parms),       "display useful parameters" },
   { "vtarg", cmd_vtarg, _fo(set_vtarget),       "set the target voltage" },

--- a/src/term.c
+++ b/src/term.c
@@ -1560,19 +1560,57 @@ finished:
 
 
 static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
-  if(argc > 1) {
+  int help = 0, onlymem = 0, onlyvariants = 0, invalid = 0, itemac = 1;
+
+  for(int ai = 0; --argc > 0; ) { // Simple option parsing
+    const char *q;
+    if(*(q=argv[++ai]) != '-' || !q[1])
+      argv[itemac++] = argv[ai];
+    else {
+      while(*++q) {
+        switch(*q) {
+        case '?':
+        case 'h':
+          help++;
+          break;
+        case 'v':
+          onlyvariants++;
+          break;
+        case 'm':
+          onlymem++;
+          break;
+        default:
+          if(!invalid++)
+            pmsg_error("(part) invalid option %c, see usage:\n", *q);
+          q = "x";
+        }
+      }
+    }
+  }
+  argc = itemac;                // (arg,c argv) still valid but options have been removed
+
+  if(argc > 1 || help || invalid || (onlymem && onlyvariants)) {
+    if(onlymem && onlyvariants)
+      pmsg_error("(part) cannot mix -v and -m\n");
     msg_error(
       "Syntax: part\n"
-      "Function: display the current part information\n"
+      "Function: display the current part information including memory and variants\n"
+      "Options:\n"
+      "    -m only display memory information\n"
+      "    -v only display variants information\n"
     );
     return -1;
   }
 
-  term_out("\v");
-  avr_display(stdout, p, "", 0);
-  avr_mem_display(stdout, p, "");
-  if(verbose)
+  if(onlymem)
+    avr_mem_display(stdout, p, "");
+  else if(onlyvariants)
     avr_variants_display(stdout, p, "");
+  else {
+    term_out("%s with programming modes %s\n", p->desc, avr_prog_modes_str(p->prog_modes));
+    avr_mem_display(stdout, p, "");
+    avr_variants_display(stdout, p, "");
+  }
   term_out("\v");
 
   return 0;

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -170,7 +170,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      fd->usb.wep = 0x02;
 		  }
 
-                  pmsg_notice("usbdev_open(): found %s, serno: %s\n", product, string);
+                  pmsg_notice2("usbdev_open(): found %s, serno: %s\n", product, string);
 		  if (serno != NULL)
 		    {
 		      /*


### PR DESCRIPTION
I'm creating this unfinished PR to start a discussion on how we want the `part` command in terminal mode, and (and output in verbose mode) to look like. I've removed a bunch of what I'd consider "non-useful information" to the average user.

The memory array width is dependent on the character width of the differetnt entries. However, the code is a bit ugly, so feel free to suggest how it can be further improved.

It would be neat if the memories could be sorted based on their offset, but I couldn't figure out a clean way of doing this. @stefanrueger?

Are there other things we should show/print in the `part` command?

This is what the output looks like on classic AVRs, modern AVRs, and Xmegas.

```
$ ./avrdude -cdryrun -patmega64 -PUSB -T 'part' -qq
AVR Part                : ATmega64
Programming modes       : PM_SPM | PM_ISP | PM_HVPP | PM_JTAG | PM_JTAGmkI

| Memory       | Size  | Pg size |
|--------------|-------|---------|
| eeprom       |  2048 |       8 |
| flash        | 65536 |     256 |
| lfuse        |     1 |       1 |
| hfuse        |     1 |       1 |
| efuse        |     1 |       1 |
| lock         |     1 |       1 |
| signature    |     3 |       1 |
| calibration  |     4 |       1 |
| io           |   224 |       1 |


$ ./avrdude -cdryrun -pavr128da48 -PUSB -T 'part' -qq
AVR Part                : AVR128DA48
Programming modes       : PM_SPM | PM_UPDI

| Memory          | Size   | Pg size | Offset    |
|-----------------|--------|---------|-----------|
| fuses           |     16 |       1 |    0x1050 |
| fuse0/wdtcfg    |      1 |       1 |    0x1050 |
| fuse1/bodcfg    |      1 |       1 |    0x1051 |
| fuse2/osccfg    |      1 |       1 |    0x1052 |
| fuse5/syscfg0   |      1 |       1 |    0x1055 |
| fuse6/syscfg1   |      1 |       1 |    0x1056 |
| fuse7/codesize  |      1 |       1 |    0x1057 |
| fuse8/bootsize  |      1 |       1 |    0x1058 |
| lock            |      4 |       1 |    0x1040 |
| prodsig/sigrow  |    128 |     128 |    0x1100 |
| signature       |      3 |       1 |    0x1100 |
| tempsense       |      4 |       1 |    0x1104 |
| sernum          |     16 |       1 |    0x1110 |
| userrow/usersig |     32 |      32 |    0x1080 |
| data            |      0 |       1 | 0x1000000 |
| io              |   4160 |       1 |       0x0 |
| sib             |     32 |       1 |       0x0 |
| eeprom          |    512 |       1 |    0x1400 |
| flash           | 131072 |     512 |  0x800000 |


$ ./avrdude -cdryrun -patxmega128a1u -PUSB -T 'part' -qq
AVR Part                : ATxmega128A1U
Programming modes       : PM_SPM | PM_PDI | PM_XMEGAJTAG

| Memory         | Size   | Pg size | Offset    |
|----------------|--------|---------|-----------|
| fuse1          |      1 |       1 |  0x8f0021 |
| fuse2          |      1 |       1 |  0x8f0022 |
| fuse4          |      1 |       1 |  0x8f0024 |
| fuse5          |      1 |       1 |  0x8f0025 |
| lock           |      1 |       1 |  0x8f0027 |
| prodsig/sigrow |     64 |      64 |  0x8e0200 |
| signature      |      3 |       1 | 0x1000090 |
| data           |      0 |       1 | 0x1000000 |
| io             |   4096 |       1 |       0x0 |
| eeprom         |   2048 |      32 |  0x8c0000 |
| flash          | 139264 |     512 |  0x800000 |
| application    | 131072 |     512 |  0x800000 |
| apptable       |   8192 |     512 |  0x81e000 |
| boot           |   8192 |     512 |  0x820000 |
| usersig        |    512 |     512 |  0x8e0400 |
| fuse0          |      1 |       1 |  0x8f0020 |
```