### PR TITLE
Harden AVRDUDE against pre-C99 libraries

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1312,7 +1312,7 @@ FILE *fileio_fopenr(const char *fname) {
 
 static FILEFMT couldbe(int first, unsigned char *line) {
   int found;
-  size_t i, nxdigs, len;
+  unsigned long i, nxdigs, len;
 
   // Check for ELF file
   if(first && line[0] == 0177 && str_starts((char *) line+1, "ELF"))
@@ -1329,7 +1329,7 @@ static FILEFMT couldbe(int first, unsigned char *line) {
 
   // Check for lines that look like Intel HEX
   if(line[0] == ':' && len >= 11 && isxdigit(line[1]) && isxdigit(line[2])) {
-    nxdigs = sscanf((char *) line+1, "%2zx", &nxdigs) == 1? 2*nxdigs + 8: len;
+    nxdigs = sscanf((char *) line+1, "%2lx", &nxdigs) == 1? 2*nxdigs + 8: len;
     for(found = 3+nxdigs <= len, i=0; found && i<nxdigs; i++)
       if(!isxdigit(line[3+i]))
         found = 0;
@@ -1339,7 +1339,7 @@ static FILEFMT couldbe(int first, unsigned char *line) {
 
   // Check for lines that look like Motorola S-record
   if(line[0] == 'S' && len >= 10 && isdigit(line[1]) && isxdigit(line[2]) && isxdigit(line[3])) {
-    nxdigs = sscanf((char *) line+2, "%2zx", &nxdigs) == 1? 2*nxdigs: len;
+    nxdigs = sscanf((char *) line+2, "%2lx", &nxdigs) == 1? 2*nxdigs: len;
     for(found = 4+nxdigs <= len, i=0; found && i<nxdigs; i++)
       if(!isxdigit(line[4+i]))
         found = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -949,6 +949,10 @@ int main(int argc, char * argv [])
     }
   }
 
+  size_t ztest;
+  if(1 != sscanf("42", "%zi", &ztest) || ztest != 42 || 1)
+    pmsg_warning("Linked C library does not conform to C99; %s may not work as expected\n", progname);
+
   /* search for system configuration file unless -C conffile was given */
   if (strlen(sys_config) == 0) {
     /*

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -299,7 +299,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 		pmsg_error("cannot set com-state for %s\n", port);
                 return -1;
 	}
-        pmsg_debug("ser_open(): opened comm port %s, handle 0x%zx\n", port, (INT_PTR) hComPort);
+        pmsg_debug("ser_open(): opened comm port %s, handle 0x%lx\n", port, (unsigned long) hComPort);
 
         pgm->fd.pfd = (void *)hComPort;
 
@@ -315,7 +315,7 @@ static void serbb_close(PROGRAMMER *pgm) {
 		pgm->setpin(pgm, PIN_AVR_RESET, 1);
 		CloseHandle (hComPort);
 	}
-        pmsg_debug("ser_close(): closed comm port handle 0x%zx\n", (INT_PTR) hComPort);
+        pmsg_debug("ser_close(): closed comm port handle 0x%lx\n", (unsigned long) hComPort);
 
 	hComPort = INVALID_HANDLE_VALUE;
 }

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -299,7 +299,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 		pmsg_error("cannot set com-state for %s\n", port);
                 return -1;
 	}
-        pmsg_debug("ser_open(): opened comm port %s, handle 0x%lx\n", port, (unsigned long) hComPort);
+        pmsg_debug("ser_open(): opened comm port %s, handle 0x%lx\n", port, (long) (INT_PTR) hComPort);
 
         pgm->fd.pfd = (void *)hComPort;
 
@@ -315,7 +315,7 @@ static void serbb_close(PROGRAMMER *pgm) {
 		pgm->setpin(pgm, PIN_AVR_RESET, 1);
 		CloseHandle (hComPort);
 	}
-        pmsg_debug("ser_close(): closed comm port handle 0x%lx\n", (unsigned long) hComPort);
+        pmsg_debug("ser_close(): closed comm port handle 0x%lx\n", (long) (INT_PTR) hComPort);
 
 	hComPort = INVALID_HANDLE_VALUE;
 }

--- a/src/term.c
+++ b/src/term.c
@@ -473,7 +473,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   // Allocate large enough data and allocation tags space
   size_t bufsz = mem->size + 8 + maxstrlen(argc-3, argv+3)+1;
   if(bufsz > INT_MAX) {
-    pmsg_error("(write) too large memory request (%zu)\n", bufsz);
+    pmsg_error("(write) too large memory request (%lu)\n", (unsigned long) bufsz);
     return -1;
   }
   unsigned char *buf = calloc(bufsz, 1), *tags = calloc(bufsz, 1);


### PR DESCRIPTION
Apparently, some Windows 7 systems have C libraries that are not C99 compliant. This PR hardens against these problems.