### PR TITLE
Provide terminal command `factory reset`

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1261,13 +1261,14 @@ It is quite possible, as is with direct writing to the underlying fuses
 and lock bits, to brick a part, i.e., make it unresponsive to further
 programming with the chosen programmer: here be dragons.
 .It Ar factory reset
-Resets the connected part to factory state as far as possible;
-bootloaders, for example, cannot write fuses and may not have a means to
-erase EEPROM. This may change the clock frequency of the part after the
-next reset when the new fuse values come into effect. As such this may
-require that avrdude is called with a different bit clock rate for the
-programmer next time. Note that the command factory can be abbreviated
-but the required argument reset needs to be spelled out.
+Resets the connected part to factory state as far as possible
+(bootloaders, for example, cannot write fuses and may not have a means to
+erase EEPROM). This command may change the clock frequency F_CPU of the
+part after the next MCU reset when the changed fuse values come into
+effect. As such, this may require that future avrdude calls use a
+different bit clock rate up to F_CPU/4 for the programmer next time. Note
+that the command factory can be abbreviated but the required argument
+reset needs to be spelled out in full.
 .It Ar regfile {<opts>}
 regfile with no further argument displays the register file of a part,
 i.e., all register names and their contents in

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1260,6 +1260,14 @@ can be uniquely resolved.
 It is quite possible, as is with direct writing to the underlying fuses
 and lock bits, to brick a part, i.e., make it unresponsive to further
 programming with the chosen programmer: here be dragons.
+.It Ar factory reset
+Resets the connected part to factory state as far as possible;
+bootloaders, for example, cannot write fuses and may not have a means to
+erase EEPROM. This may change the clock frequency of the part after the
+next reset when the new fuse values come into effect. As such this may
+require that avrdude is called with a different bit clock rate for the
+programmer next time. Note that the command factory can be abbreviated
+but the required argument reset needs to be spelled out.
 .It Ar regfile {<opts>}
 regfile with no further argument displays the register file of a part,
 i.e., all register names and their contents in

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3080,6 +3080,7 @@ part # t11
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
     synchcycles            = 6;
+    factory_fcpu           = 1200000;
 
     memory "eeprom"
         size               = 64;
@@ -3172,6 +3173,7 @@ part # t12
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
     synchcycles            = 6;
+    factory_fcpu           = 1200000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -3314,6 +3316,7 @@ part # t13
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 0;
+    factory_fcpu           = 1200000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -3478,6 +3481,7 @@ part # t15
     programlockpolltimeout = 25;
     synchcycles            = 6;
     hvspcmdexedelay        = 5;
