### PR TITLE
Add memory sram and remove memory data

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1528,8 +1528,8 @@ memtable_t avr_mem_order[100] = {
   {"bootrow",     MEM_BOOTROW | MEM_USER_TYPE},
   {"usersig",     MEM_USERROW | MEM_USER_TYPE},
   {"userrow",     MEM_USERROW | MEM_USER_TYPE},
-  {"sram",        MEM_SRAM},
   {"io",          MEM_IO},
+  {"sram",        MEM_SRAM},
   {"sib",         MEM_SIB | MEM_READONLY},
 };
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -1528,7 +1528,7 @@ memtable_t avr_mem_order[100] = {
   {"bootrow",     MEM_BOOTROW | MEM_USER_TYPE},
   {"usersig",     MEM_USERROW | MEM_USER_TYPE},
   {"userrow",     MEM_USERROW | MEM_USER_TYPE},
-  {"data",        MEM_SRAM},
+  {"sram",        MEM_SRAM},
   {"io",          MEM_IO},
   {"sib",         MEM_SIB | MEM_READONLY},
 };

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3114,6 +3114,11 @@ part # t11
         size               = 1;
     ;
 
+    memory "sram"
+        size               = 32;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
     ;
@@ -3224,6 +3229,11 @@ part # t12
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 32;
+        offset             = 0x60;
     ;
 
     memory "io"
@@ -3378,6 +3388,11 @@ part # t13
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 64;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -3521,6 +3536,11 @@ part # t15
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 32;
+        offset             = 0x60;
     ;
 
     memory "io"
@@ -3725,6 +3745,11 @@ part # 1200
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
+
+    memory "sram"
+        size               = 32;
+        offset             = 0x60;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -3822,6 +3847,11 @@ part # 4414
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -3914,6 +3944,11 @@ part # 2313
     memory "signature"
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -4008,6 +4043,11 @@ part # 2333
     memory "signature"
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -4107,6 +4147,11 @@ part # 2343
     memory "signature"
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -4275,6 +4320,11 @@ part # 8515
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -4371,6 +4421,11 @@ part # 8535
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -4415,6 +4470,10 @@ part parent "8535" # 4434
 
     memory "lock"
         max_write_delay    = 20000;
+    ;
+
+    memory "sram"
+        size               = 256;
     ;
 ;
 
@@ -4515,6 +4574,11 @@ part # m103
     memory "signature"
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 4000;
+        offset             = 0x60;
     ;
 ;
 
@@ -4662,6 +4726,11 @@ part # m64
     memory "calibration"
         size               = 4;
         read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -4834,6 +4903,11 @@ part # m128
         read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -4998,6 +5072,11 @@ part # c128
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -5138,6 +5217,11 @@ part # c64
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -5282,6 +5366,11 @@ part # c32
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -5422,6 +5511,11 @@ part # m16
     memory "calibration"
         size               = 4;
         read               = "0011.1000--000x.xxxx--0000.00aa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x60;
     ;
 
     memory "io"
@@ -5598,6 +5692,11 @@ part # m324p
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -5644,6 +5743,10 @@ part parent "m324p" # m164p
     memory "flash"
         size               = 0x4000;
         num_pages          = 128;
+    ;
+
+    memory "sram"
+        size               = 1024;
     ;
 ;
 
@@ -5919,6 +6022,11 @@ part # m644
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -6144,6 +6252,11 @@ part # m1284
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -6334,6 +6447,11 @@ part # m162
         read               = "0011.1000--00xx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -6458,6 +6576,11 @@ part # m163
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x60;
     ;
 ;
 
@@ -6606,6 +6729,11 @@ part # m169
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -6874,6 +7002,11 @@ part # m329
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -7152,6 +7285,11 @@ part # m649
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -7373,6 +7511,11 @@ part # m32
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 2048;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -7482,6 +7625,11 @@ part # m161
     memory "signature"
         size               = 3;
         read               = "0011.0000--xxxx.xxxx--xxxx.xxaa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x60;
     ;
 ;
 
@@ -7640,6 +7788,11 @@ part # m8
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 1024;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -7795,6 +7948,11 @@ part # m8515
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -7928,6 +8086,11 @@ part # m8535
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -8057,6 +8220,11 @@ part # t26
     memory "calibration"
         size               = 4;
         read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 
     memory "io"
@@ -8204,6 +8372,11 @@ part # t261
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 
     memory "io"
@@ -8379,6 +8552,11 @@ part # t461
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -8548,6 +8726,11 @@ part # t861
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -8637,6 +8820,11 @@ part # t28
 
     memory "calibration"
         size               = 1;
+    ;
+
+    memory "sram"
+        size               = 32;
+        offset             = 0x60;
     ;
 
     memory "io"
@@ -8794,6 +8982,11 @@ part # m48
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -9043,6 +9236,11 @@ part # m88
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -9298,6 +9496,11 @@ part # m168
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -9541,6 +9744,11 @@ part # t828
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -9704,6 +9912,11 @@ part # t87
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -9857,6 +10070,11 @@ part # t167
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -10006,6 +10224,11 @@ part # t48
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -10159,6 +10382,11 @@ part # t88
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -10307,6 +10535,11 @@ part # m328
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -10516,6 +10749,11 @@ part # m64m1
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -10558,6 +10796,10 @@ part parent "m64m1" # m32m1
         loadpage_hi        = "0100.1000--0000.0000--00aa.aaaa--iiii.iiii";
         writepage          = "0100.1100--00aa.aaaa--aa00.0000--xxxx.xxxx";
     ;
+
+    memory "sram"
+        size               = 2048;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -10586,6 +10828,10 @@ part parent "m32m1" # m16m1
         read_lo            = "0010.0000--000a.aaaa--aaaa.aaaa--oooo.oooo";
         read_hi            = "0010.1000--000a.aaaa--aaaa.aaaa--oooo.oooo";
         writepage          = "0100.1100--000a.aaaa--aa00.0000--xxxx.xxxx";
