### PR TITLE
Use magic memory tree interface throughout

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1083,7 +1083,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 
-    uint8_t *spc = cfg_malloc(__func__, cm->page_size);
+    uint8_t *spc = mmt_malloc(cm->page_size);
 
     // Set cwsize as rounded-up wsize
     int cwsize = (wsize + pgsize-1)/pgsize*pgsize;
@@ -1158,7 +1158,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
     }
 
     avr_free_mem(cm);
-    free(spc);
+    mmt_free(spc);
 
     if (!failure) {
       led_clr(pgm, LED_PGM);
@@ -1539,7 +1539,7 @@ int avr_get_mem_type(const char *str) {
       return avr_mem_order[i].type;
     if(!avr_mem_order[i].str) {
       pmsg_warning("avr_mem_order[] does not know %s; add to array and recompile\n", str);
-      avr_mem_order[i].str = cfg_strdup(__func__, str);
+      avr_mem_order[i].str = mmt_strdup(str);
       return avr_mem_order[i].type;
     }
   }

--- a/src/avrftdi_tpi.c
+++ b/src/avrftdi_tpi.c
@@ -19,9 +19,7 @@ static void avrftdi_tpi_disable(const PROGRAMMER *);
 static int avrftdi_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p);
 
 #ifdef notyet
