### PR TITLE
Provide lmsg_xyz() functions to start message at left margin

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -60,6 +60,7 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
 #define MSG2_INDENT1      16 // Start by printing indentation of progname+1 blanks
 #define MSG2_INDENT2      32 // Start by printing indentation of progname+2 blanks
 #define MSG2_FLUSH        64 // Flush before and after printing
+#define MSG2_LEFT_MARGIN 128 // Print \n unless last character printed was \n
 
 // Shortcuts
 #define msg_ext_error(...)  avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_EXT_ERROR, __VA_ARGS__)
@@ -72,27 +73,39 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
 #define msg_trace(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_TRACE, __VA_ARGS__)
 #define msg_trace2(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_TRACE2, __VA_ARGS__)
 
-#define pmsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
-#define pmsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
-#define pmsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
-#define pmsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
-#define pmsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE, __VA_ARGS__)
-#define pmsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_NOTICE2, __VA_ARGS__)
-#define pmsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_DEBUG, __VA_ARGS__)
-#define pmsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE, __VA_ARGS__)
-#define pmsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH, MSG_TRACE2, __VA_ARGS__)
+#define pmsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_EXT_ERROR, __VA_ARGS__)
+#define pmsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_ERROR, __VA_ARGS__)
+#define pmsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_WARNING, __VA_ARGS__)
+#define pmsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)
+#define pmsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE, __VA_ARGS__)
+#define pmsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__)
+#define pmsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__)
+#define pmsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__)
+#define pmsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_PROGNAME|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__)
 
-#define imsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT1|MSG2_FLUSH, MSG_EXT_ERROR, __VA_ARGS__)
-#define imsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT1|MSG2_FLUSH, MSG_ERROR, __VA_ARGS__)
-#define imsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT1|MSG2_FLUSH, MSG_WARNING, __VA_ARGS__)
-#define imsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
-#define imsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH, MSG_NOTICE, __VA_ARGS__)
-#define imsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH, MSG_NOTICE2, __VA_ARGS__)
-#define imsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH, MSG_DEBUG, __VA_ARGS__)
-#define imsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH, MSG_TRACE, __VA_ARGS__)
-#define imsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH, MSG_TRACE2, __VA_ARGS__)
+#define imsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT1|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_EXT_ERROR, __VA_ARGS__)
+#define imsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT1|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_ERROR, __VA_ARGS__)
+#define imsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT1|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_WARNING, __VA_ARGS__)
+#define imsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)
+#define imsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE, __VA_ARGS__)
+#define imsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__)
+#define imsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__)
+#define imsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__)
+#define imsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_INDENT2|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__)
+
+#define lmsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_EXT_ERROR, __VA_ARGS__)
+#define lmsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_ERROR, __VA_ARGS__)
+#define lmsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_WARNING, __VA_ARGS__)
+#define lmsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)
+#define lmsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_NOTICE, __VA_ARGS__)
+#define lmsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__)
+#define lmsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__)
+#define lmsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__)
+#define lmsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__)
 
 #define term_out(...)       avrdude_message2(stdout, __LINE__, __FILE__, __func__, MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