+    factory_fcpu           = 1600000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -3696,6 +3700,7 @@ part # 1200
     chiperasepulsewidth    = 15;
     programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -3798,6 +3803,7 @@ part # 4414
     chiperasepulsewidth    = 15;
     programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -3896,6 +3902,7 @@ part # 2313
     chiperasepulsewidth    = 15;
     programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -3991,6 +3998,7 @@ part # 2333
     chiperasepulsewidth    = 15;
     programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -4094,6 +4102,7 @@ part # 2343
     programfusepolltimeout = 25;
     programlockpolltimeout = 25;
     synchcycles            = 6;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -4271,6 +4280,7 @@ part # 8515
     chiperasepulsewidth    = 15;
     programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -4367,6 +4377,7 @@ part # 8535
     chiperasepulsewidth    = 15;
     programfusepulsewidth  = 2;
     programlockpolltimeout = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -4517,6 +4528,7 @@ part # m103
     chiperasepulsewidth    = 15;
     programfusepulsewidth  = 2;
     programlockpolltimeout = 10;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -4645,6 +4657,7 @@ part # m64
     spmcr                  = 0x68;
     eecr                   = 0x3c;
     ocdrev                 = 2;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -4820,6 +4833,7 @@ part # m128
     spmcr                  = 0x68;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -4989,6 +5003,7 @@ part # c128
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -5136,6 +5151,7 @@ part # c64
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -5283,6 +5299,7 @@ part # c32
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -5438,6 +5455,7 @@ part # m16
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 2;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -5609,6 +5627,7 @@ part # m324p
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -5939,6 +5958,7 @@ part # m644
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -6169,6 +6189,7 @@ part # m1284
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -6364,6 +6385,7 @@ part # m162
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 2;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -6504,6 +6526,7 @@ part # m163
     chiperasepolltimeout   = 30;
     programfusepolltimeout = 2;
     programlockpolltimeout = 2;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -6646,6 +6669,7 @@ part # m169
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 2;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -6921,6 +6945,7 @@ part # m329
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -7202,6 +7227,7 @@ part # m649
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -7436,6 +7462,7 @@ part # m32
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 2;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -7568,6 +7595,7 @@ part # m161
     chiperasepolltimeout   = 30;
     programfusepolltimeout = 2;
     programlockpolltimeout = 2;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -7715,6 +7743,7 @@ part # m8
     chiperasepolltimeout   = 20;
     programfusepolltimeout = 10;
     programlockpolltimeout = 10;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -7876,6 +7905,7 @@ part # m8515
     chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -8014,6 +8044,7 @@ part # m8535
     chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -8149,6 +8180,7 @@ part # t26
     chiperasepolltimeout   = 20;
     programfusepolltimeout = 10;
     programlockpolltimeout = 10;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -8290,6 +8322,7 @@ part # t261
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -8468,6 +8501,7 @@ part # t461
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -8642,6 +8676,7 @@ part # t861
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -8795,6 +8830,7 @@ part # t28
     chiperasepolltimeout   = 10;
     programfusepolltimeout = 5;
     programlockpolltimeout = 5;
+    factory_fcpu           = 1200000;
 
     memory "flash"
         size               = 2048;
@@ -8901,6 +8937,7 @@ part # m48
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -9155,6 +9192,7 @@ part # m88
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -9413,6 +9451,7 @@ part # m168
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -9660,6 +9699,7 @@ part # t828
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -9828,6 +9868,7 @@ part # t87
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -9987,6 +10028,7 @@ part # t167
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -10143,6 +10185,7 @@ part # t48
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -10299,6 +10342,7 @@ part # t88
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -10454,6 +10498,7 @@ part # m328
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -10666,6 +10711,7 @@ part # m64m1
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -11184,6 +11230,7 @@ part # m16hva
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -11336,6 +11383,7 @@ part # m16hvb
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -11535,6 +11583,7 @@ part # m64hve2
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -11704,6 +11753,7 @@ part # t2313
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 0;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -11891,6 +11941,7 @@ part # t4313
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 0;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -12042,6 +12093,7 @@ part # pwm1
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -12190,6 +12242,7 @@ part # pwm2
     programlockpolltimeout = 5;
     spmcr                  = 0x57;
     eecr                   = 0x3f;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -12423,6 +12476,7 @@ part # pwm161
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -12691,6 +12745,7 @@ part # t25
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -12861,6 +12916,7 @@ part # t45
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -13028,6 +13084,7 @@ part # t85
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -13181,6 +13238,7 @@ part # m640
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -13332,6 +13390,7 @@ part # m1280
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -13506,6 +13565,7 @@ part # m2560
     eecr                   = 0x3f;
     eind                   = 0x5c;
     ocdrev                 = 4;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -13932,6 +13992,7 @@ part # t24
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -14122,6 +14183,7 @@ part # t44
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -14312,6 +14374,7 @@ part # t84
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -14589,6 +14652,7 @@ part # t43u
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -14739,6 +14803,7 @@ part # m16u4
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -14890,6 +14955,7 @@ part # m32u4
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -15039,6 +15105,7 @@ part # usb646
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -15206,6 +15273,7 @@ part # usb1286
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -15375,6 +15443,7 @@ part # usb162
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -15526,6 +15595,7 @@ part # usb82
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -15678,6 +15748,7 @@ part # m32u2
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -15830,6 +15901,7 @@ part # m16u2
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -15982,6 +16054,7 @@ part # m8u2
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -16138,6 +16211,7 @@ part # m165p
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -16348,6 +16422,7 @@ part # m325
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--0000.0000--0000.0000";
     pgm_enable             = "1010.1100--0101.0011--0000.0000--0000.0000";
 
