### PR TITLE
Silence compiler warnings

### DIFF
--- a/src/dfu.c
+++ b/src/dfu.c
@@ -394,10 +394,10 @@ void dfu_show_info(struct dfu_dev *dfu)
     msg_info("    USB Product         : 0x%04hX\n",
       (unsigned short) dfu->dev_desc.idProduct);
 
-  msg_info("    USB Release         : %hu.%hu.%hu\n",
-    ((unsigned short) dfu->dev_desc.bcdDevice >> 8) & 0xFF,
-    ((unsigned short) dfu->dev_desc.bcdDevice >> 4) & 0xF,
-    ((unsigned short) dfu->dev_desc.bcdDevice >> 0) & 0xF);
+  msg_info("    USB Release         : %u.%u.%u\n",
+    (dfu->dev_desc.bcdDevice >> 8) & 0xFF,
+    (dfu->dev_desc.bcdDevice >> 4) & 0xF,
+    (dfu->dev_desc.bcdDevice >> 0) & 0xF);
 
   if (dfu->serno_str != NULL)
     msg_info("    USB Serial No       : %s\n", dfu->serno_str);

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -555,9 +555,9 @@ static void flip2_show_info(struct flip2 *flip2) {
       (char) (flip2->part_rev / 26 - 1 + 'A'),
       (char) (flip2->part_rev % 26 + 'A'));
 
-  msg_info("    Bootloader version  : 2.%hu.%hu\n",
-    ((unsigned short) flip2->boot_ver >> 4) & 0xF,
-    ((unsigned short) flip2->boot_ver >> 0) & 0xF);
+  msg_info("    Bootloader version  : 2.%u.%u\n",
+    (flip2->boot_ver >> 4) & 0xF,
+    (flip2->boot_ver >> 0) & 0xF);
 
   msg_info("    USB max packet size : %hu\n",
     (unsigned short) flip2->dfu->dev_desc.bMaxPacketSize0);
@@ -778,7 +778,7 @@ flip2_read_max1k_status:
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      pmsg_error("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
+      pmsg_error("address out of range [0x%04X,0x%04X]\n", offset, (offset+size-1) & 0xffff);
     } else
       pmsg_error("DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);
@@ -836,7 +836,7 @@ static int flip2_write_max1k(struct dfu_dev *dfu,
     if (status.bStatus == ((FLIP2_STATUS_OUTOFRANGE >> 8) & 0xFF) &&
         status.bState == ((FLIP2_STATUS_OUTOFRANGE >> 0) & 0xFF))
     {
-      pmsg_error("address out of range [0x%04hX,0x%04hX]\n", offset, offset+size-1);
+      pmsg_error("address out of range [0x%04X,0x%04X]\n", offset, (offset+size-1) & 0xffff);
     } else
       pmsg_error("DFU status %s\n", flip2_status_str(&status));
     dfu_clrstatus(dfu);

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -90,7 +90,7 @@ static int updi_physical_send(const PROGRAMMER *pgm, unsigned char *buf, size_t 
   size_t i;
   int rv;
 
-  pmsg_debug("sending %lu bytes [", len);
+  pmsg_debug("sending %lu bytes [", (unsigned long) len);
   for (i=0; i<len; i++) {
     msg_debug("0x%02x", buf[i]);
     if (i<len-1) {
@@ -114,7 +114,7 @@ static int updi_physical_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t 
     return -1;
   }
 
-  pmsg_debug("received %lu bytes [", len);
+  pmsg_debug("received %lu bytes [", (unsigned long) len);
   for (i=0; i<len; i++) {
     msg_debug("0x%02x", buf[i]);
     if (i<len-1) {


### PR DESCRIPTION
Fixes #1799 

The `%hd` converts the int argument to short before printing, so I suspect #1799 is a matter of overzealous compiler warning.