### PR TITLE
Update build.yml to add MSYS2 ucrt64, clang32 and clang64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,9 @@ jobs:
         include:
           - { sys: mingw32, env: i686 }
           - { sys: mingw64, env: x86_64 }
+          - { sys: ucrt64, env: ucrt-x86_64 }
+          - { sys: clang32, env: clang-i686 }
+          - { sys: clang64, env: clang-x86_64 }
     steps:
       - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2


### PR DESCRIPTION
This PR adds github action build for MSYS2 ucrt64, clang32 and clang64 for Windows. 
clangarm64 is not added as it is still not as mature.

Reference:
https://www.msys2.org/docs/environments/