### PR TITLE
Find exact matches of programmer name

### DIFF
--- a/src/pgm.c
+++ b/src/pgm.c
@@ -338,7 +338,6 @@ PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *p
             matches = 1;
             goto done;
           }
-          break;
         }
       }
     }


### PR DESCRIPTION
Fixes #1739.

This bug occurred when the list of ids for a programmer had a shorter initial string later in the list, eg,
```
    id                     = "jtag2fast", "jtag2";
```