### PR TITLE
issue #1600 Bootloader enhancements

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -196,6 +196,7 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
   if (stk500_getsync(pgm) < 0)
     return -1;
 
+  PDATA(pgm)->boot_success_open = true;
   return 0;
 }
 
@@ -222,6 +223,7 @@ static void arduino_setup(PROGRAMMER * pgm)
     return;
   }
   memset(pgm->cookie, 0, sizeof(struct pdata));
+  PDATA(pgm)->boot_success_open       = false;
   PDATA(pgm)->retry_attempts          = 10;
   PDATA(pgm)->rts_mode                = RTS_MODE_DEFAULT;
   PDATA(pgm)->using_enhanced_memory   = false;  // True when using "-c arduino -xem"

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -28,6 +28,7 @@
 #include "ac_cfg.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -36,6 +37,66 @@
 #include "stk500_private.h"
 #include "stk500.h"
 #include "arduino.h"
+
+#define USERROW_V0_ADDR 0x1300  /* Magic number that characterizes NVMCTRL V0: USERROW=0x1300 */
+
+/* Read single byte in interactive mode - arduino version */
+static int arduino_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
+                             unsigned long addr, unsigned char * value)
+{
+  // Limited to Microchip AVR parts with UPDI pin.
+  // Only authorized bootloaders can run it.
+  if (!PDATA(pgm)->using_enhanced_memory)
+    return -1;
+
+  unsigned char buf[16];
+
+  // Convert address for Cmnd_STK_READ_PAGE memory type 'E'.
+  addr += m->offset - PDATA(pgm)->boot_eeprom_offset;
+
+  // The valid "data" address width is 16 bits. Overflow is rounded.
+  buf[0] = Cmnd_STK_LOAD_ADDRESS;
+  buf[1] = addr & 0xff;
+  buf[2] = (addr >> 8) & 0xff;
+  buf[3] = Sync_CRC_EOP;
+
+  serial_send(&pgm->fd, buf, 4);
+
+  if (serial_recv(&pgm->fd, buf, 2) < 0)
+    return -1;
+  else if (buf[0] != Resp_STK_INSYNC) {
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    return -1;
+  }
+  if (buf[1] != Resp_STK_OK) {
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[0]);
+    return -1;
+  }
+
+  buf[0] = Cmnd_STK_READ_PAGE;
+  buf[1] = 0;
+  buf[2] = 1;
+  buf[3] = 'E';
+  buf[4] = Sync_CRC_EOP;
+
+  serial_send(&pgm->fd, buf, 5);
+
+  if (serial_recv(&pgm->fd, buf, 3) < 0)
+    return -1;
+  else if (buf[0] != Resp_STK_INSYNC) {
+    msg_error("\n");
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    return -2;
+  }
+  if (buf[2] != Resp_STK_OK) {
+    msg_error("\n");
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[4]);
+    return -3;
+  }
+
+  *value = buf[1];
+  return 0;
+}
 
 /* read signature bytes - arduino version */
 static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m) {
@@ -72,6 +133,22 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
   m->buf[0] = buf[1];
   m->buf[1] = buf[2];
   m->buf[2] = buf[3];
+
+  // Enhanced bootloader support
+  if (PDATA(pgm)->using_enhanced_memory) {
+    unsigned char chip_rev;
+    AVRMEM *m;
+    m = avr_locate_eeprom(p);
+    PDATA(pgm)->boot_eeprom_offset = m->offset;
+    // The EEPROM offset of the affected chip is typically 0x1400 from oldest to newest.
+    // That may not be the case in the future.
+
+    // Get silicon revision
+    if (arduino_read_byte(pgm, p, m, (p->syscfg_base + 1) - m->offset, &chip_rev) == 0) {
+      pmsg_debug("arduino_read_byte(): received chip silicon revision: 0x%02x\n", chip_rev);
+      pmsg_notice("silicon revision: '%c%x'\n", (chip_rev >> 4) + 'A', chip_rev & 0x0f);
+    }
+  }
 
   return 3;
 }
@@ -115,10 +192,107 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
   return 0;
 }
 
