### PR TITLE
Improve autotools build (part 2/n)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
           build-essential
           automake
           libtool
-          gettext
           flex
           bison
           libelf-dev

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -220,7 +220,7 @@ libavrdude_la_SOURCES = \
 	wiring.c \
 	xbee.h \
 	xbee.c
-libavrdude_la_LDFLAGS = -version-info 2:0
+libavrdude_la_LDFLAGS = -version-info @LIBAVRDUDE_VERSION_INFO@
 
 include_HEADERS = libavrdude.h
 include_HEADERS += libavrdude-avrintel.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,19 +57,16 @@ AM_YFLAGS    = -d
 
 avrdude_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\"
 
-libavrdude_a_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\"
-libavrdude_la_CPPFLAGS = $(libavrdude_a_CPPFLAGS)
+libavrdude_la_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\"
 
 avrdude_CFLAGS   = @ENABLE_WARNINGS@
 
-libavrdude_a_CFLAGS   = @ENABLE_WARNINGS@ $(LIBGPIOD_CFLAGS)
-libavrdude_la_CFLAGS  = $(libavrdude_a_CFLAGS)
+libavrdude_la_CFLAGS   = @ENABLE_WARNINGS@ $(LIBGPIOD_CFLAGS)
 
-avrdude_LDADD  = $(top_builddir)/$(noinst_LIBRARIES) @LIBUSB_1_0@ @LIBHIDAPI@ @LIBUSB@ @LIBFTDI1@ @LIBFTDI@ @LIBHID@ @LIBELF@ @LIBPTHREAD@ @LIBSERIALPORT@ $(LIBGPIOD_LIBS) -lm
+avrdude_LDADD  = libavrdude.la @LIBUSB_1_0@ @LIBHIDAPI@ @LIBUSB@ @LIBFTDI1@ @LIBFTDI@ @LIBHID@ @LIBELF@ @LIBPTHREAD@ @LIBSERIALPORT@ $(LIBGPIOD_LIBS) -lm
 
 bin_PROGRAMS = avrdude
 
-noinst_LIBRARIES = libavrdude.a
 lib_LTLIBRARIES = libavrdude.la
 
 # automake thinks these generated files should be in the distribution,
@@ -88,7 +85,7 @@ dist-hook: dist-hook-no-dist-built-sources-workaround
 dist-hook-no-dist-built-sources-workaround:
 	cd "$(distdir)" && rm -f $(built_sources)
 
-libavrdude_a_SOURCES = \
+libavrdude_la_SOURCES = \
 	config_gram.y \
 	lexer.l \
 	arduino.h \
@@ -223,7 +220,6 @@ libavrdude_a_SOURCES = \
 	wiring.c \
 	xbee.h \
 	xbee.c
-libavrdude_la_SOURCES = $(libavrdude_a_SOURCES)
 libavrdude_la_LDFLAGS = -version-info 2:0
 
 include_HEADERS = libavrdude.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,14 +31,18 @@ EXTRA_DIST   = \
 	avrdude.spec \
 	bootstrap
 
-CLEANFILES = \
-	config_gram.c \
-	config_gram.h \
-	lexer.c
+BUILT_SOURCES  =
+CLEANFILES     =
+
+built_sources  =
+built_sources += config_gram.c
+built_sources += config_gram.h
+built_sources += lexer.c
+
+BUILT_SOURCES += $(built_sources)
+CLEANFILES    += $(built_sources)
 
 include build-helpers/versioninfo.mk
-
-BUILT_SOURCES = $(CLEANFILES)
 
 #SUBDIRS      = doc
 #DIST_SUBDIRS = doc
@@ -77,11 +81,12 @@ lib_LTLIBRARIES = libavrdude.la
 # https://savannah.nongnu.org/bugs/index.php?func=detailitem&item_id=15536
 #
 # for why we don't want to have them.
-dist-hook:
-	rm -f \
-	$(distdir)/lexer.c \
-	$(distdir)/config_gram.c \
-	$(distdir)/config_gram.h
+#
+# We could avoid this dist-hook altogether if we could require
+# Automake >= 1.16.4 and just use its no-dist-built-sources flag.
+dist-hook: dist-hook-no-dist-built-sources-workaround
+dist-hook-no-dist-built-sources-workaround:
+	cd "$(distdir)" && rm -f $(built_sources)
 
 libavrdude_a_SOURCES = \
 	config_gram.y \