+    ;
+
+    memory "sram"
+        size               = 1024;
     ;
 ;
 
@@ -11002,6 +11248,11 @@ part # m16hva
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -11159,6 +11410,11 @@ part # m16hvb
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -11204,6 +11460,10 @@ part parent "m16hvb" # m32hvb
         read_lo            = "0010.0000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
         read_hi            = "0010.1000--00aa.aaaa--aaaa.aaaa--oooo.oooo";
         writepage          = "0100.1100--00aa.aaaa--aa00.0000--xxxx.xxxx";
+    ;
+
+    memory "sram"
+        size               = 2048;
     ;
 ;
 
@@ -11347,6 +11607,11 @@ part # m64hve2
     memory "calibration"
         size               = 1;
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -11528,6 +11793,11 @@ part # t2313
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -11704,6 +11974,11 @@ part # t4313
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -11847,6 +12122,11 @@ part # pwm1
     memory "calibration"
         size               = 1;
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -11993,6 +12273,11 @@ part # pwm2
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -12219,6 +12504,11 @@ part # pwm161
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -12251,6 +12541,10 @@ part parent "pwm161" # pwm81
         loadpage_hi        = "0100.1000--0000.0000--000a.aaaa--iiii.iiii";
         writepage          = "0100.1100--0000.aaaa--aaa0.0000--xxxx.xxxx";
     ;
+
+    memory "sram"
+        size               = 256;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -12278,6 +12572,10 @@ part parent "pwm3b" # pwm316
         loadpage_lo        = "0100.0000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
         loadpage_hi        = "0100.1000--00xx.xxxx--xxaa.aaaa--iiii.iiii";
         writepage          = "0100.1100--00aa.aaaa--aaxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "sram"
+        size               = 1024;
     ;
 ;
 
@@ -12476,6 +12774,11 @@ part # t25
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -12641,6 +12944,11 @@ part # t45
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -12803,6 +13111,11 @@ part # t85
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -12950,6 +13263,11 @@ part # m640
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 8192;
+        offset             = 0x200;
+    ;
+
     memory "io"
         size               = 480;
         offset             = 0x20;
@@ -13094,6 +13412,11 @@ part # m1280
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x200;
     ;
 
     memory "io"
@@ -13266,6 +13589,11 @@ part # m2560
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 8192;
+        offset             = 0x200;
+    ;
+
     memory "io"
         size               = 480;
         offset             = 0x20;
@@ -13355,6 +13683,10 @@ part parent "m2561" # m128rfa1
         min_write_delay    = 4500;
         max_write_delay    = 4500;
     ;
+
+    memory "sram"
+        size               = 0x4000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -13413,6 +13745,10 @@ part parent "m128rfa1" # m256rfr2
         blocksize          = 256;
         readsize           = 256;
     ;
+
+    memory "sram"
+        size               = 0x8000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -13439,6 +13775,10 @@ part parent "m256rfr2" # m128rfr2
         size               = 0x20000;
         num_pages          = 512;
         load_ext_addr      = NULL;
+    ;
+
+    memory "sram"
+        size               = 0x4000;
     ;
 ;
 
@@ -13470,6 +13810,10 @@ part parent "m128rfr2" # m64rfr2
         read_lo            = "0010.0000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
         read_hi            = "0010.1000--0aaa.aaaa--aaaa.aaaa--oooo.oooo";
         writepage          = "0100.1100--0aaa.aaaa--axxx.xxxx--xxxx.xxxx";
+    ;
+
+    memory "sram"
+        size               = 8192;
     ;
 ;
 
@@ -13671,6 +14015,11 @@ part # t24
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -13854,6 +14203,11 @@ part # t44
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
     ;
 
     memory "io"
@@ -14040,6 +14394,11 @@ part # t84
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -14111,6 +14470,10 @@ part parent "t44" # t441
         write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
+    memory "sram"
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
     ;
@@ -14155,6 +14518,10 @@ part parent "t84" # t841
     memory "efuse"
         bitmask            = 0xff;
         write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
+    ;
+
+    memory "sram"
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -14304,6 +14671,11 @@ part # t43u
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
+    ;
+
     memory "io"
         size               = 64;
         offset             = 0x20;
@@ -14446,6 +14818,11 @@ part # m16u4
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 1280;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -14594,6 +14971,11 @@ part # m32u4
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 2560;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -14736,6 +15118,11 @@ part # usb646
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -14898,6 +15285,11 @@ part # usb1286
     memory "calibration"
         size               = 1;
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -15065,6 +15457,11 @@ part # usb162
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -15209,6 +15606,11 @@ part # usb82
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -15358,6 +15760,11 @@ part # m32u2
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -15505,6 +15912,11 @@ part # m16u2
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -15650,6 +16062,11 @@ part # m8u2
     memory "calibration"
         size               = 1;
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -15801,6 +16218,11 @@ part # m165p
     memory "calibration"
         size               = 1;
         read               = "0011.1000--0000.0000--xxxx.xxxx--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -16007,6 +16429,11 @@ part # m325
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -16210,6 +16637,11 @@ part # m645
     memory "calibration"
         size               = 1;
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -16430,9 +16862,8 @@ part # .xmega
         offset             = 0x1000090;
     ;
 
-    memory "data"
-        # SRAM, only used to supply the offset
-        offset             = 0x1000000;
+    memory "sram"
+        offset             = 0x2000;
     ;
 
     memory "io"
@@ -16551,6 +16982,10 @@ part parent ".xmega-a" # x16a4u
         page_size          = 256;
         offset             = 0x8e0400;
         readsize           = 256;
+    ;
+
+    memory "sram"
+        size               = 2048;
     ;
 ;
 
@@ -16713,6 +17148,10 @@ part parent ".xmega-a" # x32a4u
         offset             = 0x8e0400;
         readsize           = 256;
     ;
+
+    memory "sram"
+        size               = 4096;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -16874,6 +17313,10 @@ part parent ".xmega-a" # x64a4u
         page_size          = 256;
         offset             = 0x8e0400;
         readsize           = 256;
