### PR TITLE
Use Levenshtein distance to suggest a valid programmer name if -c is invalid

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2799,7 +2799,7 @@ programmer # pavr
 
 programmer # pickit2
     id                     = "pickit2";
-    desc                   = "MicroChip's PICkit2 Programmer";
+    desc                   = "Microchip PICkit2 programmer in ISP mode";
     type                   = "pickit2";
     prog_modes             = PM_ISP;
     connection_type        = usb;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2701,7 +2701,7 @@ programmer # pickit4_tpi
 
 programmer # snap
     id                     = "snap", "snap_jtag";
-    desc                   = "MPLAB(R) Snap in JTAG mode";
+    desc                   = "MPLAB(R) SNAP in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
     extra_features         = HAS_VTARG_READ;
@@ -2799,7 +2799,7 @@ programmer # pavr
 
 programmer # pickit2
     id                     = "pickit2";
-    desc                   = "Microchip PICkit2 programmer in ISP mode";
+    desc                   = "Microchip PICkit 2 programmer in ISP mode";
     type                   = "pickit2";
     prog_modes             = PM_ISP;
     connection_type        = usb;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1056,7 +1056,7 @@ void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int
 void pgm_display_generic(const PROGRAMMER *pgm, const char *p);
 
 PROGRAMMER *locate_programmer_set(const LISTID programmers, const char *id, const char **setid);
-
+PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *id, const char **setid);
 PROGRAMMER *locate_programmer(const LISTID programmers, const char *configid);
 
 typedef void (*walk_programmers_cb)(const char *name, const char *desc,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1477,6 +1477,7 @@ void str_freedata(Str2data *sd);
 unsigned long long int str_int(const char *str, int type, const char **errpp);
 int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
 char *str_nexttok(char *buf, const char *delim, char **next);
+int levenshtein(const char *str1, const char *str2, int swap, int subst, int add, int del);
 
 int led_set(const PROGRAMMER *pgm, int led);
 int led_clr(const PROGRAMMER *pgm, int led);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1477,7 +1477,7 @@ void str_freedata(Str2data *sd);
 unsigned long long int str_int(const char *str, int type, const char **errpp);
 int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
 char *str_nexttok(char *buf, const char *delim, char **next);
-int levenshtein(const char *str1, const char *str2, int swap, int subst, int add, int del);
+int str_levenshtein(const char *str1, const char *str2, int swap, int subst, int add, int del);
 size_t str_weighted_damerau_levenshtein(const char *str1, const char *str2);
 
 int led_set(const PROGRAMMER *pgm, int led);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1056,7 +1056,7 @@ void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int
 void pgm_display_generic(const PROGRAMMER *pgm, const char *p);
 
 PROGRAMMER *locate_programmer_set(const LISTID programmers, const char *id, const char **setid);
-PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *id, const char **setid);
+PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *id, const char **setid, AVRPART *prt);
 PROGRAMMER *locate_programmer(const LISTID programmers, const char *configid);
 
 typedef void (*walk_programmers_cb)(const char *name, const char *desc,

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1478,6 +1478,7 @@ unsigned long long int str_int(const char *str, int type, const char **errpp);
 int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
 char *str_nexttok(char *buf, const char *delim, char **next);
 int levenshtein(const char *str1, const char *str2, int swap, int subst, int add, int del);
+size_t str_weighted_damerau_levenshtein(const char *str1, const char *str2);
 
 int led_set(const PROGRAMMER *pgm, int led);
 int led_clr(const PROGRAMMER *pgm, int led);

--- a/src/main.c
+++ b/src/main.c
@@ -497,10 +497,12 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
   }
   // Sort list so programmers with the smallest distance gets printed first
   qsort(d, idx, sizeof(*d), cmp_ptr);
