### PR TITLE
Make programmer usbasp libavrdude ready

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -44,6 +44,7 @@ extern const char *pgmid;    // Programmer -c string
 #define mmt_strdup(s) cfg_strdup(__func__, s)
 #define mmt_malloc(n) cfg_malloc(__func__, n)
 #define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
+#define mmt_free(p) free(p)
 
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...);
 

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -272,18 +272,12 @@ static int usbasp_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
 
 
 /* Interface - management */
-static void usbasp_setup(PROGRAMMER * pgm)
-{
-  if ((pgm->cookie = malloc(sizeof(struct pdata))) == 0) {
-    pmsg_error(" out of memory allocating private data\n");
-    exit(1);
-  }
-  memset(pgm->cookie, 0, sizeof(struct pdata));
+static void usbasp_setup(PROGRAMMER *pgm) {
+  pgm->cookie = mmt_malloc(sizeof(struct pdata));
 }
 
-static void usbasp_teardown(PROGRAMMER * pgm)
-{
-  free(pgm->cookie);
+static void usbasp_teardown(PROGRAMMER *pgm) {
+  mmt_free(pgm->cookie);
 }
 
 static int usbasp_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -939,7 +939,7 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 }
 
 /* The list of SCK frequencies in Hz supported by USBasp */
-static struct sckoptions_t usbaspSCKoptions[] = {
+static const struct sckoptions_t usbaspSCKoptions[] = {
   { USBASP_ISP_SCK_3000, 3000000 },
   { USBASP_ISP_SCK_1500, 1500000 },
   { USBASP_ISP_SCK_750, 750000 },
@@ -954,8 +954,6 @@ static struct sckoptions_t usbaspSCKoptions[] = {
   { USBASP_ISP_SCK_1, 1000 },
   { USBASP_ISP_SCK_0_5, 500 }
 };
-
-
 
 /*
  * Set sck period (in seconds)

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -1292,9 +1292,9 @@ static int usbasp_tpi_read_byte(const PROGRAMMER * pgm, const AVRPART *p, const 
   cmd[2] = 0;
   cmd[3] = 0;
   n = usbasp_transmit(pgm, 1, USBASP_FUNC_TPI_READBLOCK, cmd, value, 1);
-  if(n != 1)
-  {
-    pmsg_error("wrong reading bytes %x\n", n);
+  if(n != 1) {
+    if(n >= 0)
+      pmsg_error("wrong number %d of bytes read (expected 1)\n", n);
     return -3;
   }
   return 0;


### PR DESCRIPTION
 - Move static variables to PDATA space in usbasp.c
 - Utilise magic memory tree interface for usbasp.c
 - Implement usbasp_tpi_write_byte()

It's a draft that is supposed to also fix #1755. 