-static void arduino_close(PROGRAMMER * pgm)
-{
+static void arduino_close(PROGRAMMER * pgm) {
   serial_close(&pgm->fd);
   pgm->fd.ifd = -1;
+}
+
+static int arduino_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
+  pmsg_info("ignored because it doesn't work for programmer %s\n", pgmid);
+  return 0;
+}
+
+static void arduino_setup(PROGRAMMER * pgm)
+{
+  // Replaces stk500_parseextparms.
+  // Now the "-xtal" usage is no longer displayed.
+  if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
+    pmsg_error("out of memory allocating private data\n");
+    return;
+  }
+  memset(pgm->cookie, 0, sizeof(struct pdata));
+  PDATA(pgm)->retry_attempts          = 10;
+  PDATA(pgm)->using_enhanced_memory   = false;  // True when using "-c arduino -xem"
+  PDATA(pgm)->boot_userrow_v0_offset  = USERROW_V0_ADDR;
+  PDATA(pgm)->boot_nvmctrl_version    = 0;
+  // If HWV can be obtained, it is detected as '0' or more.
+  // The boot_eeprom_offset member is initialized with arduino_read_sig_bytes().
+}
+
+static void arduino_teardown(PROGRAMMER * pgm) {
+  free(pgm->cookie);
+  pgm->cookie = NULL;
+}
+
+static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
+  LNODEID ln;
+  const char *extended_param;
+  int attempts;
+  int rv = 0;
+
+  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    extended_param = ldata(ln);
+
+    if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
+      // Negative numbers are also detected, so they are excluded.
+      // That is, it accepts numbers from 1 to 99.
+      if (attempts <= 0) {
+        pmsg_info("illegal value specification\n");
+      }
+      else {
+        PDATA(pgm)->retry_attempts = attempts;
+        pmsg_info("setting number of retry attempts to %d\n", attempts);
+        continue;
+      }
+    }
+
+    else if (str_eq(extended_param, "em")) {
+      // *** ENHANCED FEATURE : -c arduino -xem option ***
+      PDATA(pgm)->using_enhanced_memory = true;
+      // Check the validity of this feature with stk500_initialize()
+      continue;
+    }
+
+    else if (str_eq(extended_param, "help")) {
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
+      msg_error("  -xattempts=<arg>      Specify no. connection retry attempts\n");
+      msg_error("  -xem                  Enables enhanced memory instructions (optiboot_x etc.)\n");
+      msg_error("  -xhelp                Show this help menu and exit\n");
+      exit(0);
+    }
+
+    pmsg_error("invalid extended parameter %s\n", extended_param);
+    rv = -1;
+  }
+
+  return rv;
+}
+
+/*** Periodic call in terminal mode to keep bootloader alive ***/
+static int arduino_term_keep_alive(const PROGRAMMER *pgm, const AVRPART *p_unused) {
+  unsigned char buf[16];
+
+  buf[0] = Cmnd_STK_GET_SYNC;
+  buf[1] = Sync_CRC_EOP;
+
+  serial_send(&pgm->fd, buf, 2);
+
+  if (serial_recv(&pgm->fd, buf, 2) < 0)
+    return -1;
+
+  if (buf[0] != Resp_STK_INSYNC) {
+    msg_error("\n");
+    pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
+    return -2;
+  }
+
+  if (buf[1] != Resp_STK_OK) {
+    msg_error("\n");
+    pmsg_error("protocol expects OK byte 0x%02x but got 0x%02x\n", Resp_STK_OK, buf[1]);
+    return -3;
+  }
+
+  return 0;
 }
 
 const char arduino_desc[] = "Arduino programmer";
