### PR TITLE
Utilise magic memory tree interface for dryrun.c

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -44,6 +44,7 @@ extern const char *pgmid;    // Programmer -c string
 #define mmt_strdup(s) cfg_strdup(__func__, s)
 #define mmt_malloc(n) cfg_malloc(__func__, n)
 #define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
+#define mmt_free(p) free(p)
 
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);
 

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -535,13 +535,13 @@ static int dryrun_readonly(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 static void dryrun_setup(PROGRAMMER *pgm) {
   pmsg_debug("%s()\n", __func__);
   // Allocate dry
-  pgm->cookie = cfg_malloc(__func__, sizeof(dryrun_t));
+  pgm->cookie = mmt_malloc(sizeof(dryrun_t));
 }
 
 
 static void dryrun_teardown(PROGRAMMER *pgm) {
   pmsg_debug("%s()\n", __func__);
-  free(pgm->cookie);
+  mmt_free(pgm->cookie);
   pgm->cookie = NULL;
 }
 


### PR DESCRIPTION
It's a simple change for libavrdude, safe to merge