### PR TITLE
Terminal mode improvements

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2592,7 +2592,7 @@ int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
   return 0;
 }
 
-static int jtag3_get_vtarget(const PROGRAMMER *pgm, double *v) {
+int jtag3_get_vtarget(const PROGRAMMER *pgm, double *v) {
   unsigned char buf[2];
 
   if(jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2499,7 +2499,7 @@ int jtag3_read_sib(const PROGRAMMER *pgm, const AVRPART *p, char *sib) {
     return status;
 
   memcpy(sib, resp+3, AVR_SIBLEN);
-  sib[AVR_SIBLEN] = 0; // Zero terminate string
+  sib[AVR_SIBLEN-1] = 0; // Zero terminate string
   pmsg_debug("jtag3_read_sib(): received SIB: %s\n", sib);
   free(resp);
   return 0;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2404,7 +2404,7 @@ static int jtag3_set_sck_period(const PROGRAMMER *pgm, double v) {
 
 static int jtag3_get_sck_period(const PROGRAMMER *pgm, double *v) {
   unsigned char conn, arch;
-  unsigned char buf[3];
+  unsigned char buf[2];
   *v = 0;
 
   if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, &conn, 1) < 0) {
@@ -2589,6 +2589,18 @@ int jtag3_set_vtarget(const PROGRAMMER *pgm, double v) {
     return -1;
   }
 
+  return 0;
+}
+
+static int jtag3_get_vtarget(const PROGRAMMER *pgm, double *v) {
+  unsigned char buf[2];
+
+  if(jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0) {
+    pmsg_error("%s(): cannot read target voltage\n", __func__);
+    return -1;
+  }
+
+  *v = b2_to_u16(buf)/1000.0;
   return 0;
 }
 
@@ -3266,6 +3278,8 @@ void jtag3_initpgm(PROGRAMMER *pgm) {
   /*
    * hardware dependent functions
    */
+  if (pgm->extra_features & HAS_VTARG_READ)
+    pgm->get_vtarget  = jtag3_get_vtarget;
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }
@@ -3305,6 +3319,8 @@ void jtag3_dw_initpgm(PROGRAMMER *pgm) {
   /*
    * hardware dependent functions
    */
+  if (pgm->extra_features & HAS_VTARG_READ)
+    pgm->get_vtarget  = jtag3_get_vtarget;
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }
@@ -3347,6 +3363,8 @@ void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
   /*
    * hardware dependent functions
    */
+  if (pgm->extra_features & HAS_VTARG_READ)
+    pgm->get_vtarget  = jtag3_get_vtarget;
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }
@@ -3391,6 +3409,8 @@ void jtag3_updi_initpgm(PROGRAMMER *pgm) {
   /*
    * hardware dependent functions
    */
+  if (pgm->extra_features & HAS_VTARG_READ)
+    pgm->get_vtarget  = jtag3_get_vtarget;
   if (pgm->extra_features & HAS_VTARG_ADJ)
     pgm->set_vtarget  = jtag3_set_vtarget;
 }
@@ -3426,4 +3446,10 @@ void jtag3_tpi_initpgm(PROGRAMMER *pgm) {
   pgm->teardown       = jtag3_teardown;
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_TPI;
+
+  /*
+   * hardware dependent functions
+   */
+  if (pgm->extra_features & HAS_VTARG_READ)
+    pgm->get_vtarget  = jtag3_get_vtarget;
 }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2408,35 +2408,35 @@ static int jtag3_get_sck_period(const PROGRAMMER *pgm, double *v) {
   *v = 0;
 
   if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, &conn, 1) < 0) {
-    pmsg_error("%s(): cannot obtain connection type\n", __func__);
+    pmsg_error("cannot obtain connection type\n");
     return -1;
   }
   if (jtag3_getparm(pgm, SCOPE_AVR, 0, PARM3_ARCH, &arch, 1) < 0) {
-    pmsg_error("%s(): cannot obtain target architecture\n", __func__);
+    pmsg_error("cannot obtain target architecture\n");
     return -1;
   }
 
   if (conn == PARM3_CONN_JTAG) {
     if (arch == PARM3_ARCH_XMEGA) {
       if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_JTAG, buf, 2) < 0) {
-        pmsg_error("%s(): cannot read Xmega JTAG clock speed\n", __func__);
+        pmsg_error("cannot read Xmega JTAG clock speed\n");
         return -1;
       }
     } else {
       if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_MEGA_PROG, buf, 2) < 0) {
-        pmsg_error("%s(): cannot read JTAG clock speed\n", __func__);
+        pmsg_error("cannot read JTAG clock speed\n");
         return -1;
       }
     }
   } else if (conn & (PARM3_CONN_PDI | PARM3_CONN_UPDI)) {
     if (jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CLK_XMEGA_PDI, buf, 2) < 0) {
-      pmsg_error("%s(): cannot read PDI/UPDI clock speed\n", __func__);
+      pmsg_error("cannot read PDI/UPDI clock speed\n");
       return -1;
     }
   }
 
   if (b2_to_u16(buf) <= 0) {
-    pmsg_error("%s(): cannot calculate programmer clock speed\n", __func__);
+    pmsg_error("cannot calculate programmer clock speed\n");
     return -1;
   }
   *v = 1.0/(1000*b2_to_u16(buf));
