### PR TITLE
Make avrftdi type programmers libavrdude ready

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -44,6 +44,7 @@ extern const char *pgmid;    // Programmer -c string
 #define mmt_strdup(s) cfg_strdup(__func__, s)
 #define mmt_malloc(n) cfg_malloc(__func__, n)
 #define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
+#define mmt_free(p) free(p)
 
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -256,7 +256,7 @@ static void avrftdi_enable(PROGRAMMER *pgm, const AVRPART *p) {
 
 	// Switch to TPI initialisation in avrftdi_tpi.c
 	if(p->prog_modes & PM_TPI)
-          avrftdi_tpi_initpgm(pgm);
+		avrftdi_tpi_initpgm(pgm);
 }
 
 static void avrftdi_disable(const PROGRAMMER *pgm) {
@@ -705,7 +705,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 	E(ftdi_set_interface(pdata->ftdic, interface) < 0, pdata->ftdic);
 	
 	const char *serial = *pgm->usbsn? pgm->usbsn: NULL; // no SN means use first available
-        // Todo: use desc and index argument, currently set to NULL and 0
+	// Todo: use desc and index argument, currently set to NULL and 0
 	err = ftdi_usb_open_desc_index(pdata->ftdic, vid, pid, NULL, serial, 0);
 	if(err) {
 		pmsg_error("error %d occurred: %s\n", err, ftdi_get_error_string(pdata->ftdic));
@@ -1691,9 +1691,9 @@ static int avrftdi_jtag_paged_read(const PROGRAMMER *pgm, const AVRPART *p,
 	unsigned int maxaddr = addr + n_bytes;
 	unsigned char *buf, *ptr;
 	unsigned int bytes;
-   
-    buf = alloca(n_bytes * 8 + 1);
-    ptr = buf;
+
+	buf = alloca(n_bytes * 8 + 1);
+	ptr = buf;
 
 	if (mem_is_flash(m)) {
 		avrftdi_jtag_ir_out(pgm, JTAG_IR_PROG_COMMANDS);

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1223,11 +1223,7 @@ static int avrftdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 static void avrftdi_setup(PROGRAMMER * pgm) {
 	avrftdi_t* pdata;
 
-	
-	if(!(pgm->cookie = calloc(1, sizeof(avrftdi_t)))) {
-		pmsg_error("Error allocating memory.\n");
-		exit(1);
-	}
+	pgm->cookie = mmt_malloc(sizeof(avrftdi_t));
 	pdata = to_pdata(pgm);
 
 	/* SCK/SDO/SDI are fixed and not invertible? */

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -111,7 +111,7 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 
 	str[0] = 0;
 
-	for(pinno = 0; mask; mask >>= 1, pinno++) {
+	for(pinno = 0; mask && n < strsiz-1; mask >>= 1, pinno++) {
 		if(!(mask & 1))
 			continue;
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -53,7 +53,7 @@
 
 static int avrftdi_noftdi_open(PROGRAMMER *pgm, const char *name) {
 	pmsg_error("no libftdi or libusb support\n");
-        imsg_error("install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again\n");
+	imsg_error("install libftdi1/libusb-1.0 or libftdi/libusb and run configure/make again\n");
 	return -1;
 }
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -94,15 +94,13 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 	char *str = pdata->name_str;
 	size_t strsiz = sizeof pdata->name_str;
 
-	char interface = '@';
-
-	/* INTERFACE_ANY is zero, so @ is used
-	 * INTERFACE_A is one, so '@' + 1 = 'A'
-	 * and so forth ...
-	 * be aware, there is an 'interface' member in ftdi_context,
-	 * however, we really want the 'index' member here.
+	/*
+	 * INTERFACE_ANY is zero: print @
+	 * INTERFACE_A is one, use '@' + 1 = 'A' and so forth ...
+	 * Be aware, there is an interface member in ftdi_context,
+	 * however, we really want the index member here.
 	 */
-	interface += pdata->ftdic->index;
+	char interface = '@' + pdata->ftdic->index;
 
 	int pinno;
 	size_t n = 0;

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -90,7 +90,8 @@ static int write_flush(avrftdi_t *);
  * the pin names used in FTDI datasheets.
  */
 static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
-	static char str[128];
+	char *str = pdata->name_str;
+	size_t strsiz = sizeof pdata->name_str;
 
 	char interface = '@';
 
@@ -103,7 +104,7 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 	interface += pdata->ftdic->index;
 
 	int pinno;
-	int n = 0;
+	size_t n = 0;
 	int mask = pin.mask[0];
 
 	const char * fmt;
@@ -130,7 +131,7 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 		else
 			fmt = ", %c%cBUS%d%n";
 
-		snprintf(&str[n], sizeof(str) - n, fmt, interface, port, pinno, &chars);
+		snprintf(&str[n], strsiz - n, fmt, interface, port, pinno, &chars);
 		n += chars;
 	}
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -126,7 +126,7 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 		else
 			port = 'C';
 
-		if(str[0] == 0)
+		if(n == 0)
 			fmt = "%c%cBUS%d%n";
 		else
 			fmt = ", %c%cBUS%d%n";

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -552,14 +552,7 @@ static int avrftdi_check_pins_mpsse(const PROGRAMMER *pgm, bool output) {
 
 	avrftdi_t* pdata = to_pdata(pgm);
 
-	/* SCK/SDO/SDI are fixed and not invertible? */
-	/* TODO: inverted SCK/SDI/SDO */
-	static const struct pindef_t valid_pins[4] = {
-		{{0x01}, {0x00}},
-		{{0x02}, {0x00}},
-		{{0x04}, {0x00}},
-		{{0x08}, {0x00}},
-	};
+	struct pindef_t *valid_pins = pdata->mpsse_pins;
 
 	/* value for 8/12/16 bit wide interface for other pins */
 	int valid_mask = ((1 << pdata->pin_limit) - 1);
@@ -593,7 +586,7 @@ static int avrftdi_check_pins_mpsse(const PROGRAMMER *pgm, bool output) {
 		pin_checklist[PIN_JTAG_TMS].mandatory = 1;
 		pin_checklist[PIN_JTAG_TMS].valid_pins = &valid_pins[FTDI_TMS_CS];
 	} else {
-	pin_checklist[PIN_AVR_SCK].mandatory = 1;
+		pin_checklist[PIN_AVR_SCK].mandatory = 1;
 		pin_checklist[PIN_AVR_SCK].valid_pins = &valid_pins[FTDI_TCK_SCK];
 		pin_checklist[PIN_AVR_SDO].mandatory = 1;
 		pin_checklist[PIN_AVR_SDO].valid_pins = &valid_pins[FTDI_TDI_SDO];
@@ -614,6 +607,7 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 	 *************/
 
 	avrftdi_t* pdata = to_pdata(pgm);
+
 
 	bool pin_check_mpsse = (0 == avrftdi_check_pins_mpsse(pgm, verbose>3));
 
@@ -1235,6 +1229,17 @@ static void avrftdi_setup(PROGRAMMER * pgm) {
 		exit(1);
 	}
 	pdata = to_pdata(pgm);
+
+	/* SCK/SDO/SDI are fixed and not invertible? */
+	/* TODO: inverted SCK/SDI/SDO */
+	const struct pindef_t valid_mpsse_pins[4] = {
+		{{0x01}, {0x00}},
+		{{0x02}, {0x00}},
+		{{0x04}, {0x00}},
+		{{0x08}, {0x00}},
+	};
+	for(int i=0; i<4; i++)
+		pdata->mpsse_pins[i] = valid_mpsse_pins[i];
 
 	pdata->ftdic = ftdi_new();
 	if(!pdata->ftdic)

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -190,7 +190,7 @@ static int set_frequency(avrftdi_t* ftdi, uint32_t freq)
 	}
 
 	char *f = str_frq(clock/2.0 / (divisor + 1), 6);
-	pmsg_info("using frequency: %s (clock divisor %d = 0x%04x)\n", f, divisor, divisor);
+	imsg_notice(" - frequency %s (clock divisor %d = 0x%04x)\n", f, divisor, divisor);
 	mmt_free(f);
 
 	*ptr++ = TCK_DIVISOR;
@@ -658,8 +658,8 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 	}
 
 
-	pmsg_info("pin direction mask: %04x\n", pdata->pin_direction);
-	pmsg_info("pin value mask: %04x\n", pdata->pin_value);
+	imsg_notice(" - pin direction mask %04x\n", pdata->pin_direction);
+	imsg_notice(" - pin value mask %04x\n", pdata->pin_value);
 
 	return 0;
 }
@@ -785,10 +785,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 			break;
 	}
 
-	if(avrftdi_pin_setup(pgm))
-		return -1;
-
-	return 0;
+	return avrftdi_pin_setup(pgm)? -1: 0;
 }
 
 static void avrftdi_close(PROGRAMMER * pgm)
@@ -799,7 +796,7 @@ static void avrftdi_close(PROGRAMMER * pgm)
 		set_pin(pgm, PIN_AVR_RESET, ON);
 
 		/* Stop driving the pins - except for the LEDs */
-		pmsg_info("LED Mask=0x%04x value =0x%04x &=0x%04x\n",
+		pmsg_debug("LED Mask 0x%04x, pin value 0x%04x,  anded 0x%04x\n",
 		  pdata->led_mask, pdata->pin_value, pdata->led_mask & pdata->pin_value);
 
 		pdata->pin_direction = pdata->led_mask;

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -105,8 +105,6 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 	size_t n = 0;
 	int mask = pin.mask[0];
 
-	const char * fmt;
-
 	str[0] = 0;
 
 	for(int pinno = 0; mask && n < strsiz-1; mask >>= 1, pinno++) {
@@ -124,12 +122,8 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 		else
 			port = 'C';
 
-		if(n == 0)
-			fmt = "%c%cBUS%d%n";
-		else
-			fmt = ", %c%cBUS%d%n";
-
-		snprintf(&str[n], strsiz - n, fmt, interface, port, pinno, &chars);
+		snprintf(&str[n], strsiz - n, "%s%c%cBUS%d%n", n? ", ": "",
+		  interface, port, pinno, &chars);
 		n += chars;
 	}
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -89,9 +89,7 @@ static int write_flush(avrftdi_t *);
  * returns a human-readable name for a pin number. The name should match with
  * the pin names used in FTDI datasheets.
  */
-static char*
-ftdi_pin_name(avrftdi_t* pdata, struct pindef_t pin)
-{
+static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 	static char str[128];
 
 	char interface = '@';
@@ -982,8 +980,7 @@ static int avrftdi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
 
 /* Load extended address byte command */
-static int
-avrftdi_lext(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int address) {
+static int avrftdi_lext(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int address) {
 	/* nothing to do if load extended address command unavailable */
 	if(m->op[AVR_OP_LOAD_EXT_ADDR] == NULL)
 		return 0;
@@ -1265,9 +1262,7 @@ static int avrftdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 		return -2;
 }
 
-static void
-avrftdi_setup(PROGRAMMER * pgm)
-{
+static void avrftdi_setup(PROGRAMMER * pgm) {
 	avrftdi_t* pdata;
 
 	
@@ -1291,9 +1286,7 @@ avrftdi_setup(PROGRAMMER * pgm)
 	pdata->lext_byte = 0xff;
 }
 
-static void
-avrftdi_teardown(PROGRAMMER * pgm)
-{
+static void avrftdi_teardown(PROGRAMMER * pgm) {
 	avrftdi_t* pdata = to_pdata(pgm);
 
 	if(pdata) {

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -111,8 +111,6 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 		if(!(mask & 1))
 			continue;
 
-		int chars = 0;
-
 		char port;
 		/* This is FTDI's naming scheme.
 		 * probably 'D' is for data and 'C' for control
@@ -122,9 +120,8 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 		else
 			port = 'C';
 
-		snprintf(&str[n], strsiz - n, "%s%c%cBUS%d%n", n? ", ": "",
-		  interface, port, pinno, &chars);
-		n += chars;
+		n += snprintf(&str[n], strsiz - n, "%s%c%cBUS%d", n? ", ": "",
+		  interface, port, pinno);
 	}
 
 	return str;

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1240,7 +1240,7 @@ static void avrftdi_setup(PROGRAMMER * pgm) {
 	pdata->ftdic = ftdi_new();
 	if(!pdata->ftdic)
 	{
-		pmsg_error("Error allocating memory.\n");
+		pmsg_error("failed to allocate memory in ftdi_new()\n");
 		exit(1);
 	}
 	E_VOID(ftdi_init(pdata->ftdic), pdata->ftdic);

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1257,7 +1257,7 @@ static void avrftdi_teardown(PROGRAMMER * pgm) {
 	if(pdata) {
 		ftdi_deinit(pdata->ftdic);
 		ftdi_free(pdata->ftdic);
-		free(pdata);
+		mmt_free(pdata);
 	}
 }
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -102,7 +102,6 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 	 */
 	char interface = '@' + pdata->ftdic->index;
 
-	int pinno;
 	size_t n = 0;
 	int mask = pin.mask[0];
 
@@ -110,7 +109,7 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 
 	str[0] = 0;
 
-	for(pinno = 0; mask && n < strsiz-1; mask >>= 1, pinno++) {
+	for(int pinno = 0; mask && n < strsiz-1; mask >>= 1, pinno++) {
 		if(!(mask & 1))
 			continue;
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1395,18 +1395,6 @@ static int avrftdi_jtag_dr_inout(const PROGRAMMER *pgm, unsigned int dr,
 
 static void avrftdi_jtag_enable(PROGRAMMER *pgm, const AVRPART *p)
 {
-	if(!ovsigck) {
-		if(str_eq(p->id, "m128a") || str_eq(p->id, "m128") ||
-		   str_eq(p->id, "m64a") || str_eq(p->id, "m64") ||
-		   str_eq(p->id, "m32a") || str_eq(p->id, "m32") ||
-		   str_eq(p->id, "m16a") || str_eq(p->id, "m16") ||
-		   str_eq(p->id, "m162")) {
-			pmsg_error("programmer type %s is known not to work for %s\n", pgm->type, p->desc);
-			imsg_error("exiting; use -F to carry on regardless\n");
-			exit(1);
-		}
-	}
-
 	pgm->powerup(pgm);
 
 	set_pin(pgm, PIN_AVR_RESET, OFF);
@@ -1419,6 +1407,18 @@ static void avrftdi_jtag_enable(PROGRAMMER *pgm, const AVRPART *p)
 
 static int avrftdi_jtag_initialize(const PROGRAMMER *pgm, const AVRPART *p)
 {
+	if(!ovsigck) {
+		if(str_eq(p->id, "m128a") || str_eq(p->id, "m128") ||
+		   str_eq(p->id, "m64a") || str_eq(p->id, "m64") ||
+		   str_eq(p->id, "m32a") || str_eq(p->id, "m32") ||
+		   str_eq(p->id, "m16a") || str_eq(p->id, "m16") ||
+		   str_eq(p->id, "m162")) {
+			pmsg_error("programmer type %s is known not to work for %s\n", pgm->type, p->desc);
+			imsg_error("exiting; use -F to carry on regardless\n");
+			return LIBAVRDUDE_EXIT;
+		}
+	}
+
 	set_pin(pgm, PPI_AVR_BUFF, ON);
 
 	avrftdi_jtag_reset(pgm);

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1232,12 +1232,12 @@ static void avrftdi_setup(PROGRAMMER * pgm) {
 }
 
 static void avrftdi_teardown(PROGRAMMER * pgm) {
-	avrftdi_t* pdata = to_pdata(pgm);
-
-	if(pdata) {
+	if(pgm->cookie) {
+		avrftdi_t *pdata = to_pdata(pgm);
 		ftdi_deinit(pdata->ftdic);
 		ftdi_free(pdata->ftdic);
 		mmt_free(pdata);
+		pgm->cookie = NULL;
 	}
 }
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -529,15 +529,15 @@ static int avrftdi_check_pins_bb(const PROGRAMMER *pgm, bool output) {
 	int valid_mask = ((1 << pdata->pin_limit) - 1);
 
 	pmsg_debug("using valid mask bitbanging: 0x%08x\n", valid_mask);
-	static struct pindef_t valid_pins;
-	valid_pins.mask[0] = valid_mask;
-	valid_pins.inverse[0] = valid_mask ;
+	struct pindef_t *valid_pins_p = &pdata->valid_pins;
+	valid_pins_p->mask[0] = valid_mask;
+	valid_pins_p->inverse[0] = valid_mask ;
 
 	/* build pin checklist */
 	for(pin = 0; pin < N_PINS; ++pin) {
 		pin_checklist[pin].pinname = pin;
 		pin_checklist[pin].mandatory = 0;
-		pin_checklist[pin].valid_pins = &valid_pins;
+		pin_checklist[pin].valid_pins = valid_pins_p;
 	}
 
 	/* assumes all checklists above have same number of entries */

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -176,19 +176,22 @@ static int set_frequency(avrftdi_t* ftdi, uint32_t freq)
 	}
 
 	if (divisor < 0) {
-		pmsg_warning("frequency too high (%u > %u MHz)\n", freq, clock/2/1000000);
-		imsg_warning("resetting frequency to %u MHz\n", clock/2/1000000);
+		char *f = str_frq(freq, 6), *h = str_frq(clock/2.0, 6);
+		pmsg_warning("frequency %s too high, resetting to %s\n", f, h);
+		mmt_free(f); mmt_free(h);
 		divisor = 0;
 	}
 
 	if (divisor > 65535) {
-		pmsg_warning("frequency too low (%u < %.3f Hz)\n", freq, (double) clock / 2 / 65536);
-		imsg_warning("resetting frequency to %.3f Hz\n", (double) clock / 2 / 65536);
+		char *f = str_frq(freq, 6), *l = str_frq(clock/2.0 / 65536, 6);
+		pmsg_warning("frequency %s too low, resetting to %s\n", f, l);
+		mmt_free(f); mmt_free(l);
 		divisor = 65535;
 	}
 
-	pmsg_info("using frequency: %.3f\n", (double) clock / 2 / (divisor + 1));
-	imsg_info("clock divisor: %d, 0x%04x\n", divisor, divisor);
+	char *f = str_frq(clock/2.0 / (divisor + 1), 6);
+	pmsg_info("using frequency: %s (clock divisor %d = 0x%04x)\n", f, divisor, divisor);
+	mmt_free(f);
 
 	*ptr++ = TCK_DIVISOR;
 	*ptr++ = (uint8_t)(divisor & 0xff);

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -111,17 +111,9 @@ static char *ftdi_pin_name(avrftdi_t *pdata, struct pindef_t pin) {
 		if(!(mask & 1))
 			continue;
 
-		char port;
-		/* This is FTDI's naming scheme.
-		 * probably 'D' is for data and 'C' for control
-		 */
-		if(pinno < 8)
-			port = 'D';
-		else
-			port = 'C';
-
+		// FTDI port: probably 'D' for data and 'C' for control
 		n += snprintf(&str[n], strsiz - n, "%s%c%cBUS%d", n? ", ": "",
-		  interface, port, pinno);
+		  interface, pinno < 8? 'D': 'C', pinno);
 	}
 
 	return str;

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -564,15 +564,15 @@ static int avrftdi_check_pins_mpsse(const PROGRAMMER *pgm, bool output) {
 	}
 
 	pmsg_debug("using valid mask mpsse: 0x%08x\n", valid_mask);
-	static struct pindef_t valid_pins_others;
-	valid_pins_others.mask[0] = valid_mask;
-	valid_pins_others.inverse[0] = valid_mask ;
+	struct pindef_t *valid_pins_others_p = &pdata->other_pins;
+	valid_pins_others_p->mask[0] = valid_mask;
+	valid_pins_others_p->inverse[0] = valid_mask ;
 
 	/* build pin checklist */
 	for(pin = 0; pin < N_PINS; ++pin) {
 		pin_checklist[pin].pinname = pin;
 		pin_checklist[pin].mandatory = 0;
-		pin_checklist[pin].valid_pins = &valid_pins_others;
+		pin_checklist[pin].valid_pins = valid_pins_others_p;
 	}
 
 	/* now set mpsse specific pins */

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -894,6 +894,7 @@ static int avrftdi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned
 static int avrftdi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 	int i;
 	unsigned char buf[4];
+	int polli = p->pollindex - 1, pollok = polli >= 0 && polli < (int) sizeof buf;
 
 	memset(buf, 0, sizeof(buf));
 
@@ -906,7 +907,7 @@ static int avrftdi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 
 	for(i = 0; i < 4; i++) {
 		pgm->cmd(pgm, buf, buf);
-		if (buf[p->pollindex-1] != p->pollvalue) {
+		if (pollok && buf[polli] != p->pollvalue) {
 			pmsg_warning("program enable command not successful%s\n", i < 3? "; retrying": "");
 			set_pin(pgm, PIN_AVR_RESET, ON);
 			usleep(20);

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -96,6 +96,7 @@ typedef struct avrftdi_s {
 
   char name_str[128];           // Used in ftdi_pin_name()
   struct pindef_t valid_pins;   // Used in avrftdi_check_pins_bb()
+  struct pindef_t mpsse_pins[4]; // Used in avrftdi_check_pins_mpsse()
 } avrftdi_t;
 
 #endif /* DO_NOT_BUILD_AVRFDTI */

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -97,6 +97,7 @@ typedef struct avrftdi_s {
   char name_str[128];           // Used in ftdi_pin_name()
   struct pindef_t valid_pins;   // Used in avrftdi_check_pins_bb()
   struct pindef_t mpsse_pins[4]; // Used in avrftdi_check_pins_mpsse()
+  struct pindef_t other_pins;   // Used in avrftdi_check_pins_mpsse()
 } avrftdi_t;
 
 #endif /* DO_NOT_BUILD_AVRFDTI */

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -111,6 +111,8 @@ typedef struct avrftdi_s {
   bool use_bitbanging;
   /* bits 16-23 of extended 24-bit word flash address for parts with flash > 128k */
   uint8_t lext_byte;
+
+  char name_str[128];           // Used in ftdi_pin_name()
 } avrftdi_t;
 
 void avrftdi_log(int level, const char * func, int line, const char * fmt, ...);

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -26,39 +26,21 @@
 
 #ifndef DO_NOT_BUILD_AVRFTDI
 
-enum { ERR, WARN, INFO, DEBUG, TRACE };
-
-#define __log(lvl, fmt, ...)                                  \
-  do {                                                        \
-    avrftdi_log(lvl, __func__, __LINE__, fmt, ##__VA_ARGS__); \
+#define E(x, ftdi)                                             \
+  do {                                                         \
+    if((x)) {                                                  \
+      pmsg_error("%s: %s (%d)\n", #x, strerror(errno), errno); \
+      imsg_error("%s\n", ftdi_get_error_string(ftdi));         \
+      return -1;                                               \
+    }                                                          \
   } while(0)
 
-
-#define log_err(fmt, ...)   __log(ERR, fmt, ##__VA_ARGS__)
-#define log_warn(fmt, ...)  __log(WARN,  fmt, ##__VA_ARGS__)
-#define log_info(fmt, ...)  __log(INFO,  fmt, ##__VA_ARGS__)
-#define log_debug(fmt, ...) __log(DEBUG, fmt, ##__VA_ARGS__)
-#define log_trace(fmt, ...) __log(TRACE, fmt, ##__VA_ARGS__)
-
-#define E(x, ftdi)                                                  \
-  do {                                                              \
-    if ((x))                                                        \
-    {                                                               \
-      msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",                   \
-          __FILE__, __LINE__, __FUNCTION__,                         \
-          #x, strerror(errno), errno, ftdi_get_error_string(ftdi)); \
-      return -1;                                                    \
-    }                                                               \
-  } while(0)
-
-#define E_VOID(x, ftdi)                                             \
-  do {                                                              \
-    if ((x))                                                        \
-    {                                                               \
-      msg_error("%s:%d %s() %s: %s (%d)\n\t%s\n",                   \
-          __FILE__, __LINE__, __FUNCTION__,                         \
-          #x, strerror(errno), errno, ftdi_get_error_string(ftdi)); \
-    }                                                               \
+#define E_VOID(x, ftdi)                                        \
+  do {                                                         \
+    if((x)) {                                                  \
+      pmsg_error("%s: %s (%d)\n", #x, strerror(errno), errno); \
+      imsg_error("%s\n", ftdi_get_error_string(ftdi));         \
+    }                                                          \
   } while(0)
 
 enum {
@@ -114,8 +96,6 @@ typedef struct avrftdi_s {
 
   char name_str[128];           // Used in ftdi_pin_name()
 } avrftdi_t;
-
-void avrftdi_log(int level, const char * func, int line, const char * fmt, ...);
 
 #endif /* DO_NOT_BUILD_AVRFDTI */
 

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -95,6 +95,7 @@ typedef struct avrftdi_s {
   uint8_t lext_byte;
 
   char name_str[128];           // Used in ftdi_pin_name()
+  struct pindef_t valid_pins;   // Used in avrftdi_check_pins_bb()
 } avrftdi_t;
 
 #endif /* DO_NOT_BUILD_AVRFDTI */

--- a/src/avrftdi_tpi.c
+++ b/src/avrftdi_tpi.c
@@ -56,9 +56,9 @@ avrftdi_debug_frame(uint16_t frame)
 	line1[32] = 0;
 	line2[32] = 0;
 
-	log_debug("%s\n", line0);
-	log_debug("%s\n", line1);
-	//log_debug("%s\n", line2);
+	msg_debug("%s\n", line0);
+	msg_debug("%s\n", line1);
+	// msg_debug("%s\n", line2);
 }
 #endif /* notyet */
 
@@ -69,7 +69,7 @@ avrftdi_tpi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 	avrftdi_t* pdata = to_pdata(pgm);
 	unsigned char buf[] = { MPSSE_DO_WRITE | MPSSE_WRITE_NEG | MPSSE_LSB, 0x01, 0x00, 0xff, 0xff };
 
-	log_info("Setting /Reset pin low\n");
+	pmsg_info("Setting /Reset pin low\n");
 	pgm->setpin(pgm, PIN_AVR_RESET, OFF);
 	pgm->setpin(pgm, PIN_AVR_SCK, OFF);
 	pgm->setpin(pgm, PIN_AVR_SDO, ON);
@@ -84,7 +84,7 @@ avrftdi_tpi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 	/*wait at least 20ms bevor issuing spi commands to avr */
 	usleep(20 * 1000);
 	
-	log_info("Sending 16 init clock cycles ...\n");
+	pmsg_info("Sending 16 init clock cycles ...\n");
 	ret = ftdi_write_data(pdata->ftdic, buf, sizeof(buf));
 
 	return ret;
@@ -92,7 +92,7 @@ avrftdi_tpi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
 
 void avrftdi_tpi_initpgm(PROGRAMMER *pgm) {
-	  log_info("Using TPI interface\n");
+	  pmsg_info("Using TPI interface\n");
 
 	  pgm->program_enable = avrftdi_tpi_program_enable;
 	  pgm->cmd_tpi = avrftdi_cmd_tpi;
@@ -172,7 +172,7 @@ avrftdi_tpi_write_byte(const PROGRAMMER *pgm, unsigned char byte) {
 	buffer[3] = frame & 0xff;
 	buffer[4] = frame >> 8;
 	
-	log_trace("Byte %02x, frame: %04x, MPSSE: 0x%02x 0x%02x 0x%02x  0x%02x 0x%02x\n",
+	msg_trace("Byte %02x, frame: %04x, MPSSE: 0x%02x 0x%02x 0x%02x  0x%02x 0x%02x\n",
 			byte, frame, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4]);
 
 	//avrftdi_debug_frame(frame);
@@ -200,7 +200,7 @@ avrftdi_tpi_read_byte(const PROGRAMMER *pgm, unsigned char *byte) {
 	buffer[2] = ((bytes-1) >> 8) & 0xff;
 	buffer[3] = SEND_IMMEDIATE;
 
-	log_trace("MPSSE: 0x%02x 0x%02x 0x%02x 0x%02x (Read frame)\n",
+	msg_trace("MPSSE: 0x%02x 0x%02x 0x%02x 0x%02x (Read frame)\n",
 			buffer[0], buffer[1], buffer[2], buffer[3]);
 
 	ftdi_write_data(to_pdata(pgm)->ftdic, buffer, 4);
@@ -215,14 +215,14 @@ avrftdi_tpi_read_byte(const PROGRAMMER *pgm, unsigned char *byte) {
 	} while(i < bytes);
 
 
-	log_trace("MPSSE: 0x%02x 0x%02x 0x%02x 0x%02x (Read frame)\n",
+	msg_trace("MPSSE: 0x%02x 0x%02x 0x%02x 0x%02x (Read frame)\n",
 			buffer[0], buffer[1], buffer[2], buffer[3]);
 
 
 	frame = buffer[0] | (buffer[1] << 8);
 	
 	err = tpi_frame2byte(frame, byte);
-	log_trace("Frame: 0x%04x, byte: 0x%02x\n", frame, *byte);
+	pmsg_trace("Frame: 0x%04x, byte: 0x%02x\n", frame, *byte);
 	
 	//avrftdi_debug_frame(frame);
 
@@ -262,7 +262,7 @@ avrftdi_tpi_disable(const PROGRAMMER *pgm) {
 	unsigned char cmd[] = {TPI_OP_SSTCS(TPIPCR), 0};
 	pgm->cmd_tpi(pgm, cmd, sizeof(cmd), NULL, 0);
 
-	log_info("Leaving Programming mode.\n");
+	pmsg_info("Leaving Programming mode.\n");
 }
 
 #endif /* DO_NOT_BUILD_AVRFTDI */

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -1124,7 +1124,7 @@ static void buspirate_setup(PROGRAMMER *pgm)
 
 static void buspirate_teardown(PROGRAMMER *pgm)
 {
-	free(pgm->cookie);
+	mmt_free(pgm->cookie);
 }
 const char buspirate_desc[] = "Using the Bus Pirate's SPI interface for programming";
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -59,6 +59,7 @@ typedef uint32_t pinmask_t;
 #define LIBAVRDUDE_NOTSUPPORTED (-2) // operation not supported
 #define LIBAVRDUDE_SOFTFAIL (-3) // returned, eg, by avr_signature() if caller
                                  // might proceed with chip erase
+#define LIBAVRDUDE_EXIT (-4)     // End all operations in this session
 
 /* formerly lists.h */
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1504,6 +1504,7 @@ void str_freedata(Str2data *sd);
 unsigned long long int str_int(const char *str, int type, const char **errpp);
 int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
 char *str_nexttok(char *buf, const char *delim, char **next);
+char *str_frq(double f, int n);
 int str_levenshtein(const char *str1, const char *str2, int swap, int subst, int add, int del);
 size_t str_weighted_damerau_levenshtein(const char *str1, const char *str2);
 

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1037,6 +1037,16 @@ char *str_nexttok(char *buf, const char *delim, char **next) {
   return (char *) q;
 }
 
+// Return allocated string for frequency with n significant digits and xHz unit
+char *str_frq(double f, int n) {
+  struct { double fq; const char *pre; } prefix[] = {{1e9, "G"},  {1e6, "M"},  {1e3, "k"},};
+
+  for(size_t i = 0; i < sizeof prefix/sizeof*prefix; i++)
+     if(f >= prefix[i].fq)
+        return str_sprintf("%.*g %sHz", n, f/prefix[i].fq, prefix[i].pre);
+  return str_sprintf("%.*g Hz", n, f);
+}
+
 /*
  * From https://github.com/git/git/blob/master/levenshtein.c
  *


### PR DESCRIPTION
  - Replace the logging system of avrftdi programmers with AVRDUDE's msg_...() system so that GUIs benefit from that
  - Move static variables to PDATA so programmer can be initialised and de-initialised multiple times: needed for Joerg's GUI

Please test some programmers of `avrftdi` type with high `-vvvvv` level including the jtag variant:
```
$ avrdude -c*/At | grep type...prog	avrftdi	type	"avrftdi"
.prog	ft2232h	type	"avrftdi"
.prog	2232hio	type	"avrftdi"
.prog	tigard	type	"avrftdi"
.prog	avrisp-u	type	"avrftdi"
.prog	ft2232h_jtag	type	"avrftdi_jtag"
.prog	ft4232h	type	"avrftdi"
.prog	4232h	type	"avrftdi"
.prog	jtagkey	type	"avrftdi"
.prog	ft232h	type	"avrftdi"
.prog	ft232h_jtag	type	"avrftdi_jtag"
.prog	um232h	type	"avrftdi"
.prog	c232hm	type	"avrftdi"
.prog	o-link	type	"avrftdi"
.prog	openmoko	type	"avrftdi"
.prog	lm3s811	type	"avrftdi"
.prog	tumpa	type	"avrftdi"
.prog	tumpa-b	type	"avrftdi"
.prog	tumpa_jtag	type	"avrftdi_jtag"
.prog	ktlink	type	"avrftdi"
.prog	digilent-hs2	type	"avrftdi"
.prog	flyswatter2	type	"avrftdi"
```