### PR TITLE
Remove artificial 1Mhz limit on jtag3/atmelice/etc ISP bitclock

### DIFF
--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3567,8 +3567,8 @@ static int stk500v2_jtag3_set_sck_period(const PROGRAMMER *pgm, double v) {
   unsigned char value[3];
   unsigned int sck;
 
-  if (v < 1E-6)
-    sck = 0x400;
+  if (v < 1 / (1000.0 * 0xffff))
+    sck = 0xffff;
   else if (v > 1E-3)
     sck = 1;
   else


### PR DESCRIPTION
Previously, the code would limit the clock to 1Mhz. If a higher clock was specified, it would be set to 1.024Mhz (0x400 khz).

This commit removes this artificial limit, while still preventing overflowing the two bytes available in the command (effectively limiting to 65535 kHz).

The original limit seems inappropriate, because the JTAGEICE3 and ATMEL ICE actually support higher clocks than the old limit. For SPI, the JTAGICE3 documents supporting up to 1.875Mhz and the ATMEL ICE up to 5Mhz. In practice the JTAGEICE3 (with the newer EDBG version where it becomes pretty much identical to the ATMEL ICE) also works up to 5Mhz.

When trying to set higher values, the behaviour seems to depend on the current value. The programmer seems to either keep the previous value (e.g. from 3Mhz to 10Mhz), or use 8kHz / 125μs (e.g. from 5Mhz to 10Mhz). In any case, the value read back afterwards (and printed with -v) reflects the actual value.

Also note that the code also applies a lower limit of 1kHz (to ensure the raw value sent to the device, in kHz, is never zero), but in practice sending a value of lower than 8kHz ends up setting 8kHz (125μs). This is also the minimum value in the device documentation.

This commit was tested with:

         Programmer Type       : JTAG3_ISP
         Description           : Atmel AVR JTAGICE3 in ISP mode
         ICE HW version        : 2
         ICE FW version        : 3.55 (rel. 130)
                 
~~I've marked this PR as a draft, since I want to test it with an Atmel ICE as well, but I won't be around one until later this week.~~ W00ps, clicked the wrong button. Oh well.

It might also be good to test this on other programmers that use the same code. From avrdude.conf.in, that would be:
 - Atmel AVR XplainedMini in ISP mode
 - Atmel PowerDebugger (ARM/AVR) in ISP mode
 - MPLAB(R) PICkit 4 in ISP mode
 - MPLAB(R) SNAP in ISP mode

I do not have access to any of these, unfortunately.