-  msg_info("similar matches:\n");
-  for(int i = 0; i < idx; i++)
-    msg_info("%-*s = %s\n", pgmid_maxlen, d[i].pgmid, d[i].desc);
-  msg_info("use -c? to see all possible programmers for this part\n");
+  if(idx) {
+    msg_info("similar matches:\n");
+    for(int i = 0; i < idx; i++)
+      msg_info("%-*s = %s\n", pgmid_maxlen, d[i].pgmid, d[i].desc);
+    msg_info("use -c? to see all possible programmers for this part\n");
+  }
   for(int i = 0; i < idx; i++) {
     if(d[i].pgmid)
       free(d[i].pgmid);

--- a/src/main.c
+++ b/src/main.c
@@ -518,7 +518,7 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
     }
   }
   if(comp) {
-    msg_info("similar programmer name%s:\n", str_plural(n));
+    msg_info("similar programmer name%s:\n", str_plural(comp));
     for(size_t i = 0; i < n; i++)
       if(d[i].common_modes)
         msg_info("  %-*s = %s\n", pgmid_maxlen, d[i].pgmid, d[i].desc);

--- a/src/main.c
+++ b/src/main.c
@@ -494,8 +494,7 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
         d[idx].pgmid = ldata(ln2);
         d[idx].desc = pgm->desc;
         d[idx].dist = str_weighted_damerau_levenshtein(d[idx].pgmid, programmer);
-        if(p)
-          d[idx].common_modes = p->prog_modes & pgm->prog_modes;
+        d[idx].common_modes = pgm->prog_modes & (p? p->prog_modes: -1);
         idx++;
       }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -464,8 +464,8 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
   int pgmid_maxlen = 0;
   typedef struct {
     int distance;
-    char *pgmid;
-    char *desc;
+    const char *pgmid;
+    const char *desc;
   } pgm_distance;
 
   pgm_distance *d = malloc(1);
@@ -487,8 +487,8 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
           return -1;
         }
         d[idx].distance = dist;
-        d[idx].pgmid = cfg_strdup(__func__, id);
-        d[idx].desc = cfg_strdup(__func__, pgm->desc);
+        d[idx].pgmid = id;
+        d[idx].desc = pgm->desc;
         idx++;
         if(strlen(id) > (size_t)pgmid_maxlen)
           pgmid_maxlen = (int)strlen(id);
@@ -502,11 +502,6 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
     for(int i = 0; i < idx; i++)
       msg_info("%-*s = %s\n", pgmid_maxlen, d[i].pgmid, d[i].desc);
     msg_info("use -c? to see all possible programmers for this part\n");
-  }
-  for(int i = 0; i < idx; i++) {
-    if(d[i].pgmid)
-      free(d[i].pgmid);
-      free(d[i].desc);
   }
   free(d);
   return idx;

