### PR TITLE
Provide and use libavrude functions to access part config values

### DIFF
--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -29,7 +29,6 @@
 
 #include "avrdude.h"
 #include "libavrdude.h"
-#include "avrintel.h"
 
 /*
  * Provides an API for cached bytewise access

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -517,15 +517,20 @@ const Configitem_t *avr_locate_config(const Configitem_t *cfg, int nc, const cha
 static AVRMEM *avr_locate_config_mem_c_value(const PROGRAMMER *pgm, const AVRPART *p,
   const char *cname, const Configitem_t **cp, int *valp) {
 
-  int id = p->mcuid;
+  int idx = -1;
 
-  if(id < 0 || id >= (int) (sizeof uP_table/sizeof *uP_table)) {
-    pmsg_error("%s does not have a valid mcuid (%d)\n", p->desc, id);
+  if(p->mcuid >= 0)
+    idx = upidxmcuid(p->mcuid);
+  if(idx < 0 && p->desc && *p->desc)
+    idx = upidxname(p->desc);
+  if(idx < 0) {
+    pmsg_error("uP_table neither knows mcuid %d nor part %s\n",
+      p->mcuid, p->desc && *p->desc? p->desc: "???");
     return NULL;
   }
 
-  int nc = uP_table[id].nconfigs;
-  const Configitem_t *cfg = uP_table[id].cfgtable;
+  int nc = uP_table[idx].nconfigs;
+  const Configitem_t *cfg = uP_table[idx].cfgtable;
   if(nc < 1 || !cfg) {
     pmsg_error("%s does not have config information in avrintel.c\n", p->desc);
     return NULL;

--- a/src/config.c
+++ b/src/config.c
@@ -32,7 +32,6 @@
 #include "avrdude.h"
 #include "libavrdude.h"
 #include "config.h"
-#include "avrintel.h"
 
 #include "config_gram.h"
 

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -64,17 +64,6 @@ struct pdata
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
 
 /*
- * The OCDEN fuse is bit 7 of the high fuse (hfuse).  In order to
- * perform memory operations on MTYPE_SPM and MTYPE_EEPROM, OCDEN
- * needs to be programmed.
- *
- * OCDEN should probably rather be defined via the configuration, but
- * if this ever changes to a different fuse byte for one MCU, quite
- * some code here needs to be generalized anyway.
- */
-#define OCDEN (1 << 7)
-
-/*
  * Table of baud rates supported by the mkI ICE, accompanied by their
  * internal parameter value.
  *
@@ -550,12 +539,9 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (jtagmkI_reset(pgm) < 0)
     return -1;
 
-  AVRMEM *hf = avr_locate_hfuse(p);
-  if (!hf || jtagmkI_read_byte(pgm, p, hf, 1, &b) < 0)
-    return -1;
-  if ((b & OCDEN) != 0)
-    pmsg_warning("OCDEN fuse not programmed, "
-      "single-byte EEPROM updates not possible\n");
+  int ocden = 0;
+  if(avr_get_config_value(pgm, p, "ocden", &ocden) == 0 && ocden) // ocden == 1 means disabled
+    pmsg_warning("OCDEN fuse not programmed, single-byte EEPROM updates not possible\n");
 
   return 0;
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1420,7 +1420,12 @@ typedef struct {
 extern "C" {
 #endif
 
-const Configitem_t *avr_locate_config(const Configitem_t *cfg, int nc, const char *name);
+int avr_locate_upidx(const AVRPART *p);
+const Configitem_t *avr_locate_configitems(const AVRPART *p, int *nc);
+const Configitem_t *avr_locate_config(const Configitem_t *cfg, int nc, const char *name,
+  int (*match)(const char *, const char*));
+const Configitem_t **avr_locate_configlist(const Configitem_t *cfg, int nc, const char *name,
+  int (*match)(const char *, const char*));
 int avr_get_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int *valuep);
 int avr_set_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int value);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -25,6 +25,7 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "avrintel.h"
 
 typedef uint32_t pinmask_t;
 /*
@@ -1418,6 +1419,10 @@ typedef struct {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+const Configitem_t *avr_locate_config(const Configitem_t *cfg, int nc, const char *name);
+int avr_get_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int *valuep);
+int avr_set_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int value);
 
 int setport_from_serialadapter(char **portp, const SERIALADAPTER *ser, const char *sernum);
 int setport_from_vid_pid(char **portp, int vid, int pid, const char *sernum);

--- a/src/term.c
+++ b/src/term.c
@@ -35,7 +35,6 @@
 #include <errno.h>
 
 #include "libavrdude.h"
-#include "avrintel.h"
 
 #if defined(HAVE_LIBREADLINE)
 #include <readline/readline.h>


### PR DESCRIPTION
This PR provides `avr_get_config_value()` and `avr_set_config_value()` functions

Example usage:
```    
  int ocden = 0;
  if(avr_get_config_value(pgm, p, "ocden", &ocden) == 0 && ocden) // ocden == 1 means disabled
    pmsg_warning("OCDEN fuse not programmed, single-byte EEPROM updates not possible\n");
```

Fixes #1537 

Best way to test this PR is to program a classic part with jtag mkI or jtag mkII programmers. There should be no warning when the OCDEN fuse is programmed, and there should be a warning if it isn't.