### PR TITLE
Make default EEPROM readback values 0xff for STK500 v1 programmer

### DIFF
--- a/src/stk500.c
+++ b/src/stk500.c
@@ -489,6 +489,8 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if ((m = avr_locate_eeprom(p))) {
     buf[11] = m->readback[0];
     buf[12] = m->readback[1];
+    if(!buf[11] && !buf[12])    // Make default readback values 0xff for eeproms
+      buf[11] = buf[12] = 0xff;
     buf[15] = (m->size >> 8) & 0x00ff;
     buf[16] = m->size & 0x00ff;
   } else {


### PR DESCRIPTION
Fixes #1713

That bug probably affects all classic parts. Rather than changing the config `readback` values to `0xff 0xff`, this PR
 - Keeps the `readback` values as specified in the .atdf (`0x00 0x00`)
 - Insert a statement in stk500.c to change `0x00 0x00` values to `0xff 0xff`

Please check a few other parts than m328p (basically any classic part) whether they exhibit the EEPROM writing problem without this PR and whether this PR would introduce a regression.