### PR TITLE
Allow slash in part variant name for `-p`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -450,7 +450,7 @@ static int dev_opt(const char *str) {
   return
     !str? 0:
     str_eq(str, "*") || str_starts(str, "*/")? 2:
-    strchr(str, '/') && !locate_part(part_list, str): 0;
+    strchr(str, '/') && !locate_part(part_list, str);
 }
 
 typedef struct {

--- a/src/main.c
+++ b/src/main.c
@@ -445,12 +445,12 @@ static void replace_backslashes(char *s)
   }
 }
 
-// Return 2 if string is * or starts with */, 1 if string contains /, 0 otherwise
+// Return 2 if str is * or starts with */, 1 if str contains / but is not a valid part, 0 otherwise
 static int dev_opt(const char *str) {
   return
     !str? 0:
     str_eq(str, "*") || str_starts(str, "*/")? 2:
-    !!strchr(str, '/');
+    strchr(str, '/') && !locate_part(part_list, str): 0;
 }
 
 typedef struct {


### PR DESCRIPTION
Developer options are added to part names or wildcards by a `/` suffix followed by the option characters. However, some part variant names also contain a slash, eg, `AVR64DB64-E/MR`. This PR gives priority to such a variant name and does not interpret the slash as developer option.

With this PR:
```
$ avrdude -qq -p AVR64DB64-E/MR -c dryrun && echo OK
OK
```

Without this PR:
```
$ avrdude -qq -p AVR64DB64-E/MR -c dryrun
avrdude: flags for developer option -p <wildcard>/<flags> not recognised
Wildcard examples (these need protecting in the shell through quoting):
         * all known parts
  ATtiny10 just this part
  *32[0-9] matches ATmega329, ATmega325 and ATmega328
      *32? matches ATmega329, ATmega32A, ATmega325 and ATmega328
Flags (one or more of the characters below):
       d  description of core part features
       A  show entries of avrdude.conf parts with all values
       S  show entries of avrdude.conf parts with necessary values
       s  show short entries of avrdude.conf parts using parent
       r  show entries of avrdude.conf parts as raw dump
       c  check and report errors in address bits of SPI commands
       o  opcodes for SPI programming parts and memories
       w  wd_... constants for ISP parts
       *  all of the above except s and S
       t  use tab separated values as much as possible
       i  inject assignments from source code table
Examples:
  $ avrdude -p ATmega328P/s
  $ avrdude -p m328*/st | grep chip_erase_delay
  avrdude -p*/r | sort
Notes:
  -p * is the same as -p */s
  This help message is printed using any unrecognised flag, eg, -p/h
  Leaving no space after -p can be an OK substitute for quoting in shells
  /s, /S and /A outputs are designed to be used as input in avrdude.conf
  Sorted /r output should stay invariant when rearranging avrdude.conf
  The /c, /o and /w flags are less generic and may be removed sometime
  These options are just to help development, so not further documented
```
