### PR TITLE
Make programmer avr910 libavrdude ready

### DIFF
--- a/src/avr910.c
+++ b/src/avr910.c
@@ -362,12 +362,9 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 
 static int avr910_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
-  /*
-   *  If baudrate was not specified use 19.200 Baud
-   */
-  if(pgm->baudrate == 0) {
+
+  if(pgm->baudrate == 0)
     pgm->baudrate = 19200;
-  }
 
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate;
@@ -376,10 +373,7 @@ static int avr910_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
-  /*
-   * drain any extraneous input
-   */
-  avr910_drain (pgm, 0);
+  (void) avr910_drain (pgm, 0);
 	
   return 0;
 }

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -270,9 +270,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
 
 static void avr910_disable(const PROGRAMMER *pgm) {
-  /* Do nothing. */
-
-  return;
+  avr910_leave_prog_mode(pgm);
 }
 
 
@@ -373,10 +371,7 @@ static int avr910_open(PROGRAMMER *pgm, const char *port) {
   return 0;
 }
 
-static void avr910_close(PROGRAMMER * pgm)
-{
-  avr910_leave_prog_mode(pgm);
-
+static void avr910_close(PROGRAMMER *pgm) {
   serial_close(&pgm->fd);
   pgm->fd.ifd = -1;
 }

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -145,11 +145,8 @@ static int avr910_leave_prog_mode(const PROGRAMMER *pgm) {
 }
 
 
-/*
- * issue the 'program enable' command to the AVR device
- */
 static int avr910_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
-  return -1;
+  return avr910_enter_prog_mode(pgm);
 }
 
 
@@ -268,9 +265,7 @@ static int avr910_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   pmsg_notice("avr910_devcode selected: 0x%02x\n", (unsigned) buf[1]);
 
-  avr910_enter_prog_mode(pgm);
-
-  return 0;
+  return pgm->program_enable(pgm, p);
 }
 
 

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -83,6 +83,7 @@ static void avr910_setup(PROGRAMMER * pgm) {
 
 static void avr910_teardown(PROGRAMMER * pgm) {
   mmt_free(pgm->cookie);
+  pgm->cookie = NULL;
 }
 
 

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -338,7 +338,7 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       msg_error("  -xdevcode=<arg> Override device code\n");
       msg_error("  -xno_blockmode  Disable default checking for block transfer capability\n");
       msg_error("  -xhelp          Show this help menu and exit\n");
-      exit(0);
+      return LIBAVRDUDE_EXIT;
     }
 
     pmsg_error("invalid extended parameter '%s'\n", extended_param);
@@ -596,9 +596,9 @@ static int avr910_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     cmd[3] = isee? 'E': 'F';
 
     while (addr < max_addr) {
-      if ((max_addr - addr) < blocksize) {
+      if ((max_addr - addr) < blocksize)
         blocksize = max_addr - addr;
-      };
+
       memcpy(&cmd[4], &m->buf[addr], blocksize);
       cmd[1] = (blocksize >> 8) & 0xff;
       cmd[2] = blocksize & 0xff;

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -600,7 +600,7 @@ static int avr910_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     if (!cmd) return -1;
      
     cmd[0] = 'B';
-    cmd[3] = toupper((int)(m->desc[0]));
+    cmd[3] = isee? 'E': 'F';
 
     while (addr < max_addr) {
       if ((max_addr - addr) < blocksize) {
@@ -648,7 +648,7 @@ static int avr910_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     int blocksize = PDATA(pgm)->buffersize;
 
     cmd[0] = 'g';
-    cmd[3] = toupper((int)(m->desc[0]));
+    cmd[3] = isee? 'E': 'F';
 
     while (addr < max_addr) {
       if (max_addr - addr < (unsigned int) blocksize)

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -108,8 +108,8 @@ static int avr910_vfy_cmd_sent(const PROGRAMMER *pgm, char *errmsg) {
 
   EI(avr910_recv(pgm, &c, 1));
   if (c != '\r') {
-    pmsg_error("programmer did not respond to command: %s\n", errmsg);
-    return 1;
+    pmsg_error("protocol error for command: %s\n", errmsg);
+    return -1;
   }
 
   return 0;

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -44,6 +44,7 @@ extern const char *pgmid;    // Programmer -c string
 #define mmt_strdup(s) cfg_strdup(__func__, s)
 #define mmt_malloc(n) cfg_malloc(__func__, n)
 #define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
+#define mmt_free(p) free(p)
 
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -59,6 +59,7 @@ typedef uint32_t pinmask_t;
 #define LIBAVRDUDE_NOTSUPPORTED (-2) // operation not supported
 #define LIBAVRDUDE_SOFTFAIL (-3) // returned, eg, by avr_signature() if caller
                                  // might proceed with chip erase
+#define LIBAVRDUDE_EXIT (-4)     // End all operations in this session
 
 /* formerly lists.h */
 


### PR DESCRIPTION
 - Check virtually all relevant function calls whether they were successful (and return with error msg if they were not)
 - Provide `program_enable()`: AVRDUDE only uses this implicitly through pgm->initialize(), but is relevant for `libavrdude`
 - Provide `disable()`: relevant for `libavrdude`
 - Create PDATA cache for `avr910_read_byte_flash()`
 - Invalidate read cache when writing to device
 - Return number of bytes read/written for paged calls, not the highest address (relevant for `libavrdude`)
 - Utilise magic memory tree interface that a `libavrdude` application might want to swap out for sth else

As this is a relatively large change, it would be prudent to test as with all the other revised programmers that come along. @mcuee or @MCUdude, could you give this a try? In particular does access to flash and eeprom work?