### PR TITLE
Remove gcc warning when printf format is ""

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,7 @@ if(MSVC)
     list(APPEND EXTRA_WINDOWS_INCLUDES "msvc")
 else()
     set(LIB_MATH m)
-    add_compile_options(-Wall -Wextra -Wno-unused-parameter)
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-format-zero-length)
 endif()
 
 # =====================================

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -45,7 +45,11 @@ extern const char *pgmid;    // Programmer -c string
 #define mmt_malloc(n) cfg_malloc(__func__, n)
 #define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
 
-int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);
+int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...)
+#if defined(__GNUC__)           // Ask gcc to check whether format and parameters match
+   __attribute__ ((format (printf, 7, 8)))
+#endif
+;
 
 #define MSG_EXT_ERROR   (-3) // OS-type error, no -v option, can be suppressed with -qqqqq
 #define MSG_ERROR       (-2) // Avrdude error, no -v option, can be suppressed with -qqqq

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -556,7 +556,7 @@ fi
 # If we are compiling with gcc, enable all warnings and make warnings errors.
 ENABLE_WARNINGS=""
 if test "x$GCC" = xyes; then
-	ENABLE_WARNINGS="-Wall -Wextra -Wno-unused-parameter"
+	ENABLE_WARNINGS="-Wall -Wextra -Wno-unused-parameter -Wno-format-zero-length"
 
 	# does this compiler support -Wno-pointer-sign ?
 	AC_MSG_CHECKING([if gcc accepts -Wno-pointer-sign ])


### PR DESCRIPTION
This warning only occurs when checking the msg_...() functions for having the correct parameters. The way I do that is by replacing the avrdude.h file with one that #defines the msg_... functions to printf for which the compiler knows which paramaters of which type are expected given that the format is a string constant. That check, however, produces false alarms which are not helpful.

This commit switches these unhelpful warnings from gcc off.