### PR TITLE
Add buspirate hiz and pullups feature

### DIFF
--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -63,7 +63,7 @@
 #define BP_FLAG_XPARM_CPUFREQ       (1<<5)
 #define BP_FLAG_XPARM_RAWFREQ       (1<<6)
 #define BP_FLAG_NOPAGEDREAD         (1<<7)
-#define BP_FLAG_PUPS                (1<<8)
+#define BP_FLAG_PULLUPS             (1<<8)
 #define BP_FLAG_HIZ                 (1<<9)
 
 struct pdata
@@ -89,8 +89,8 @@ buspirate_uses_ascii(const PROGRAMMER *pgm) {
 }
 
 static inline int
-buspirate_uses_pups(const PROGRAMMER *pgm) {
-	return (PDATA(pgm)->flag & BP_FLAG_PUPS);
+buspirate_uses_pullups(const PROGRAMMER *pgm) {
+	return (PDATA(pgm)->flag & BP_FLAG_PULLUPS);
 }
 
 static inline int
@@ -310,7 +310,7 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 		}
 
 		if (str_eq(extended_param, "pullups")) {
-			PDATA(pgm)->flag |= BP_FLAG_PUPS;
+			PDATA(pgm)->flag |= BP_FLAG_PULLUPS;
 			continue;
 		}
 
@@ -627,7 +627,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 	/* 0b0100wxyz - Configure peripherals w=power, x=pull-ups/aux2, y=AUX, z=CS
 	 * we want power (0x48) and all reset pins high. */
 	PDATA(pgm)->current_peripherals_config  = 0x48 | PDATA(pgm)->reset;
