### PR TITLE
Remove calls to exit() from libavrdude library functions

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -471,7 +471,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
   if (mem_is_signature(mem)) {
     if (pgm->read_sig_bytes) {
       int rc = pgm->read_sig_bytes(pgm, p, mem);
-      if (rc < 0)
+      if (rc < 0 && rc != LIBAVRDUDE_EXIT)
         led_set(pgm, LED_ERR);
       led_clr(pgm, LED_PGM);
       return rc;
@@ -1236,13 +1236,13 @@ int avr_signature(const PROGRAMMER *pgm, const AVRPART *p) {
   if(verbose > 1)
     report_progress(0, 1, "Reading");
   rc = avr_read(pgm, p, "signature", 0);
-  if (rc < LIBAVRDUDE_SUCCESS) {
+  if (rc < LIBAVRDUDE_SUCCESS && rc != LIBAVRDUDE_EXIT) {
     pmsg_error("unable to read signature data for part %s, rc=%d\n", p->desc, rc);
     return rc;
   }
   report_progress(1, 1, NULL);
 
-  return LIBAVRDUDE_SUCCESS;
+  return rc < LIBAVRDUDE_SUCCESS? LIBAVRDUDE_EXIT: LIBAVRDUDE_SUCCESS;
 }
 
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -1208,10 +1208,9 @@ static void avrftdi_setup(PROGRAMMER * pgm) {
 		pdata->mpsse_pins[i] = valid_mpsse_pins[i];
 
 	pdata->ftdic = ftdi_new();
-	if(!pdata->ftdic)
-	{
-		pmsg_error("failed to allocate memory in ftdi_new()\n");
-		exit(1);
+	if(!pdata->ftdic) {
+		pmsg_ext_error("ftdi_new() failed to allocate memory\n");
+		exit(1);        // pgm->setup() should return an int, but it doesn't
 	}
 	E_VOID(ftdi_init(pdata->ftdic), pdata->ftdic);
 

--- a/src/config.c
+++ b/src/config.c
@@ -217,6 +217,11 @@ char *cfg_strdup(const char *funcname, const char *s) {
 }
 
 
+void cfg_free(void *ptr) {
+  mmt_free(ptr);
+}
+
+
 int yywrap()
 {
   return 1;

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -93,10 +93,6 @@ static int opcodecmp(const OPCODE *op1, const OPCODE *op2, int opnum) {
 
   opstr1 = opcode2str(op1, opnum, 1);
   opstr2 = opcode2str(op2, opnum, 1);
-  if(!opstr1 || !opstr2) {
-    dev_info("%s: out of memory\n", progname);
-    exit(1);
-  }
 
   // Don't care x and 0 are functionally equivalent
   for(p=opstr1; *p; p++)

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -281,8 +281,8 @@ int dfu_getstatus(struct dfu_dev *dfu, struct dfu_status *status)
   }
 
   if (result > (int) sizeof(struct dfu_status)) {
-    pmsg_error("oversize read (should not happen); exiting\n");
-    exit(1);
+    pmsg_error("oversize read (should not happen)\n");
+    return -1;
   }
 
   pmsg_trace("dfu_getstatus(): bStatus 0x%02x, bwPollTimeout %d, bState 0x%02x, iString %d\n",
@@ -382,8 +382,8 @@ int dfu_upload(struct dfu_dev *dfu, void *ptr, int size)
   }
 
   if (result > size) {
-    pmsg_error("oversize read (should not happen); exiting\n");
-    exit(1);
+    pmsg_error("oversize read (should not happen)\n");
+    return -1;
   }
 
   return 0;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1790,17 +1790,15 @@ static int jtag3_open(PROGRAMMER *pgm, const char *port) {
   if (rc < 0)
     return rc;
 
-  if (jtag3_getsync(pgm, PARM3_CONN_JTAG) < 0)
-    return -1;
-
-  return 0;
+  return jtag3_getsync(pgm, PARM3_CONN_JTAG) < 0? -1: 0;
 }
 
 static int jtag3_open_dw(PROGRAMMER *pgm, const char *port) {
   pmsg_notice2("jtag3_open_dw()\n");
 
-  if (jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode) < 0)
-    return -1;
+  int rc = jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode);
+  if (rc < 0)
+    return rc;
 
   if (jtag3_getsync(pgm, PARM3_CONN_DW) < 0)
     return -1;
@@ -1810,14 +1808,11 @@ static int jtag3_open_dw(PROGRAMMER *pgm, const char *port) {
 
 static int jtag3_open_pdi(PROGRAMMER *pgm, const char *port) {
   pmsg_notice2("jtag3_open_pdi()\n");
+  int rc = jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode);
+  if (rc < 0)
+    return rc;
 
-  if (jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode) < 0)
-    return -1;
-
-  if (jtag3_getsync(pgm, PARM3_CONN_PDI) < 0)
-    return -1;
-
-  return 0;
+  return jtag3_getsync(pgm, PARM3_CONN_PDI) < 0? -1: 0;
 }
 
 static int jtag3_open_updi(PROGRAMMER *pgm, const char *port) {
@@ -1829,13 +1824,11 @@ static int jtag3_open_updi(PROGRAMMER *pgm, const char *port) {
     msg_notice2(" %d", *(int *) ldata(ln));
   msg_notice2("\n");
 
-  if (jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode) < 0)
-    return -1;
+  int rc = jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode);
+  if (rc < 0)
+    return rc;
 
-  if (jtag3_getsync(pgm, PARM3_CONN_UPDI) < 0)
-    return -1;
-
-  return 0;
+  return jtag3_getsync(pgm, PARM3_CONN_UPDI) < 0? -1: 0;
 }
 
 void jtag3_close(PROGRAMMER * pgm) {
@@ -3118,9 +3111,7 @@ static int jtag3_chip_erase_tpi(const PROGRAMMER *pgm, const AVRPART *p) {
 static int jtag3_open_tpi(PROGRAMMER *pgm, const char *port) {
   pmsg_notice2("jtag3_open_tpi()\n");
 
-  if (jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode) < 0)
-    return -1;
-  return 0;
+  return jtag3_open_common(pgm, port, PDATA(pgm)->pk4_snap_mode);
 }
 
 void jtag3_close_tpi(PROGRAMMER *pgm) {

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1379,10 +1379,9 @@ extern "C" {
 #endif
 
 void *cfg_malloc(const char *funcname, size_t n);
-
 void *cfg_realloc(const char *funcname, void *p, size_t n);
-
 char *cfg_strdup(const char *funcname, const char *s);
+void cfg_free(void *ptr);
 
 int init_config(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1554,6 +1554,10 @@ skipopen:
     usleep(waittime);
     if (init_ok) {
       rc = avr_signature(pgm, p);
+      if (rc == LIBAVRDUDE_EXIT) {
+        exitrc = 0;
+        goto main_exit;
+      }
       if (rc != LIBAVRDUDE_SUCCESS) {
         if (rc == LIBAVRDUDE_SOFTFAIL && (p->prog_modes & PM_UPDI) && attempt < 1) {
           attempt++;

--- a/src/main.c
+++ b/src/main.c
@@ -1390,6 +1390,11 @@ int main(int argc, char * argv [])
 
   rc = pgm->open(pgm, port);
   if (rc < 0) {
+    if(rc == LIBAVRDUDE_EXIT) {
+      exitrc = 0;
+      goto main_exit;
+    }
+
     pmsg_error("unable to open port %s for programmer %s\n", port, pgmid);
 skipopen:
     if (print_ports && pgm->conntype == CONNTYPE_SERIAL) {

--- a/src/main.c
+++ b/src/main.c
@@ -1243,7 +1243,10 @@ int main(int argc, char * argv [])
           pmsg_error("programmer does not support extended parameter -x %s, option ignored\n", extended_param);
       }
     } else {
-      if (pgm->parseextparams(pgm, extended_params) < 0) {
+      int rc = pgm->parseextparams(pgm, extended_params);
+      if(rc == LIBAVRDUDE_EXIT)
+        exit(0);
+      if(rc < 0) {
         pmsg_error("unable to parse extended parameter list\n");
         exit(1);
       }

--- a/src/main.c
+++ b/src/main.c
@@ -1517,6 +1517,10 @@ skipopen:
    */
   init_ok = (rc = pgm->initialize(pgm, p)) >= 0;
   if (!init_ok) {
+    if(rc == LIBAVRDUDE_EXIT) {
+      exitrc = 0;
+      goto main_exit;
+    }
     pmsg_error("initialization failed, rc=%d\n", rc);
     if (rc == -2)
       imsg_error("the programmer ISP clock is too fast for the target\n");


### PR DESCRIPTION
The PR addresses a longstanding issue #774. Rather than using `exit(0)` the latest git main already uses `return LIBAVRDUDE_EXIT`, but these return now need to be percolated to the top layer (`main.c` in the AVRDUDE application), which then should `exit(0)`. Other applications built with `libavrdude` might want to stop the session without further errors. There is still a smattering of `exit(1)` in the `libavrdude` code, but that is for really tricky situations where recovery is neigh impossible, for example when the process has run out of memory. To all intents and purposes this PR fixes #774.