--- a/src/main.c
+++ b/src/main.c
@@ -528,7 +528,7 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
 
 static void programmer_not_found(const char *programmer, PROGRAMMER *pgm) {
   msg_error("\n");
-  if(str_eq(programmer, "?")) {
+  if(programmer && str_eq(programmer, "?")) {
     msg_error("\nValid programmers are:\n");
     list_programmers(stderr, "  ", programmers, ~0);
     msg_error("\n");

--- a/src/main.c
+++ b/src/main.c
@@ -522,32 +522,31 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
     for(size_t i = 0; i < n; i++)
       if(d[i].common_modes)
         msg_info("  %-*s = %s\n", pgmid_maxlen, d[i].pgmid, d[i].desc);
-    msg_info("use -c? to see all possible programmers\n");
   }
   free(d);
   return n;
 }
 
 static void programmer_not_found(const char *programmer, PROGRAMMER *pgm) {
-  int pgm_suggestions = 0;
   msg_error("\n");
-  if(programmer && *programmer) {
-    if(!pgm || !pgm->id || !lsize(pgm->id)) {
-      pmsg_error("cannot find programmer id %s\n", programmer);
-      pgm_suggestions = suggest_programmers(programmer, programmers);
-    }
-    else
-      pmsg_error("programmer %s lacks %s setting\n", programmer,
-        !pgm->prog_modes? "prog_modes": !pgm->initpgm? "type": "some");
-  } else {
-    pmsg_error("no programmer has been specified on the command line or in the\n");
-    imsg_error("config file(s); specify one using the -c option and try again\n");
-  }
-
-  if(pgm_suggestions <= 0) {
+  if(str_eq(programmer, "?")) {
     msg_error("\nValid programmers are:\n");
     list_programmers(stderr, "  ", programmers, ~0);
     msg_error("\n");
+  } else {
+    if(programmer && *programmer) {
+      if(!pgm || !pgm->id || !lsize(pgm->id)) {
+        pmsg_error("cannot find programmer id %s\n", programmer);
+        suggest_programmers(programmer, programmers);
+        msg_info("use -c? to see all possible programmers\n");
+      }
+      else
+        pmsg_error("programmer %s lacks %s setting\n", programmer,
+          !pgm->prog_modes? "prog_modes": !pgm->initpgm? "type": "some");
+    } else {
+      pmsg_error("no programmer has been specified on the command line or in the\n");
+      imsg_error("config file(s); specify one using the -c option and try again\n");
+    }
   }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -500,7 +500,7 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
   msg_info("similar matches:\n");
   for(int i = 0; i < idx; i++)
     msg_info("%-*s = %s\n", pgmid_maxlen, d[i].pgmid, d[i].desc);
-  msg_info("(use -c? to see all possible programmers for this part)\n");
+  msg_info("use -c? to see all possible programmers for this part\n");
   for(int i = 0; i < idx; i++) {
     if(d[i].pgmid)
       free(d[i].pgmid);

--- a/src/main.c
+++ b/src/main.c
@@ -503,17 +503,15 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
   int n = 0, pgmid_maxlen = 0, comp = 0, len;
   if(nid) {                     // Sort list so programmers according to string distance
     qsort(d, nid, sizeof(*d), cmp_pgmid);
-    size_t dst = d[nid > 2? 2: nid-1].dist; // Print at least 3 close suggestions if possible
+    size_t dst = d[nid > 2? 2: nid-1].dist;
     if(dst > max_distance)
       dst = max_distance;
-    for(; n < nid; n++) {
-      if(d[n].dist > dst)
-        break;
-      if((len = strlen(d[n].pgmid)) > pgmid_maxlen)
-        pgmid_maxlen = len;
-      if(d[n].common_modes)
+    for(; n < nid && d[n].dist <= dst; n++)
+      if(d[n].common_modes) {
+        if((len = strlen(d[n].pgmid)) > pgmid_maxlen)
+          pgmid_maxlen = len;
         comp++;
-    }
+      }
   }
   if(comp) {
     msg_info("similar programmer name%s:\n", str_plural(comp));

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -313,9 +313,9 @@ void pgm_display_generic(const PROGRAMMER *pgm, const char *p) {
 }
 
 // Locate a real programmer entry by partial initial id and set the matching id
-PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *pgid, const char **setid) {
-  PROGRAMMER *p, *matchp;
-  int matches, p1;
+PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *pgid, const char **setid, AVRPART *prt) {
+  PROGRAMMER *pgm, *matchp;
+  int matches, p1, pmode = prt? prt->prog_modes: -1;
   const char *matchid;
   size_t l;
 
@@ -326,12 +326,12 @@ PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *p
   matches = 0;
   matchp = NULL;
   for(LNODEID ln1=lfirst(programmers); ln1; ln1=lnext(ln1)) {
-    p = ldata(ln1);
-    if(is_programmer(p))
-      for(LNODEID ln2=lfirst(p->id); ln2; ln2=lnext(ln2)) {
+    pgm = ldata(ln1);
+    if(is_programmer(pgm) && (pgm->prog_modes & pmode))
+      for(LNODEID ln2=lfirst(pgm->id); ln2; ln2=lnext(ln2)) {
         const char *id = (const char *) ldata(ln2);
         if(p1 == *id && !strncasecmp(id, pgid, l)) { // Partial initial match
-          matchp = p;
+          matchp = pgm;
           matchid = id;
           matches++;
           if(id[l] == 0) {      // Exact match; return straight away

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -312,6 +312,48 @@ void pgm_display_generic(const PROGRAMMER *pgm, const char *p) {
   pgm_display_generic_mask(pgm, p, SHOW_ALL_PINS);
 }
 
+// Locate a real programmer entry by partial initial id and set the matching id
+PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *pgid, const char **setid) {
+  PROGRAMMER *p, *matchp;
+  int matches, p1;
+  const char *matchid;
+  size_t l;
+
+  if(!pgid || !(p1 = *pgid))
+    return NULL;
+
+  l = strlen(pgid);
+  matches = 0;
+  matchp = NULL;
+  for(LNODEID ln1=lfirst(programmers); ln1; ln1=lnext(ln1)) {
+    p = ldata(ln1);
+    if(is_programmer(p))
+      for(LNODEID ln2=lfirst(p->id); ln2; ln2=lnext(ln2)) {
+        const char *id = (const char *) ldata(ln2);
+        if(p1 == *id && !strncasecmp(id, pgid, l)) { // Partial initial match
+          matchp = p;
+          matchid = id;
+          matches++;
+          if(id[l] == 0) {      // Exact match; return straight away
+            matches = 1;
+            goto done;
+          }
+          break;
+        }
+      }
+    }
+
+done:
+  if(matches == 1) {
+    if(setid)
+      *setid = matchid;
+    return matchp;
+  }
+
+  return NULL;
+}
+
+// Locate a programmer (or serial adapter) by full name and set the matching id
 PROGRAMMER *locate_programmer_set(const LISTID programmers, const char *configid, const char **setid) {
   for(LNODEID ln1=lfirst(programmers); ln1; ln1=lnext(ln1)) {
     PROGRAMMER *p = ldata(ln1);

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1067,7 +1067,7 @@ char *str_nexttok(char *buf, const char *delim, char **next) {
  * - add (for insertion, AKA "Add")
  * - del (as in "Deletion")
  *
- * Note that this algorithm calculates a distance _iff_ d == a.
+ * Note that this algorithm calculates a distance _iff_ del == add.
  */
 
 int levenshtein(const char *str1, const char *str2,

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1033,6 +1033,8 @@ char *str_nexttok(char *buf, const char *delim, char **next) {
 }
 
 /*
+ * From https://github.com/git/git/blob/master/levenshtein.c
+ *
  * This function implements the Damerau-Levenshtein algorithm to
  * calculate a distance between strings.
  *

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1073,7 +1073,7 @@ char *str_nexttok(char *buf, const char *delim, char **next) {
  * Note that this algorithm calculates a distance _iff_ del == add.
  */
 
-int levenshtein(const char *str1, const char *str2,
+int str_levenshtein(const char *str1, const char *str2,
   int swap, int subst, int add, int del) {
 
   int i, j, len1 = strlen(str1), len2 = strlen(str2);

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1076,9 +1076,9 @@ int levenshtein(const char *str1, const char *str2,
   int swap, int subst, int add, int del) {
 
   int i, j, len1 = strlen(str1), len2 = strlen(str2);
-  int *row0 = calloc(len2 + 1, sizeof(int*));
-  int *row1 = calloc(len2 + 1, sizeof(int*));
-  int *row2 = calloc(len2 + 1, sizeof(int*));
+  int *row0 = cfg_malloc(__func__, (len2+1)*sizeof*row0);
+  int *row1 = cfg_malloc(__func__, (len2+1)*sizeof*row1);
+  int *row2 = cfg_malloc(__func__, (len2+1)*sizeof*row2);
 
   for (j = 0; j <= len2; j++)
     row1[j] = j * add;

--- a/src/term.c
+++ b/src/term.c
@@ -1652,7 +1652,7 @@ static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
 
     if(!*rlist) {
       pmsg_error("(regfile) register %s not found in register file\n", *reg? reg: "''");
-      imsg_error("type regfile for all possible values\n", reg);
+      imsg_error("type regfile for all possible values\n");
       goto error;
     }
 
@@ -1723,7 +1723,7 @@ static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
     term_out("%s", r->reg);
     int c = *r->caption;
     if(verb)
-      term_out("%*s # %c%s", maxlen-strlen(r->reg), "", c? toupper(c): ' ', c? r->caption+1: "");
+      term_out("%*s # %c%s", maxlen - (int) strlen(r->reg), "", c? toupper(c): ' ', c? r->caption+1: "");
     term_out("\n");
   }
 


### PR DESCRIPTION
See #1591 for details. The same for -p could also be done, but ideally in a separate PR.

Right now there is no weighing, but this can easily be added by tweaking the last four parameters in this line:

```c
int dist = levenshtein(programmer, id, 1, 1, 1, 1);
```

Examples:
```
$ ./avrdude -cusbast -patmega328p

avrdude error: cannot find programmer id usbast
similar matches:
usbasp = USBasp ISP and TPI programmer
use -c? to see all possible programmers for this part


$ ./avrdude -csdk500 -patmega328p

avrdude error: cannot find programmer id sdk500
similar matches:
stk500   = Atmel STK500 (probes STK500v2 first then STK500v1)
stk600   = Atmel STK600
stk500pp = Atmel STK500 v2 in parallel programming mode
stk500v1 = Atmel STK500 version 1.x firmware
stk500v2 = Atmel STK500 version 2.x firmware
use -c? to see all possible programmers for this part

$ ./avrdude -cstk600_pp -patmega328p

avrdude error: cannot find programmer id stk600_pp
similar matches:
stk600pp   = Atmel STK600 in parallel programming mode
stk500pp   = Atmel STK500 v2 in parallel programming mode
stk600     = Atmel STK600
stk600hvsp = Atmel STK600 in high-voltage serial programming mode
use -c? to see all possible programmers for this part
```