### PR TITLE
Fix -Wcalloc-transposed-args warning

### DIFF
--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1271,7 +1271,7 @@ avrftdi_setup(PROGRAMMER * pgm)
 	avrftdi_t* pdata;
 
 	
-	if(!(pgm->cookie = calloc(sizeof(avrftdi_t), 1))) {
+	if(!(pgm->cookie = calloc(1, sizeof(avrftdi_t)))) {
 		log_err("Error allocating memory.\n");
 		exit(1);
 	}


### PR DESCRIPTION
The calloc(3) function has two arguments: the number of members, and the size of one member.

sizeof(...) makes more sense as member size, and 1 as number of members. At least that is what the gcc warning wants.

This was the only compiler warning I could get on my Fedora 40 test build (gcc 14) with CFLAGS="-Wall -Wextra -Werror".