@@ -2596,7 +2596,7 @@ static int jtag3_get_vtarget(const PROGRAMMER *pgm, double *v) {
   unsigned char buf[2];
 
   if(jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0) {
-    pmsg_error("%s(): cannot read target voltage\n", __func__);
+    pmsg_error("cannot read target voltage\n");
     return -1;
   }
 

--- a/src/jtag3.h
+++ b/src/jtag3.h
@@ -41,6 +41,7 @@ int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen
 void jtag3_display(const PROGRAMMER *pgm, const char *p);
 void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp);
 int jtag3_set_vtarget(const PROGRAMMER *pgm, double voltage);
+int jtag3_get_vtarget(const PROGRAMMER *pgm, double *voltage);
 extern const char jtag3_desc[];
 extern const char jtag3_dw_desc[];
 extern const char jtag3_pdi_desc[];

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2437,9 +2437,9 @@ static int jtagmkII_get_sck_period(const PROGRAMMER *pgm, double *v) {
   else if (buf[0] == 1)
     clk = 2.8e6;
   else if (buf[0] <= 5)
-    clk = 5.35e6 / (double)buf[0];
+    clk = 5.35e6 / buf[0];
   else
-    clk = 5.35e6 / (double)buf[0];
+    clk = 5.35e6 / buf[0];
 
   *v = 1 / clk;
   return 0;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2424,6 +2424,26 @@ static int jtagmkII_set_sck_period(const PROGRAMMER *pgm, double v) {
   return jtagmkII_setparm(pgm, PAR_OCD_JTAG_CLK, &dur);
 }
 
+static int jtagmkII_get_sck_period(const PROGRAMMER *pgm, double *v) {
+  unsigned char buf[4];
+  double clk;
+  if (jtagmkII_getparm(pgm, PAR_OCD_JTAG_CLK, buf) < 0) {
+    pmsg_error("cannot read JTAG clock speed\n");
+    return -1;
+  }
+
+  if (buf[0] == 0)
+    clk = 6.4e6;
+  else if (buf[0] == 1)
+    clk = 2.8e6;
+  else if (buf[0] <= 5)
+    clk = 5.35e6 / (double)buf[0];
+  else
+    clk = 5.35e6 / (double)buf[0];
+
+  *v = 1 / clk;
+  return 0;
+}
 
 /*
  * Read an emulator parameter.  As the maximal parameter length is 4
@@ -3614,6 +3634,7 @@ void jtagmkII_initpgm(PROGRAMMER *pgm) {
   pgm->page_erase     = jtagmkII_page_erase;
   pgm->print_parms    = jtagmkII_print_parms;
   pgm->set_sck_period = jtagmkII_set_sck_period;
+  pgm->get_sck_period = jtagmkII_get_sck_period;
   pgm->parseextparams = jtagmkII_parseextparms;
   pgm->setup          = jtagmkII_setup;
   pgm->teardown       = jtagmkII_teardown;
@@ -3747,6 +3768,7 @@ void jtagmkII_dragon_initpgm(PROGRAMMER *pgm) {
   pgm->page_erase     = jtagmkII_page_erase;
   pgm->print_parms    = jtagmkII_print_parms;
   pgm->set_sck_period = jtagmkII_set_sck_period;
+  pgm->get_sck_period = jtagmkII_get_sck_period;
   pgm->parseextparams = jtagmkII_parseextparms;
   pgm->setup          = jtagmkII_setup;
   pgm->teardown       = jtagmkII_teardown;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -2436,8 +2436,6 @@ static int jtagmkII_get_sck_period(const PROGRAMMER *pgm, double *v) {
     clk = 6.4e6;
   else if (buf[0] == 1)
     clk = 2.8e6;
-  else if (buf[0] <= 5)
-    clk = 5.35e6 / buf[0];
   else
     clk = 5.35e6 / buf[0];
 

--- a/src/main.c
+++ b/src/main.c
@@ -686,14 +686,23 @@ int main(int argc, char * argv [])
           /* trailing unit of measure present */
           int suffixlen = strlen(e);
           switch (suffixlen) {
+          case 1:
+            if (e[0] == 'm' || e[0] == 'M')
+              bitclock = 1.0 / bitclock;
+            else if (e[0] == 'k' || e[0] == 'K')
+              bitclock = 1e3 / bitclock;
+            else if (e[0] == 'h' || e[0] == 'H')
+              bitclock = 1e6 / bitclock;
+            else if (e[0] != 'u')
+              bitclock = 0.0;
+            break;
           case 2:
-            if ((e[0] != 'h' && e[0] != 'H') || e[1] != 'z')
+            if (e[0] == 'u' || e[0] == 'U');
+            else if ((e[0] != 'h' && e[0] != 'H') || e[1] != 'z')
               bitclock = 0.0;
             else
-              /* convert from Hz to microseconds */
-              bitclock = 1E6 / bitclock;
+              bitclock = 1e6 / bitclock;
             break;
-
           case 3:
             if ((e[1] != 'h' && e[1] != 'H') || e[2] != 'z')
               bitclock = 0.0;

--- a/src/main.c
+++ b/src/main.c
@@ -680,59 +680,24 @@ int main(int argc, char * argv [])
         }
         break;
 
-      case 'B': /* specify JTAG ICE bit clock period */
+      case 'B': /* specify bit clock period */
         bitclock = strtod(optarg, &e);
-        if (*e != 0) {
-          /* trailing unit of measure present */
-          int suffixlen = strlen(e);
-          switch (suffixlen) {
-          case 1:
-            if (e[0] == 'm' || e[0] == 'M')
-              bitclock = 1.0 / bitclock;
-            else if (e[0] == 'k' || e[0] == 'K')
-              bitclock = 1e3 / bitclock;
-            else if (e[0] == 'h' || e[0] == 'H')
-              bitclock = 1e6 / bitclock;
-            else if (e[0] != 'u')
-              bitclock = 0.0;
-            break;
-          case 2:
-            if (e[0] == 'u' || e[0] == 'U');
-            else if ((e[0] != 'h' && e[0] != 'H') || e[1] != 'z')
-              bitclock = 0.0;
-            else
-              bitclock = 1e6 / bitclock;
-            break;
-          case 3:
-            if ((e[1] != 'h' && e[1] != 'H') || e[2] != 'z')
-              bitclock = 0.0;
-            else {
-              switch (e[0]) {
-              case 'M':
-              case 'm': /* no Millihertz here :) */
-                bitclock = 1.0 / bitclock;
-                break;
-
-              case 'k':
-                bitclock = 1E3 / bitclock;
-                break;
-
-              default:
-                bitclock = 0.0;
-                break;
-              }
-            }
-            break;
-
-          default:
-            bitclock = 0.0;
-            break;
-          }
-          if (bitclock == 0.0)
-            pmsg_error("invalid bit clock unit of measure '%s'\n", e);
+        if ((e == optarg) || bitclock <= 0.0) {
+          pmsg_error("invalid bit clock period %s\n", optarg);
+          exit(1);
         }
-        if ((e == optarg) || bitclock == 0.0) {
-          pmsg_error("invalid bit clock period specified '%s'\n", optarg);
+        while(*e && isascii(*e & 0xff) && isspace(*e & 0xff))
+          e++;
+        if(*e == 0 || str_caseeq(e, "us")) // us is optional and the default
+          ;
+        else if(str_caseeq(e, "m") || str_caseeq(e, "mhz"))
+          bitclock = 1 / bitclock;
+        else if(str_caseeq(e, "k") || str_caseeq(e, "khz"))
+          bitclock = 1e3 / bitclock;
+        else if(str_caseeq(e, "hz"))
+          bitclock = 1e6 / bitclock;
+        else {
+          pmsg_error("invalid bit clock unit %s\n", e);
           exit(1);
         }
         break;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3919,7 +3919,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
     }
     fmsg_out(fp, "%sSCK period            : %.1f us\n", p, stk500v2_sck_duration_value(pgm));
     if (pgm->extra_features & HAS_FOSC_ADJ) {
-      f = stk500v2_sck_duration_value(pgm);
+      f = stk500v2_fosc_value(pgm);
       f = f_to_kHz_MHz(f, &unit);
       fmsg_out(fp, "%sOscillator            : %.3f %s\n", p, f, unit);
     }
@@ -5195,6 +5195,7 @@ void stk600_initpgm(PROGRAMMER *pgm) {
   pgm->get_vtarget    = stk500v2_get_vtarget;
   pgm->set_varef      = stk600_set_varef;
   pgm->set_fosc       = stk600_set_fosc;
+  pgm->get_fosc       = stk500v2_get_fosc;
   pgm->set_sck_period = stk600_set_sck_period;
   pgm->get_sck_period = stk500v2_get_sck_period;
   pgm->perform_osccal = stk500v2_perform_osccal;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3237,10 +3237,20 @@ static int stk500v2_set_varef(const PROGRAMMER *pgm, unsigned int chan /* unused
 }
 
 
-static int stk500v2_get_varef(const PROGRAMMER *pgm, unsigned int chan /* unused */,
-                              double *v)
+static int stk500v2_get_varef(const PROGRAMMER *pgm, unsigned int chan, double *v)
 {
-  *v = stk500v2_varef_value(pgm);
+  if(PDATA(pgm)->pgmtype == PGMTYPE_STK500)
+    *v = stk500v2_varef_value(pgm);
+  else if(PDATA(pgm)->pgmtype == PGMTYPE_STK600) {
+    if(chan == 0)
+      *v = stk600_varef_0_value(pgm);
+    else if(chan == 1)
+      *v = stk600_varef_1_value(pgm);
+    else {
+      pmsg_error("invalid Varef channel %d specified\n", chan);
+      return -1;
+    }
+  }
   return 0;
 }
 
@@ -5194,6 +5204,7 @@ void stk600_initpgm(PROGRAMMER *pgm) {
   pgm->set_vtarget    = stk600_set_vtarget;
   pgm->get_vtarget    = stk500v2_get_vtarget;
   pgm->set_varef      = stk600_set_varef;
+  pgm->get_varef      = stk500v2_get_varef;
   pgm->set_fosc       = stk600_set_fosc;
   pgm->get_fosc       = stk500v2_get_fosc;
   pgm->set_sck_period = stk600_set_sck_period;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -5192,6 +5192,7 @@ void stk600_initpgm(PROGRAMMER *pgm) {
   pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_vtarget    = stk600_set_vtarget;
+  pgm->get_vtarget    = stk500v2_get_vtarget;
   pgm->set_varef      = stk600_set_varef;
   pgm->set_fosc       = stk600_set_fosc;
   pgm->set_sck_period = stk600_set_sck_period;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -5242,9 +5242,13 @@ void stk600pp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_load     = stk500pp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_vtarget    = stk600_set_vtarget;
+  pgm->get_vtarget    = stk500v2_get_vtarget;
   pgm->set_varef      = stk600_set_varef;
+  pgm->get_varef      = stk500v2_get_varef;
   pgm->set_fosc       = stk600_set_fosc;
+  pgm->get_fosc       = stk500v2_get_fosc;
   pgm->set_sck_period = stk600_set_sck_period;
+  pgm->get_sck_period = stk500v2_get_sck_period;
   pgm->parseextparams = stk500v2_parseextparms;
   pgm->setup          = stk500v2_setup;
   pgm->teardown       = stk500v2_teardown;
@@ -5277,9 +5281,13 @@ void stk600hvsp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_load     = stk500hvsp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_vtarget    = stk600_set_vtarget;
+  pgm->get_vtarget    = stk500v2_get_vtarget;
   pgm->set_varef      = stk600_set_varef;
+  pgm->get_varef      = stk500v2_get_varef;
   pgm->set_fosc       = stk600_set_fosc;
+  pgm->get_fosc       = stk500v2_get_fosc;
   pgm->set_sck_period = stk600_set_sck_period;
+  pgm->get_sck_period = stk500v2_get_sck_period;
   pgm->parseextparams = stk500v2_parseextparms;
   pgm->setup          = stk500v2_setup;
   pgm->teardown       = stk500v2_teardown;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3562,6 +3562,10 @@ static int stk500v2_jtag3_get_sck_period(const PROGRAMMER *pgm, double *v) {
   }
 
   unsigned int sck = cmd[1] | (cmd[2] << 8);
+  if(!sck) {
+    pmsg_error("reported ISP clock speed not valid\n");
+    return -1;
+  }
   *v = 1 / (1000.0 * sck);
   return 0;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -5196,6 +5196,7 @@ void stk600_initpgm(PROGRAMMER *pgm) {
   pgm->set_varef      = stk600_set_varef;
   pgm->set_fosc       = stk600_set_fosc;
   pgm->set_sck_period = stk600_set_sck_period;
+  pgm->get_sck_period = stk500v2_get_sck_period;
   pgm->perform_osccal = stk500v2_perform_osccal;
   pgm->parseextparams = stk500v2_parseextparms;
   pgm->setup          = stk500v2_setup;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -5073,6 +5073,7 @@ void stk500v2_jtagmkII_initpgm(PROGRAMMER *pgm) {
   pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
+  pgm->get_sck_period = stk500v2_get_sck_period;
   pgm->perform_osccal = stk500v2_perform_osccal;
   pgm->setup          = stk500v2_jtagmkII_setup;
   pgm->teardown       = stk500v2_jtagmkII_teardown;
@@ -5107,6 +5108,8 @@ void stk500v2_dragon_isp_initpgm(PROGRAMMER *pgm) {
   pgm->page_erase     = NULL;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
+  pgm->get_sck_period = stk500v2_get_sck_period;
+  pgm->perform_osccal = stk500v2_perform_osccal;
   pgm->setup          = stk500v2_jtagmkII_setup;
   pgm->teardown       = stk500v2_jtagmkII_teardown;
   pgm->page_size      = 256;
@@ -5138,6 +5141,7 @@ void stk500v2_dragon_pp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_load     = stk500pp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
+  pgm->get_sck_period = stk500v2_get_sck_period;
   pgm->setup          = stk500v2_jtagmkII_setup;
   pgm->teardown       = stk500v2_jtagmkII_teardown;
   pgm->page_size      = 256;
@@ -5169,6 +5173,7 @@ void stk500v2_dragon_hvsp_initpgm(PROGRAMMER *pgm) {
   pgm->paged_load     = stk500hvsp_paged_load;
   pgm->print_parms    = stk500v2_print_parms;
   pgm->set_sck_period = stk500v2_set_sck_period_mk2;
+  pgm->get_sck_period = stk500v2_get_sck_period;
   pgm->setup          = stk500v2_jtagmkII_setup;
   pgm->teardown       = stk500v2_jtagmkII_teardown;
   pgm->page_size      = 256;

--- a/src/term.c
+++ b/src/term.c
@@ -1978,7 +1978,7 @@ static int cmd_sck(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
           v = 0.0;
         break;
       case 2:
-        if (endp[0] == 'u' && endp[1] == 's');
+        if (endp[0] == 'u' || endp[0] == 'U');
         else if ((endp[0] != 'h' && endp[0] != 'H') || endp[1] != 'z')
           v = 0.0;
         else

--- a/src/term.c
+++ b/src/term.c
@@ -1964,55 +1964,20 @@ static int cmd_sck(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
   }
 
   v = strtod(argv[1], &endp);
-  if (*endp != 0) {
-    int suffixlen = strlen(endp);
-    switch (suffixlen) {
-      case 1:
-        if (endp[0] == 'm' || endp[0] == 'M')
-          v = 1.0 / v;
-        else if (endp[0] == 'k' || endp[0] == 'K')
-          v = 1e3 / v;
-        else if (endp[0] == 'h' || endp[0] == 'H')
-          v = 1e6 / v;
-        else if (endp[0] != 'u')
-          v = 0.0;
-        break;
-      case 2:
-        if (endp[0] == 'u' || endp[0] == 'U');
-        else if ((endp[0] != 'h' && endp[0] != 'H') || endp[1] != 'z')
-          v = 0.0;
-        else
-          v = 1e6 / v;
-        break;
-      case 3:
-        if ((endp[1] != 'h' && endp[1] != 'H') || endp[2] != 'z')
-          v = 0.0;
-        else {
-          switch (endp[0]) {
-          case 'M':
-          case 'm':
-            v = 1.0 / v;
-            break;
-          case 'k':
-            v = 1e3 / v;
-            break;
-          default:
-            v = 0.0;
-            break;
-          }
-        }
-        break;
-      default:
-        v = 0.0;
-        break;
-    }
-    if (v == 0.0) {
-      pmsg_error("(sck) invalid SCK unit of measure '%s'\n", endp);
-      return -1;
-    }
+  if ((endp == argv[1]) || v <= 0.0) {
+    pmsg_error("(sck) invalid bit clock period %s\n", argv[1]);
+    return -1;
   }
-  if ((endp == argv[1]) || v == 0.0) {
-    pmsg_error("(sck) invalid SCK period specified '%s'\n", argv[1]);
+  if(*endp == 0 || str_caseeq(endp, "us")) // us is optional and the default
+    ;
+  else if(str_caseeq(endp, "m") || str_caseeq(endp, "mhz"))
+    v = 1 / v;
+  else if(str_caseeq(endp, "k") || str_caseeq(endp, "khz"))
+    v = 1e3 / v;
+  else if(str_caseeq(endp, "hz"))
+    v = 1e6 / v;
+  else {
+    pmsg_error("(sck) invalid bit clock unit %s\n", endp);
     return -1;
   }
   v *= 1e-6; // us to s

--- a/src/term.c
+++ b/src/term.c
@@ -1967,8 +1967,19 @@ static int cmd_sck(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
   if (*endp != 0) {
     int suffixlen = strlen(endp);
     switch (suffixlen) {
+      case 1:
+        if (endp[0] == 'm' || endp[0] == 'M' || endp[0] == 'u')
+          v = 1.0 / v;
+        else if (endp[0] == 'k' || endp[0] == 'K')
+          v = 1e3 / v;
+        else if (endp[0] == 'h' || endp[0] == 'H')
+          v = 1e6 / v;
+        else
+          v = 0.0;
+        break;
       case 2:
-        if ((endp[0] != 'h' && endp[0] != 'H') || endp[1] != 'z')
+        if (endp[0] == 'u' && endp[1] == 's');
+        else if ((endp[0] != 'h' && endp[0] != 'H') || endp[1] != 'z')
           v = 0.0;
         else
           v = 1e6 / v;

--- a/src/term.c
+++ b/src/term.c
@@ -1968,13 +1968,13 @@ static int cmd_sck(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
     int suffixlen = strlen(endp);
     switch (suffixlen) {
       case 1:
-        if (endp[0] == 'm' || endp[0] == 'M' || endp[0] == 'u')
+        if (endp[0] == 'm' || endp[0] == 'M')
           v = 1.0 / v;
         else if (endp[0] == 'k' || endp[0] == 'K')
           v = 1e3 / v;
         else if (endp[0] == 'h' || endp[0] == 'H')
           v = 1e6 / v;
-        else
+        else if (endp[0] != 'u')
           v = 0.0;
         break;
       case 2:


### PR DESCRIPTION
Extends #1574 

* Fix bug that makes Avrdude segfault when trying to set a new clock speed using the `sck` command using a JTAG3 compatible programmer (bug was introduced when we added SIB read support
* Make it possible to use the `sck` command to set the clock speed in Hz, kHz, and MHz.
* running `sck` without a second argument now prints the clock speed in kHz as well as us.
* `jtag3_get_vtarget` and `jtag3_get_sck_period` added to jtag3.c

**TODO:** 
Test all JTAG2, stk500v2, and stk600 compatible programmers I have to make sure all of them can read the target voltage in terminal mode using `vtarg`, and clock speed using `sck`. When this is done (and missing programmers added), I'll mark this PR as "ready to review".

Resolves issue #1329