@@ -16558,6 +16633,7 @@ part # m645
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--1000.0000--0000.0000--0000.0000";
     pgm_enable             = "1010.1100--0101.0011--0000.0000--0000.0000";
 
@@ -16816,6 +16892,7 @@ part # .xmega
     mcu_base               = 0x0090;
     nvm_base               = 0x01c0;
     autobaud_sync          = 0x20;
+    factory_fcpu           = 2000000;
 
     memory "fuse1"
         size               = 1;
@@ -19196,6 +19273,7 @@ part # t1634
     spmcr                  = 0x57;
     eecr                   = 0x3c;
     ocdrev                 = 1;
+    factory_fcpu           = 1000000;
     chip_erase             = "1010.1100--100x.xxxx--xxxx.xxxx--xxxx.xxxx";
     pgm_enable             = "1010.1100--0101.0011--xxxx.xxxx--xxxx.xxxx";
 
@@ -19365,6 +19443,7 @@ part parent ".reduced_core_tiny" # t4
     mcuid                  = 0;
     n_interrupts           = 10;
     signature              = 0x1e 0x8f 0x0a;
+    factory_fcpu           = 1000000;
 
     memory "flash"
         size               = 512;
@@ -19408,6 +19487,7 @@ part parent ".reduced_core_tiny" # t9
     mcuid                  = 2;
     n_interrupts           = 10;
     signature              = 0x1e 0x90 0x08;
+    factory_fcpu           = 1000000;
 
     memory "flash"
         size               = 1024;
@@ -19457,6 +19537,7 @@ part parent ".reduced_core_tiny" # t20
     mcuid                  = 4;
     n_interrupts           = 17;
     signature              = 0x1e 0x91 0x0f;
+    factory_fcpu           = 1000000;
 
     memory "flash"
         size               = 2048;
@@ -19497,6 +19578,7 @@ part parent ".reduced_core_tiny" # t40
     mcuid                  = 5;
     n_interrupts           = 18;
     signature              = 0x1e 0x92 0x0e;
+    factory_fcpu           = 1000000;
 
     memory "flash"
         size               = 4096;
@@ -19539,6 +19621,7 @@ part parent ".reduced_core_tiny" # t102
     mcuid                  = 6;
     n_interrupts           = 16;
     signature              = 0x1e 0x90 0x0c;
+    factory_fcpu           = 1000000;
 
     memory "flash"
         size               = 1024;
@@ -19581,6 +19664,7 @@ part parent ".reduced_core_tiny" # t104
     mcuid                  = 7;
     n_interrupts           = 16;
     signature              = 0x1e 0x90 0x0b;
+    factory_fcpu           = 1000000;
 
     memory "flash"
         size               = 1024;
@@ -19646,6 +19730,7 @@ part # m406
     spmcr                  = 0x57;
     eecr                   = 0x3f;
     ocdrev                 = 3;
+    factory_fcpu           = 1000000;
 
     memory "eeprom"
         size               = 512;
@@ -19709,6 +19794,7 @@ part # .avr8x
     nvm_base               = 0x1000;
     ocd_base               = 0x0f80;
     syscfg_base            = 0x0f00;
+    factory_fcpu           = 20000000;
 
     memory "fuses"
         size               = 10;
@@ -20700,6 +20786,7 @@ part parent "t416" # t416auto
         "ATtiny416-MZT: VQFN20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 290;
     signature              = 0x1e 0x92 0x28;
+    factory_fcpu           = 16000000;
 
     memory "fuse2"
         initval            = 0x7d;
@@ -22157,6 +22244,7 @@ part # .avrdx
     nvm_base               = 0x1000;
     ocd_base               = 0x0f80;
     syscfg_base            = 0x0f00;
+    factory_fcpu           = 4000000;
 
     memory "fuses"
         size               = 16;
