### PR TITLE
jtagmkII_updi_term_keep_alive

### DIFF
--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -3601,13 +3601,8 @@ static int jtagmkII_flash_clear_pagebuffer32(const PROGRAMMER *pgm) {
     return -1;
 }
 
-/*** Periodic calls in terminal mode to keep `JTAGMKII_UPDI` enabled. ***/
-/*
- * GET_SYNC is not guaranteed to be harmless to other program devices.
- * (JTAG2UPDI and UPDI4AVR are definitely harmless)
- * So this is probably only available in `jtagmkII_updi_initpgm`.
- */
-static int jtagmkII_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unused) {
+// Periodic calls in terminal mode to keep the programmer jtagmkii_updi enabled
+static int jtagmkII_updi_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unused) {
   unsigned char buf[2], *resp, c = 0xff;
   int status;
 
@@ -3615,14 +3610,13 @@ static int jtagmkII_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unus
   jtagmkII_send(pgm, buf, 1);
 
   status = jtagmkII_recv(pgm, &resp);
-  c = resp[0];
-
   if (status <= 0) {
     msg_notice2("\n");
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return -1;
   }
 
+  c = resp[0];
   free(resp);
   if (c != RSP_OK) {
     pmsg_error("bad response to `get_sync` command: %s\n", jtagmkII_get_rc(c));
@@ -3768,7 +3762,7 @@ void jtagmkII_updi_initpgm(PROGRAMMER *pgm) {
   pgm->read_chip_rev  = jtagmkII_read_chip_rev;
   pgm->page_size      = 256;
   pgm->flag           = PGM_FL_IS_PDI;
-  pgm->term_keep_alive= jtagmkII_term_keep_alive;
+  pgm->term_keep_alive= jtagmkII_updi_term_keep_alive;
 }
 
 const char jtagmkII_dragon_desc[] = "Atmel AVR Dragon in JTAG mode";

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -3616,7 +3616,6 @@ static int jtagmkII_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unus
 
   status = jtagmkII_recv(pgm, &resp);
   c = resp[0];
-  free(resp);
 
   if (status <= 0) {
     msg_notice2("\n");
@@ -3624,6 +3623,7 @@ static int jtagmkII_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unus
     return -1;
   }
 
+  free(resp);
   if (c != RSP_OK) {
     pmsg_error("bad response to `get_sync` command: %s\n", jtagmkII_get_rc(c));
     return -1;


### PR DESCRIPTION
[issue #1600] This small patch adds a keepalive to `jtagmkII_updi`. This avoids his 250ms timeout in the `JTAG2UPDI` firmware and allows the interactive mode `-t` to be used normally, making troubleshooting follow-up easier.

- Useful for users of JTAG2UPDI original and variants.
- Tasks such as unlocking a locked device using `-t -F`.
- It can also be used with *Arduino Nano Every* (`-t -r`), but the 60 second limit fixed by firmware cannot be avoided.

```
bash-3.2$ time ./build_darwin/src/avrdude -c jtag2updi -P /dev/cu.usbmodem1201 -p avr32da32 -tqv

avrdude: Version 7.2-20231221 (06156d9c)
         Copyright the AVRDUDE authors;
         see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

         System wide configuration file is /Users/askn/Collaborator/avrdude_issue1600/build_darwin/src/avrdude.conf
         User configuration file is /Users/askn/.avrduderc

         Using port            : /dev/cu.usbmodem1201
         Using programmer      : jtag2updi
         Programmer baud rate  : 115200
         AVR Part              : AVR32DA32
         Programming modes     : UPDI, SPM
         Programmer Type       : JTAGMKII_UPDI
         Description           : JTAGv2 to UPDI bridge
         Main MCU HW version   : 1
         Main MCU FW version   : 6.00
         Sec. MCU HW version   : 1
         Sec. MCU FW version   : 6.00
         Serial number         : 00:00:00:00:00:00
avrdude: silicon revision: 1.3
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9533 (probably avr32da32)

avrdude: processing -t interactive terminal
avrdude> dump sernum
>>> dump sernum 0x0 0x10
0000  42 05 11 41 21 00 05 13  01 32 01 14 00 00 00 00  |B..A!....2......|
avrdude> dump userrow
>>> dump userrow 0x0 0x20
0000  54 68 65 20 71 75 69 63  6b 20 62 72 6f 77 6e 20  |The quick brown |
0010  66 6f 78 20 6a 75 6d 70  73 20 6f 76 65 72 20 74  |fox jumps over t|
avrdude> dump eeprom 0 64
0000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0010  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0020  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0030  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
avrdude> q

avrdude done.  Thank you.


real	0m23.699s
user	0m0.058s
sys	0m0.064s
```