### PR TITLE
Change return type for avr_(ms|us)timestamp() to uint64_t

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -572,15 +572,15 @@ error:
 }
 
 
-// Return us since program start, rolls over after ca 1h 12min
-unsigned long avr_ustimestamp() {
+// Return us since first call
+uint64_t avr_ustimestamp() {
   struct timeval tv;
 
   memset(&tv, 0, sizeof tv);
   if(gettimeofday(&tv, NULL) == 0) {
-    static unsigned long long epoch;
+    static uint64_t epoch;
     static int init;
-    unsigned long long now;
+    uint64_t now;
 
     now = tv.tv_sec*1000000ULL + tv.tv_usec;
     if(!init) {
@@ -593,8 +593,8 @@ unsigned long avr_ustimestamp() {
   return 0;
 }
 
-// Return ms since program start, rolls over after ca 49d 17h
-unsigned long avr_mstimestamp() {
+// Return ms since first call to avr_ustimestamp() above
+uint64_t avr_mstimestamp() {
   return avr_ustimestamp()/1000;
 }
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1121,9 +1121,9 @@ int avr_read(const PROGRAMMER * pgm, const AVRPART *p, const char *memstr, const
 int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem,
                    unsigned long addr);
 
-unsigned long avr_ustimestamp(void);
+uint64_t avr_ustimestamp(void);
 
-unsigned long avr_mstimestamp(void);
+uint64_t avr_mstimestamp(void);
 
 double avr_timestamp(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -652,7 +652,7 @@ int main(int argc, char * argv [])
   char  * logfile;     /* Use logfile rather than stderr for diagnostics */
   enum updateflags uflags = UF_AUTO_ERASE | UF_VERIFY; /* Flags for do_op() */
 
-  (void) avr_ustimestamp();
+  (void) avr_ustimestamp();     // Base timestamps from program start
 
 #ifdef _MSC_VER
   _set_printf_count_output(1);

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1984,7 +1984,7 @@ static int urclock_getsync(const PROGRAMMER *pgm) {
         break;
     } else {                    // Board not yet out of reset or bootloader twiddles lights
       int slp = 32<<(attempt<3? attempt: 3);
-      pmsg_debug("%4ld ms: sleeping for %d ms\n", avr_mstimestamp(), slp);
+      pmsg_debug("%4lld ms: sleeping for %d ms\n", (long long) avr_mstimestamp(), slp);
       usleep(slp*1000);
     }
     if(attempt > 5) {           // Don't report first six attempts
@@ -2248,10 +2248,10 @@ static int urclock_open(PROGRAMMER *pgm, const char *port) {
   if((120+ur.delay) > 0)
     usleep((120+ur.delay)*1000); // Wait until board comes out of reset
 
-  pmsg_debug("%4ld ms: enter urclock_getsync()\n", avr_mstimestamp());
+  pmsg_debug("%4lld ms: enter urclock_getsync()\n", (long long) avr_mstimestamp());
   if(urclock_getsync(pgm) < 0)
     return -1;
-  pmsg_debug("%4ld ms: all good, ready to rock\n", avr_mstimestamp());
+  pmsg_debug("%4lld ms: all good, ready to rock\n", (long long) avr_mstimestamp());
 
   return 0;
 }


### PR DESCRIPTION
Fixes #1722

@ndim Does commit https://github.com/avrdudes/avrdude/commit/2283b970ecda3da4f2824a56fcb26905e3dd32f7 increment the libavrdude version correctly? 