+    ;
+
+    memory "sram"
+        size               = 4096;
     ;
 ;
 
@@ -17286,6 +17729,10 @@ part parent ".xmega" # x128c3
         offset             = 0x8e0400;
         readsize           = 256;
     ;
+
+    memory "sram"
+        size               = 8192;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17548,6 +17995,10 @@ part parent ".xmega" # x128a4
         offset             = 0x8e0400;
         readsize           = 256;
     ;
+
+    memory "sram"
+        size               = 8192;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -17621,6 +18072,10 @@ part parent ".xmega-a" # x128a4u
         page_size          = 256;
         offset             = 0x8e0400;
         readsize           = 256;
+    ;
+
+    memory "sram"
+        size               = 8192;
     ;
 ;
 
@@ -17699,6 +18154,10 @@ part parent ".xmega" # x128b1
         page_size          = 256;
         offset             = 0x8e0400;
         readsize           = 256;
+    ;
+
+    memory "sram"
+        size               = 8192;
     ;
 ;
 
@@ -17787,6 +18246,10 @@ part parent ".xmega" # x192c3
         page_size          = 512;
         offset             = 0x8e0400;
         readsize           = 256;
+    ;
+
+    memory "sram"
+        size               = 0x4000;
     ;
 ;
 
@@ -18019,6 +18482,10 @@ part parent ".xmega" # x256c3
         page_size          = 512;
         offset             = 0x8e0400;
         readsize           = 256;
+    ;
+
+    memory "sram"
+        size               = 0x4000;
     ;
 ;
 
@@ -18363,6 +18830,10 @@ part parent ".xmega" # x384c3
         offset             = 0x8e0400;
         readsize           = 256;
     ;
+
+    memory "sram"
+        size               = 0x8000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -18457,6 +18928,10 @@ part parent ".xmega-e" # x8e5
         offset             = 0x8e0400;
         readsize           = 256;
     ;
+
+    memory "sram"
+        size               = 1024;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -18533,6 +19008,10 @@ part parent ".xmega-e" # x16e5
         offset             = 0x8e0400;
         readsize           = 256;
     ;
+
+    memory "sram"
+        size               = 2048;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -18608,6 +19087,10 @@ part parent ".xmega-e" # x32e5
         page_size          = 128;
         offset             = 0x8e0400;
         readsize           = 256;
+    ;
+
+    memory "sram"
+        size               = 4096;
     ;
 ;
 
@@ -18795,6 +19278,11 @@ part # t1634
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
+    ;
+
     memory "io"
         size               = 224;
         offset             = 0x20;
@@ -18852,6 +19340,11 @@ part # .reduced_core_tiny
         size               = 1;
         page_size          = 16;
         offset             = 0x3f80;
+    ;
+
+    memory "sram"
+        size               = 32;
+        offset             = 0x40;
     ;
 ;
 
@@ -18975,6 +19468,10 @@ part parent ".reduced_core_tiny" # t20
         n_word_writes      = 2;
     ;
 
+    memory "sram"
+        size               = 128;
+    ;
+
     memory "io"
         size               = 64;
     ;
@@ -19009,6 +19506,10 @@ part parent ".reduced_core_tiny" # t40
     memory "fuse"
         bitmask            = 0x77;
         n_word_writes      = 4;
+    ;
+
+    memory "sram"
+        size               = 256;
     ;
 
     memory "io"
@@ -19179,6 +19680,11 @@ part # m406
 
     memory "signature"
         size               = 3;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 
     memory "io"
@@ -19354,11 +19860,6 @@ part # .avr8x
         readsize           = 1;
     ;
 
-    memory "data"
-        # SRAM, only used to supply the offset
-        offset             = 0x1000000;
-    ;
-
     memory "io"
         size               = 4352;
         readsize           = 1;
@@ -19464,6 +19965,11 @@ part parent ".avr8x_tiny" # t202
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x3f80;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -19509,6 +20015,11 @@ part parent ".avr8x_tiny" # t204
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x3f80;
     ;
 ;
 
@@ -19556,6 +20067,11 @@ part parent ".avr8x_tiny" # t402
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x3f00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -19601,6 +20117,11 @@ part parent ".avr8x_tiny" # t404
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x3f00;
     ;
 ;
 
@@ -19650,6 +20171,11 @@ part parent ".avr8x_tiny" # t406
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x3f00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -19684,6 +20210,11 @@ part parent ".avr8x_tiny" # t804
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
     ;
 ;
 
@@ -19724,6 +20255,11 @@ part parent ".avr8x_tiny" # t806
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -19760,6 +20296,11 @@ part parent ".avr8x_tiny" # t807
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -19794,6 +20335,11 @@ part parent ".avr8x_tiny" # t1604
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
     ;
 ;
 
@@ -19834,6 +20380,11 @@ part parent ".avr8x_tiny" # t1606
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -19869,6 +20420,11 @@ part parent ".avr8x_tiny" # t1607
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
     ;
 ;
 
@@ -19916,6 +20472,11 @@ part parent ".avr8x_tiny" # t212
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x3f80;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -19961,6 +20522,11 @@ part parent ".avr8x_tiny" # t214
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x3f80;
     ;
 ;
 
@@ -20008,6 +20574,11 @@ part parent ".avr8x_tiny" # t412
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x3f00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20053,6 +20624,11 @@ part parent ".avr8x_tiny" # t414
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x3f00;
     ;
 ;
 
@@ -20101,6 +20677,11 @@ part parent ".avr8x_tiny" # t416
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x3f00;
     ;
 ;
 
@@ -20166,6 +20747,11 @@ part parent ".avr8x_tiny" # t417
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x3f00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20212,6 +20798,11 @@ part parent ".avr8x_tiny" # t814
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
     ;
 ;
 
@@ -20264,6 +20855,11 @@ part parent ".avr8x_tiny" # t816
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20311,6 +20907,11 @@ part parent ".avr8x_tiny" # t817
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20356,6 +20957,11 @@ part parent ".avr8x_tiny" # t1614
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
     ;
 ;
 
