### PR TITLE
Move static buffer to PDATA region in buspirate.c

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -40,6 +40,11 @@ extern int quell_progress;   // Quell progress report -q, reduce effective verbo
 extern const char *partdesc; // Part -p string
 extern const char *pgmid;    // Programmer -c string
 
+// Magic memory tree: these functions succeed or exit()
+#define mmt_strdup(s) cfg_strdup(__func__, s)
+#define mmt_malloc(n) cfg_malloc(__func__, n)
+#define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
+
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);
 
 #define MSG_EXT_ERROR   (-3) // OS-type error, no -v option, can be suppressed with -qqqqq

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -691,8 +691,8 @@ static int buspirate_start_spi_mode_ascii(const PROGRAMMER *pgm) {
 }
 
 static void buspirate_enable(PROGRAMMER *pgm, const AVRPART *p) {
-	static const char *reset_str = "#\n";
-	static const char *accept_str = "y\n";
+	const char * const reset_str = "#\n";
+	const char * const accept_str = "y\n";
 	char *rcvd;
 	int rc, print_banner = 0;
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -82,8 +82,7 @@ struct pdata
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
 
 /* ====== Feature checks ====== */
-static inline int
-buspirate_uses_ascii(const PROGRAMMER *pgm) {
+static inline int buspirate_uses_ascii(const PROGRAMMER *pgm) {
 	return (PDATA(pgm)->flag & BP_FLAG_XPARM_FORCE_ASCII);
 }
 
@@ -277,8 +276,7 @@ static void buspirate_dummy_6(const PROGRAMMER *pgm, const char *p) {
 }
 
 /* ====== Config / parameters handling functions ====== */
-static int
-buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
+static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 	LNODEID ln;
 	const char *extended_param;
 	char reset[10];
@@ -395,8 +393,7 @@ buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 	return 0;
 }
 
-static int
-buspirate_verifyconfig(const PROGRAMMER *pgm) {
+static int buspirate_verifyconfig(const PROGRAMMER *pgm) {
 	/* Default reset pin is CS */
 	if (PDATA(pgm)->reset == 0x00)
 		PDATA(pgm)->reset |= BP_RESET_CS;

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -77,6 +77,7 @@ struct pdata
 	unsigned char pin_val;		/* Last written pin values for bitbang mode */
 	int     unread_bytes;		/* How many bytes we expected, but ignored */
 	int     flag;
+	char buf_local[100];            /* Local buffer for buspirate_readline_noexit() */
 };
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
 
@@ -174,12 +175,9 @@ static char *buspirate_readline_noexit(const PROGRAMMER *pgm, char *buf, size_t 
 	int c;
 	long orig_serial_recv_timeout = serial_recv_timeout;
 
-	/* Static local buffer - this may come handy at times */
-	static char buf_local[100];
-
 	if (buf == NULL) {
-		buf = buf_local;
-		len = sizeof(buf_local);
+		buf = PDATA(pgm)->buf_local;
+		len = sizeof(PDATA(pgm)->buf_local);
 	}
 	buf_p = buf;
 	memset(buf, 0, len);

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -1085,7 +1085,7 @@ static int buspirate_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static void buspirate_setup(PROGRAMMER *pgm)
 {
 	/* Allocate private data */
-	pgm->cookie = cfg_malloc(__func__, sizeof(struct pdata));
+	pgm->cookie = mmt_malloc(sizeof(struct pdata));
 	PDATA(pgm)->serial_recv_timeout = 100;
 }
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -570,7 +570,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 		pgm->paged_write = NULL;
 	} else {
 		/* Check for write-then-read without !CS/CS and disable paged_write if absent: */
-		static const unsigned char buf2[] = {5,0,0,0,0};
+		const unsigned char buf2[] = {5, 0, 0, 0, 0};
 		buspirate_send_bin(pgm, buf2, sizeof(buf2));
 		buspirate_recv_bin(pgm, buf, 1);
 		if (buf[0] != 0x01) {
@@ -616,7 +616,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 			return -1;
 		if (rv) {
 			unsigned int ver = 0;
-			static const unsigned char buf2[] = {1};
+			const unsigned char buf2[] = {1};
 			buspirate_send_bin(pgm, buf2, sizeof(buf2));
 			buspirate_recv_bin(pgm, buf, 3);
 			ver = buf[1] << 8 | buf[2];

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -1085,10 +1085,7 @@ static int buspirate_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static void buspirate_setup(PROGRAMMER *pgm)
 {
 	/* Allocate private data */
-	if ((pgm->cookie = calloc(1, sizeof(struct pdata))) == 0) {
-		pmsg_error("out of memory allocating private data\n");
-		exit(1);
-	}
+	pgm->cookie = cfg_malloc(__func__, sizeof(struct pdata));
 	PDATA(pgm)->serial_recv_timeout = 100;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -188,7 +188,8 @@ int init_config(void)
 void *cfg_malloc(const char *funcname, size_t n) {
   void *ret = malloc(n);
   if(!ret) {
-    pmsg_error("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
+    pmsg_error("out of memory in %s() for malloc(); needed %lu bytes\n",
+      funcname, (unsigned long) n);
     exit(1);
   }
   memset(ret, 0, n);
@@ -197,12 +198,11 @@ void *cfg_malloc(const char *funcname, size_t n) {
 
 void *cfg_realloc(const char *funcname, void *p, size_t n) {
   void *ret;
-
   if(!(ret = p? realloc(p, n): calloc(1, n))) {
-    pmsg_error("out of memory in %s (needed %lu bytes)\n", funcname, (unsigned long) n);
+    pmsg_error("out of memory in %s() for %salloc(); needed %lu bytes\n",
+      funcname, p? "re": "c", (unsigned long) n);
     exit(1);
   }
-
   return ret;
 }
 
@@ -210,7 +210,7 @@ void *cfg_realloc(const char *funcname, void *p, size_t n) {
 char *cfg_strdup(const char *funcname, const char *s) {
   char *ret = strdup(s);
   if(!ret) {
-    pmsg_error("out of memory in %s\n", funcname);
+    pmsg_error("out of memory in %s() for strdup()\n", funcname);
     exit(1);
   }
   return ret;


### PR DESCRIPTION
In the good old days when programmers were only written for *one* part-programmer combo in AVRDUDE, static variables in functions were OK. Now that libavrdude aspires to serve more complex applications, static-variable use needs to be reviewed and, if possible, moved into the per-programmer PDATA space that is allocated and free'd. This avoids that a static programmer variable is no longer fresh on the *second* (or more) use of the programmer.

I plan do do this programmer-by-programmer so each programmer's code change can be reviewed and tested independently.