@@ -23971,6 +24059,7 @@ part parent ".avrdx" # .avrex
     id                     = ".avrex";
     # Shared UPDI pin, HV on _RESET
     hvupdi_variant         = 2;
+    factory_fcpu           = 20000000;
 
     memory "fuse2"
         bitmask            = 0x08;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -183,6 +183,7 @@ avrdude_conf_version = "@AVRDUDE_FULL_VERSION@";
 #       chip_erase       = <instruction format> ;
 #       # parameters for bootloaders
 #       autobaud_sync    = <num> ;                # autobaud detection byte, default 0x30
+#       factory_fcpu     = <num> ;                # F_CPU in Hz on reset and factory-set fuses
 #
 #       memory <memstr>
 #           paged           = <yes/no> ;          # yes/no (flash of classic parts only)

--- a/src/config.c
+++ b/src/config.c
@@ -136,6 +136,7 @@ Component_t avr_comp[] = {
   part_comp_desc(syscfg_base, COMP_INT),
   part_comp_desc(ocdrev, COMP_INT),
   part_comp_desc(autobaud_sync, COMP_CHAR),
+  part_comp_desc(factory_fcpu, COMP_INT),
 
   // AVRMEM
   mem_comp_desc(paged, COMP_BOOL),

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -725,6 +725,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
   _if_partout(intcmp, "0x%04x", syscfg_base);
   _if_partout(intcmp, "%d", ocdrev);
   _if_partout(intcmp, "0x%02x", autobaud_sync);
+  _if_partout(intcmp, "%d", factory_fcpu);
 
   for(int i=0; i < AVR_OP_MAX; i++)
     if(!base || opcodecmp(p->op[i], base->op[i], i))

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2463,6 +2463,17 @@ It is quite possible, as is with direct writing to the underlying fuses
 and lock bits, to brick a part, i.e., make it unresponsive to further
 programming with the chosen programmer: here be dragons.
 
+@item factory reset
+Resets the connected part to factory state as far as possible;
+bootloaders, for example, cannot write fuses and may not have a means to
+erase EEPROM. This may change the clock frequency of the part after the
+next reset when the new fuse values come into effect. As such this may
+require that avrdude is called with a different bit clock rate for the
+programmer next time. Note that the command @code{factory} can be
+abbreviated  but the required argument @code{reset} needs to be spelled
+out.
+
+
 @item regfile [@var{opts}]
 @code{regfile} with no further argument displays the register file of a
 part, i.e., all register names and their contents in  @code{io} memory, if

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -2464,15 +2464,14 @@ and lock bits, to brick a part, i.e., make it unresponsive to further
 programming with the chosen programmer: here be dragons.
 
 @item factory reset
-Resets the connected part to factory state as far as possible;
-bootloaders, for example, cannot write fuses and may not have a means to
-erase EEPROM. This may change the clock frequency of the part after the
-next reset when the new fuse values come into effect. As such this may
-require that avrdude is called with a different bit clock rate for the
-programmer next time. Note that the command @code{factory} can be
-abbreviated  but the required argument @code{reset} needs to be spelled
-out.
-
+Resets the connected part to factory state as far as possible
+(bootloaders, for example, cannot write fuses and may not have a means to
+erase EEPROM). This command may change the clock frequency F_CPU of the
+part after the next MCU reset when the changed fuse values come into
+effect. As such, this may require that future avrdude calls use a
+different bit clock rate up to F_CPU/4 for the programmer next time. Note
+that the command @code{factory} can be abbreviated but the required
+argument @code{reset} needs to be spelled out in full.
 
 @item regfile [@var{opts}]
 @code{regfile} with no further argument displays the register file of a

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -3323,6 +3323,7 @@ part
     chip_erase       = <instruction format> ;
     # parameters for bootloaders
     autobaud_sync    = <num> ;                # autobaud detection byte, default 0x30
+    factory_fcpu     = <num> ;                # F_CPU in Hz on reset and factory-set fuses
 
     memory <memstr>
         paged           = <yes/no> ;          # yes/no (flash of classic parts only)

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -155,7 +155,7 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
   hventerstabdelay | progmodedelay | latchcycles | togglevtg | poweroffdelay | resetdelayms | resetdelayus | resetdelay | hvleavestabdelay |
   chiperasetime | (chiperase|program(fuse|lock))(polltimeout|pulsewidth) | synchcycles | hvspcmdexedelay |
   mcu_base | nvm_base | ocd_base | syscfg_base | ocdrev |
-  autobaud_sync | idr | rampz | spmcr | eecr | eind |
+  autobaud_sync | factory_fcpu | idr | rampz | spmcr | eecr | eind |
   paged | size | num_pages | initval | bitmask | n_word_writes | offset | min_write_delay | max_write_delay | pwroff_after_write |
   readback_p1 | readback_p2 | mode | delay | blocksize | readsize ) {
   /* struct components for PROGRAMMER, AVRPART and AVRMEM */

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -315,6 +315,7 @@ typedef struct avrpart {
 
   /* Bootloader paramater */
   unsigned char autobaud_sync;  /* Sync byte for bootloader autobaud,  must be <= 0x30 */
+  int factory_fcpu;             /* Initial F_CPU after reset assuming factory settings */
 
   OPCODE      * op[AVR_OP_MAX]; /* opcodes */
 

--- a/src/term.c
+++ b/src/term.c
@@ -58,36 +58,36 @@
 
 struct command {
   char *name;
-  int (*func)(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
+  int (*func)(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
   size_t fnoff;
   char *desc;
 };
 
 
-static int cmd_dump   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_write  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_save   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_flush  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_abort  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_erase  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_config (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_sig    (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_part   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_help   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_quit   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_send   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_parms  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_vtarg  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_varef  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_fosc   (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_sck    (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_spi    (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_pgm    (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_verbose(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
-static int cmd_quell  (const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]);
+static int cmd_dump   (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_write  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_save   (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_flush  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_abort  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_erase  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_config (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_sig    (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_part   (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_help   (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_quit   (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_send   (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_parms  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_vtarg  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_varef  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_fosc   (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_sck    (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_spi    (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_pgm    (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_verbose(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
+static int cmd_quell  (const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]);
 
 #define _fo(x) offsetof(PROGRAMMER, x)
 
@@ -203,7 +203,7 @@ static int hexdump_buf(const FILE *f, const AVRMEM *m, int startaddr, const unsi
 }
 
 
-static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   static struct mem_addr_len {
     int addr;
     int len;
@@ -232,11 +232,11 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
   }
 
   enum { read_size = 256 };
-  char *memstr;
+  const char *memstr;
   if(argc > 1)
     memstr = argv[1];
   else
-    memstr = (char*)read_mem[i].mem->desc;
+    memstr = read_mem[i].mem->desc;
   const AVRMEM *mem = avr_locate_mem(p, memstr);
   if (mem == NULL) {
     pmsg_error("(%s) memory %s not defined for part %s\n", cmd, memstr, p->desc);
@@ -357,7 +357,7 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 }
 
 
-static size_t maxstrlen(int argc, char **argv) {
+static size_t maxstrlen(int argc, const char **argv) {
   size_t max = 0;
 
   for(int i=0; i<argc; i++)
@@ -372,7 +372,7 @@ typedef enum {
   WRITE_MODE_FILL     = 1,
 } Write_mode_t;
 
-static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if (argc < 3 || (argc > 1 && str_eq(argv[1], "-?"))) {
     msg_error(
       "Syntax: write <mem> <addr> <data>[,] {<data>[,]}\n"
@@ -426,7 +426,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   int write_mode;               // Operation mode, standard or fill
   int start_offset;             // Which argc argument
   int len;                      // Number of bytes to write to memory
-  char *memstr = argv[1];       // Memory name string
+  const char *memstr = argv[1]; // Memory name string
   const AVRMEM *mem = avr_locate_mem(p, memstr);
   if (mem == NULL) {
     pmsg_error("(write) memory %s not defined for part %s\n", memstr, p->desc);
@@ -631,7 +631,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   return 0;
 }
 
-static int cmd_save(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_save(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc < 3 || (argc > 1 && str_eq(argv[1], "-?"))) {
     msg_error(
       "Syntax: save <mem> {<addr> <len>} <file>[:<format>]\n"
@@ -653,7 +653,7 @@ static int cmd_save(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 
   // Last char of filename is format if the penultimate char is a colon
   FILEFMT format = FMT_RBIN;
-  char *fn = argv[argc-1];
+  const char *fn = argv[argc-1];
   size_t len = strlen(fn);
   if(len > 2 && fn[len-2] == ':') { // Assume format specified
     format = fileio_format(fn[len-1]);
@@ -738,7 +738,7 @@ static int cmd_save(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
   return ret < 0? ret: 0;
 }
 
-static int cmd_flush(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_flush(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error(
       "Syntax: flush\n"
@@ -752,7 +752,7 @@ static int cmd_flush(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
 }
 
 
-static int cmd_abort(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_abort(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error(
       "Syntax: abort\n"
@@ -766,7 +766,7 @@ static int cmd_abort(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
 }
 
 
-static int cmd_send(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_send(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   unsigned char cmd[4], res[4];
   const char *errptr;
   int rc, len;
@@ -820,7 +820,7 @@ static int cmd_send(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 }
 
 
-static int cmd_erase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_erase(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if (argc > 4 || argc == 3 || (argc > 1 && str_eq(argv[1], "-?"))) {
     msg_error(
       "Syntax: erase <mem> <addr> <len> # Fill section with 0xff values\n"
@@ -832,13 +832,13 @@ static int cmd_erase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
   }
 
   if (argc > 1) {
-    char *memstr = argv[1];
+    const char *memstr = argv[1];
     const AVRMEM *mem = avr_locate_mem(p, memstr);
     if (mem == NULL) {
       pmsg_error("(erase) memory %s not defined for part %s\n", argv[1], p->desc);
       return -1;
     }
-    char *args[] = {"write", memstr, "", "", "0xff", "...", NULL};
+    const char *args[] = {"write", memstr, "", "", "0xff", "...", NULL};
     // erase <mem>
     if (argc == 2) {
       args[2] = "0";
@@ -899,7 +899,7 @@ static int cmd_erase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
 }
 
 
-static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc != 3 || (argc > 1 && str_eq(argv[1], "-?"))) {
     msg_error(
       "Syntax: pgerase <mem> <addr>\n"
@@ -908,7 +908,7 @@ static int cmd_pgerase(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
     return -1;
   }
 
-  char *memstr = argv[1];
+  const char *memstr = argv[1];
   const AVRMEM *mem = avr_locate_mem(p, memstr);
   if(!mem) {
     pmsg_error("(pgerase) memory %s not defined for part %s\n", memstr, p->desc);
@@ -1253,7 +1253,7 @@ static void printfuse(Cfg_t *cc, int ii, Flock_t *fc, int nf, int printed, Cfg_o
 }
 
 // Show or change configuration properties of the part
-static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   Cfg_opts_t o = { 0 };
   int help = 0, invalid = 0, itemac=1;
 
@@ -1551,7 +1551,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *a
 
   const char *av[] = { "confirm", cc[ci].t->name, NULL };
   if(o.verb > 0 && !str_eq(argv[0], "confirm"))
-    cmd_config(pgm, p, 2, (char **) av);
+    cmd_config(pgm, p, 2, av);
 
 finished:
   free(cc);
@@ -1561,7 +1561,7 @@ finished:
 }
 
 // Show or change I/O registers of the part (programmer permitting)
-static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int show_addr = 0, offset = 0, show_size = 0, show_mem = 0, verb = 0, help = 0, invalid = 0, itemac = 1;
   AVRMEM *io = avr_locate_io(p);
 
@@ -1636,7 +1636,7 @@ static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
     return -1;
   }
 
-  char *reg = argc > 1? argv[1]: "", *rhs = strrchr(reg, '=');
+  char *reg = cfg_strdup(__func__, argc > 1? argv[1]: ""), *rhs = strrchr(reg, '=');
   if(rhs)                       // Right-hand side of assignment
     *rhs++ = 0;                 // Terminate lhs
 
@@ -1728,15 +1728,17 @@ static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
   }
 
 success:
+  free(reg);
   free(rlist);
   return 0;
 
 error:
+  free(reg);
   free(rlist);
   return -1;
 }
 
-static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int help = 0, onlymem = 0, onlyvariants = 0, invalid = 0, itemac = 1;
 
   for(int ai = 0; --argc > 0; ) { // Simple option parsing
@@ -1794,7 +1796,7 @@ static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 }
 
 
-static int cmd_sig(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_sig(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int i;
   int rc;
   const AVRMEM *m;
@@ -1825,7 +1827,7 @@ static int cmd_sig(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
 }
 
 
-static int cmd_quit(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_quit(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error(
       "Syntax: quit\n"
@@ -1842,7 +1844,7 @@ static int cmd_quit(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 }
 
 
-static int cmd_parms(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_parms(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error(
       "Syntax: parms\n"
@@ -1857,7 +1859,7 @@ static int cmd_parms(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
 }
 
 
-static int cmd_vtarg(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_vtarg(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int rc;
   double v = 0;
   char *endp;
@@ -1891,7 +1893,7 @@ static int cmd_vtarg(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
 }
 
 
-static int cmd_fosc(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_fosc(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int rc;
   double v = 0;
   char *endp;
@@ -1940,7 +1942,7 @@ static int cmd_fosc(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
 }
 
 
-static int cmd_sck(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_sck(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int rc;
   double v;
   char *endp;
@@ -1989,7 +1991,7 @@ static int cmd_sck(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
 }
 
 
-static int cmd_varef(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_varef(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int rc;
   unsigned int chan;
   double v;
@@ -2040,7 +2042,7 @@ static int cmd_varef(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
 }
 
 
-static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error(
       "Syntax: help\n"
@@ -2069,7 +2071,7 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *arg
   return 0;
 }
 
-static int cmd_spi(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_spi(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error(
       "Syntax: spi\n"
@@ -2083,7 +2085,7 @@ static int cmd_spi(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
   return 0;
 }
 
-static int cmd_pgm(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_pgm(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error(
       "Syntax: pgm\n"
@@ -2099,7 +2101,7 @@ static int cmd_pgm(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv
 }
 
 
-static int cmd_verbose(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_verbose(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int nverb;
   const char *errptr;
 
@@ -2131,7 +2133,7 @@ static int cmd_verbose(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *
 }
 
 
-static int cmd_quell(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_quell(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int nquell;
   const char *errptr;
 
@@ -2182,10 +2184,11 @@ static int cmd_quell(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *ar
  * command line. On error NULL is returned.
  *
  */
-static char *tokenize(char *s, int *argcp, char ***argvp) {
+static char *tokenize(char *s, int *argcp, const char ***argvp) {
   size_t slen;
   int n, nargs;
-  char **argv, *buf, *q, *r;
+  const char **argv;
+  char *buf, *q, *r;
 
   // Upper estimate of the number of arguments
   for(nargs=0, q=s; *q; nargs++) {
@@ -2233,7 +2236,7 @@ static char *tokenize(char *s, int *argcp, char ***argvp) {
 }
 
 
-static int do_cmd(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int do_cmd(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int hold, matches;
   size_t len;
 
@@ -2282,7 +2285,7 @@ char *terminal_get_input(const char *prompt) {
 
 static int process_line(char *q, const PROGRAMMER *pgm, const AVRPART *p) {
   int argc, rc = 0;
-  char **argv;
+  const char **argv;
 
   // Find the start of the command, skipping any white space
   while(*q && isspace((unsigned char) *q))
@@ -2304,6 +2307,7 @@ static int process_line(char *q, const PROGRAMMER *pgm, const AVRPART *p) {
 
     if(argc == 1 && **argv == '!') {
       if(allow_subshells) {
+        const char *q;
         for(q=argv[0]+1; *q && isspace((unsigned char) *q); q++)
           continue;
         errno = 0;
@@ -2495,7 +2499,7 @@ int terminal_mode(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 
-static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, char *argv[]) {
+static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   int help = 0, invalid = 0, echo = 0, itemac=1;
 
   for(int ai = 0; --argc > 0; ) { // Simple option parsing

--- a/src/term.c
+++ b/src/term.c
@@ -1614,7 +1614,7 @@ static int cmd_factory(const PROGRAMMER *pgm, const AVRPART *p, int argc, const 
   }
 
   if(pgm->prog_modes & PM_SPM) { // Bootloader
-    pmsg_warning("-c %s is for bootloaders, which cannot set fuses\n", pgmid);
+    pmsg_warning("-c %s is for bootloaders, which cannot set fuses;\n", pgmid);
     imsg_warning("only erasing flash and other writable memories as far as possible\n");
     if((m = avr_locate_flash(p))) { // First erase flash
       args[1] = m->desc;

--- a/src/term.c
+++ b/src/term.c
@@ -1624,7 +1624,7 @@ static int cmd_factory(const PROGRAMMER *pgm, const AVRPART *p, int argc, const 
 
     for(LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
       m = ldata(ln);
-      if(!mem_is_in_fuses(m) && !mem_is_lock(m) && !mem_is_readonly(m) && !mem_is_in_flash(m)) {
+      if(mem_is_eeprom(m) || mem_is_user_type(m)) {
         args[1] = m->desc;
         if(cmd_erase(pgm, p, 2, args) < 0)
           ret = -1;
@@ -1651,7 +1651,7 @@ static int cmd_factory(const PROGRAMMER *pgm, const AVRPART *p, int argc, const 
 
   for(LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln)) {
     m = ldata(ln);
-    if(!mem_is_in_fuses(m) && !mem_is_lock(m) && !mem_is_readonly(m)) {
+    if(mem_is_flash(m) || mem_is_eeprom(m) || mem_is_user_type(m)) {
       args[1] = m->desc;
       if(cmd_erase(pgm, p, 2, args) < 0)
         ret = -1;


### PR DESCRIPTION
Fixes #1619

Resets the connected part to factory state as far as possible (bootloaders, for example, cannot write fuses and may not have a means to erase EEPROM). This command may change the clock frequency F_CPU of the part after the next MCU reset when the changed fuse values come into effect. As such, this may require that future avrdude calls use a different bit clock rate (up to F_CPU/4) for the programmer next time. Note that the command `factory` can be abbreviated but the required argument `reset` needs to be spelled out in full.

```
$ cat test-file

write eeprom 0 "the five boxing wizards jump quickly"
write flash 0 -1025 0xcffccffdcffecfff ...
write usersig /dev/random
write bootrow 0 "Sphinx of black quartz, judge my vow"

####
# Do not try this at home with a real programmer/part
#
write fuses /dev/random 

config bootsize
read eeprom  0 16
read flash   0 16
read usersig 0 16
read bootrow 0 16

factory reset

config bootsize
read eeprom  0 16
read flash   0 16
read usersig 0 16
read bootrow 0 16


$ avrdude -qqcdryrun -pavr64du32 -T "include test-file"

config bootsize=95 # 95
0000  74 68 65 20 66 69 76 65  20 62 6f 78 69 6e 67 20  |the five boxing |
0000  ff cf fe cf fd cf fc cf  ff cf fe cf fd cf fc cf  |................|
0000  a1 fc d9 a7 2c 9a 5f 34  d9 0f fe 17 9f ec e3 cc  |....,._4........|
0000  53 70 68 69 6e 78 20 6f  66 20 62 6c 61 63 6b 20  |Sphinx of black |

erasing chip ...
after the next reset the part will have F_CPU = 4.000 MHz

config bootsize=0 # 0
0000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
0000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|

$ avrdude -qqcdryboot -pm328p -t
avrdude> factory reset
avrdude warning: -c dryboot is for bootloaders, which cannot set fuses;
        only erasing flash and other writable memories as far as possible
```