@@ -20405,6 +21011,11 @@ part parent ".avr8x_tiny" # t1616
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20450,6 +21061,11 @@ part parent ".avr8x_tiny" # t1617
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
     ;
 ;
 
@@ -20501,6 +21117,11 @@ part parent ".avr8x_tiny" # t3216
     memory "userrow"
         size               = 64;
         page_size          = 64;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
     ;
 ;
 
@@ -20562,6 +21183,11 @@ part parent ".avr8x_tiny" # t424
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20610,6 +21236,11 @@ part parent ".avr8x_tiny" # t426
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20649,6 +21280,11 @@ part parent ".avr8x_tiny" # t427
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x3e00;
     ;
 ;
 
@@ -20693,6 +21329,11 @@ part parent ".avr8x_tiny" # t824
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
     ;
 ;
 
@@ -20742,6 +21383,11 @@ part parent ".avr8x_tiny" # t826
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20781,6 +21427,11 @@ part parent ".avr8x_tiny" # t827
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
     ;
 ;
 
@@ -20825,6 +21476,11 @@ part parent ".avr8x_tiny" # t1624
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
     ;
 ;
 
@@ -20874,6 +21530,11 @@ part parent ".avr8x_tiny" # t1626
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -20913,6 +21574,11 @@ part parent ".avr8x_tiny" # t1627
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
     ;
 ;
 
@@ -20957,6 +21623,11 @@ part parent ".avr8x_tiny" # t3224
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 3072;
+        offset             = 0x3400;
     ;
 ;
 
@@ -21006,6 +21677,11 @@ part parent ".avr8x_tiny" # t3226
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 3072;
+        offset             = 0x3400;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21045,6 +21721,11 @@ part parent ".avr8x_tiny" # t3227
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 3072;
+        offset             = 0x3400;
     ;
 ;
 
@@ -21093,6 +21774,11 @@ part parent ".avr8x_tiny" # m808
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21135,6 +21821,11 @@ part parent ".avr8x_tiny" # m809
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x3c00;
     ;
 ;
 
@@ -21183,6 +21874,11 @@ part parent ".avr8x_tiny" # m1608
     memory "lock"
         initval            = 0xc5;
     ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21225,6 +21921,11 @@ part parent ".avr8x_tiny" # m1609
 
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x3800;
     ;
 ;
 
@@ -21275,6 +21976,11 @@ part parent ".avr8x_mega" # m3208
         page_size          = 128;
         readsize           = 128;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x3000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21319,6 +22025,11 @@ part parent ".avr8x_mega" # m3209
         size               = 128;
         page_size          = 128;
         readsize           = 128;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x3000;
     ;
 ;
 
@@ -21369,6 +22080,11 @@ part parent ".avr8x_mega" # m4808
         page_size          = 128;
         readsize           = 128;
     ;
+
+    memory "sram"
+        size               = 6144;
+        offset             = 0x2800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21414,6 +22130,11 @@ part parent ".avr8x_mega" # m4809
         size               = 128;
         page_size          = 128;
         readsize           = 128;
+    ;
+
+    memory "sram"
+        size               = 6144;
+        offset             = 0x2800;
     ;
 ;
 
@@ -21574,11 +22295,6 @@ part # .avrdx
         alias "userrow";
     ;
 
-    memory "data"
-        # SRAM, only used to supply the offset
-        offset             = 0x1000000;
-    ;
-
     memory "io"
         size               = 4160;
         readsize           = 1;
@@ -21635,6 +22351,11 @@ part parent ".avrdx" # avr32da28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21680,6 +22401,11 @@ part parent ".avrdx" # avr32da32
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21724,6 +22450,11 @@ part parent ".avrdx" # avr32da48
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
     ;
 ;
 
@@ -21772,6 +22503,11 @@ part parent ".avrdx" # avr64da28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21816,6 +22552,11 @@ part parent ".avrdx" # avr64da32
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
     ;
 ;
 
@@ -21862,6 +22603,11 @@ part parent ".avrdx" # avr64da48
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21906,6 +22652,11 @@ part parent ".avrdx" # avr64da64
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
     ;
 ;
 
@@ -21954,6 +22705,11 @@ part parent ".avrdx" # avr128da28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -21998,6 +22754,11 @@ part parent ".avrdx" # avr128da32
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
     ;
 ;
 
@@ -22044,6 +22805,11 @@ part parent ".avrdx" # avr128da48
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22089,6 +22855,11 @@ part parent ".avrdx" # avr128da64
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22130,6 +22901,11 @@ part parent ".avrdx" # avr32db28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22169,6 +22945,11 @@ part parent ".avrdx" # avr32db32
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22207,6 +22988,11 @@ part parent ".avrdx" # avr32db48
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
     ;
 ;
 
@@ -22249,6 +23035,11 @@ part parent ".avrdx" # avr64db28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22287,6 +23078,11 @@ part parent ".avrdx" # avr64db32
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
     ;
 ;
 
@@ -22327,6 +23123,11 @@ part parent ".avrdx" # avr64db48
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22365,6 +23166,11 @@ part parent ".avrdx" # avr64db64
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
     ;
 ;
 
@@ -22407,6 +23213,11 @@ part parent ".avrdx" # avr128db28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22445,6 +23256,11 @@ part parent ".avrdx" # avr128db32
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
     ;
 ;
 
@@ -22485,6 +23301,11 @@ part parent ".avrdx" # avr128db48
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22524,6 +23345,11 @@ part parent ".avrdx" # avr128db64
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x4000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22561,6 +23387,11 @@ part parent ".avrdx" # avr16dd14
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
     ;
 ;
 
@@ -22600,6 +23431,11 @@ part parent ".avrdx" # avr16dd20
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
     ;
 ;
 
@@ -22642,6 +23478,11 @@ part parent ".avrdx" # avr16dd28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22681,6 +23522,11 @@ part parent ".avrdx" # avr16dd32
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22718,6 +23564,11 @@ part parent ".avrdx" # avr32dd14
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
     ;
 ;
 