+#define lterm_out(...)      avrdude_message2(stdout, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)
+
 #define fmsg_out(fp, ...)   avrdude_message2(fp, __LINE__, __FILE__, __func__, MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -87,9 +87,8 @@ static const char *avrdude_message_type(int msglvl) {
 
 
 /*
- * Core msg_xyz() routine
+ * Core messaging routine for msg_xyz(), [pli]msg_xyz() and term_out()
  * See #define lines in avrdude.h of how it is normally called
- * Side note: if format starts with \v print \n but only if *not* at beginning of line
  */
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...) {
     int rc = 0;
@@ -120,9 +119,12 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
 
     // Reduce effective verbosity level by number of -q above one when printing to stderr
     if ((quell_progress < 2 || fp != stderr? verbose: verbose+1-quell_progress) >= msglvl) {
+        if(msgmode & MSG2_LEFT_MARGIN && !bols[bi].bol) {
+          fprintf(fp, "\n");
+          bols[bi].bol = 1;
+        }
+
         if(msgmode & MSG2_PROGNAME) {
-          if(!bols[bi].bol)
-            fprintf(fp, "\n");
           fprintf(fp, "%s", progname);
           if(verbose >= MSG_NOTICE && (msgmode & MSG2_FUNCTION))
             fprintf(fp, " %s()", func);
@@ -145,15 +147,6 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
         } else if(msgmode & MSG2_INDENT2) {
           fprintf(fp, "%*s", (int) strlen(progname)+2, "");
           bols[bi].bol = 0;
-        }
-
-        // Vertical tab at start of format string is a conditional new line
-        if(*format == '\v') {
-          format++;
-          if(!bols[bi].bol) {
-            fprintf(fp, "\n");
-            bols[bi].bol = 1;
-          }
         }
 
         // Figure out whether this print will leave us at beginning of line
@@ -522,7 +515,6 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
 }
 
 static void programmer_not_found(const char *programmer, PROGRAMMER *pgm, int pmode) {
-  msg_error("\v");
   if(!programmer || !*programmer) {
     pmsg_error("no programmer has been specified on the command line or in the\n");
     imsg_error("config file(s); specify one using the -c option and try again\n");
@@ -530,7 +522,7 @@ static void programmer_not_found(const char *programmer, PROGRAMMER *pgm, int pm
   }
 
   if(str_eq(programmer, "?")) {
-    msg_error("Valid programmers are:\n");
+    lmsg_error("Valid programmers are:\n");
     list_programmers(stderr, "  ", programmers, ~0);
     msg_error("\n");
     return;
@@ -553,7 +545,7 @@ static void programmer_not_found(const char *programmer, PROGRAMMER *pgm, int pm
       }
   }
   if(pmatches) {
-    msg_error("%s is not a unique start of a programmer name; consider:\n", programmer);
+    pmsg_error("%s is not a unique start of a programmer name; consider:\n", programmer);
     for(LNODEID ln1=lfirst(programmers); ln1; ln1=lnext(ln1)) {
      PROGRAMMER *pg = ldata(ln1);
       if(is_programmer(pg) && (pg->prog_modes & pmode))
@@ -1152,7 +1144,7 @@ int main(int argc, char * argv [])
       list_available_serialports(programmers);
       exit(0);
     } else if(str_eq(port, "?sa")) {
-      msg_error("\vValid serial adapters are:\n");
+      lmsg_error("Valid serial adapters are:\n");
       list_serialadapters(stderr, "  ", programmers);
       exit(0);
     }
@@ -1505,7 +1497,7 @@ skipopen:
     programmer_display(pgm, progbuf);
   }
 
-  msg_info("\v");
+  lmsg_info("");
 
   exitrc = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -124,6 +124,15 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
           bols[bi].bol = 1;
         }
 
+        // Keep vertical tab at start of format string as conditional new line
+        if(*format == '\v') {
+          format++;
+          if(!bols[bi].bol) {
+            fprintf(fp, "\n");
+            bols[bi].bol = 1;
+          }
+        }
+
         if(msgmode & MSG2_PROGNAME) {
           fprintf(fp, "%s", progname);
           if(verbose >= MSG_NOTICE && (msgmode & MSG2_FUNCTION))

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -447,11 +447,10 @@ void list_serialadapters(FILE *fp, const char *prefix, LISTID programmers) {
 }
 
 void serialadapter_not_found(const char *sea_id) {
-  msg_error("\v");
   if(sea_id && *sea_id)
     pmsg_error("cannot find serial adapter id %s\n", sea_id);
 
-  msg_error("\nValid serial adapters are:\n");
+  lmsg_error("\nValid serial adapters are:\n");
   list_serialadapters(stderr, "  ", programmers);
   msg_error("\n");
 }

--- a/src/term.c
+++ b/src/term.c
@@ -349,7 +349,7 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
   report_progress(1, 1, NULL);
 
   hexdump_buf(stdout, mem, read_mem[i].addr, buf, read_mem[i].len);
-  term_out("\v");
+  lterm_out("");
 
   free(buf);
 
@@ -598,7 +598,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, const ch
     len + bytes_grown, str_plural(len + bytes_grown), addr);
   if (write_mode == WRITE_MODE_FILL && filling)
     msg_notice2("; remaining space filled with %s", argv[argc - 2]);
-  msg_notice2("\v");
+  msg_notice2("\n");
 
   report_progress(0, 1, avr_has_paged_access(pgm, mem)? "Caching": "Writing");
   for (i = 0; i < len + bytes_grown; i++) {
@@ -1904,7 +1904,7 @@ static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
     avr_mem_display(stdout, p, "");
     avr_variants_display(stdout, p, "");
   }
-  term_out("\v");
+  lterm_out("");
 
   return 0;
 }
@@ -1968,7 +1968,7 @@ static int cmd_parms(const PROGRAMMER *pgm, const AVRPART *p, int argc, const ch
   }
 
   pgm->print_parms(pgm, stdout);
-  term_out("\v");
+  lterm_out("");
   return 0;
 }
 