-	if (buspirate_uses_pups(pgm)) {
+	if (buspirate_uses_pullups(pgm)) {
 		PDATA(pgm)->current_peripherals_config |= 1<<2;
         submode.config &= ~(1<<3);
         pmsg_info("enabling pull-ups (open-collector)\n");

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -63,6 +63,8 @@
 #define BP_FLAG_XPARM_CPUFREQ       (1<<5)
 #define BP_FLAG_XPARM_RAWFREQ       (1<<6)
 #define BP_FLAG_NOPAGEDREAD         (1<<7)
+#define BP_FLAG_PUPS                (1<<8)
+#define BP_FLAG_HIZ                 (1<<9)
 
 struct pdata
 {
@@ -84,6 +86,16 @@ struct pdata
 static inline int
 buspirate_uses_ascii(const PROGRAMMER *pgm) {
 	return (PDATA(pgm)->flag & BP_FLAG_XPARM_FORCE_ASCII);
+}
+
+static inline int
+buspirate_uses_pups(const PROGRAMMER *pgm) {
+	return (PDATA(pgm)->flag & BP_FLAG_PUPS);
+}
+
+static inline int
+buspirate_uses_hiz(const PROGRAMMER *pgm) {
+	return (PDATA(pgm)->flag & BP_FLAG_HIZ);
 }
 
 /* ====== Serial talker functions - binmode ====== */
@@ -297,6 +309,16 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 			continue;
 		}
 
+		if (str_eq(extended_param, "pullups")) {
+			PDATA(pgm)->flag |= BP_FLAG_PUPS;
+			continue;
+		}
+
+		if (str_eq(extended_param, "hiz")) {
+			PDATA(pgm)->flag |= BP_FLAG_HIZ;
+			continue;
+		}
+
 		if (sscanf(extended_param, "spifreq=%u", &spifreq) == 1) {
 			if (spifreq & (~0x07)) {
 				pmsg_error("spifreq must be between 0 and 7\n");
@@ -386,6 +408,8 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 			msg_error("  -xnopagedread               Disable page read functionality\n");
 			msg_error("  -xcpufreq=<125..4000>       Set the AUX pin to output a frequency to n [kHz]\n");
 			msg_error("  -xserial_recv_timeout=<arg> Set serial receive timeout to <arg> [ms]\n");
+			msg_error("  -xpullups                   Enable internal pull-ups\n");
+			msg_error("  -xhiz                       SPI HiZ mode (open collector)\n");
 			msg_error("  -xhelp                      Show this help menu and exit\n");
 			exit(0);
 		}
@@ -515,6 +539,10 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 		 *          of the pulse (0)
 		 *       => 0b10001010 = 0x8a */
 		submode.config = 0x8A;
+		if (buspirate_uses_hiz(pgm)) {
+			submode.config &= ~(1<<3);
+            pmsg_info("spi hi-z mode (open-collector)\n");
+        }
 	}
 
 	unsigned char buf[20] = { '\0' };
@@ -599,6 +627,11 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 	/* 0b0100wxyz - Configure peripherals w=power, x=pull-ups/aux2, y=AUX, z=CS
 	 * we want power (0x48) and all reset pins high. */
 	PDATA(pgm)->current_peripherals_config  = 0x48 | PDATA(pgm)->reset;
+	if (buspirate_uses_pups(pgm)) {
+		PDATA(pgm)->current_peripherals_config |= 1<<2;
+        submode.config &= ~(1<<3);
+        pmsg_info("enabling pull-ups (open-collector)\n");
+    }
 	if (buspirate_expect_bin_byte(pgm, PDATA(pgm)->current_peripherals_config, 0x01) < 0)
 		return -1;
 	usleep(50000); // sleep for 50ms after power up
@@ -721,7 +754,7 @@ static void buspirate_enable(PROGRAMMER *pgm, const AVRPART *p) {
 
 	msg_info("attempting to initiate BusPirate ASCII mode ...\n");
 
-	/* Call buspirate_send_bin() instead of buspirate_send() 
+	/* Call buspirate_send_bin() instead of buspirate_send()
 	 * because we don't know if BP is in text or bin mode */
 	rc = buspirate_send_bin(pgm, (const unsigned char*)reset_str, strlen(reset_str));
 	if (rc) {
@@ -1180,7 +1213,7 @@ static void buspirate_bb_enable(PROGRAMMER *pgm, const AVRPART *p) {
 	return;
 }
 
-/* 
+/*
    Direction:
    010xxxxx
    Input (1) or output (0):
@@ -1248,7 +1281,7 @@ static int buspirate_bb_setpin_internal(const PROGRAMMER *pgm, int pin, int valu
 
 	if (value)
 		PDATA(pgm)->pin_val |= (1 << (pin - 1));
-	else 
+	else
 		PDATA(pgm)->pin_val &= ~(1 << (pin - 1));
 
 	buf[0] = PDATA(pgm)->pin_val | 0x80;

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1456,11 +1456,15 @@ are available. Paged writing is not implemented in this mode.
 
 @item @samp{pullups}
 Enable the Bus Pirate's built-in pull-up resistors. These resistors are 
-useful when working with different voltage levels. 
+useful when working with different voltage levels. VPU pin of the Bus Pirate 
+must be connected to an external voltage. 
+For example: connect VPU pun to the +5V pin or an external power supply. 
 
 @item @samp{hiz}
 Enable the Bus Pirate's HiZ mode on SPI, allowing it to work as an 
 open-collector and interface with external pull-up circuits. 
+If the external target circuit does not have pull-ups, the Bus Pirate 
+will not be able to send data. 
 
 @item @samp{ascii}
 Attempt to use ASCII mode even when the firmware supports BinMode (binary

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1454,6 +1454,14 @@ of the default binary SPI mode:
 The only advantage of the ``raw-wire'' mode is that different SPI frequencies
 are available. Paged writing is not implemented in this mode.
 
+@item @samp{pullups}
+Enable the Bus Pirate's built-in pull-up resistors. These resistors are 
+useful when working with different voltage levels. 
+
+@item @samp{hiz}
+Enable the Bus Pirate's HiZ mode on SPI, allowing it to work as an 
+open-collector and interface with external pull-up circuits. 
+
 @item @samp{ascii}
 Attempt to use ASCII mode even when the firmware supports BinMode (binary
 mode).

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1458,7 +1458,7 @@ are available. Paged writing is not implemented in this mode.
 Enable the Bus Pirate's built-in pull-up resistors. These resistors are 
 useful when working with different voltage levels. VPU pin of the Bus Pirate 
 must be connected to an external voltage. 
-For example: connect VPU pun to the +5V pin or an external power supply. 
+For example: connect VPU pin to the +5V pin or an external power supply. 
 
 @item @samp{hiz}
 Enable the Bus Pirate's HiZ mode on SPI, allowing it to work as an 


### PR DESCRIPTION
This pull request introduces new functionality to the project by adding support for the Bus Pirate "HiZ mode" and "pull-up resistors" feature. 

These enhancements aim to provide users with more flexibility and control over their hardware interactions, making the tool even more versatile.

- **pullups**: Enable the Bus Pirate's built-in pull-up resistors. These resistors are useful when working **with different voltage levels**. 
- **hiz**: Enable the Bus Pirate's HiZ mode on SPI, allowing it to work as an open-collector and interface with external pull-up circuits. 

Example: Bus Pirate v3 connected to arduino uno clone ICSP + **VPU to 5V** Arduino pin:

![image](https://github.com/avrdudes/avrdude/assets/9882181/c25976e3-4879-4733-8d55-3144721ca155)

- The first command works well because VPU is connected to +5V, so it is working! (5V pull-ups)
- The second command "hiz" fails because this ICSP doesn't have external pull-ups, so it is working! (open-collector standalone)
- The third command works because SPI is working in Normal Mode 3v3 with pull-ups off, so it is working!

----

![image](https://github.com/avrdudes/avrdude/assets/9882181/a736268e-ed68-4485-b685-eaa2a630d0e5)

----

This PR doesn't break anything from before and is **100% backward compatible**.