@@ -22757,6 +23608,11 @@ part parent ".avrdx" # avr32dd20
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
     ;
 ;
 
@@ -22799,6 +23655,11 @@ part parent ".avrdx" # avr32dd28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22838,6 +23699,11 @@ part parent ".avrdx" # avr32dd32
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22876,6 +23742,11 @@ part parent ".avrdx" # avr64dd14
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22913,6 +23784,11 @@ part parent ".avrdx" # avr64dd20
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
     ;
 ;
 
@@ -22955,6 +23831,11 @@ part parent ".avrdx" # avr64dd28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -22993,6 +23874,11 @@ part parent ".avrdx" # avr64dd32
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
     ;
 ;
 
@@ -23168,6 +24054,11 @@ part parent ".avrex" # avr16ea28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -23198,6 +24089,11 @@ part parent ".avrex" # avr16ea32
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
     ;
 ;
 
@@ -23230,6 +24126,11 @@ part parent ".avrex" # avr16ea48
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -23260,6 +24161,11 @@ part parent ".avrex" # avr32ea28
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
     ;
 ;
 
@@ -23292,6 +24198,11 @@ part parent ".avrex" # avr32ea32
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -23322,6 +24233,11 @@ part parent ".avrex" # avr32ea48
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
     ;
 ;
 
@@ -23357,6 +24273,11 @@ part parent ".avrex" # avr64ea28
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 6144;
+        offset             = 0x6800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -23391,6 +24312,11 @@ part parent ".avrex" # avr64ea32
     memory "lock"
         initval            = 0x5cc5c55c;
     ;
+
+    memory "sram"
+        size               = 6144;
+        offset             = 0x6800;
+    ;
 ;
 
 #------------------------------------------------------------
@@ -23424,6 +24350,11 @@ part parent ".avrex" # avr64ea48
 
     memory "lock"
         initval            = 0x5cc5c55c;
+    ;
+
+    memory "sram"
+        size               = 6144;
+        offset             = 0x6800;
     ;
 ;
 
@@ -23494,6 +24425,11 @@ part parent ".avrex" # avr16eb14
 
     memory "userrow"
         offset             = 0x1200;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3114,13 +3114,13 @@ part # t11
         size               = 1;
     ;
 
+    memory "io"
+        size               = 64;
+    ;
+
     memory "sram"
         size               = 32;
         offset             = 0x60;
-    ;
-
-    memory "io"
-        size               = 64;
     ;
 ;
 
@@ -3231,13 +3231,13 @@ part # t12
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "io"
+        size               = 64;
+    ;
+
     memory "sram"
         size               = 32;
         offset             = 0x60;
-    ;
-
-    memory "io"
-        size               = 64;
     ;
 ;
 
@@ -3388,14 +3388,14 @@ part # t13
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 64;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 64;
+        offset             = 0x60;
     ;
 ;
 
@@ -3538,13 +3538,13 @@ part # t15
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
+    memory "io"
+        size               = 64;
+    ;
+
     memory "sram"
         size               = 32;
         offset             = 0x60;
-    ;
-
-    memory "io"
-        size               = 64;
     ;
 ;
 
@@ -4728,14 +4728,14 @@ part # m64
         read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -4903,14 +4903,14 @@ part # m128
         read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -5072,14 +5072,14 @@ part # c128
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -5219,14 +5219,14 @@ part # c64
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -5366,14 +5366,14 @@ part # c32
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 2048;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 ;
 
@@ -5513,14 +5513,14 @@ part # m16
         read               = "0011.1000--000x.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x60;
     ;
 ;
 
@@ -5692,14 +5692,14 @@ part # m324p
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 2048;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 ;
 
@@ -6022,14 +6022,14 @@ part # m644
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -6252,14 +6252,14 @@ part # m1284
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 0x4000;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 0x4000;
+        offset             = 0x100;
     ;
 ;
 
@@ -6447,14 +6447,14 @@ part # m162
         read               = "0011.1000--00xx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -7004,14 +7004,14 @@ part # m329
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 2048;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 ;
 
@@ -7285,14 +7285,14 @@ part # m649
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -7511,14 +7511,14 @@ part # m32
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 2048;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x60;
     ;
 ;
 
@@ -7788,14 +7788,14 @@ part # m8
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x60;
     ;
 ;
 
@@ -7948,14 +7948,14 @@ part # m8515
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
     ;
 ;
 
@@ -8086,14 +8086,14 @@ part # m8535
         read               = "0011.1000--00xx.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
     ;
 ;
 
@@ -8222,14 +8222,14 @@ part # t26
         read               = "0011.1000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 128;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -8374,14 +8374,14 @@ part # t261
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 128;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -8552,14 +8552,14 @@ part # t461
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 256;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
     ;
 ;
 
@@ -8726,14 +8726,14 @@ part # t861
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
     ;
 ;
 
@@ -8822,14 +8822,14 @@ part # t28
         size               = 1;
     ;
 
-    memory "sram"
-        size               = 32;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 32;
+        offset             = 0x60;
     ;
 ;
 
@@ -8984,14 +8984,14 @@ part # m48
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -9238,14 +9238,14 @@ part # m88
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -9496,14 +9496,14 @@ part # m168
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -9744,14 +9744,14 @@ part # t828
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -9912,14 +9912,14 @@ part # t87
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -10070,14 +10070,14 @@ part # t167
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -10226,14 +10226,14 @@ part # t48
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 256;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x100;
     ;
 ;
 
@@ -10382,14 +10382,14 @@ part # t88
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -10537,14 +10537,14 @@ part # m328
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 2048;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 ;
 
@@ -10749,14 +10749,14 @@ part # m64m1
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -11248,14 +11248,14 @@ part # m16hva
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -11410,14 +11410,14 @@ part # m16hvb
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -11609,14 +11609,14 @@ part # m64hve2
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -11793,14 +11793,14 @@ part # t2313
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 128;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -11974,14 +11974,14 @@ part # t4313
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 256;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
     ;
 ;
 
