### PR TITLE
Add more PL2303 compatible USB PIDs

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3026,8 +3026,7 @@ serialadapter # pl2303
     id                     = "pl2303";
     desc                   = "Profilic PL2303 USB to serial adapter";
     usbvid                 = 0x067b;
-    usbpid                 =
-        0x2303, 0x2304, 0x23a3, 0x23b3, 0x23c3, 0x23d3, 0x23e3, 0x23f4;
+    usbpid                 = 0x2303, 0x2304, 0x23a3, 0x23b3, 0x23c3, 0x23d3, 0x23e3, 0x23f4;
 ;
 
 #

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3026,7 +3026,8 @@ serialadapter # pl2303
     id                     = "pl2303";
     desc                   = "Profilic PL2303 USB to serial adapter";
     usbvid                 = 0x067b;
-    usbpid                 = 0x2303;
+    usbpid                 =
+        0x2303, 0x2304, 0x23a3, 0x23b3, 0x23c3, 0x23d3, 0x23e3, 0x23f4;
 ;
 
 #

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3026,7 +3026,7 @@ serialadapter # pl2303
     id                     = "pl2303";
     desc                   = "Profilic PL2303 USB to serial adapter";
     usbvid                 = 0x067b;
-    usbpid                 = 0x2303, 0x2304, 0x23a3, 0x23b3, 0x23c3, 0x23d3, 0x23e3, 0x23f4;
+    usbpid                 = 0x2303, 0x2304, 0x23a3, 0x23b3, 0x23c3, 0x23d3, 0x23e3, 0x23f3;
 ;
 
 #


### PR DESCRIPTION
I recently bought a PL2303GC chip to replace a USB to serial adapter I accidentally fried.
To my surprise, this chip uses a different USB PID than the more common PL2303HX (0x23a3 instead of 0x2303).

I found [a list](https://github.com/torvalds/linux/blob/18d46e76d7c2eedd8577fae67e3f1d4db25018b0/drivers/usb/serial/pl2303.h#L3) of the most common PL2303 PIDs supported by the Linux kernel. I decided to only include the "native" ones, and not 3rd party VID/PIDs.