@@ -131,9 +305,15 @@ void arduino_initpgm(PROGRAMMER *pgm) {
   stk500_initpgm(pgm);
 
   strcpy(pgm->type, "Arduino");
-  pgm->read_sig_bytes = arduino_read_sig_bytes;
-  pgm->open = arduino_open;
-  pgm->close = arduino_close;
+  pgm->read_sig_bytes  = arduino_read_sig_bytes;
+  pgm->open            = arduino_open;
+  pgm->close           = arduino_close;
+  pgm->chip_erase      = arduino_chip_erase;
+  pgm->setup           = arduino_setup;
+  pgm->teardown        = arduino_teardown;
+  pgm->parseextparams  = arduino_parseextparms;
+  pgm->read_byte       = arduino_read_byte;   // write_byte() is not replaced (not used)
+  pgm->term_keep_alive = arduino_term_keep_alive;
 
   disable_trailing_ff_removal(); /* so that arduino bootloader can ignore chip erase */
 }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -116,7 +116,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
 
   for (attempt = 0; attempt < max_sync_attempts; attempt++) {
     // Restart Arduino bootloader for every sync attempt
-    if (str_eq(pgm->type, "Arduino")) {
+    if (str_eq(pgm->type, "Arduino") && !PDATA(pgm)->boot_success_open) {
       // Set RTS/DTR high to discharge the series-capacitor, if present
       serial_set_dtr_rts(&pgm->fd, 0);
       usleep(250 * 1000);
@@ -1664,6 +1664,7 @@ static void stk500_setup(PROGRAMMER * pgm)
     PDATA(pgm)->xtal = STK500_XTAL;
 
   // Disable unused extensions
+  PDATA(pgm)->boot_success_open = false;
   PDATA(pgm)->using_enhanced_memory = false;
   PDATA(pgm)->rts_mode = RTS_MODE_DEFAULT;
 }

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -62,6 +62,7 @@ struct pdata {
 
   // Arduino Bootloader enhancment : Limited to UPDI equipped Microchip AVR only.
   bool using_enhanced_memory;   // True when using "-c arduino -x em"
+  int rts_mode;                 // Serial RTS/DTR setting
   unsigned int boot_nvmctrl_version;
   unsigned int boot_eeprom_offset;
   unsigned int boot_userrow_v0_offset;

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -63,6 +63,7 @@ struct pdata {
   // Arduino Bootloader enhancment : Limited to UPDI equipped Microchip AVR only.
   bool using_enhanced_memory;   // True when using "-c arduino -x em"
   int rts_mode;                 // Serial RTS/DTR setting
+  unsigned int boot_success_open;
   unsigned int boot_nvmctrl_version;
   unsigned int boot_eeprom_offset;
   unsigned int boot_userrow_v0_offset;

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -59,6 +59,12 @@ struct pdata {
   double fosc_data;
 
   unsigned xtal;                // Set STK500 XTAL frequency
+
+  // Arduino Bootloader enhancment : Limited to UPDI equipped Microchip AVR only.
+  bool using_enhanced_memory;   // True when using "-c arduino -x em"
+  unsigned int boot_nvmctrl_version;
+  unsigned int boot_eeprom_offset;
+  unsigned int boot_userrow_v0_offset;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -60,10 +60,10 @@ struct pdata {
 
   unsigned xtal;                // Set STK500 XTAL frequency
 
-  // Arduino Bootloader enhancment : Limited to UPDI equipped Microchip AVR only.
-  bool using_enhanced_memory;   // True when using "-c arduino -x em"
+  // Arduino Enhanced Bootloader : Limited to UPDI equipped Microchip AVR only.
   int rts_mode;                 // Serial RTS/DTR setting
-  unsigned int boot_success_open;
+  bool using_boot_reopen;       // True when using "-c arduino -x reopen"
+  bool using_enhanced_memory;   // True when using "-c arduino -x em"
   unsigned int boot_nvmctrl_version;
   unsigned int boot_eeprom_offset;
   unsigned int boot_userrow_v0_offset;

--- a/src/stk500_private.h
+++ b/src/stk500_private.h
@@ -101,3 +101,10 @@
 
 
 // *****************************[ End Of COMMAND.H ]**************************
+
+/* Extension for bootloader */
+typedef enum {
+  RTS_MODE_DEFAULT,
+  RTS_MODE_LOW,
+  RTS_MODE_HIGH
+} stk500_rts_mode;


### PR DESCRIPTION
This is the memory read enhancement patch for the Adruino compatible bootloader mentioned in issue #1600.

Allows the following memory reads similar to EEPROM only for PM_SPM + PM_UPDI parts.
This trick works for all bootloaders that support READ memchr == 'E'.
  -U : userrow usersig bootrow sigrow prodsig and signature
  -T dump : userrow and bootrow

This trick is useful if OCD or UPDI control becomes unavailable for some reason (damaged pins due to high voltage, unintentional FUSE rewrite, etc.) but the bootloader is still working. This is important for debugging and verification tasks because BOOTROW can only be read by boot code.

*The good thing about bootloaders is that there is no risk of further damage to the chip.*

There are some things that can be read with -U but not with -T dump. This is probably because it is currently prohibited by `avr_has_paged_access(pgm, mem)`. Unfortunately, I can't read LOCK and FUSE as a result.

A similar implementation is possible in urclock.c, but it is not as easily extended as stk500.c. I tried it, but this time I gave up. It seems like there are too many things that need to be redone.

The ability to write USERROW and BOOTROW is not integrated at this time as it requires new BIGBOOT development. At least someone has to decide on memory types other than "F" and "E".
(Example: "X". For this he needs an absolute address in 64KiB space. Using a relative address like 'E' will make the boot code obese)

*P.S.1 : I don't think this patch will be rushed to 7.3. Because that may still be up for debate.*
*P.S.2 : There is one place in the code to suppress extra warnings that are not related to the PM_UPDI part.*