@@ -12124,14 +12124,14 @@ part # pwm1
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -12504,14 +12504,14 @@ part # pwm161
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -12774,14 +12774,14 @@ part # t25
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 128;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -12944,14 +12944,14 @@ part # t45
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 256;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
     ;
 ;
 
@@ -13111,14 +13111,14 @@ part # t85
         read               = "0011.1000--000x.xxxx--0000.000a--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
     ;
 ;
 
@@ -13263,14 +13263,14 @@ part # m640
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 8192;
-        offset             = 0x200;
-    ;
-
     memory "io"
         size               = 480;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x200;
     ;
 ;
 
@@ -13414,14 +13414,14 @@ part # m1280
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 8192;
-        offset             = 0x200;
-    ;
-
     memory "io"
         size               = 480;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x200;
     ;
 ;
 
@@ -13589,14 +13589,14 @@ part # m2560
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 8192;
-        offset             = 0x200;
-    ;
-
     memory "io"
         size               = 480;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x200;
     ;
 ;
 
@@ -14015,14 +14015,14 @@ part # t24
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 128;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 128;
+        offset             = 0x60;
     ;
 ;
 
@@ -14205,14 +14205,14 @@ part # t44
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 256;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
     ;
 ;
 
@@ -14394,14 +14394,14 @@ part # t84
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x60;
     ;
 ;
 
@@ -14470,12 +14470,12 @@ part parent "t44" # t441
         write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
-    memory "sram"
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
+    ;
+
+    memory "sram"
+        offset             = 0x100;
     ;
 ;
 
@@ -14520,12 +14520,12 @@ part parent "t84" # t841
         write              = "1010.1100--1010.0100--xxxx.xxxx--iiii.iiii";
     ;
 
-    memory "sram"
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
+    ;
+
+    memory "sram"
+        offset             = 0x100;
     ;
 ;
 
@@ -14671,14 +14671,14 @@ part # t43u
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 256;
-        offset             = 0x60;
-    ;
-
     memory "io"
         size               = 64;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 256;
+        offset             = 0x60;
     ;
 ;
 
@@ -14820,14 +14820,14 @@ part # m16u4
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1280;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1280;
+        offset             = 0x100;
     ;
 ;
 
@@ -14971,14 +14971,14 @@ part # m32u4
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 2560;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2560;
+        offset             = 0x100;
     ;
 ;
 
@@ -15120,14 +15120,14 @@ part # usb646
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -15287,14 +15287,14 @@ part # usb1286
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 8192;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x100;
     ;
 ;
 
@@ -15457,14 +15457,14 @@ part # usb162
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -15608,14 +15608,14 @@ part # usb82
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -15760,14 +15760,14 @@ part # m32u2
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -15912,14 +15912,14 @@ part # m16u2
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -16064,14 +16064,14 @@ part # m8u2
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 512;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 512;
+        offset             = 0x100;
     ;
 ;
 
@@ -16220,14 +16220,14 @@ part # m165p
         read               = "0011.1000--0000.0000--xxxx.xxxx--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -16429,14 +16429,14 @@ part # m325
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 2048;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 ;
 
@@ -16639,14 +16639,14 @@ part # m645
         read               = "0011.1000--0000.0000--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 4096;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x100;
     ;
 ;
 
@@ -16862,13 +16862,13 @@ part # .xmega
         offset             = 0x1000090;
     ;
 
-    memory "sram"
-        offset             = 0x2000;
-    ;
-
     memory "io"
         size               = 4096;
         readsize           = 1;
+    ;
+
+    memory "sram"
+        offset             = 0x2000;
     ;
 ;
 
@@ -19278,14 +19278,14 @@ part # t1634
         read               = "0011.1000--000x.xxxx--0000.0000--oooo.oooo";
     ;
 
-    memory "sram"
-        size               = 1024;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 1024;
+        offset             = 0x100;
     ;
 ;
 
@@ -19468,12 +19468,12 @@ part parent ".reduced_core_tiny" # t20
         n_word_writes      = 2;
     ;
 
-    memory "sram"
-        size               = 128;
-    ;
-
     memory "io"
         size               = 64;
+    ;
+
+    memory "sram"
+        size               = 128;
     ;
 ;
 
@@ -19508,12 +19508,12 @@ part parent ".reduced_core_tiny" # t40
         n_word_writes      = 4;
     ;
 
-    memory "sram"
-        size               = 256;
-    ;
-
     memory "io"
         size               = 64;
+    ;
+
+    memory "sram"
+        size               = 256;
     ;
 ;
 
@@ -19682,14 +19682,14 @@ part # m406
         size               = 3;
     ;
 
-    memory "sram"
-        size               = 2048;
-        offset             = 0x100;
-    ;
-
     memory "io"
         size               = 224;
         offset             = 0x20;