--- a/src/build-helpers/versioninfo.m4
+++ b/src/build-helpers/versioninfo.m4
@@ -9,6 +9,8 @@ dnl This must be the same sequence as the versioninfo script writes.
 m4_pattern_forbid([versioninfo_items])
 m4_define([versioninfo_items], [
   [CMAKE_PROJECT_VERSION],
+  [CMAKE_LIBAVRDUDE_VERSION],
+  [CMAKE_LIBAVRDUDE_SOVERSION],
   [GIT_COMMIT_DATE],
   [GIT_COMMIT_HASH],
   [GIT_TAG_HASH]

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -32,9 +32,10 @@ dnl 2018-02-25 automake 1.16
 dnl 2018-03-11 automake 1.16.1  install-sh symlink fix
 
 
-dnl Change this definition if you want to change the dist tarball name
-dnl pattern from avrdude-7.3 for releases and avrdude-7.3-${COMMIT_DATE}
-dnl for snapshots.
+dnl Define the dist tarball name as
+dnl   * avrdude-7.3 for releases
+dnl   * avrdude-7.3-${COMMIT_DATE} for snapshots
+dnl just like CMakeLists.txt does.
 m4_define([versioninfo_AVRDUDE_PACKAGE_VERSION],
           m4_case(m4_defn([versioninfo_GIT_COMMIT_HASH]),
 	          m4_defn([versioninfo_GIT_TAG_HASH]),
@@ -64,6 +65,9 @@ AM_INIT_AUTOMAKE([
 AM_SILENT_RULES([yes])
 
 
+dnl Set up the macro definitions for versioninfo_* which we hand to AC_INIT.
+dnl Yes, it does work to expand the VERSIONINFO_SETUP macro *after* AC_INIT.
+dnl For details, see the build-helpers/versioninfo.{md,m4,mk,sh} files.
 VERSIONINFO_SETUP()
 
 dnl Inform about the derived PACKAGE_VERSION

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -64,10 +64,13 @@ AM_INIT_AUTOMAKE([
 
 AM_SILENT_RULES([yes])
 
-
 dnl Set up the macro definitions for versioninfo_* which we hand to AC_INIT.
-dnl Yes, it does work to expand the VERSIONINFO_SETUP macro *after* AC_INIT.
+dnl
+dnl Yes, it does work to expand the VERSIONINFO_SETUP macro *after* AC_INIT:
+dnl The presence of VERSIONINFO_SETUP pulls in the definitions at the top.
+dnl
 dnl For details, see the build-helpers/versioninfo.{md,m4,mk,sh} files.
+m4_pattern_forbid([VERSIONINFO_SETUP])dnl
 VERSIONINFO_SETUP()
 
 dnl Inform about the derived PACKAGE_VERSION
@@ -97,13 +100,17 @@ AC_PROG_SED
 AC_PROG_YACC
 AC_PROG_LEX([noyywrap])
 AM_PROG_AR
+
+m4_pattern_forbid([LT_INIT])dnl
 LT_INIT()
 
-# If macro PKG_PROG_PKG_CONFIG is not available, Autoconf generates a misleading error message,
-# so check for existence first, and otherwise provide helpful advice.
+dnl If macro PKG_PROG_PKG_CONFIG is not available, Autoconf generates
+dnl a misleading error message, so check for existence first, and
+dnl otherwise provide helpful advice.
 m4_ifndef([PKG_PROG_PKG_CONFIG], [m4_fatal(m4_normalize([
   Macro PKG_PROG_PKG_CONFIG is not available.
   It is usually defined in file pkg.m4 provided by package pkg-config.]))])
+m4_pattern_forbid([PKG_PROG_PKG_CONFIG])dnl
 PKG_PROG_PKG_CONFIG([0.23])
 
 AH_TEMPLATE([HAVE_YYLEX_DESTROY],

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -92,6 +92,33 @@ AC_DEFINE_UNQUOTED([AVRDUDE_FULL_VERSION], ["$AVRDUDE_FULL_VERSION"],
 AC_SUBST([AVRDUDE_FULL_VERSION])
 
 
+# Define libavrdude libtool version from cmake libavrdude information
+dnl
+dnl This is a very simple consistency check. If this check ever fails,
+dnl the library versioning policy and its technical implementation
+dnl must be adapted.
+m4_case(m4_defn([versioninfo_CMAKE_LIBAVRDUDE_SOVERSION])[.0.0],
+        m4_defn([versioninfo_CMAKE_LIBAVRDUDE_VERSION]),
+	[],
+	[m4_fatal([
+The cmake libavrdude VERSION should be SOVERSION.0.0 ("]m4_defn([versioninfo_CMAKE_LIBAVRDUDE_SOVERSION])[.0.0"),
+but it is actually "]m4_defn([versioninfo_CMAKE_LIBAVRDUDE_VERSION])[".
+
+This is an internal error in the logic which transfers library version
+information from the cmake buildsystem to the automake buildsystem.
+
+Please file a GitHub issue for avrdude and mention @ndim.
+	])])dnl
+dnl
+AC_MSG_CHECKING([versioninfo derived libtool -version-info for libavrdude])
+libavrdude_lt_cur=$CMAKE_LIBAVRDUDE_SOVERSION
+libavrdude_lt_rev=0
+libavrdude_lt_age=0
+AC_SUBST([LIBAVRDUDE_VERSION_INFO],
+         [${libavrdude_lt_cur}:${libavrdude_lt_rev}:${libavrdude_lt_age}])
+AC_MSG_RESULT([$LIBAVRDUDE_VERSION_INFO])
+
+
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_INSTALL


### PR DESCRIPTION
This is a continuation which is based on https://github.com/avrdudes/avrdude/pull/1681 to keep the PR sizes manageable both for the submitter and the reviewers.

Starting this as a Draft PR, expect rebases and force-pushing, e.g. rebasing to main after PR #1681 has been merged to main.

Some goals for this second round of fixing the autotools build:

  - [x] let autotools build use libavrdude VERSION and SOVERSION from cmake build, and define useful rules for the values (similar to what https://github.com/avrdudes/avrdude/pull/1663 did with the PACKAGE_VERSION)
  - [ ] texi doc build related things
      - [ ] let the default rules from automake build HTML, PDF from texinfo
      - [ ] deprecate `--enable-versioned-doc`, have people use `--docdir` to deviate from the default docdir
      - [ ] make the doc builds work for out of tree builds, and therefore the whole tree work for out of tree builds
      - [ ] get rid of recursive make for doc builds, allowing direct building of the generated `*.texi` files
      - [ ] fix the FreeBSD doc build (texi part), possibly more
  - [ ] make builds on NetBSD succeed out of the box
  - [ ] make builds on OpenBSD succeed out of the box
  - [ ] document the tip to try "gmake" if present
  - [ ] fix the warnings generated at autoreconf runs with the **automake** `-Wall` option
  - [x] get rid of non-libtool library (`_LIBRARIES`)
  - [ ] add resource file to Windows builds
  - [ ] support the release process, as described in https://github.com/avrdudes/avrdude/pull/1681#issuecomment-1951040663

Concerning both cmake *and* autotools builds:

  - [ ] use pkg-config `*.pc` files to find our own dependencies
  - [ ] ship libavrdude.pc file for pkg-config

Optionally, move `$top_srcdir/src/configure.ac` to `$top_srcdir/configure.ac`:

  - [ ] include `README.md`, `NEWS`, and especially `COPYING` into `make dist` tarball
  - [ ] include 'CMakeLists.txt' etc. to allow cmake builds from the dist tarball
  - [ ] have `make check` run `tools/test-avrdude`, so `make distcheck` would cover everything in CI builds and the compile and install stages will only need to run once during `make distcheck` (about halves the CPU cycles needed for autotools CI builds)
  - [ ] allows shipping a dist source tarball after some processing, e.g. with complete version information, for both releases and snapshots
  - [ ] have cmake builds use the version information recorded in the dist tarball
  - [ ] to distinguish the dist tarballs from the release and snapshot tarballs generated by Github, make the dist tarballs `.tar.xz` and the Github tarballs `.tar.gz`
  - [ ] generate dist tarballs as part of CI builds for commits and releases, and add the dist tarball to the release assets