### PR TITLE
Change fuse bit test from wdton to ckout for reduced-core ATtiny parts

### DIFF
--- a/tools/test-avrdude
+++ b/tools/test-avrdude
@@ -348,8 +348,8 @@ for (( p=0; p<$arraylength; p++ )); do
         specify="fuse access: clear, set and read eesave fuse bit"
         command=(${avrdude[@]} -T '"config eesave=0; config eesave=1; config eesave"')
       else
-        specify="fuse access: clear, set and read wdton fuse bit"
-        command=(${avrdude[@]} -T '"config wdton=0; config wdton=1; config wdton"')
+        specify="fuse access: clear, set and read ckout fuse bit"
+        command=(${avrdude[@]} -T '"config ckout=0; config ckout=1; config ckout"')
       fi
       execute "${command[@]}" > $outfile
       fusebit=$(grep ^config $outfile | awk '{print $4}')


### PR DESCRIPTION
Setting WDT on in the fuse can render reduced-core ATtiny parts unprogrammable using TPI. Affected parts are t4, t5, t9, t10, t20, t40, t102 and t104. So, the tests better involve putting the clock signal on PB2 (fuse bit ckout).

Still needs to be confirmed and tested (<s>@mhei?</s> [edit: @brouwer?] @MCUdude?)