+    ;
+
+    memory "sram"
+        size               = 2048;
+        offset             = 0x100;
     ;
 ;
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -512,10 +512,7 @@ AVRMEM *avr_locate_mem_by_type(const AVRPART *p, memtype_t type) {
 
 // Return offset of memory data
 unsigned int avr_data_offset(const AVRPART *p) {
-  AVRMEM *data = avr_locate_data(p);
-  if(!data)
-    pmsg_warning("cannot locate data memory; is avrdude.conf up to date?\n");
-  return data? data->offset: 0;
+  return p->prog_modes & (PM_PDI | PM_UPDI)? 0x1000000: 0;
 }
 
 AVRMEM_ALIAS *avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig) {

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -771,7 +771,7 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       *lowbound = 0;
       *highbound = 0x7Fffff;    // Max 8 MiB
       *fileoff = 0;
-    } else if (mem_is_sram(mem)) { // SRAM
+    } else if (mem_is_io(mem) || mem_is_sram(mem)) { // IO & SRAM in data space
       *lowbound = 0x800000 + mem->offset;
       *highbound = 0x80ffff;
       *fileoff = 0;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -771,8 +771,8 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       *lowbound = 0;
       *highbound = 0x7Fffff;    // Max 8 MiB
       *fileoff = 0;
-    } else if (mem_is_data(mem)) { // SRAM for XMEGAs
-      *lowbound = 0x802000;
+    } else if (mem_is_sram(mem)) { // SRAM
+      *lowbound = 0x800000 + mem->offset;
       *highbound = 0x80ffff;
       *fileoff = 0;
     } else if (mem_is_eeprom(mem)) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2168,7 +2168,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     cmd[3] = MTYPE_OSCCAL_BYTE;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (mem_is_io(mem)) {
+  } else if (mem_is_io(mem) || mem_is_sram(mem)) {
     cmd[3] = MTYPE_SRAM;
   } else if (mem_is_sib(mem)) {
     if(addr >= AVR_SIBLEN) {
@@ -2325,7 +2325,7 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
       unsupp = 1;
   } else if (mem_is_userrow(mem)) {
     cmd[3] = MTYPE_USERSIG;
-  } else if (mem_is_io(mem))
+  } else if (mem_is_io(mem) || mem_is_sram(mem))
     cmd[3] = MTYPE_SRAM;
 
   // Read-only memories or unsupported by debugWire

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1212,10 +1212,10 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         u32_to_b4(xd.nvm_user_sig_offset, m->offset);
       } else if (mem_is_sigrow(m)) {
         u32_to_b4(xd.nvm_prod_sig_offset, m->offset);
-      } else if (mem_is_data(m)) {
-        u32_to_b4(xd.nvm_data_offset, m->offset);
       }
     }
+    if(p->prog_modes & (PM_PDI | PM_UPDI))
+      u32_to_b4(xd.nvm_data_offset, DATA_OFFSET);
 
     if (jtag3_setparm(pgm, SCOPE_AVR, 2, PARM3_DEVICEDESC, (unsigned char *)&xd, sizeof xd) < 0)
       return -1;

--- a/src/jtag3_private.h
+++ b/src/jtag3_private.h
@@ -379,6 +379,7 @@
 #define TPI_NVMCMD_ADDRESS                  0x33
 #define TPI_NVMCSR_ADDRESS                  0x32
 
+#define DATA_OFFSET                    0x1000000
 
 #if !defined(JTAG3_PRIVATE_EXPORTED)
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2222,7 +2222,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   } else if ((p->prog_modes & (PM_PDI | PM_UPDI)) && mem_is_in_sigrow(mem)) {
     cmd[1] = MTYPE_PRODSIG;
     pmsg_notice2("in_sigrow addr 0x%05lx\n", addr);
-  } else if (mem_is_io(mem)) {
+  } else if (mem_is_io(mem) || mem_is_sram(mem)) {
     cmd[1] = MTYPE_FLASH;
     addr += avr_data_offset(p);
   } else {
@@ -2346,7 +2346,7 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
     cmd[1] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (mem_is_io(mem)) {
+  } else if (mem_is_io(mem) || mem_is_sram(mem)) {
     cmd[1] = MTYPE_FLASH; // Works with jtag2updi, does not work with any xmega
     addr += avr_data_offset(p);
   } else if(mem_is_readonly(mem)) {

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -987,10 +987,10 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
     } else if (mem_is_sigrow(m)) {
       u32_to_b4(sendbuf.dd.nvm_prod_sig_offset, m->offset);
       pmsg_notice2("prod_sig_offset addr 0x%05x\n", m->offset);
-    } else if (mem_is_data(m)) {
-      u32_to_b4(sendbuf.dd.nvm_data_offset, m->offset);
     }
   }
+  if(p->prog_modes & (PM_PDI | PM_UPDI))
+    u32_to_b4(sendbuf.dd.nvm_data_offset, DATA_OFFSET);
 
   pmsg_notice2("%s() sending set Xmega params command: ", __func__);
   jtagmkII_send(pgm, (unsigned char *)&sendbuf, sizeof sendbuf);

--- a/src/jtagmkII_private.h
+++ b/src/jtagmkII_private.h
@@ -321,6 +321,8 @@
 #define AVR32_SET4RUNNING            0x0008
 //#define AVR32_RESET_COMMON           (AVR32_RESET_READ | AVR32_RESET_WRITE | AVR32_RESET_CHIP_ERASE )
 