-static void
-avrftdi_debug_frame(uint16_t frame)
-{
+static void avrftdi_debug_frame(uint16_t frame) {
 	static char bit_name[] = "IDLES01234567PSS";
 	//static char bit_name[] = "SSP76543210SELDI";
 	char line0[34], line1[34], line2[34];
@@ -106,8 +104,7 @@ void avrftdi_tpi_initpgm(PROGRAMMER *pgm) {
 
 #define TPI_PARITY_MASK 0x2000
 
-static inline int count1s(unsigned int x)
-{
+static inline int count1s(unsigned int x) {
 #if defined(__GNUC__)
 	return __builtin_popcount(x);
 #else
@@ -123,9 +120,7 @@ static inline int count1s(unsigned int x)
 #endif
 }
 
-static uint16_t
-tpi_byte2frame(uint8_t byte)
-{
+static uint16_t tpi_byte2frame(uint8_t byte) {
 	uint16_t frame = 0xc00f;
 	int parity = count1s(byte) & 1;
 
@@ -137,9 +132,7 @@ tpi_byte2frame(uint8_t byte)
 	return frame;
 }
 
-static int
-tpi_frame2byte(uint16_t frame, uint8_t * byte)
-{
+static int tpi_frame2byte(uint16_t frame, uint8_t * byte) {
 	/* drop idle and start bit(s) */
 	*byte = (frame >> 5) & 0xff;
 
@@ -150,8 +143,7 @@ tpi_frame2byte(uint16_t frame, uint8_t * byte)
 }
 
 #ifdef notyet
-static int
-avrftdi_tpi_break(const PROGRAMMER *pgm) {
+static int avrftdi_tpi_break(const PROGRAMMER *pgm) {
 	unsigned char buffer[] = { MPSSE_DO_WRITE | MPSSE_WRITE_NEG | MPSSE_LSB, 1, 0, 0, 0 };
 	E(ftdi_write_data(to_pdata(pgm)->ftdic, buffer, sizeof(buffer)) != sizeof(buffer), to_pdata(pgm)->ftdic);
 
@@ -159,8 +151,7 @@ avrftdi_tpi_break(const PROGRAMMER *pgm) {
 }
 #endif /* notyet */
 
-static int
-avrftdi_tpi_write_byte(const PROGRAMMER *pgm, unsigned char byte) {
+static int avrftdi_tpi_write_byte(const PROGRAMMER *pgm, unsigned char byte) {
 	uint16_t frame;
 
 	struct ftdi_context* ftdic = to_pdata(pgm)->ftdic;
@@ -185,8 +176,7 @@ avrftdi_tpi_write_byte(const PROGRAMMER *pgm, unsigned char byte) {
 #define TPI_FRAME_SIZE 12
 #define TPI_IDLE_BITS   2
 
-static int
-avrftdi_tpi_read_byte(const PROGRAMMER *pgm, unsigned char *byte) {
+static int avrftdi_tpi_read_byte(const PROGRAMMER *pgm, unsigned char *byte) {
 	uint16_t frame;
 	
 	/* use 2 guard bits, 2 default idle bits + 12 frame bits = 16 bits total */
@@ -229,8 +219,7 @@ avrftdi_tpi_read_byte(const PROGRAMMER *pgm, unsigned char *byte) {
 	return err;
 }
 
-static int
-avrftdi_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
+static int avrftdi_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 	return avr_tpi_program_enable(pgm, p, TPIPCR_GT_2b);
 }
 
@@ -257,8 +246,7 @@ avrftdi_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd, int cmd_len,
 	return 0;
 }
 
-static void
-avrftdi_tpi_disable(const PROGRAMMER *pgm) {
+static void avrftdi_tpi_disable(const PROGRAMMER *pgm) {
 	unsigned char cmd[] = {TPI_OP_SSTCS(TPIPCR), 0};
 	pgm->cmd_tpi(pgm, cmd, sizeof(cmd), NULL, 0);
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -989,7 +989,7 @@ void avr_free_part(AVRPART * d) {
   d->mem = NULL;
   ldestroy_cb(d->mem_alias, (void(*)(void *)) avr_free_memalias);
   d->mem_alias = NULL;
-  ldestroy_cb(d->variants, cfg_free);
+  ldestroy_cb(d->variants, mmt_f_free);
   d->variants = NULL;
 
   /* do not free d->parent_id and d->config_file */

--- a/src/config.c
+++ b/src/config.c
@@ -217,7 +217,7 @@ char *cfg_strdup(const char *funcname, const char *s) {
 }
 
 
-void cfg_free(void *ptr) {
+void mmt_f_free(void *ptr) {
   mmt_free(ptr);
 }
 

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -491,7 +491,7 @@ usb_pid_list:
     {
       /* overwrite pids, so clear the existing entries */
       if(current_prog->usbpid)
-        ldestroy_cb(current_prog->usbpid, free);
+        ldestroy_cb(current_prog->usbpid, mmt_f_free);
       current_prog->usbpid = lcreat(NULL, 0);
     }
     {
@@ -520,7 +520,7 @@ hvupdi_support_list:
     {
       /* overwrite list entries, so clear the existing entries */
       if(current_prog->hvupdi_support)
-        ldestroy_cb(current_prog->hvupdi_support, free);
+        ldestroy_cb(current_prog->hvupdi_support, mmt_f_free);
       current_prog->hvupdi_support = lcreat(NULL, 0);
     }
     {
@@ -631,7 +631,7 @@ part_parm :
 
   K_VARIANTS TKN_EQUAL K_NULL {
     {
-      ldestroy_cb(current_part->variants, free);
+      ldestroy_cb(current_part->variants, mmt_f_free);
       current_part->variants = lcreat(NULL, 0);
     }
   } |

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -436,7 +436,7 @@ prog_parm :
     {
       while (lsize(string_list)) {
         TOKEN *t = lrmv_n(string_list, 1);
-        ladd(current_prog->id, cfg_strdup("config_gram.y", t->value.string));
+        ladd(current_prog->id, mmt_strdup(t->value.string));
         free_token(t);
       }
     }
@@ -495,7 +495,7 @@ usb_pid_list:
       current_prog->usbpid = lcreat(NULL, 0);
     }
     {
-      int *ip = cfg_malloc("usb_pid_list", sizeof(int));
+      int *ip = mmt_malloc(sizeof(int));
       *ip = $1->value.number;
       ladd(current_prog->usbpid, ip);
       free_token($1);
@@ -503,7 +503,7 @@ usb_pid_list:
   } |
   usb_pid_list TKN_COMMA numexpr {
     {
-      int *ip = cfg_malloc("usb_pid_list", sizeof(int));
+      int *ip = mmt_malloc(sizeof(int));
       *ip = $3->value.number;
       ladd(current_prog->usbpid, ip);
       free_token($3);
@@ -524,7 +524,7 @@ hvupdi_support_list:
       current_prog->hvupdi_support = lcreat(NULL, 0);
     }
     {
-      int *ip = cfg_malloc("hvupdi_support_list", sizeof(int));
+      int *ip = mmt_malloc(sizeof(int));
       *ip = $1->value.number;
       ladd(current_prog->hvupdi_support, ip);
       free_token($1);
@@ -532,7 +532,7 @@ hvupdi_support_list:
   } |
   hvupdi_support_list TKN_COMMA numexpr {
     {
-      int *ip = cfg_malloc("hvupdi_support_list", sizeof(int));
+      int *ip = mmt_malloc(sizeof(int));
       *ip = $3->value.number;
       ladd(current_prog->hvupdi_support, ip);
       free_token($3);
@@ -648,7 +648,7 @@ part_parm :
           }
         }
         if(!found)
-          ladd(current_part->variants, cfg_strdup("config_gram.y", t->value.string));
+          ladd(current_part->variants, mmt_strdup(t->value.string));
         free_token(t);
       }
     }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1374,7 +1374,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
         for(LNODEID *ln=lfirst(pgm->id); ln; ln=lnext(ln))
           if(str_casematch(pgminj[i].pgmid, ldata(ln)))
             dev_part_strct_entry(tsv, ".prog", ldata(ln), NULL,
-              pgminj[i].var, strdup(pgminj[i].value), NULL);
+              pgminj[i].var, mmt_strdup(pgminj[i].value), NULL);
 
   if(!tsv) {
     dev_cout(pgm->comments, ";", 0, 0);

--- a/src/developer_opts_private.h
+++ b/src/developer_opts_private.h
@@ -67,7 +67,7 @@ static int dev_message(int msglvl, const char *fmt, ...);
     dev_part_strct_entry(tsv, ".prog", id, NULL, #component, dev_sprintf("%s", pgm->component? "true": "false"), pgm->comments); \
 } while(0)
 
-// Result must be a malloc'd string
+// Result must be an mmt_malloc'd string
 #define _if_pgmout_str(cmp, result, component) do { \
   if(!base || cmp(base->component, pgm->component)) \
     dev_part_strct_entry(tsv, ".prog", id, NULL, #component, result, pgm->comments); \
@@ -92,17 +92,17 @@ static int dev_message(int msglvl, const char *fmt, ...);
     dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, dev_sprintf(fmt, p->component), p->comments); \
 } while(0)
 
-// Result must be a malloc'd string
+// Result must be an mmt_malloc'd string
 #define _partout_str(result, component) \
   dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result, p->comments)
 
-// Result must be a malloc'd string
+// Result must be an mmt_malloc'd string
 #define _if_partout_str(cmp, result, component) do { \
   if(!base || cmp(base->component, p->component)) \
     dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result, p->comments); \
 } while(0)
 
-// Result must be a malloc'd string
+// Result must be an mmt_malloc'd string
 #define _if_n_partout_str(cmp, n, result, component) do { \
   if(!base || cmp(base->component, p->component, n)) \
     dev_part_strct_entry(tsv, ".pt", p->desc, NULL, #component, result, p->comments); \
@@ -117,18 +117,18 @@ static int dev_message(int msglvl, const char *fmt, ...);
     dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, dev_sprintf(fmt, m->component), m->comments); \
 } while(0)
 
-// Result must be a malloc'd string
+// Result must be an mmt_malloc'd string
 #define _memout_str(result, component) \
   dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result, m->comments)
 
-// Result must be a malloc'd string
+// Result must be an mmt_malloc'd string
 #define _if_n_memout_str(cmp, n, result, component) do { \
   if(!bm || cmp(bm->component, m->component, n)) \
     dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, result, m->comments); \
 } while(0)
 
 #define _memout_yn(component) \
-  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_memout_yn()", m->component? "yes": "no"), m->comments)
+  dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, mmt_strdup(m->component? "yes": "no"), m->comments)
 
 #define _if_memout_bool(component) do { \
   if(!bm || !!bm->component != !!m->component) \
@@ -137,18 +137,18 @@ static int dev_message(int msglvl, const char *fmt, ...);
 
 #define _if_memout_yn(component) do { \
   if(!bm || bm->component != m->component) \
-    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, cfg_strdup("_if_memout_yn()", m->component? "yes": "no"), m->comments); \
+    dev_part_strct_entry(tsv, ".ptmm", p->desc, m->desc, #component, mmt_strdup(m->component? "yes": "no"), m->comments); \
 } while(0)
 
 #define _flagout(mask, name) \
-  _partout_str(cfg_strdup("_flagout()", p->flags & (mask)? "yes": "no"), name)
+  _partout_str(mmt_strdup(p->flags & (mask)? "yes": "no"), name)
 
 #define _if_flagout(mask, name) do { \
   if(!base || (base->flags & (mask)) != (p->flags & (mask))) \
-    _partout_str(cfg_strdup("_if_flagout()", p->flags & (mask)? "yes": "no"), name); \
+    _partout_str(mmt_strdup(p->flags & (mask)? "yes": "no"), name); \
 } while(0)
 
-// Result must be a malloc'd string
+// Result must be an mmt_malloc'd string
 #define _cmderr(result, component) \
   dev_part_strct_entry(tsv, ".cmderr", p->desc, m->desc, #component, result, NULL)
 

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -115,11 +115,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
   }
 
   if(':' == port_spec[3]) {
-      bus_name = strdup(port_spec + 3 + 1);
-      if (bus_name == NULL) {
-        pmsg_error("out of memory in strdup\n");
-        return NULL;
-      }
+      bus_name = mmt_strdup(port_spec + 3 + 1);
 
       dev_name = strchr(bus_name, ':');
       if(NULL != dev_name)
@@ -130,14 +126,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
    * strings for use in dfu_initialize().
    */
 
-  dfu = calloc(1, sizeof(struct dfu_dev));
-
-  if (dfu == NULL)
-  {
-    pmsg_error("out of memory\n");
-    free(bus_name);
-    return NULL;
-  }
+  dfu = mmt_malloc(sizeof(struct dfu_dev));
 
   dfu->bus_name = bus_name;
   dfu->dev_name = dev_name;
@@ -251,13 +240,13 @@ void dfu_close(struct dfu_dev *dfu)
   if (dfu->dev_handle != NULL)
     usb_close(dfu->dev_handle);
   if (dfu->bus_name != NULL)
-    free(dfu->bus_name);
+    mmt_free(dfu->bus_name);
   if (dfu->manf_str != NULL)
-    free(dfu->manf_str);
+    mmt_free(dfu->manf_str);
   if (dfu->prod_str != NULL)
-    free(dfu->prod_str);
+    mmt_free(dfu->prod_str);
   if (dfu->serno_str != NULL)
-    free(dfu->serno_str);
+    mmt_free(dfu->serno_str);
 }
 
 int dfu_getstatus(struct dfu_dev *dfu, struct dfu_status *status)
@@ -432,15 +421,10 @@ char * get_usb_string(usb_dev_handle * dev_handle, int index) {
     return NULL;
   }
 
-  str = malloc(result+1);
-
-  if (str == NULL) {
-    pmsg_error("out of memory allocating a string\n");
-    return 0;
-  }
-
+  str = mmt_malloc(result+1);
   memcpy(str, buffer, result);
   str[result] = '\0';
+
   return str;
 }
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -97,13 +97,13 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
 }
 
 ["]([^"\\\n]|\\.|\\\n)*["] {
-  char *str= cfg_strdup("lexer.l", yytext);
+  char *str= mmt_strdup(yytext);
   cfg_unescape(str, str+1);
   size_t len = strlen(str);
   if(len)
     str[len-1] = 0;
   yylval = new_string(str);
-  free(str);
+  mmt_free(str);
   return TKN_STRING;
 }
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1381,7 +1381,7 @@ extern "C" {
 void *cfg_malloc(const char *funcname, size_t n);
 void *cfg_realloc(const char *funcname, void *p, size_t n);
 char *cfg_strdup(const char *funcname, const char *s);
-void cfg_free(void *ptr);
+void mmt_f_free(void *ptr);
 
 int init_config(void);
 

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -147,7 +147,7 @@ static int linuxspi_open(PROGRAMMER *pgm, const char *pt) {
       "please use the format /dev/spidev:/dev/gpiochip[:resetno]\n";
     char port_default[] = "/dev/spidev0.0:/dev/gpiochip0";
     char *spidev, *gpiochip, *reset_pin;
-    char *port = cfg_strdup("linuxspi_open()", pt);
+    char *port = mmt_strdup(pt);
     struct gpiohandle_request req;
     int ret;
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -40,19 +40,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "avrdude.h"
 #include "libavrdude.h"
 
 #define MAGIC 0xb05b05b0
 
 #define CHECK_MAGIC 0 /* set to 1 to enable memory overwrite detection */
 
-#ifdef BOS
-#define MALLOC(size,x) kmalloc(size,x)
-#define FREE           kfree
-#else
-#define MALLOC(size,x) malloc(size)
-#define FREE           free
-#endif
+#define MALLOC(size,x) mmt_malloc(size)
+#define FREE           mmt_free
 
 
 /*------------------------------------------------------------
@@ -397,13 +393,13 @@ free_listnode ( LIST * l, LISTNODE * ln )
   
   If liststruct is not NULL, it is used to provide the memory space
   for the list structure instance, otherwise, the necessary memory is
-  malloc'd.
+  mmt_malloc'd.
 
   If elements is zero, the default poolsize is used, otherwise,
-  poolsizes of 'elements' elements are malloc'd to obtain the memory
+  poolsizes of 'elements' elements are mmt_malloc'd to obtain the memory
   for list nodes.  Minimum element count is 5.
 
-  The first node pool is not preallocated; instead it is malloc'd at
+  The first node pool is not preallocated; instead it is mmt_malloc'd at
   the time of the first use.
   ----------------------------------------------------------------------*/
 LISTID

--- a/src/lists.c
+++ b/src/lists.c
@@ -126,8 +126,7 @@ static int insert_ln ( LIST * l, LISTNODE * ln, void * data_ptr );
 
 
 #if CHECK_MAGIC
-static int cknpmagic ( LIST * l )
-{
+static int cknpmagic ( LIST * l ) {
   NODEPOOL * np;
   int i;
 
@@ -152,8 +151,7 @@ static int cknpmagic ( LIST * l )
 
 
 
-static int cklnmagic ( LIST * l )
-{
+static int cklnmagic ( LIST * l ) {
   LISTNODE * ln;
   int i;
 
@@ -177,8 +175,7 @@ static int cklnmagic ( LIST * l )
 }
 
 
-static int cklmagic ( LIST * l )
-{
+static int cklmagic ( LIST * l ) {
   CKMAGIC(l);
   CKNPMAGIC(l);
   CKLNMAGIC(l);
@@ -196,10 +193,7 @@ static int cklmagic ( LIST * l )
 |  bytes reserved.  The first available list node resides at
 |  offset sizeof(NODEPOOL).
  ------------------------------------------------------------*/
-static
-NODEPOOL * 
-new_nodepool ( LIST * l )
-{
+static NODEPOOL *new_nodepool ( LIST * l ) {
   NODEPOOL * np;
   LISTNODE * ln;
   int i;
@@ -282,10 +276,7 @@ new_nodepool ( LIST * l )
 |  list nodes, another pool of list nodes is allocated.  If
 |  that fails, NULL is returned.
  ------------------------------------------------------------*/
-static
-LISTNODE * 
-get_listnode ( LIST * l )
-{
+static LISTNODE * get_listnode ( LIST * l ) {
   LISTNODE * ln;
   NODEPOOL * np;
 
@@ -364,10 +355,7 @@ get_listnode ( LIST * l )
 |  call to 'get_listnode', with return the most recently
 |  freed one.
  ------------------------------------------------------------*/
-static
-int 
-free_listnode ( LIST * l, LISTNODE * ln )
-{
+static int  free_listnode ( LIST * l, LISTNODE * ln ) {
   CKLMAGIC(l);
 
   /*--------------------------------------------------
@@ -869,10 +857,7 @@ lget_ln ( LISTID lid, unsigned int n )
 |  by list manipulation routines within this module, in which ln is
 |  known to point to a valid list node.
  ----------------------------------------------------------------------*/
-static 
-int 
-insert_ln ( LIST * l, LISTNODE * ln, void * data_ptr )
-{
+static int insert_ln ( LIST * l, LISTNODE * ln, void * data_ptr ) {
   LISTNODE * lnptr;
 
   CKLMAGIC(l);
@@ -1033,10 +1018,7 @@ lins_ln ( LISTID lid, LNODEID lnid, void * data_ptr )
 |  routines within this module, in which ln is known to point to a
 |  valid list node.
  ----------------------------------------------------------------------*/
-static
-void * 
-remove_ln ( LIST * l, LISTNODE * ln )
-{
+static void * remove_ln ( LIST * l, LISTNODE * ln ) {
   void * r;
 
   CKLMAGIC(l);

--- a/src/main.c
+++ b/src/main.c
@@ -409,7 +409,7 @@ static void exithook(void)
 static void cleanup_main(void)
 {
     if (updates) {
-        ldestroy_cb(updates, (void(*)(void*))free_update);
+        ldestroy_cb(updates, (void(*)(void*)) free_update);
         updates = NULL;
     }
     if (extended_params) {

--- a/src/msvc/getopt.c
+++ b/src/msvc/getopt.c
@@ -114,18 +114,14 @@ static const char noarg[] = "option doesn't take an argument -- %.*s";
 static const char illoptchar[] = "unknown option -- %c";
 static const char illoptstring[] = "unknown option -- %s";
 
-static void
-_vwarnx(const char *fmt,va_list ap)
-{
+static void _vwarnx(const char *fmt,va_list ap) {
   (void)fprintf(stderr,"%s: ",__progname);
   if (fmt != NULL)
     (void)vfprintf(stderr,fmt,ap);
   (void)fprintf(stderr,"\n");
 }
 
-static void
-warnx(const char *fmt,...)
-{
+static void warnx(const char *fmt,...) {
   va_list ap;
   va_start(ap,fmt);
   _vwarnx(fmt,ap);
@@ -135,9 +131,7 @@ warnx(const char *fmt,...)
 /*
  * Compute the greatest common divisor of a and b.
  */
-static int
-gcd(int a, int b)
-{
+static int gcd(int a, int b) {
 	int c;
 
 	c = a % b;
@@ -155,10 +149,7 @@ gcd(int a, int b)
  * from nonopt_end to opt_end (keeping the same order of arguments
  * in each block).
  */
-static void
-permute_args(int panonopt_start, int panonopt_end, int opt_end,
-	char * const *nargv)
-{
+static void permute_args(int panonopt_start, int panonopt_end, int opt_end, char * const *nargv) {
 	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
 	char *swap;
 
@@ -192,10 +183,9 @@ permute_args(int panonopt_start, int panonopt_end, int opt_end,
  *	Parse long options in argc/argv argument vector.
  * Returns -1 if short_too is set and the option does not match long_options.
  */
-static int
-parse_long_options(char * const *nargv, const char *options,
-	const struct option *long_options, int *idx, int short_too)
-{
+static int parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too) {
+
 	char *current_argv, *has_equal;
 	size_t current_argv_len;
 	int i, ambiguous, match;
@@ -320,10 +310,9 @@ parse_long_options(char * const *nargv, const char *options,
  * getopt_internal --
  *	Parse argc/argv argument vector.  Called by user level routines.
  */
-static int
-getopt_internal(int nargc, char * const *nargv, const char *options,
-	const struct option *long_options, int *idx, int flags)
-{
+static int getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags) {
+
 	char *oli;				/* option letter list index */
 	int optchar, short_too;
 	static int posixly_correct = -1;

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -182,15 +182,15 @@ PROGRAMMER *pgm_new(void) {
 void pgm_free(PROGRAMMER *p) {
   if(p) {
     if(p->id) {
-      ldestroy_cb(p->id, free);
+      ldestroy_cb(p->id, mmt_f_free);
       p->id = NULL;
     }
     if(p->usbpid) {
-      ldestroy_cb(p->usbpid, free);
+      ldestroy_cb(p->usbpid, mmt_f_free);
       p->usbpid = NULL;
     }
     if(p->hvupdi_support) {
-      ldestroy_cb(p->hvupdi_support, free);
+      ldestroy_cb(p->hvupdi_support, mmt_f_free);
       p->hvupdi_support = NULL;
     }
     mmt_free(p->leds); p->leds = NULL;
@@ -205,9 +205,9 @@ PROGRAMMER *pgm_dup(const PROGRAMMER *src) {
   PROGRAMMER *pgm = pgm_new();
 
   if(src) {
-    ldestroy_cb(pgm->id, free);
-    ldestroy_cb(pgm->usbpid, free);
-    ldestroy_cb(pgm->hvupdi_support, free);
+    ldestroy_cb(pgm->id, mmt_f_free);
+    ldestroy_cb(pgm->usbpid, mmt_f_free);
+    ldestroy_cb(pgm->hvupdi_support, mmt_f_free);
     // There must be only one cache, even though the part is duplicated
     if(pgm->cp_flash)
       mmt_free(pgm->cp_flash);

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -354,7 +354,7 @@ const char * pins_to_str(const struct pindef_t * const pindef) {
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation
- * @returns a pointer to a string, which was created by cfg_strdup()
+ * @returns a pointer to a string, which was created by mmt_strdup()
  */
 char *pins_to_strdup(const struct pindef_t * const pindef) {
   char buf[6*(PIN_MAX+1)], *p = buf;
@@ -369,7 +369,7 @@ char *pins_to_strdup(const struct pindef_t * const pindef) {
     }
   }
 
-  return cfg_strdup("pins_to_strdup()", buf);
+  return mmt_strdup(buf);
 }
 
 /**

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -288,10 +288,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
   struct addrinfo hints;
   struct addrinfo *result, *rp;
 
-  if ((hstr = hp = strdup(port)) == NULL) {
-    pmsg_error("out of memory\n");
-    return -1;
-  }
+  hstr = hp = mmt_strdup(port);
 
   /*
    * As numeric IPv6 addresses use colons as separators, we need to
@@ -348,7 +345,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
   freeaddrinfo(result);
 
 error:
-  free(hp);
+  mmt_free(hp);
   return ret;
 }
 

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -164,14 +164,10 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 		return -1;
 	}
 
-	if ((hstr = strdup(port)) == NULL) {
-		pmsg_error("out of memory\n");
-		return -1;
-	}
-
+	hstr = mmt_strdup(port);
 	if (((pstr = strchr(hstr, ':')) == NULL) || (pstr == hstr)) {
 		pmsg_error("mangled host:port string %s\n", hstr);
-		free(hstr);
+		mmt_free(hstr);
 		return -1;
 	}
 
@@ -184,17 +180,17 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 
 	if ((*pstr == '\0') || (*end != '\0') || (pnum == 0) || (pnum > 65535)) {
 		pmsg_error("bad port number %s\n", pstr);
-		free(hstr);
+		mmt_free(hstr);
 		return -1;
 	}
 
 	if ((hp = gethostbyname(hstr)) == NULL) {
 		pmsg_error("unknown host %s\n", hstr);
-		free(hstr);
+		mmt_free(hstr);
 		return -1;
 	}
 
-	free(hstr);
+	mmt_free(hstr);
 
 	if ((fd = socket(PF_INET, SOCK_STREAM, 0)) < 0) {
 		FormatMessage(
@@ -256,7 +252,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	if (str_casestarts(port, "com")) {
 
 	    // prepend "\\\\.\\" to name, required for port # >= 10
-	    newname = cfg_malloc(__func__, strlen("\\\\.\\") + strlen(port) + 1);
+	    newname = mmt_malloc(strlen("\\\\.\\") + strlen(port) + 1);
 	    strcpy(newname, "\\\\.\\");
 	    strcat(newname, port);
 
@@ -305,7 +301,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 	}
 
 	if (newname != 0) {
-	    free(newname);
+	    mmt_free(newname);
 	}
 	return 0;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3890,7 +3890,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
       pgmcp->id = lcreat(NULL, 0);
       // Copy pgm->id contents over to pgmcp->id
       for(LNODEID ln=lfirst(pgm->id); ln; ln=lnext(ln))
-        ladd(pgmcp->id, cfg_strdup("stk500v2_display()", ldata(ln)));
+        ladd(pgmcp->id, mmt_strdup(ldata(ln)));
       jtag3_print_parms1(pgmcp, p, fp);
       pgm_free(pgmcp);
     }

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -579,12 +579,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
 
   unsigned int temp_buffer_size = 3 + 3 + 2 + (words * 2) + 3;
   unsigned int num=0;
-  unsigned char* temp_buffer = malloc(temp_buffer_size);
-
-  if (temp_buffer == 0) {
-    pmsg_debug("allocating temporary buffer failed\n");
-    return -1;
-  }
+  unsigned char* temp_buffer = mmt_malloc(temp_buffer_size);
 
   if (blocksize == -1) {
     blocksize = temp_buffer_size;
@@ -608,7 +603,7 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
   if (blocksize < 10) {
     if (updi_physical_send(pgm, temp_buffer, 6) < 0) {
       pmsg_debug("unable to send first package\n");
-      free(temp_buffer);
+      mmt_free(temp_buffer);
       return -1;
     }
     num = 6;
@@ -625,13 +620,13 @@ int updi_link_st_ptr_inc16_RSD(const PROGRAMMER *pgm, unsigned char *buffer, uin
 
     if (updi_physical_send(pgm, temp_buffer + num, next_package_size) < 0) {
       pmsg_debug("unable to send package\n");
-      free(temp_buffer);
+      mmt_free(temp_buffer);
       return -1;
     }
 
     num+=next_package_size;
   }
-  free(temp_buffer);
+  mmt_free(temp_buffer);
   return 0;
 }
 

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -134,11 +134,11 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
   if (hid_get_serial_number_string(dev, sn, sizeof(sn)/sizeof(*sn)) == 0) {
     size_t n = wcstombs(NULL, sn, 0) + 1;
     if (n) {
-      char *cn = cfg_malloc(__func__, n);
+      char *cn = mmt_malloc(n);
       if (wcstombs(cn, sn, n) != (size_t) -1)
         if(serdev)
           serdev->usbsn = cache_string(cn);
-      free(cn);
+      mmt_free(cn);
     }
   }
 

--- a/src/whereami.c
+++ b/src/whereami.c
@@ -14,6 +14,8 @@ extern "C" {
 
 #if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
 #include <stdlib.h>
+#include "avrdude.h"
+#include "libavrdude.h"
 #endif
 
 #if !defined(WAI_MALLOC)

--- a/src/whereami.c
+++ b/src/whereami.c
@@ -17,15 +17,15 @@ extern "C" {
 #endif
 
 #if !defined(WAI_MALLOC)
-#define WAI_MALLOC(size) malloc(size)
+#define WAI_MALLOC(size) mmt_malloc(size)
 #endif
 
 #if !defined(WAI_FREE)
-#define WAI_FREE(p) free(p)
+#define WAI_FREE(p) mmt_free(p)
 #endif
 
 #if !defined(WAI_REALLOC)
-#define WAI_REALLOC(p, size) realloc(p, size)
+#define WAI_REALLOC(p, size) mmt_realloc(p, size)
 #endif
 
 #ifndef WAI_NOINLINE

--- a/src/whereami.h
+++ b/src/whereami.h
@@ -23,7 +23,7 @@ extern "C" {
  * Usage:
  *  - first call `int length = wai_getExecutablePath(NULL, 0, NULL);` to
  *    retrieve the length of the path
- *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - allocate the destination buffer with `path = (char*) mmt_malloc(length + 1);`
  *  - call `wai_getExecutablePath(path, length, NULL)` again to retrieve the
  *    path
  *  - add a terminal NUL character with `path[length] = '\0';`
@@ -45,7 +45,7 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length);
  * Usage:
  *  - first call `int length = wai_getModulePath(NULL, 0, NULL);` to retrieve
  *    the length  of the path
- *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - allocate the destination buffer with `path = (char*) mmt_malloc(length + 1);`
  *  - call `wai_getModulePath(path, length, NULL)` again to retrieve the path
  *  - add a terminal NUL character with `path[length] = '\0';`
  *


### PR DESCRIPTION
Using mmt_malloc(), mmt_realloc(), mmt_strdup() and mmt_free() has the benefit of adding another layer of indirection in `avrdude.h` so that applications can replace the memory allocation and management routines at compile time if they so wish.

Next step is to move static and global variables into a context structure, but probably in a separate PR once this one is merged