### PR TITLE
Use correct file locations in the documentation

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -2009,7 +2009,7 @@ Alternative location of the per-user configuration file if above file does not e
 Initialization file for the
 .Xr readline 3
 library
-.It Pa <prefix>/doc/avrdude/avrdude.pdf
+.It Pa <prefix>/share/doc/avrdude/avrdude.pdf
 User manual
 .El
 .\" .Sh EXAMPLES


### PR DESCRIPTION
The avrdude documentation (avrdude.1 man page, avrdude.info page, html+pdf docs) contains references to file locations.

Some of those file locations have changed over time without the documentation completely reflecting those changes, and this PR wants to fix that.