+#define DATA_OFFSET               0x1000000
+
 typedef enum
 {
   RTS_MODE_DEFAULT,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1132,6 +1132,8 @@ int avr_mem_is_eeprom_type(const AVRMEM *mem);
 
 int avr_mem_is_usersig_type(const AVRMEM *mem);
 
+int avr_mem_cmp(void *mem1, void *mem2);
+
 int avr_mem_is_known(const char *str);
 
 int avr_mem_might_be_known(const char *str);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -360,7 +360,7 @@ typedef struct {
 #define MEM_OSC20ERR    (1<<19) // osc20err
 #define MEM_BOOTROW     (1<<20) // bootrow
 #define MEM_USERROW     (1<<21) // userrow usersig
-#define MEM_SRAM        (1<<22) // data
+#define MEM_SRAM        (1<<22) // sram
 #define MEM_IO          (1<<23) // io
 #define MEM_SIB         (1<<24) // sib
 
@@ -393,7 +393,7 @@ typedef struct {
 #define avr_locate_bootrow(p) avr_locate_mem_by_type((p), MEM_BOOTROW)
 #define avr_locate_usersig(p) avr_locate_mem_by_type((p), MEM_USERROW)
 #define avr_locate_userrow(p) avr_locate_mem_by_type((p), MEM_USERROW)
-#define avr_locate_data(p) avr_locate_mem_by_type((p), MEM_SRAM)
+#define avr_locate_sram(p) avr_locate_mem_by_type((p), MEM_SRAM)
 #define avr_locate_io(p) avr_locate_mem_by_type((p), MEM_IO)
 #define avr_locate_sib(p) avr_locate_mem_by_type((p), MEM_SIB)
 
@@ -441,7 +441,7 @@ typedef struct {
 #define mem_is_osc20err(mem) (!!((mem)->type & MEM_OSC20ERR))
 #define mem_is_bootrow(mem) (!!((mem)->type & MEM_BOOTROW))
 #define mem_is_userrow(mem) (!!((mem)->type & MEM_USERROW))
-#define mem_is_data(mem) (!!((mem)->type & MEM_SRAM))
+#define mem_is_sram(mem) (!!((mem)->type & MEM_SRAM))
 #define mem_is_io(mem) (!!((mem)->type & MEM_IO))
 #define mem_is_sib(mem) (!!((mem)->type & MEM_SIB))
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -360,8 +360,8 @@ typedef struct {
 #define MEM_OSC20ERR    (1<<19) // osc20err
 #define MEM_BOOTROW     (1<<20) // bootrow
 #define MEM_USERROW     (1<<21) // userrow usersig
-#define MEM_SRAM        (1<<22) // sram
-#define MEM_IO          (1<<23) // io
+#define MEM_IO          (1<<22) // io
+#define MEM_SRAM        (1<<23) // sram
 #define MEM_SIB         (1<<24) // sib
 
 // Attributes
@@ -393,8 +393,8 @@ typedef struct {
 #define avr_locate_bootrow(p) avr_locate_mem_by_type((p), MEM_BOOTROW)
 #define avr_locate_usersig(p) avr_locate_mem_by_type((p), MEM_USERROW)
 #define avr_locate_userrow(p) avr_locate_mem_by_type((p), MEM_USERROW)
-#define avr_locate_sram(p) avr_locate_mem_by_type((p), MEM_SRAM)
 #define avr_locate_io(p) avr_locate_mem_by_type((p), MEM_IO)
+#define avr_locate_sram(p) avr_locate_mem_by_type((p), MEM_SRAM)
 #define avr_locate_sib(p) avr_locate_mem_by_type((p), MEM_SIB)
 
 #define avr_locate_fuse(p) avr_locate_mem_by_type((p), MEM_IS_A_FUSE | MEM_FUSE0)
@@ -441,8 +441,8 @@ typedef struct {
 #define mem_is_osc20err(mem) (!!((mem)->type & MEM_OSC20ERR))
 #define mem_is_bootrow(mem) (!!((mem)->type & MEM_BOOTROW))
 #define mem_is_userrow(mem) (!!((mem)->type & MEM_USERROW))
-#define mem_is_sram(mem) (!!((mem)->type & MEM_SRAM))
 #define mem_is_io(mem) (!!((mem)->type & MEM_IO))
+#define mem_is_sram(mem) (!!((mem)->type & MEM_SRAM))
 #define mem_is_sib(mem) (!!((mem)->type & MEM_SIB))
 
 #define mem_is_in_flash(mem) (!!((mem)->type & MEM_IN_FLASH))

--- a/src/main.c
+++ b/src/main.c
@@ -1033,6 +1033,11 @@ int main(int argc, char * argv [])
     }
   }
 
+  // Sort memories of all parts in canonical order
+  for(LNODEID ln1 = lfirst(part_list); ln1; ln1 = lnext(ln1))
+    if((p = ldata(ln1))->mem)
+      lsort(p->mem, avr_mem_cmp);
+
   // set bitclock from configuration files unless changed by command line
   if (default_bitclock > 0 && bitclock == 0.0) {
     bitclock = default_bitclock;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -4270,7 +4270,7 @@ static int stk600_xprog_write_byte(const PROGRAMMER *pgm, const AVRPART *p, cons
         memcode = XPRG_MEM_TYPE_BOOT;
     } else if (mem_is_eeprom(mem)) {
         memcode = XPRG_MEM_TYPE_EEPROM;
-    } else if (mem_is_io(mem)) {
+    } else if (mem_is_io(mem) || mem_is_sram(mem)) {
         memcode = XPRG_MEM_TYPE_APPL;
         addr += avr_data_offset(p);
     } else if (mem_is_lock(mem)) {
@@ -4347,7 +4347,7 @@ static int stk600_xprog_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
         b[1] = XPRG_MEM_TYPE_BOOT;
     } else if (mem_is_eeprom(mem)) {
         b[1] = XPRG_MEM_TYPE_EEPROM;
-    } else if (mem_is_io(mem)) {
+    } else if (mem_is_io(mem) || mem_is_sram(mem)) {
         b[1] = XPRG_MEM_TYPE_APPL;
         addr += avr_data_offset(p);
     } else if (mem_is_signature(mem)) {
@@ -4421,7 +4421,7 @@ static int stk600_xprog_paged_load(const PROGRAMMER *pgm, const AVRPART *p, cons
             use_ext_addr = (1UL << 31);
     } else if (mem_is_eeprom(mem)) {
         mtype = XPRG_MEM_TYPE_EEPROM;
-    } else if (mem_is_io(mem)) {
+    } else if (mem_is_io(mem) || mem_is_sram(mem)) {
         mtype = XPRG_MEM_TYPE_APPL;
         addr += avr_data_offset(p);
     } else if (mem_is_signature(mem)) {


### PR DESCRIPTION
The memory `data` was introduced for the sole purpose to provide an `nvm_data_offset` for Microchip programmers. As an address offset it would tell programmers to read/write in data space. It so turned out that this `nvm_data_offset` always was `0x1000000` for PDI and UPDI parts.

This PR removes this artificial `data` memory and treats the `data` offset in the code as what it currently is: a constant.

At the same time the PR introduces an `sram` memory with offset and size for virtually all parts known to AVRDUDE.

Here a [summary](https://github.com/avrdudes/avrdude/issues/1559#issuecomment-1812198808) for the `sram` memory sizes and offsets (Issue #1559).

Known issues
 - The memory `sram` is not yet documented (but will be if this PR is accepted in principle)
 - <s>The code base does not yet have code to r/w to the `sram` memory</s>