@@ -2549,7 +2549,7 @@ static void term_gotline(char *cmdstr) {
     }
   } else {
     // End of file or terminal ^D
-    term_out("\v");
+    lterm_out("");
     cmd_quit(term_pgm, term_p, 0, NULL);
     term_running = 0;
   }
@@ -2665,11 +2665,11 @@ static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, const 
       if(verbose > 0)
        term_out("%d: ", lineno);
       term_out("%s", buffer);
-      term_out("\v");
+      lterm_out("");
     }
     if(process_line(buffer, pgm, p) < 0)
       rc = -1;
-    term_out("\v");
+    lterm_out("");
   }
   if(errstr) {
     pmsg_error("(include) read error in file %s: %s\n", argv[1], errstr);
@@ -2689,7 +2689,7 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
   setvbuf(stderr, (char *) NULL, _IONBF, 0);
 
   if(hdr) {
-    msg_info("\v");
+    lmsg_info("");
     last = done = 0;
     if(header)
       free(header);
@@ -2713,7 +2713,7 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
     msg_info("\r%s | %s | %d%% %0.2f s ", header, hashes, showperc, etime);
     if(percent == 100) {
       if(finish)
-        msg_info("\v");
+        lmsg_info("");
       done = 1;
     }
   }
@@ -2730,7 +2730,7 @@ static void update_progress_no_tty(int percent, double etime, const char *hdr, i
   percent = percent > 100? 100: percent < 0? 0: percent;
 
   if(hdr) {
-    msg_info("\v%s | ", hdr);
+    lmsg_info("%s | ", hdr);
     last = done = 0;
   }
 
@@ -2741,7 +2741,7 @@ static void update_progress_no_tty(int percent, double etime, const char *hdr, i
     if(percent == 100) {
       msg_info(" | %d%% %0.2fs", finish >= 0? 100: last, etime);
       if(finish)
-        msg_info("\v");
+        lmsg_info("");
       done = 1;
     }
   }

--- a/src/update.c
+++ b/src/update.c
@@ -369,7 +369,7 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd, enum updat
   Filestats fs, fs_patched;
   char *tofree;
 
-  msg_info("\v\n");
+  lmsg_info("\n");              // Ensure an empty line for visual separation of operations
   pmsg_info("processing %s\n", tofree = update_str(upd));
   free(tofree);
 


### PR DESCRIPTION
This PR adds a `MSG2_LEFT_MARGIN` flag as alternative to the `\v` messaging convention.

Some messaging needs a functionality to end an open line, so that the next message starts at the left margin, ie, the ability to print a `\n` iff the last printed character was not already a `\n`. This used to be effected by `\v` as first char in the message format.

This PR introduces a dedicated `lmsg_`*xyz*`()` set of messaging functions that utilises a `MSG2_LEFT_MARGIN` flag to enforce a left margin start for the message. The PR keeps vertical tab `\v` at  the start of the format string for the time being for backward compatibility, but neither AVRDUDE itself nor `libavrdude` uses the `\v` convention any more.

The PR is motivated by the observation in the current PR #1714 that, for other applications, `\v` processing can be more difficult than processing a flag such as `MSG2_LEFT_MARGIN`.


In order to test against regression, I suggest `dryrun` runs with `-vvv` and compare outputs, eg,
```
$ avrdude_main -vvv -cdryrun -pm328p -U some-sketch.hex >& /tmp/a
$ avrdude_pr   -vvv -cdryrun -pm328p -U some-sketch.hex |& diff - /tmp/a
```