### PR TITLE
Make butterfly programmer libvrdude ready

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -44,6 +44,7 @@ extern const char *pgmid;    // Programmer -c string
 #define mmt_strdup(s) cfg_strdup(__func__, s)
 #define mmt_malloc(n) cfg_malloc(__func__, n)
 #define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
+#define mmt_free(p) free(p)
 
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -82,11 +82,11 @@ struct pdata
 } while(0)
 
 
-static void butterfly_setup(PROGRAMMER * pgm) {
+static void butterfly_setup(PROGRAMMER *pgm) {
   pgm->cookie = mmt_malloc(sizeof(struct pdata));
 }
 
-static void butterfly_teardown(PROGRAMMER * pgm) {
+static void butterfly_teardown(PROGRAMMER *pgm) {
   mmt_free(pgm->cookie);
 }
 
@@ -96,14 +96,7 @@ static int butterfly_send(const PROGRAMMER *pgm, char *buf, size_t len) {
 
 
 static int butterfly_recv(const PROGRAMMER *pgm, char *buf, size_t len) {
-  int rv;
-
-  rv = serial_recv(&pgm->fd, (unsigned char *)buf, len);
-  if (rv < 0) {
-    pmsg_error("programmer is not responding\n");
-    return -1;
-  }
-  return 0;
+  return serial_recv(&pgm->fd, (unsigned char *) buf, len);
 }
 
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -155,9 +155,9 @@ static int butterfly_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 
-static void butterfly_enter_prog_mode(const PROGRAMMER *pgm) {
-  EV(butterfly_send(pgm, "P", 1));
-  butterfly_vfy_cmd_sent(pgm, "enter prog mode");
+static int butterfly_enter_prog_mode(const PROGRAMMER *pgm) {
+  EI(butterfly_send(pgm, "P", 1));
+  return butterfly_vfy_cmd_sent(pgm, "enter prog mode");
 }
 
 
@@ -167,11 +167,8 @@ static void butterfly_leave_prog_mode(const PROGRAMMER *pgm) {
 }
 
 
-/*
- * issue the 'program enable' command to the AVR device
- */
 static int butterfly_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-  return -1;
+  return butterfly_enter_prog_mode(pgm);
 }
 
 
@@ -348,7 +345,8 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   pmsg_notice("devcode selected: 0x%02x\n", (unsigned) buf[1]);
 
-  butterfly_enter_prog_mode(pgm);
+  if(pgm->program_enable(pgm, p) < 0)
+    return -1;
   (void) butterfly_drain(pgm, 0);
 
   return 0;

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -119,9 +119,10 @@ static int butterfly_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
 
   EI(butterfly_recv(pgm, &c, 1));
   if (c != '\r') {
-    pmsg_error("programmer did not respond to command: %s\n", errmsg);
+    pmsg_error("protocol error for command: %s\n", errmsg);
     return -1;
   }
+
   return 0;
 }
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -88,6 +88,7 @@ static void butterfly_setup(PROGRAMMER *pgm) {
 
 static void butterfly_teardown(PROGRAMMER *pgm) {
   mmt_free(pgm->cookie);
+  pgm->cookie = NULL;
 }
 
 static int butterfly_send(const PROGRAMMER *pgm, char *buf, size_t len) {

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -249,7 +249,7 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       do {
 	msg_notice(".");
 	EI(butterfly_send(pgm, "\033", 1));
-	butterfly_drain(pgm, 0);
+	(void) butterfly_drain(pgm, 0);
 	EI(butterfly_send(pgm, "S", 1));
 	EI(butterfly_recv(pgm, &c, 1));
 	if (c != '?') {
@@ -267,7 +267,7 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
 
   /* Get the HW and SW versions to see if the programmer is present. */
-  butterfly_drain(pgm, 0);
+  (void) butterfly_drain(pgm, 0);
 
   EI(butterfly_send(pgm, "V", 1));
   EI(butterfly_recv(pgm, sw, sizeof(sw)));
@@ -348,7 +348,7 @@ static int butterfly_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   pmsg_notice("devcode selected: 0x%02x\n", (unsigned) buf[1]);
 
   butterfly_enter_prog_mode(pgm);
-  butterfly_drain(pgm, 0);
+  (void) butterfly_drain(pgm, 0);
 
   return 0;
 }
@@ -385,7 +385,7 @@ static int butterfly_open(PROGRAMMER *pgm, const char *port) {
   /*
    * drain any extraneous input
    */
-  butterfly_drain (pgm, 0);
+  (void) butterfly_drain(pgm, 0);
 
   return 0;
 }


### PR DESCRIPTION
 - Check virtually all relevant function calls whether they were successful (and return with error msg if they were not)
 - Provide `program_enable()`: AVRDUDE only uses this implicitly through pgm->initialize(), but is relevant for `libavrdude`
 - Move static cache to PDATA for `butterfly_read_byte_flash()`
 - Invalidate read cache when writing to device
 - Return number of bytes read/written for paged calls, not the highest address (relevant for `libavrdude`)
 - Utilise magic memory tree interface that a `libavrdude` application might want to swap out for sth else

As this is a relatively large change, it would be prudent to test as with all the other revised programmers that come along. @mcuee or @MCUdude, could you give this a try? In particular does access to flash, eeprom, usersig and prodsig still work?