### PR TITLE
Fix cmake build errors related to ac_cfg.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ cscope.out
 out/
 build/
 build_*/
+CMakeFiles/
+/CMakeCache.txt
+cmake_install.cmake
 
 # Visual Studio
 .vs/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,10 +113,19 @@ endif()
 # Configure files
 # =====================================
 
-configure_file(cmake_config.h.in ac_cfg.h)
-configure_file(avrdude.spec.in avrdude.spec)
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake_config.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/ac_cfg.h"
+)
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/avrdude.spec.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/avrdude.spec"
+)
 if(WIN32 OR MINGW)
-    configure_file(windows.rc.in windows.rc)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/windows.rc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/windows.rc"
+  )
 endif()
 
 add_custom_command(
@@ -142,7 +151,7 @@ add_custom_target(conf ALL DEPENDS avrdude.conf)
 # =====================================
 
 add_library(libavrdude
-    ac_cfg.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ac_cfg.h
     arduino.h
     arduino.c
     avr.c
@@ -316,6 +325,7 @@ add_executable(avrdude
     developer_opts_private.h
     whereami.c
     whereami.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ac_cfg.h
     ${EXTRA_WINDOWS_RESOURCES}
     )
 

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -25,7 +25,7 @@
  * are read differently.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/avr.c
+++ b/src/avr.c
@@ -19,7 +19,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -25,7 +25,7 @@
  * protocol described in application note avr910.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -18,7 +18,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -21,7 +21,7 @@
 /*
  * Interface to the MPSSE Engine of FTDI Chips using libftdi.
  */
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdint.h>
 

--- a/src/avrftdi_tpi.c
+++ b/src/avrftdi_tpi.c
@@ -1,4 +1,4 @@
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdint.h>
 #include <string.h>

--- a/src/avrintel.c
+++ b/src/avrintel.c
@@ -13,7 +13,7 @@
  *
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <ctype.h>
 #include <string.h>

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -23,7 +23,8 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include "avrdude.h"
 #include "libavrdude.h"
 

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -19,7 +19,7 @@
  */
  /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -35,7 +35,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -35,7 +35,7 @@
  */
 
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -22,7 +22,7 @@
  * Interface to the CH341A programmer
  *
  */
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/config.c
+++ b/src/config.c
@@ -19,7 +19,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <errno.h>
 #include <stdio.h>

--- a/src/confwin.c
+++ b/src/confwin.c
@@ -17,7 +17,8 @@
  */
 
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include "avrdude.h"
 #include "libavrdude.h"
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -28,7 +28,7 @@
  *
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -18,7 +18,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -21,7 +21,7 @@
 #ifndef dfu_h
 #define dfu_h
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #ifdef HAVE_LIBUSB
 #if defined(HAVE_USB_H)

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -23,7 +23,7 @@
  * pretending all operations work well.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -19,7 +19,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <limits.h>
 #include <stdio.h>

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -21,7 +21,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdint.h>
 #include <stdio.h>

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -18,7 +18,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdint.h>
 #include <stdio.h>

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -50,7 +50,7 @@
 */
 
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -23,7 +23,7 @@
  * avrdude interface for Atmel JTAGICE3 programmer
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <ctype.h>
 #include <limits.h>

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -22,7 +22,7 @@
  * avrdude interface for Atmel JTAG ICE (mkI) programmer
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -30,7 +30,7 @@
  * as well.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <ctype.h>
 #include <limits.h>

--- a/src/leds.c
+++ b/src/leds.c
@@ -16,7 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <string.h>
 #include "avrdude.h"
 #include "libavrdude.h"

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -20,7 +20,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -24,7 +24,7 @@
  */
 
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include "avrdude.h"
 #include "libavrdude.h"

--- a/src/lists.c
+++ b/src/lists.c
@@ -35,7 +35,7 @@
   Date   : 10 January, 1990
   ------------------------------------------------------------------------*/
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@
  */
 
 /* For AVRDUDE_FULL_VERSION and possibly others */
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
  *
  */
 
+/* For AVRDUDE_FULL_VERSION and possibly others */
 #include "ac_cfg.h"
 
 #include <stdio.h>
@@ -50,9 +51,6 @@
 #include "libavrdude.h"
 #include "config.h"
 #include "developer_opts.h"
-
-/* Get VERSION from ac_cfg.h */
-char * version      = AVRDUDE_FULL_VERSION;
 
 char * progname;
 char   progbuf[PATH_MAX]; /* temporary buffer of spaces the same
@@ -266,7 +264,7 @@ static void usage(void)
     "  -l logfile             Use logfile rather than stderr for diagnostics\n"
     "  -?                     Display this usage\n"
     "\navrdude version %s, https://github.com/avrdudes/avrdude\n",
-    progname, strlen(cfg) < 24? "config file ": "", cfg, version);
+    progname, strlen(cfg) < 24? "config file ": "", cfg, AVRDUDE_FULL_VERSION);
 
   free(cfg);
 }
@@ -1058,7 +1056,7 @@ int main(int argc, char * argv [])
    * they are running
    */
   msg_notice("\n");
-  pmsg_notice("Version %s\n", version);
+  pmsg_notice("Version %s\n", AVRDUDE_FULL_VERSION);
   imsg_notice("Copyright the AVRDUDE authors;\n");
   imsg_notice("see https://github.com/avrdudes/avrdude/blob/main/AUTHORS\n\n");
 
@@ -1092,9 +1090,9 @@ int main(int argc, char * argv [])
     }
   }
 
-  if(!str_eq(avrdude_conf_version, version)) {
+  if(!str_eq(avrdude_conf_version, AVRDUDE_FULL_VERSION)) {
     pmsg_warning("System wide configuration file version (%s)\n", avrdude_conf_version);
-    imsg_warning("does not match Avrdude build version (%s)\n", version);
+    imsg_warning("does not match Avrdude build version (%s)\n", AVRDUDE_FULL_VERSION);
   }
 
   if (lsize(additional_config_files) > 0) {

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -36,7 +36,7 @@
 // Example:
 // avrdude -c micronucleus -p t85 -x wait -V -U flash:w:main.hex
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/par.c
+++ b/src/par.c
@@ -18,7 +18,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -19,7 +19,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/pgm_type.c
+++ b/src/pgm_type.c
@@ -19,7 +19,7 @@
 
 /* $Id: pgm.c 976 2011-08-23 21:03:36Z joerg_wunsch $ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -43,7 +43,7 @@
  * SDO  - AUX (6)
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -22,7 +22,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include "avrdude.h"
 #include "libavrdude.h"
 

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -21,7 +21,7 @@
 
 #if !defined(WIN32)
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #if HAVE_PARPORT
 

--- a/src/ppiwin.c
+++ b/src/ppiwin.c
@@ -30,7 +30,7 @@ reg = register as defined in an enum in ppi.h. This must be converted
 */
 
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #if defined(HAVE_PARPORT) && defined(WIN32)
 

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -24,7 +24,7 @@
  * Serial Interface emulation for USB programmer "AVR-Doper" in HID mode.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #if defined(HAVE_LIBHIDAPI)
 

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -25,7 +25,7 @@
 
 #if !defined(WIN32)
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <ctype.h>
 #include <stdbool.h>

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -21,7 +21,7 @@
  * Native Win32 serial interface for avrdude.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #if defined(WIN32)
 

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -25,7 +25,7 @@
 
 #if !defined(WIN32)
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -28,7 +28,7 @@
 #if defined(WIN32)
 
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -17,7 +17,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -25,7 +25,8 @@
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
-#include "ac_cfg.h"
+
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -28,7 +28,7 @@
  *
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -28,7 +28,7 @@
  * misses out on the extended -x options of the successful programmer.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -35,7 +35,7 @@
  *
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <math.h>
 #include <stdio.h>

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -17,7 +17,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -34,7 +34,8 @@
 // Example:
 // avrdude -c teensy -p m32u4 -x wait -V -U flash:w:main.hex:i
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/term.c
+++ b/src/term.c
@@ -20,7 +20,7 @@
 
 /* $Id$ */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <ctype.h>
 #include <string.h>

--- a/src/update.c
+++ b/src/update.c
@@ -28,7 +28,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include "avrdude.h"
 #include "libavrdude.h"
 

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -24,7 +24,7 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/updi_nvm.c
+++ b/src/updi_nvm.c
@@ -24,7 +24,8 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/updi_nvm_v0.c
+++ b/src/updi_nvm_v0.c
@@ -24,7 +24,8 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/updi_nvm_v2.c
+++ b/src/updi_nvm_v2.c
@@ -24,7 +24,8 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/updi_nvm_v3.c
+++ b/src/updi_nvm_v3.c
@@ -24,7 +24,8 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/updi_nvm_v4.c
+++ b/src/updi_nvm_v4.c
@@ -24,7 +24,8 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/updi_nvm_v5.c
+++ b/src/updi_nvm_v5.c
@@ -24,7 +24,8 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/updi_readwrite.c
+++ b/src/updi_readwrite.c
@@ -24,7 +24,7 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/updi_state.c
+++ b/src/updi_state.c
@@ -24,7 +24,7 @@
  * See https://github.com/microchip-pic-avr-tools/pymcuprog
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include "libavrdude.h"
 #include "updi_state.h"

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -203,7 +203,7 @@
  *
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -22,7 +22,7 @@
  * USB interface via libhidapi for avrdude.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 #if defined(HAVE_LIBHIDAPI)
 
 

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -23,7 +23,7 @@
  * USB interface via libusb for avrdude.
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 #if defined(HAVE_LIBUSB)
 
 

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -24,7 +24,8 @@
  *
  * See http://www.fischl.de/usbasp/
  */
-#include "ac_cfg.h"
+
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -23,7 +23,7 @@
  * For example schematics and detailed documentation
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -37,7 +37,7 @@
  *
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -28,7 +28,7 @@
  * https://github.com/davidsainty/xbeeboot
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <sys/time.h>
 


### PR DESCRIPTION
This fixes a few errors related to how cmake builds deal with `ac_cfg.h`. This has been discussed in https://github.com/avrdudes/avrdude/pull/1681#issuecomment-1962747588 and following comments, and then in issue https://github.com/avrdudes/avrdude/issues/1706.

  * While testing, I ran `cmake .` a few times which generates a cmake buildsystem inside the source tree. Some of those files still had to be added to `.gitignore`.

  * Using the identifier `version` inside `src/main.c` to refer to `AVRDUDE_FULL_VERSION` is about as confusing as using `VERSION` instead of `AVRDUDE_FULL_VERSION` was. So I removed `char *version` and just let the functions reference `AVRDUDE_FULL_VERSION` directly. I trust compilers these days to have all those references refer to the same bit of constant memory, and not allocate several copies of `AVRDUDE_FULL_VERSION`.
 
  * Fix cmake not finding the generated `ac_cfg.h` when the (often unused and unnecessary) `src/ac_cfg.h` does *NOT* exist. See commit message.

  * And most importantly, fix the C preprocessor mistakenly looking in `src/` before `build_$ostype/src/` when looking for `ac_cfg.h`: Change from `#include "ac_cfg.h"` to `#include <ac_cfg.h>` in all source files.