### PR TITLE
Put static variables into context structure

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -135,5 +135,5 @@ void arduino_initpgm(PROGRAMMER *pgm) {
   pgm->open = arduino_open;
   pgm->close = arduino_close;
 
-  disable_trailing_ff_removal(); /* so that arduino bootloader can ignore chip erase */
+  cx->avr_disableffopt = 1;     // Disable trailing 0xff removal
 }

--- a/src/avr.c
+++ b/src/avr.c
@@ -1443,10 +1443,12 @@ int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles) {
 
 
 /*
- * Returns a string in closed-circuit space with a comma-separated list of
- * programming modes; variant creates the list in subtly different way
- *  - 0: PM_SPM prints bootloader, pm == 0 prints "?"
- *  - 1: PM_SPM prints SPM, pm == 0 prints "0"
+ * Returns a string in closed-circuit space with a list of programming
+ * modes encoded in pm; variant creates the list in subtly different ways:
+ *  - variants == 0: PM_SPM prints bootloader
+ *  - variants == 1: PM_SPM prints SPM
+ *  - variants == 2: rather than a comma-separated list it's | PM_... separated
+ * If pm is 0 (no programming modes) returns "0"
  */
 static char *prog_modes_string(int pm, int variant) {
   // Return string is overwritten after a few calls
@@ -1457,48 +1459,52 @@ static char *prog_modes_string(int pm, int variant) {
   if((size_t) (type - cx->avr_space) > sizeof cx->avr_space - 128)
     type = cx->avr_space;
 
-  strcpy(type, variant? "0": "?");
-  if(variant == 0 && (pm & PM_SPM))
-    strcat(type, ", bootloader");
-  if(pm & PM_TPI)
-    strcat(type, ", TPI");
-  if(pm & PM_ISP)
-    strcat(type, ", ISP");
-  if(pm & PM_PDI)
-    strcat(type, ", PDI");
-  if(pm & PM_UPDI)
-    strcat(type, ", UPDI");
-  if(pm & PM_HVSP)
-    strcat(type, ", HVSP");
-  if(pm & PM_HVPP)
-    strcat(type, ", HVPP");
-  if(pm & PM_debugWIRE)
-    strcat(type, ", debugWIRE");
-  if(pm & PM_JTAG)
-    strcat(type, ", JTAG");
-  if(pm & PM_JTAGmkI)
-    strcat(type, ", JTAGmkI");
-  if(pm & PM_XMEGAJTAG)
-    strcat(type, ", XMEGAJTAG");
-  if(pm & PM_AVR32JTAG)
-    strcat(type, ", AVR32JTAG");
-  if(pm & PM_aWire)
-    strcat(type, ", aWire");
-  if(variant == 1 && (pm & PM_SPM))
-    strcat(type, ", SPM");
+  const char *spm = variant? "SPM": "bootloader";
+  const char *sep = variant == 2? " | PM_": ", ";
+  int skip = 3 + (variant == 2);
 
-  cx->avr_s = type + (type[1] == 0? 0: 3);
+  strcpy(type, "0");
+  if(pm & PM_SPM)
+    strcat(strcat(type, sep), spm);
+  if(pm & PM_TPI)
+    strcat(strcat(type, sep), "TPI");
+  if(pm & PM_ISP)
+    strcat(strcat(type, sep), "ISP");
+  if(pm & PM_PDI)
+    strcat(strcat(type, sep), "PDI");
+  if(pm & PM_UPDI)
+    strcat(strcat(type, sep), "UPDI");
+  if(pm & PM_HVSP)
+    strcat(strcat(type, sep), "HVSP");
+  if(pm & PM_HVPP)
+    strcat(strcat(type, sep), "HVPP");
+  if(pm & PM_debugWIRE)
+    strcat(strcat(type, sep), "debugWIRE");
+  if(pm & PM_JTAG)
+    strcat(strcat(type, sep), "JTAG");
+  if(pm & PM_JTAGmkI)
+    strcat(strcat(type, sep), "JTAGmkI");
+  if(pm & PM_XMEGAJTAG)
+    strcat(strcat(type, sep), "XMEGAJTAG");
+  if(pm & PM_AVR32JTAG)
+    strcat(strcat(type, sep), "AVR32JTAG");
+  if(pm & PM_aWire)
+    strcat(strcat(type, sep), "aWire");
+
+  cx->avr_s = type + (type[1] == 0? 0: skip);
   return cx->avr_s;
 }
 
-// Returns a string in closed-circuit space with list of programming modes or "0"
-char *avr_prog_modes_str(int pm) {
+char *avr_prog_modes(int pm) {  // PM_SPM prints bootloader
+  return prog_modes_string(pm, 0);
+}
+
+char *str_prog_modes(int pm) {  // PM_SPM prints SPM
   return prog_modes_string(pm, 1);
 }
 
-// Returns a string in closed-circuit space with list of programming modes or "?"
-char *avr_prog_modes(int pm) {
-  return prog_modes_string(pm, 0);
+char *dev_prog_modes(int pm) {  // Symbolic C code of prog_modes
+  return prog_modes_string(pm, 2);
 }
 
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -1442,8 +1442,13 @@ int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles) {
 }
 
 
-// Returns a string in closed-circuit space with list of programming modes
-char *avr_prog_modes(int pm) {
+/*
+ * Returns a string in closed-circuit space with a comma-separated list of
+ * programming modes; variant creates the list in subtly different way
+ *  - 0: PM_SPM prints bootloader, pm == 0 prints "?"
+ *  - 1: PM_SPM prints SPM, pm == 0 prints "0"
+ */
+static char *prog_modes_string(int pm, int variant) {
   // Return string is overwritten after a few calls
   if(!cx->avr_s)
     cx->avr_s = cx->avr_space;
@@ -1452,8 +1457,8 @@ char *avr_prog_modes(int pm) {
   if((size_t) (type - cx->avr_space) > sizeof cx->avr_space - 128)
     type = cx->avr_space;
 
-  strcpy(type, "?");
-  if(pm & PM_SPM)
+  strcpy(type, variant? "0": "?");
+  if(variant == 0 && (pm & PM_SPM))
     strcat(type, ", bootloader");
   if(pm & PM_TPI)
     strcat(type, ", TPI");
@@ -1479,9 +1484,21 @@ char *avr_prog_modes(int pm) {
     strcat(type, ", AVR32JTAG");
   if(pm & PM_aWire)
     strcat(type, ", aWire");
+  if(variant == 1 && (pm & PM_SPM))
+    strcat(type, ", SPM");
 
   cx->avr_s = type + (type[1] == 0? 0: 3);
   return cx->avr_s;
+}
+
+// Returns a string in closed-circuit space with list of programming modes or "0"
+char *avr_prog_modes_str(int pm) {
+  return prog_modes_string(pm, 1);
+}
+
+// Returns a string in closed-circuit space with list of programming modes or "?"
+char *avr_prog_modes(int pm) {
+  return prog_modes_string(pm, 0);
 }
 
 

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -330,13 +330,6 @@ error:
 }
 
 
-// Does the memory region only haxe 0xff?
-static int _is_all_0xff(const void *p, size_t n) {
-  const unsigned char *q = (const unsigned char *) p;
-  return n <= 0 || (*q == 0xff && memcmp(q, q+1, n-1) == 0);
-}
-
-
 // A coarse guess where any bootloader might start (prob underestimates the start)
 static int guessBootStart(const PROGRAMMER *pgm, const AVRPART *p) {
   int bootstart = 0;
@@ -539,7 +532,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       } else if(mems[i].iseeprom) {
         // Don't know whether chip erase has zapped EEPROM
         for(int n = 0; n < cp->size; n += cp->page_size) {
-          if(!_is_all_0xff(cp->copy + n, cp->page_size)) { // First page that had EEPROM data
+          if(!is_memset(cp->copy + n, 0xff, cp->page_size)) { // First page that had EEPROM data
             if(avr_read_page_default(pgm, p, mem, n, cp->copy + n) < 0) {
               report_progress(1, -1, NULL);
               if(quell_progress)
@@ -547,8 +540,8 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
               pmsg_error("EEPROM read failed at addr 0x%04x\n", n);
               return LIBAVRDUDE_GENERAL_FAILURE;
             }
-            // EEPROM zapped by chip erase? Set all copy to 0xff
-            if(_is_all_0xff(cp->copy + n, cp->page_size))
+            // EEPROM zapped by chip erase? Set all of copy to 0xff
+            if(is_memset(cp->copy + n, 0xff, cp->page_size))
               memset(cp->copy, 0xff, cp->size);
             break;
           }
@@ -729,10 +722,10 @@ int avr_chip_erase_cached(const PROGRAMMER *pgm, const AVRPART *p) {
       bool erasedee = 0;
       for(int pgno = 0, n = 0; n < cp->size; pgno++, n += cp->page_size) {
         if(cp->iscached[pgno]) {
-          if(!_is_all_0xff(cp->copy + n, cp->page_size)) { // Page has EEPROM data?
+          if(!is_memset(cp->copy + n, 0xff, cp->page_size)) { // Page has EEPROM data?
             if(avr_read_page_default(pgm, p, mem, n, cp->copy + n) < 0)
               return LIBAVRDUDE_GENERAL_FAILURE;
-            erasedee = _is_all_0xff(cp->copy + n, cp->page_size);
+            erasedee = is_memset(cp->copy + n, 0xff, cp->page_size);
             break;
           }
         }
@@ -788,7 +781,7 @@ int avr_page_erase_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
   if(loadCachePage(cp, pgm, p, mem, (int) addr, cacheaddr, 0) < 0)
     return LIBAVRDUDE_GENERAL_FAILURE;
 
-  if(!_is_all_0xff(cp->cont + (cacheaddr & ~(cp->page_size-1)), cp->page_size))
+  if(!is_memset(cp->cont + (cacheaddr & ~(cp->page_size-1)), 0xff, cp->page_size))
     return LIBAVRDUDE_GENERAL_FAILURE;
 
   return LIBAVRDUDE_SUCCESS;

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -44,6 +44,7 @@ extern const char *pgmid;    // Programmer -c string
 #define mmt_strdup(s) cfg_strdup(__func__, s)
 #define mmt_malloc(n) cfg_malloc(__func__, n)
 #define mmt_realloc(p, n) cfg_realloc(__func__, p, n)
+#define mmt_sprintf(...) str_sprintf(__VA_ARGS__)
 #define mmt_free(p) free(p)
 
 int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int msgmode, int msglvl, const char *format, ...)

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -176,22 +176,19 @@ static int set_frequency(avrftdi_t* ftdi, uint32_t freq)
 	}
 
 	if (divisor < 0) {
-		char *f = str_frq(freq, 6), *h = str_frq(clock/2.0, 6);
-		pmsg_warning("frequency %s too high, resetting to %s\n", f, h);
-		mmt_free(f); mmt_free(h);
+		pmsg_warning("frequency %s too high, resetting to %s\n",
+			str_ccfrq(freq, 6), str_ccfrq(clock/2.0, 6));
 		divisor = 0;
 	}
 
 	if (divisor > 65535) {
-		char *f = str_frq(freq, 6), *l = str_frq(clock/2.0 / 65536, 6);
-		pmsg_warning("frequency %s too low, resetting to %s\n", f, l);
-		mmt_free(f); mmt_free(l);
+		pmsg_warning("frequency %s too low, resetting to %s\n",
+			str_ccfrq(freq, 6), str_ccfrq(clock/2.0 / 65536, 6));
 		divisor = 65535;
 	}
 
-	char *f = str_frq(clock/2.0 / (divisor + 1), 6);
-	imsg_notice(" - frequency %s (clock divisor %d = 0x%04x)\n", f, divisor, divisor);
-	mmt_free(f);
+	imsg_notice(" - frequency %s (clock divisor %d = 0x%04x)\n",
+		str_ccfrq(clock/2.0 / (divisor + 1), 6), divisor, divisor);
 
 	*ptr++ = TCK_DIVISOR;
 	*ptr++ = (uint8_t)(divisor & 0xff);

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -611,7 +611,7 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 				avr_pin_name(PIN_JTAG_TDO), avr_pin_name(PIN_JTAG_TMS),
 				*ptck? ptck: "?", *ptdi? ptdi: "?",
 				*ptdo? ptdo: "?", *ptms? ptms: "?");
-			free(ptck); free(ptdi); free(ptdo); free(ptms);
+			mmt_free(ptck); mmt_free(ptdi); mmt_free(ptdo); mmt_free(ptms);
 		} else {
 			char *psck = pins_to_strdup(&pgm->pin[PIN_AVR_SCK]),
 			     *psdo = pins_to_strdup(&pgm->pin[PIN_AVR_SDO]),
@@ -621,7 +621,7 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 				avr_pin_name(PIN_AVR_SDI),
 				*psck? psck: "?", *psdo? psdo: "?",
 				*psdi? psdi: "?");
-			free(psck); free(psdo); free(psdi);
+			mmt_free(psck); mmt_free(psdo); mmt_free(psdi);
 		}
 		imsg_error("if other pin configuration is used, fallback to slower bitbanging mode is used\n");
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -219,11 +219,9 @@ static int set_pin(const PROGRAMMER *pgm, int pinfunc, int value) {
 		return 0;
 	}
 
-	char *pmsk = pinmask_to_strdup(pin.mask);
-	pmsg_debug("setting pin %s (%s) as %s: %s (%s active)\n", pmsk,
-		ftdi_pin_name(pdata, pin), avr_pin_name(pinfunc),
+	pmsg_debug("setting pin %s (%s) as %s: %s (%s active)\n",
+		pinmask_to_str(pin.mask), ftdi_pin_name(pdata, pin), avr_pin_name(pinfunc),
 		(value) ? "high" : "low", (pin.inverse[0]) ? "low" : "high");
-	mmt_free(pmsk);
 
 	pdata->pin_value = SET_BITS_0(pdata->pin_value, pgm, pinfunc, value);
 
@@ -599,26 +597,21 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 		avrftdi_check_pins_bb(pgm, true);
 		imsg_error("pin configuration for FTDI MPSSE must be:\n");
 		if (pgm->flag == PGM_FL_IS_JTAG) {
-			char *ptck = pins_to_strdup(&pgm->pin[PIN_JTAG_TCK]),
-			     *ptdi = pins_to_strdup(&pgm->pin[PIN_JTAG_TDI]),
-			     *ptdo = pins_to_strdup(&pgm->pin[PIN_JTAG_TDO]),
-			     *ptms = pins_to_strdup(&pgm->pin[PIN_JTAG_TMS]);
 			imsg_error("%s: 0; %s: 1; %s: 2; %s: 3 (is: %s; %s; %s; %s)\n",
 				avr_pin_name(PIN_JTAG_TCK), avr_pin_name(PIN_JTAG_TDI),
 				avr_pin_name(PIN_JTAG_TDO), avr_pin_name(PIN_JTAG_TMS),
-				*ptck? ptck: "?", *ptdi? ptdi: "?",
-				*ptdo? ptdo: "?", *ptms? ptms: "?");
-			mmt_free(ptck); mmt_free(ptdi); mmt_free(ptdo); mmt_free(ptms);
+				pins_to_str(&pgm->pin[PIN_JTAG_TCK]),
+				pins_to_str(&pgm->pin[PIN_JTAG_TDI]),
+				pins_to_str(&pgm->pin[PIN_JTAG_TDO]),
+				pins_to_str(&pgm->pin[PIN_JTAG_TMS]));
 		} else {
-			char *psck = pins_to_strdup(&pgm->pin[PIN_AVR_SCK]),
-			     *psdo = pins_to_strdup(&pgm->pin[PIN_AVR_SDO]),
-			     *psdi = pins_to_strdup(&pgm->pin[PIN_AVR_SDI]);
 			imsg_error("%s: 0; %s: 1; %s: 2 (is: %s; %s; %s)\n",
-				avr_pin_name(PIN_AVR_SCK), avr_pin_name(PIN_AVR_SDO),
+				avr_pin_name(PIN_AVR_SCK),
+				avr_pin_name(PIN_AVR_SDO),
 				avr_pin_name(PIN_AVR_SDI),
-				*psck? psck: "?", *psdo? psdo: "?",
-				*psdi? psdi: "?");
-			mmt_free(psck); mmt_free(psdo); mmt_free(psdi);
+				pins_to_str(&pgm->pin[PIN_AVR_SCK]),
+				pins_to_str(&pgm->pin[PIN_AVR_SDO]),
+				pins_to_str(&pgm->pin[PIN_AVR_SDI]));
 		}
 		imsg_error("if other pin configuration is used, fallback to slower bitbanging mode is used\n");
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -601,21 +601,26 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 		avrftdi_check_pins_bb(pgm, true);
 		imsg_error("pin configuration for FTDI MPSSE must be:\n");
 		if (pgm->flag == PGM_FL_IS_JTAG) {
-			imsg_error("%s: 0, %s: 1, %s: 2, %s :3 (is: %s, %s, %s, %s)\n",
+			char *ptck = pins_to_strdup(&pgm->pin[PIN_JTAG_TCK]),
+			     *ptdi = pins_to_strdup(&pgm->pin[PIN_JTAG_TDI]),
+			     *ptdo = pins_to_strdup(&pgm->pin[PIN_JTAG_TDO]),
+			     *ptms = pins_to_strdup(&pgm->pin[PIN_JTAG_TMS]);
+			imsg_error("%s: 0; %s: 1; %s: 2; %s: 3 (is: %s; %s; %s; %s)\n",
 				avr_pin_name(PIN_JTAG_TCK), avr_pin_name(PIN_JTAG_TDI),
 				avr_pin_name(PIN_JTAG_TDO), avr_pin_name(PIN_JTAG_TMS),
-				pins_to_str(&pgm->pin[PIN_JTAG_TCK]),
-				pins_to_str(&pgm->pin[PIN_JTAG_TDI]),
-				pins_to_str(&pgm->pin[PIN_JTAG_TDO]),
-				pins_to_str(&pgm->pin[PIN_JTAG_TMS]));
+				*ptck? ptck: "?", *ptdi? ptdi: "?",
+				*ptdo? ptdo: "?", *ptms? ptms: "?");
+			free(ptck); free(ptdi); free(ptdo); free(ptms);
 		} else {
-			imsg_error("%s: 0, %s: 1, %s: 2 (is: %s, %s, %s)\n",
-				avr_pin_name(PIN_AVR_SCK),
-				avr_pin_name(PIN_AVR_SDO),
+			char *psck = pins_to_strdup(&pgm->pin[PIN_AVR_SCK]),
+			     *psdo = pins_to_strdup(&pgm->pin[PIN_AVR_SDO]),
+			     *psdi = pins_to_strdup(&pgm->pin[PIN_AVR_SDI]);
+			imsg_error("%s: 0; %s: 1; %s: 2 (is: %s; %s; %s)\n",
+				avr_pin_name(PIN_AVR_SCK), avr_pin_name(PIN_AVR_SDO),
 				avr_pin_name(PIN_AVR_SDI),
-				pins_to_str(&pgm->pin[PIN_AVR_SCK]),
-				pins_to_str(&pgm->pin[PIN_AVR_SDO]),
-				pins_to_str(&pgm->pin[PIN_AVR_SDI]));
+				*psck? psck: "?", *psdo? psdo: "?",
+				*psdi? psdi: "?");
+			free(psck); free(psdo); free(psdi);
 		}
 		imsg_error("if other pin configuration is used, fallback to slower bitbanging mode is used\n");
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -222,10 +222,11 @@ static int set_pin(const PROGRAMMER *pgm, int pinfunc, int value) {
 		return 0;
 	}
 
-	pmsg_debug("setting pin %s (%s) as %s: %s (%s active)\n",
-	          pinmask_to_str(pin.mask), ftdi_pin_name(pdata, pin),
-						avr_pin_name(pinfunc),
-	          (value) ? "high" : "low", (pin.inverse[0]) ? "low" : "high");
+	char *pmsk = pinmask_to_strdup(pin.mask);
+	pmsg_debug("setting pin %s (%s) as %s: %s (%s active)\n", pmsk,
+		ftdi_pin_name(pdata, pin), avr_pin_name(pinfunc),
+		(value) ? "high" : "low", (pin.inverse[0]) ? "low" : "high");
+	mmt_free(pmsk);
 
 	pdata->pin_value = SET_BITS_0(pdata->pin_value, pgm, pinfunc, value);
 

--- a/src/avrftdi_tpi.c
+++ b/src/avrftdi_tpi.c
@@ -20,7 +20,7 @@ static int avrftdi_tpi_program_enable(const PROGRAMMER *pgm, const AVRPART *p);
 
 #ifdef notyet
 static void avrftdi_debug_frame(uint16_t frame) {
-	static char bit_name[] = "IDLES01234567PSS";
+	static const char bit_name[] = "IDLES01234567PSS";
 	//static char bit_name[] = "SSP76543210SELDI";
 	char line0[34], line1[34], line2[34];
 	int bit, pos;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -766,7 +766,7 @@ int avr_set_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cn
 
 
 static char *print_num(const char *fmt, int n) {
-  return str_sprintf(n<10? "%d": fmt, n);
+  return mmt_sprintf(n<10? "%d": fmt, n);
 }
 
 static int num_len(const char *fmt, int n) {
@@ -835,7 +835,7 @@ void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix) {
 
     // Create mem desc string including alias if present
     AVRMEM_ALIAS *a = avr_find_memalias(p, m);
-    char *m_desc_str = str_sprintf("%s%s%s", m->desc, a? "/": "", a? a->desc: "");
+    char *m_desc_str = mmt_sprintf("%s%s%s", m->desc, a? "/": "", a? a->desc: "");
 
     // Print memory table content
     if(p->prog_modes & (PM_PDI | PM_UPDI)) {

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -1086,7 +1086,7 @@ void sort_avrparts(LISTID avrparts)
 
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part              : %s\n", prefix, p->desc);
-  fprintf(f, "%sProgramming modes     : %s\n", prefix, avr_prog_modes_str(p->prog_modes));
+  fprintf(f, "%sProgramming modes     : %s\n", prefix, str_prog_modes(p->prog_modes));
 
   if(verbose > 1) {
     avr_mem_display(f, p, prefix);

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -1083,40 +1083,6 @@ void sort_avrparts(LISTID avrparts)
   lsort(avrparts,(int (*)(void*, void*)) sort_avrparts_compare);
 }
 
-const char *avr_prog_modes_str(int pm) {
-  static char type[1024];
-
-  strcpy(type, "0");
-  if(pm & PM_TPI)
-    strcat(type, ", TPI");
-  if(pm & PM_ISP)
-    strcat(type, ", ISP");
-  if(pm & PM_PDI)
-    strcat(type, ", PDI");
-  if(pm & PM_UPDI)
-    strcat(type, ", UPDI");
-  if(pm & PM_HVSP)
-    strcat(type, ", HVSP");
-  if(pm & PM_HVPP)
-    strcat(type, ", HVPP");
-  if(pm & PM_debugWIRE)
-    strcat(type, ", debugWIRE");
-  if(pm & PM_JTAG)
-    strcat(type, ", JTAG");
-  if(pm & PM_JTAGmkI)
-    strcat(type, ", JTAGmkI");
-  if(pm & PM_XMEGAJTAG)
-    strcat(type, ", XMEGAJTAG");
-  if(pm & PM_AVR32JTAG)
-    strcat(type, ", AVR32JTAG");
-  if(pm & PM_aWire)
-    strcat(type, ", aWire");
-  if(pm & PM_SPM)
-    strcat(type, ", SPM");
-
-  return type + (type[1] == 0? 0: 3);
-}
-
 
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose) {
   fprintf(f, "%sAVR Part              : %s\n", prefix, p->desc);

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -44,21 +44,12 @@
 #include "tpi.h"
 #include "bitbang.h"
 
-static int delay_decrement;
-
 #if defined(WIN32)
-static int has_perfcount;
-static LARGE_INTEGER freq;
+#define freq (*(LARGE_INTEGER *)&cx->bb_freq)
 #else
-static volatile int done;
-
-typedef void (*mysighandler_t)(int);
-static mysighandler_t saved_alarmhandler;
-
-static void alarmhandler(int signo)
-{
-  done = 1;
-  signal(SIGALRM, saved_alarmhandler);
+static void alarmhandler(int signo) {
+  *(volatile int *)&cx->bb_done = 1;
+  signal(SIGALRM, cx->bb_saved_alarmf);
 }
 #endif /* WIN32 */
 
@@ -75,7 +66,7 @@ static void bitbang_calibrate_delay(void)
    */
   if (QueryPerformanceFrequency(&freq))
   {
-    has_perfcount = 1;
+    cx->bb_has_perfcount = 1;
     pmsg_notice2("using performance counter for bitbang delays\n");
   }
   else
@@ -90,7 +81,7 @@ static void bitbang_calibrate_delay(void)
      * comparable hardware.
      */
     pmsg_notice2("using guessed per-microsecond delay count for bitbang delays\n");
-    delay_decrement = 100;
+    cx->bb_delay_decrement = 100;
   }
 #else  /* !WIN32 */
   struct itimerval itv;
@@ -98,8 +89,8 @@ static void bitbang_calibrate_delay(void)
 
   pmsg_notice2("calibrating delay loop ...");
   i = 0;
-  done = 0;
-  saved_alarmhandler = signal(SIGALRM, alarmhandler);
+  *(volatile int *)&cx->bb_done = 0;
+  cx->bb_saved_alarmf = signal(SIGALRM, alarmhandler);
   /*
    * Set ITIMER_REAL to 100 ms.  All known systems have a timer
    * granularity of 10 ms or better, so counting the delay cycles
@@ -114,16 +105,15 @@ static void bitbang_calibrate_delay(void)
   itv.it_value.tv_usec = 100000;
   itv.it_interval.tv_sec = itv.it_interval.tv_usec = 0;
   setitimer(ITIMER_REAL, &itv, 0);
-  while (!done)
+  while (!*(volatile int *)&cx->bb_done)
     i--;
   itv.it_value.tv_sec = itv.it_value.tv_usec = 0;
   setitimer(ITIMER_REAL, &itv, 0);
   /*
    * Calculate back from 100 ms to 1 us.
    */
-  delay_decrement = -i / 100000;
-  msg_notice2(" calibrated to %d cycles per us\n",
-                  delay_decrement);
+  cx->bb_delay_decrement = -i / 100000;
+  msg_notice2(" calibrated to %d cycles per us\n", cx->bb_delay_decrement);
 #endif /* WIN32 */
 }
 
@@ -137,7 +127,7 @@ void bitbang_delay(unsigned int us)
 #if defined(WIN32)
   LARGE_INTEGER countNow, countEnd;
 
-  if (has_perfcount)
+  if (cx->bb_has_perfcount)
   {
     QueryPerformanceCounter(&countNow);
     countEnd.QuadPart = countNow.QuadPart + freq.QuadPart * us / 1000000ll;
@@ -148,7 +138,7 @@ void bitbang_delay(unsigned int us)
   else /* no performance counters -- run normal uncalibrated delay */
   {
 #endif  /* WIN32 */
-  volatile unsigned int del = us * delay_decrement;
+  volatile unsigned int del = us * cx->bb_delay_decrement;
 
   while (del > 0)
     del--;

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -2,6 +2,7 @@
  * avrdude - A Downloader/Uploader for AVR device programmers
  * Copyright (C) 2000-2004  Brian S. Dean <bsd@bdmicro.com>
  * Copyright (C) 2006 Joerg Wunsch <j@uriah.heep.sax.de>
+ * Copyright (C) 2022- Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -51,7 +51,7 @@ static int assign_pin_list(int invert);
 static int which_opcode(TOKEN * opcode);
 static int parse_cmdbits(OPCODE * op, int opnum);
 
-static int pin_name;
+#define pin_name (cx->cfgy_pin_name)
 %}
 
 %token K_NULL;

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -549,7 +549,10 @@ pin_number_non_empty:
 pin_number:
   pin_number_non_empty
   |
-  /* empty */ { pin_clear_all(&(current_prog->pin[pin_name])); }
+  /* empty */ {
+    if(pin_name >= 0 && pin_name < N_PINS)
+      pin_clear_all(&(current_prog->pin[pin_name]));
+  }
 ;
 
 pin_list_element:
@@ -568,7 +571,10 @@ pin_list_non_empty:
 pin_list:
   pin_list_non_empty
   |
-  /* empty */ { pin_clear_all(&(current_prog->pin[pin_name])); }
+  /* empty */ {
+    if(pin_name >= 0 && pin_name < N_PINS)
+      pin_clear_all(&(current_prog->pin[pin_name]));
+  }
 ;
 
 prog_parm_pins:

--- a/src/confwin.c
+++ b/src/confwin.c
@@ -1,6 +1,6 @@
 /*
  * avrdude - A Downloader/Uploader for AVR device programmers
- * Copyright (C) 2003-2004  Eric B. Weddington <eric@ecentral.com>
+ * Copyright (C) 2024 Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,24 +27,10 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-static char *filename;
-
-void win_sys_config_set(char sys_config[PATH_MAX])
-{
-    sys_config[0] = 0;
-
-    /* Use Windows API call to search for the Windows default system config file.*/
-    SearchPath(NULL, SYSTEM_CONF_FILE, NULL, PATH_MAX, sys_config, &filename);
-    return;
-}
-
-void win_usr_config_set(char usr_config[PATH_MAX])
-{
-    usr_config[0] = 0;
-
-    /* Use Windows API call to search for the Windows default user config file. */
-	SearchPath(NULL, USER_CONF_FILE, NULL, PATH_MAX, usr_config, &filename);
-    return;
+// Store the full path of a file using a registry-dependent system search path
+int win_set_path(char *path, int n, const char *file) {
+  *path = 0;
+  return SearchPath(NULL, file, NULL, n, path, NULL);
 }
 
 #endif

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -492,11 +492,6 @@ static void dev_raw_dump(const void *v, int nbytes, const char *name, const char
   }
 }
 
-static int _is_all_zero(const void *p, size_t n) {
-  const char *q = (const char *) p;
-  return n <= 0 || (*q == 0 && memcmp(q, q+1, n-1) == 0);
-}
-
 static char *opsnm(const char *pre, int opnum) {
   static char ret[128];
   sprintf(ret, "%.31s.%.95s", pre, opcodename(opnum));
@@ -510,7 +505,7 @@ static void dev_part_raw(const AVRPART *part) {
   dev_raw_dump(&dp, (char *)&dp.base-(char *)&dp, part->desc, "part.intro", 0);
   dev_raw_dump(&dp.base, sizeof dp.base, part->desc, "part", 0);
   for(int i=0; i<AVR_OP_MAX; i++)
-    if(!_is_all_zero(dp.ops+i, sizeof*dp.ops))
+    if(!is_memset(dp.ops+i, 0, sizeof*dp.ops))
       dev_raw_dump(dp.ops+i, sizeof*dp.ops, part->desc, opsnm("part", i), 1);
 
   for(int i=0; i<di; i++) {
@@ -519,7 +514,7 @@ static void dev_part_raw(const AVRPART *part) {
     dev_raw_dump(nm, sizeof dp.mems[i].descbuf, part->desc, nm, i+2);
     dev_raw_dump(&dp.mems[i].base, sizeof dp.mems[i].base, part->desc, nm, i+2);
     for(int j=0; j<AVR_OP_MAX; j++)
-      if(!_is_all_zero(dp.mems[i].ops+j, sizeof(OPCODE)))
+      if(!is_memset(dp.mems[i].ops+j, 0, sizeof(OPCODE)))
         dev_raw_dump(dp.mems[i].ops+j, sizeof(OPCODE), part->desc, opsnm(nm, j), i+2);
   }
 }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1304,13 +1304,10 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
   _if_pgmout_str(strcmp, cfg_escape(pgm->usbproduct), usbproduct);
 
   for(int i=0; i<N_PINS; i++) {
-    char *str = pins_to_strdup(pgm->pin+i);
-    char *bstr = base? pins_to_strdup(base->pin+i): NULL;
+    const char *str = pins_to_str(pgm->pin+i);
+    const char *bstr = base? pins_to_str(base->pin+i): NULL;
     if(!base || !str_eq(bstr, str))
       _pgmout_fmt(avr_pin_lcname(i), "%s", str);
-
-    mmt_free(str);
-    mmt_free(bstr);
   }
 
   pgmstr = dev_hvupdi_support_liststr(pgm);

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -133,43 +133,6 @@ static void printallopcodes(const AVRPART *p, const char *d, OPCODE * const *opa
 }
 
 
-
-// Programming modes
-
-static char *prog_modes_str(int pm) {
-  static char type[1024];
-
-  strcpy(type, "0");
-  if(pm & PM_SPM)
-    strcat(type, " | PM_SPM");
-  if(pm & PM_TPI)
-    strcat(type, " | PM_TPI");
-  if(pm & PM_ISP)
-    strcat(type, " | PM_ISP");
-  if(pm & PM_PDI)
-    strcat(type, " | PM_PDI");
-  if(pm & PM_UPDI)
-    strcat(type, " | PM_UPDI");
-  if(pm & PM_HVSP)
-    strcat(type, " | PM_HVSP");
-  if(pm & PM_HVPP)
-    strcat(type, " | PM_HVPP");
-  if(pm & PM_debugWIRE)
-    strcat(type, " | PM_debugWIRE");
-  if(pm & PM_JTAG)
-    strcat(type, " | PM_JTAG");
-  if(pm & PM_JTAGmkI)
-    strcat(type, " | PM_JTAGmkI");
-  if(pm & PM_XMEGAJTAG)
-    strcat(type, " | PM_XMEGAJTAG");
-  if(pm & PM_AVR32JTAG)
-    strcat(type, " | PM_AVR32JTAG");
-  if(pm & PM_aWire)
-    strcat(type, " | PM_aWire");
-
-  return type + (type[1] == 0? 0: 4);
-}
-
 static char *extra_features_str(int m) {
   static char mode[1024];
 
@@ -620,7 +583,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
   }
 
   _if_partout_str(strcmp, cfg_escape(p->family_id), family_id);
-  _if_partout_str(intcmp, mmt_strdup(prog_modes_str(p->prog_modes)), prog_modes);
+  _if_partout_str(intcmp, mmt_strdup(dev_prog_modes(p->prog_modes)), prog_modes);
   if(p->mcuid == 21) {
     _if_partout_str(intcmp, mmt_strdup("XVII + IV"), mcuid);
   } else {
@@ -1124,7 +1087,7 @@ void dev_output_part_defs(char *partdesc) {
           nfuses,
           ok,
           p->flags,
-          prog_modes_str(p->prog_modes),
+          dev_prog_modes(p->prog_modes),
           p->config_file, p->lineno
         );
       }
@@ -1318,7 +1281,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
   _if_pgmout_str(strcmp, cfg_escape(pgm->desc), desc);
   if(!base || base->initpgm != pgm->initpgm)
     _pgmout_fmt("type", "\"%s\"", locate_programmer_type_id(pgm->initpgm));
-  _if_pgmout_str(intcmp, mmt_strdup(prog_modes_str(pgm->prog_modes)), prog_modes);
+  _if_pgmout_str(intcmp, mmt_strdup(dev_prog_modes(pgm->prog_modes)), prog_modes);
   _if_pgmout_str(boolcmp, mmt_strdup(pgm->is_serialadapter? "yes": "no"), is_serialadapter);
   _if_pgmout_str(intcmp, mmt_strdup(extra_features_str(pgm->extra_features)), extra_features);
   if(!base || base->conntype != pgm->conntype)

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -59,14 +59,14 @@
 //  - Output again with -p*/s or -c*/s (no /i) and use that for final avrdude.conf
 //  - Remove entries from below tables
 
-static struct {
+static const struct {
   const char *pgmid, *var, *value;
 } pgminj[] = {
   // Add triples here, eg, {"stk500v2", "prog_modes", "PM_TPI|PM_ISP"},
   {NULL, NULL, NULL},
 };
 
-static struct {
+static const struct {
   const char *mcu, *var, *value;
 } ptinj[] = {
   // Add triples here, eg, {"ATmega328P", "mcuid", "999"},

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -88,8 +88,6 @@ int dfu_upload(struct dfu_dev *dfu, void * ptr, int size) {
  * is sent to the device.
  */
 
-static uint16_t wIndex = 0;
-
 /* INTERNAL FUNCTION PROTOTYPES
  */
 
@@ -325,10 +323,10 @@ int dfu_dnload(struct dfu_dev *dfu, void *ptr, int size)
   int result;
 
   pmsg_trace("dfu_dnload(): issuing control OUT message, wIndex = %d, ptr = %p, size = %d\n",
-    wIndex, ptr, size);
+    cx->dfu_wIndex, ptr, size);
 
   result = usb_control_msg(dfu->dev_handle,
-    USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_DNLOAD, wIndex++, 0,
+    USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_DNLOAD, cx->dfu_wIndex++, 0,
     ptr, size, dfu->timeout);
 
   if (result < 0) {
@@ -354,10 +352,10 @@ int dfu_upload(struct dfu_dev *dfu, void *ptr, int size)
   int result;
 
   pmsg_trace("dfu_upload(): issuing control IN message, wIndex = %d, ptr = %p, size = %d\n",
-    wIndex, ptr, size);
+    cx->dfu_wIndex, ptr, size);
 
   result = usb_control_msg(dfu->dev_handle,
-    0x80 | USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_UPLOAD, wIndex++, 0,
+    0x80 | USB_TYPE_CLASS | USB_RECIP_INTERFACE, DFU_UPLOAD, cx->dfu_wIndex++, 0,
     ptr, size, dfu->timeout);
 
   if (result < 0) {

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -740,8 +740,7 @@ static int srec2b(const char *infile, FILE * inf,
  * the entire ELF file "as is" (including things like the program
  * header table itself).
  */
-static inline
-int is_section_in_segment(Elf32_Shdr *sh, Elf32_Phdr *ph)
+static inline int is_section_in_segment(Elf32_Shdr *sh, Elf32_Phdr *ph)
 {
     if (sh->sh_offset < ph->p_offset)
         return 0;

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -764,7 +764,7 @@ static int flip1_set_mem_page(struct dfu_dev *dfu, unsigned short page_addr) {
 }
 
 static const char *flip1_status_str(const struct dfu_status *status) {
-  static const char *msg[] = {
+  static const char * const msg[] = {
     "No error condition is present",
     "File is not targeted for use by this device",
     "File is for this device but fails some vendor-specific verification test",

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1483,6 +1483,7 @@ const char *str_ccprintf(const char *fmt, ...)
    __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
+const char *str_ccstrdup(const char *str);
 char *str_fgets(FILE *fp, const char **errpp);
 char *str_lc(char *s);
 char *str_uc(char *s);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1571,6 +1571,9 @@ typedef struct {
 
   // Static variable from dfu.c
   uint16_t dfu_wIndex;          // A running number for USB messages
+
+  // Static variable from config_gram.y
+ int cfgy_pin_name;             // Temporary variable for grammar parsing
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1470,7 +1470,11 @@ int str_casematch(const char *pattern, const char *string);
 int str_matched_by(const char *string, const char *pattern);
 int str_casematched_by(const char *string, const char *pattern);
 int str_is_pattern(const char *str);
-char *str_sprintf(const char *fmt, ...);
+char *str_sprintf(const char *fmt, ...)
+#if defined(__GNUC__)           // Ask gcc to check whether format and parameters match
+   __attribute__ ((format (printf, 1, 2)))
+#endif
+;
 char *str_fgets(FILE *fp, const char **errpp);
 char *str_lc(char *s);
 char *str_uc(char *s);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1548,6 +1548,16 @@ typedef struct {
   char avr_space[1024], *avr_s; // Closed-circuit space for avr+prog_modes()
   int avr_last_percent;         // Last valid percentage for report_progress()
   double avr_start_time;        // Start time in s of report_progress() activity
+
+  // Static variables from bitbang.c
+  int bb_delay_decrement;
+#if defined(WIN32)
+  int bb_has_perfcount;
+  uint64_t bb_freq;             // Should be LARGE_INTEGER but what to include?
+#else
+  int bb_done;                  // Handshake variable in alarm handler
+  void (*bb_saved_alarmf)(int); // Saved alarm handler
+#endif
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1484,7 +1484,7 @@ const char *str_outname(const char *fn);
 const char *str_interval(int a, int b);
 bool is_bigendian(void);
 void change_endian(void *p, int size);
-int memall(const void *p, char c, size_t n);
+int is_memset(const void *p, char c, size_t n);
 unsigned long long int str_ull(const char *str, char **endptr, int base);
 Str2data *str_todata(const char *str, int type, const AVRPART *part, const char *memstr);
 void str_freedata(Str2data *sd);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1515,6 +1515,8 @@ int terminal_line(const PROGRAMMER *pgm, const AVRPART *p, const char *line);
 char *terminal_get_input(const char *prompt);
 void terminal_setup_update_progress(void);
 
+char *avr_cc_buffer(size_t n);
+
 #ifdef __cplusplus
 }
 #endif
@@ -1530,11 +1532,13 @@ void terminal_setup_update_progress(void);
  */
 
 typedef struct {
+  // Closed-circuit space for returning strings in a persistent buffer
+  char *avr_s, avr_space[8192];
+
   // Static variables from avr.c
   int avr_disableffopt;         // Disables trailing 0xff flash optimisation
   uint64_t avr_epoch;           // Epoch for avr_ustimestamp()
   int avr_epoch_init;           // Whether above epoch is initialised
-  char avr_space[1024], *avr_s; // Closed-circuit space for avr+prog_modes()
   int avr_last_percent;         // Last valid percentage for report_progress()
   double avr_start_time;        // Start time in s of report_progress() activity
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1567,6 +1567,11 @@ typedef struct {
 
   // Static variable from ppi.c
   unsigned char ppi_shadow[3];
+
+  // Static variables from ser_avrdoper.c
+  unsigned char sad_avrdoperRxBuffer[280]; // Buffer for receiving data
+  int sad_avrdoperRxLength;     // Amount of valid bytes in rx buffer
+  int sad_avrdoperRxPosition;   // Amount of bytes already consumed in rx buffer
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -751,18 +751,18 @@ const char * avr_pin_lcname(int pinname);
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation
- * @returns a string that was created by mmt_strdup()
+ * @returns a temporary string that lives in closed-circuit space
  */
-char *pins_to_strdup(const struct pindef_t * const pindef);
+const char *pins_to_str(const struct pindef_t * const pindef);
 
 /**
  * This function returns a string representation of pins in the mask, eg, 1, 3, 5-7, 9, 12
  * Consecutive pin numbers are represented as start-end.
  *
  * @param[in] pinmask the pin mask for which we want the string representation
- * @returns a string that was created by mmt_strdup()
+ * @returns a temporary string that lives in closed-circuit space
  */
-char *pinmask_to_strdup(const pinmask_t * const pinmask);
+const char *pinmask_to_str(const pinmask_t * const pinmask);
 
 /* formerly serial.h */
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1616,6 +1616,12 @@ typedef struct {
   // Static variables from update.c
   const char **upd_wrote, **upd_termcmds;
   int upd_nfwritten, upd_nterms;
+
+  // Static variables from usb_libusb.c
+#include "usbdevs.h"
+  char usb_buf[USBDEV_MAX_XFER_3];
+  int usb_buflen, usb_bufptr; // @@@ Check whether usb_buflen needs initialising with -1
+  int usb_interface;
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -573,7 +573,8 @@ AVRPART * locate_part(const LISTID parts, const char *partdesc);
 AVRPART * locate_part_by_avr910_devcode(const LISTID parts, int devcode);
 AVRPART * locate_part_by_signature(const LISTID parts, unsigned char *sig, int sigsize);
 AVRPART * locate_part_by_signature_pm(const LISTID parts, unsigned char *sig, int sigsize, int prog_modes);
-const char *avr_prog_modes_str(int pm);
+char *avr_prog_modes(int pm);
+char *avr_prog_modes_str(int pm);
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose);
 int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix);
 
@@ -1154,8 +1155,6 @@ int avr_verify(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, const 
 int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles);
 
 int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles);
-
-char *avr_prog_modes(int pm);
 
 int avr_get_mem_type(const char *str);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1558,6 +1558,17 @@ typedef struct {
   int bb_done;                  // Handshake variable in alarm handler
   void (*bb_saved_alarmf)(int); // Saved alarm handler
 #endif
+
+  // Static variables from config.c
+  char **cfg_hstrings[1<<12];   // Hash lists for cache_string()
+  LISTID cfg_comms;             // A chain of comment lines
+  LISTID cfg_prologue;          // Comment lines at start of avrdude.conf
+  char *cfg_lkw;                // Last seen keyword
+  int cfg_lkw_lineno;           // Line number of that
+  LISTID cfg_strctcomms;        // Passed on to config_gram.y
+  LISTID cfg_pushedcomms;       // Temporarily pushed main comments
+  int cfg_pushed;               // ... for memory sections
+  int cfg_init_search;          // used in cfg_comp_search()
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1568,6 +1568,9 @@ typedef struct {
   LISTID cfg_pushedcomms;       // Temporarily pushed main comments
   int cfg_pushed;               // ... for memory sections
   int cfg_init_search;          // used in cfg_comp_search()
+
+  // Static variable from dfu.c
+  uint16_t dfu_wIndex;          // A running number for USB messages
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1598,6 +1598,20 @@ typedef struct {
   struct termios ser_original_termios;
   int ser_saved_original_termios;
 #endif
+
+  // Static variables from term.c
+  int term_spi_mode;
+  struct mem_addr_len {
+    const AVRMEM *mem;
+    int addr, len;
+  } term_rmem[32];
+  int term_mi;
+  const PROGRAMMER *term_pgm;
+  const AVRPART *term_p;
+  int term_running;
+  char *term_header;
+  int term_tty_last, term_tty_todo;
+  int term_notty_last, term_notty_todo;
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1171,7 +1171,6 @@ int avr_mem_is_known(const char *str);
 
 int avr_mem_might_be_known(const char *str);
 
-#define disable_trailing_ff_removal() avr_mem_hiaddr(NULL)
 int avr_mem_hiaddr(const AVRMEM * mem);
 
 int avr_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
@@ -1531,6 +1530,28 @@ void terminal_setup_update_progress(void);
 #ifdef __cplusplus
 }
 #endif
+
+/*
+ * Context structure
+ *
+ * Global and static variables should go here; the only remaining static
+ * variables ought to be read-only tables. Access should be via a global
+ * pointer cx_t *cx; applications using libavrdude ought to allocate cx =
+ * mmt_malloc(sizeof *cx) for each instantiation (and set initial values
+ * if needed) and deallocate with mmt_free(cx).
+ */
+
+typedef struct {
+  // Static variables from avr.c
+  int avr_disableffopt;         // Disables trailing 0xff flash optimisation
+  uint64_t avr_epoch;           // Epoch for avr_ustimestamp()
+  int avr_epoch_init;           // Whether above epoch is initialised
+  char avr_space[1024], *avr_s; // Closed-circuit space for avr+prog_modes()
+  int avr_last_percent;         // Last valid percentage for report_progress()
+  double avr_start_time;        // Start time in s of report_progress() activity
+} cx_t;
+
+extern cx_t *cx;
 
 /* formerly confwin.h */
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1564,6 +1564,9 @@ typedef struct {
 
   // Static variable from config_gram.y
  int cfgy_pin_name;             // Temporary variable for grammar parsing
+
+  // Static variable from ppi.c
+  unsigned char ppi_shadow[3];
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1539,9 +1539,9 @@ char *avr_cc_buffer(size_t n);
  *
  * Global and static variables should go here; the only remaining static
  * variables ought to be read-only tables. Access should be via a global
- * pointer cx_t *cx; applications using libavrdude ought to allocate cx =
- * mmt_malloc(sizeof *cx) for each instantiation (and set initial values
- * if needed) and deallocate with mmt_free(cx).
+ * pointer libavrdude_context *cx; applications using libavrdude ought to
+ * allocate cx = mmt_malloc(sizeof *cx) for each instantiation (and set
+ * initial values if needed) and deallocate with mmt_free(cx).
  */
 
 typedef struct {
@@ -1622,9 +1622,9 @@ typedef struct {
   char usb_buf[USBDEV_MAX_XFER_3];
   int usb_buflen, usb_bufptr; // @@@ Check whether usb_buflen needs initialising with -1
   int usb_interface;
-} cx_t;
+} libavrdude_context;
 
-extern cx_t *cx;
+extern libavrdude_context *cx;
 
 /* formerly confwin.h */
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -745,15 +745,6 @@ const char * avr_pin_name(int pinname);
 const char * avr_pin_lcname(int pinname);
 
 /**
- * This function returns a string of defined pins, eg, ~1,2,~4,~5,7 or " (not used)"
- * Another execution of this function will overwrite the previous result in the static buffer.
- *
- * @param[in] pindef the pin definition for which we want the string representation
- * @returns pointer to a static string.
- */
-const char * pins_to_str(const struct pindef_t * const pindef);
-
-/**
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1612,6 +1612,10 @@ typedef struct {
   char *term_header;
   int term_tty_last, term_tty_todo;
   int term_notty_last, term_notty_todo;
+
+  // Static variables from update.c
+  const char **upd_wrote, **upd_termcmds;
+  int upd_nfwritten, upd_nterms;
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -573,8 +573,7 @@ AVRPART * locate_part(const LISTID parts, const char *partdesc);
 AVRPART * locate_part_by_avr910_devcode(const LISTID parts, int devcode);
 AVRPART * locate_part_by_signature(const LISTID parts, unsigned char *sig, int sigsize);
 AVRPART * locate_part_by_signature_pm(const LISTID parts, unsigned char *sig, int sigsize, int prog_modes);
-char *avr_prog_modes(int pm);
-char *avr_prog_modes_str(int pm);
+char *avr_prog_modes(int pm), *str_prog_modes(int pm), *dev_prog_modes(int pm);
 void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose);
 int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1581,8 +1581,7 @@ extern cx_t *cx;
 extern "C" {
 #endif
 
-void win_sys_config_set(char sys_config[PATH_MAX]);
-void win_usr_config_set(char usr_config[PATH_MAX]);
+int win_set_path(char *path, int n, const char *file);
 
 #ifdef __cplusplus
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1478,6 +1478,11 @@ char *str_sprintf(const char *fmt, ...)
    __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
+const char *str_ccprintf(const char *fmt, ...)
+#if defined(__GNUC__)
+   __attribute__ ((format (printf, 1, 2)))
+#endif
+;
 char *str_fgets(FILE *fp, const char **errpp);
 char *str_lc(char *s);
 char *str_uc(char *s);
@@ -1498,7 +1503,7 @@ void str_freedata(Str2data *sd);
 unsigned long long int str_int(const char *str, int type, const char **errpp);
 int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
 char *str_nexttok(char *buf, const char *delim, char **next);
-char *str_frq(double f, int n);
+const char *str_ccfrq(double f, int n);
 int str_levenshtein(const char *str1, const char *str2, int swap, int subst, int add, int del);
 size_t str_weighted_damerau_levenshtein(const char *str1, const char *str2);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1488,7 +1488,7 @@ char *str_endnumber(const char *str);
 const char *str_plural(int x);
 const char *str_inname(const char *fn);
 const char *str_outname(const char *fn);
-const char *str_interval(int a, int b);
+const char *str_ccinterval(int a, int b);
 bool is_bigendian(void);
 void change_endian(void *p, int size);
 int is_memset(const void *p, char c, size_t n);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -26,6 +26,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#if !defined(WIN32)
+#include <termios.h>
+#endif
 
 #ifdef LIBAVRDUDE_INCLUDE_INTERNAL_HEADERS
 #error LIBAVRDUDE_INCLUDE_INTERNAL_HEADERS is defined. Do not do that.
@@ -1581,6 +1584,13 @@ typedef struct {
   unsigned char sad_avrdoperRxBuffer[280]; // Buffer for receiving data
   int sad_avrdoperRxLength;     // Amount of valid bytes in rx buffer
   int sad_avrdoperRxPosition;   // Amount of bytes already consumed in rx buffer
+
+  // Static variables from ser_win32.c/ser_posix.c
+#if defined(WIN32)
+#else
+  struct termios ser_original_termios;
+  int ser_saved_original_termios;
+#endif
 } cx_t;
 
 extern cx_t *cx;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1587,6 +1587,7 @@ typedef struct {
 
   // Static variables from ser_win32.c/ser_posix.c
 #if defined(WIN32)
+  unsigned char ser_serial_over_ethernet;
 #else
   struct termios ser_original_termios;
   int ser_saved_original_termios;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1533,7 +1533,8 @@ char *avr_cc_buffer(size_t n);
 
 typedef struct {
   // Closed-circuit space for returning strings in a persistent buffer
-  char *avr_s, avr_space[8192];
+#define AVR_SAFETY_MARGIN 128
+  char *avr_s, avr_space[8192+AVR_SAFETY_MARGIN];
 
   // Static variables from avr.c
   int avr_disableffopt;         // Disables trailing 0xff flash optimisation

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -748,19 +748,18 @@ const char * avr_pin_lcname(int pinname);
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation
- * @returns a pointer to a string, which was created by strdup
+ * @returns a string that was created by mmt_strdup()
  */
 char *pins_to_strdup(const struct pindef_t * const pindef);
 
 /**
- * This function returns a string representation of pins in the mask, eg, 1,3,5-7,9,12
- * Another execution of this function will overwrite the previous result in the static buffer.
- * Consecutive pin number are represented as start-end.
+ * This function returns a string representation of pins in the mask, eg, 1, 3, 5-7, 9, 12
+ * Consecutive pin numbers are represented as start-end.
  *
  * @param[in] pinmask the pin mask for which we want the string representation
- * @returns pointer to a static string.
+ * @returns a string that was created by mmt_strdup()
  */
-const char * pinmask_to_str(const pinmask_t * const pinmask);
+char *pinmask_to_strdup(const pinmask_t * const pinmask);
 
 /* formerly serial.h */
 

--- a/src/main.c
+++ b/src/main.c
@@ -218,8 +218,8 @@ static void usage(void)
   char *home = getenv("HOME");
   size_t l = home? strlen(home): 0;
   char *cfg = home && str_casestarts(usr_config, home)?
-     str_sprintf("~/%s", usr_config+l+(usr_config[l]=='/')):
-     str_sprintf("%s", usr_config);
+     mmt_sprintf("~/%s", usr_config+l+(usr_config[l]=='/')):
+     mmt_sprintf("%s", usr_config);
 
   msg_error(
     "Usage: %s [options]\n"

--- a/src/main.c
+++ b/src/main.c
@@ -188,6 +188,9 @@ struct list_walk_cookie
     const char *prefix;
 };
 
+
+cx_t *cx;                       // Context pointer, eventually the only global variable
+
 static LISTID updates = NULL;
 
 static LISTID extended_params = NULL;
@@ -642,6 +645,7 @@ int main(int argc, char * argv [])
   char  * logfile;     /* Use logfile rather than stderr for diagnostics */
   enum updateflags uflags = UF_AUTO_ERASE | UF_VERIFY; /* Flags for do_op() */
 
+  cx = mmt_malloc(sizeof *cx);  // Allocate and initialise context structure
   (void) avr_ustimestamp();     // Base timestamps from program start
 
 #ifdef _MSC_VER
@@ -823,7 +827,7 @@ int main(int argc, char * argv [])
         /* fall through */
 
       case 'A': /* explicit disabling of trailing-0xff removal */
-        disable_trailing_ff_removal();
+        cx->avr_disableffopt = 1;
         break;
 
       case 'e': /* perform a chip erase */

--- a/src/main.c
+++ b/src/main.c
@@ -750,7 +750,7 @@ int main(int argc, char * argv [])
 
    // Determine the location of personal configuration file
 #if defined(WIN32)
-  win_usr_config_set(usr_config);
+  win_set_path(usr_config, sizeof usr_config, USER_CONF_FILE);
 #else
   usr_config[0] = 0;
   if(!concatpath(usr_config, getenv("XDG_CONFIG_HOME"), XDG_USER_CONF_FILE, sizeof usr_config))
@@ -1024,7 +1024,7 @@ int main(int argc, char * argv [])
     if (!sys_config_found) {
       // 3. Check CONFIG_DIR/avrdude.conf
 #if defined(WIN32)
-      win_sys_config_set(sys_config);
+      win_set_path(sys_config, sizeof sys_config, SYSTEM_CONF_FILE);
 #else
       strcpy(sys_config, CONFIG_DIR);
       i = strlen(sys_config);

--- a/src/main.c
+++ b/src/main.c
@@ -189,7 +189,7 @@ struct list_walk_cookie
 };
 
 
-cx_t *cx;                       // Context pointer, eventually the only global variable
+libavrdude_context *cx;         // Context pointer, eventually the only global variable
 
 static LISTID updates = NULL;
 

--- a/src/main.c
+++ b/src/main.c
@@ -52,7 +52,7 @@
 #include "config.h"
 #include "developer_opts.h"
 
-char * progname;
+char * progname = "avrdude";
 char   progbuf[PATH_MAX]; /* temporary buffer of spaces the same
                              length as progname; used for lining up
                              multiline messages */

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -289,9 +289,8 @@ void programmer_display(PROGRAMMER *pgm, const char * p) {
 void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int show) {
   for(int pbit = 1; pbit < N_PINS; pbit++)
     if(show & (1<<pbit)) {
-      char *pinstr = pins_to_strdup(pgm->pin + pbit);
+      const char *pinstr = pins_to_str(pgm->pin + pbit);
       msg_info("%s  %-6s = %s\n", p, avr_pin_name(pbit), *pinstr? pinstr: "(not used)");
-      mmt_free(pinstr);
     }
 }
 

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -291,7 +291,7 @@ void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int
     if(show & (1<<pbit)) {
       char *pinstr = pins_to_strdup(pgm->pin + pbit);
       msg_info("%s  %-6s = %s\n", p, avr_pin_name(pbit), *pinstr? pinstr: "(not used)");
-      free(pinstr);
+      mmt_free(pinstr);
     }
 }
 

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -287,34 +287,12 @@ void programmer_display(PROGRAMMER *pgm, const char * p) {
 
 
 void pgm_display_generic_mask(const PROGRAMMER *pgm, const char *p, unsigned int show) {
-  if(show & (1<<PPI_AVR_VCC)) 
-    msg_info("%s  VCC     = %s\n", p, pins_to_str(&pgm->pin[PPI_AVR_VCC]));
-  if(show & (1<<PPI_AVR_BUFF))
-    msg_info("%s  BUFF    = %s\n", p, pins_to_str(&pgm->pin[PPI_AVR_BUFF]));
-  if(show & (1<<PIN_AVR_RESET))
-    msg_info("%s  RESET   = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_RESET]));
-  if(show & (1<<PIN_AVR_SCK))
-    msg_info("%s  SCK     = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_SCK]));
-  if(show & (1<<PIN_AVR_SDO))
-    msg_info("%s  SDO     = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_SDO]));
-  if(show & (1<<PIN_AVR_SDI))
-    msg_info("%s  SDI     = %s\n", p, pins_to_str(&pgm->pin[PIN_AVR_SDI]));
-  if(show & (1<<PIN_JTAG_TCK))
-    msg_info("%s  TCK     = %s\n", p, pins_to_str(&pgm->pin[PIN_JTAG_TCK]));
-  if(show & (1<<PIN_JTAG_TDI))
-    msg_info("%s  TDI     = %s\n", p, pins_to_str(&pgm->pin[PIN_JTAG_TDI]));
-  if(show & (1<<PIN_JTAG_TDO))
-    msg_info("%s  TDO     = %s\n", p, pins_to_str(&pgm->pin[PIN_JTAG_TDO]));
-  if(show & (1<<PIN_JTAG_TMS))
-    msg_info("%s  TMS     = %s\n", p, pins_to_str(&pgm->pin[PIN_JTAG_TMS]));
-  if(show & (1<<PIN_LED_ERR))
-    msg_info("%s  ERR LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_ERR]));
-  if(show & (1<<PIN_LED_RDY))
-    msg_info("%s  RDY LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_RDY]));
-  if(show & (1<<PIN_LED_PGM))
-    msg_info("%s  PGM LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_PGM]));
-  if(show & (1<<PIN_LED_VFY))
-    msg_info("%s  VFY LED = %s\n", p, pins_to_str(&pgm->pin[PIN_LED_VFY]));
+  for(int pbit = 1; pbit < N_PINS; pbit++)
+    if(show & (1<<pbit)) {
+      char *pinstr = pins_to_strdup(pgm->pin + pbit);
+      msg_info("%s  %-6s = %s\n", p, avr_pin_name(pbit), *pinstr? pinstr: "(not used)");
+      free(pinstr);
+    }
 }
 
 void pgm_display_generic(const PROGRAMMER *pgm, const char *p) {

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -156,9 +156,9 @@ int pgm_fill_old_pins(PROGRAMMER * const pgm) {
  * Consecutive pin numbers are represented as start-end.
  *
  * @param[in] pinmask the pin mask for which we want the string representation
- * @returns a string that was created by mmt_strdup()
+ * @returns a temporary string that lives in closed-circuit space
  */
-char *pinmask_to_strdup(const pinmask_t * const pinmask) {
+const char *pinmask_to_str(const pinmask_t * const pinmask) {
   char buf[6 * (PIN_MAX + 1)];
   char *p = buf;
   int n;
@@ -196,7 +196,7 @@ char *pinmask_to_strdup(const pinmask_t * const pinmask) {
     p += n;
   }
 
-  return mmt_strdup(*buf? buf: "(no pins)");
+  return str_ccstrdup(*buf? buf: "(no pins)");
 }
 
 
@@ -269,36 +269,26 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     }
     if(invalid) {
       if(output) {
-        char *mskinvalid = pinmask_to_strdup(invalid_used);
         pmsg_error("%s: these pins are not valid pins for this function: %s\n",
-          avr_pin_name(pinname), mskinvalid);
-        mmt_free(mskinvalid);
-        char *mskvalid = pinmask_to_strdup(valid_pins->mask);
+          avr_pin_name(pinname), pinmask_to_str(invalid_used));
         pmsg_notice("%s: valid pins for this function are: %s\n",
-          avr_pin_name(pinname), mskvalid);
-        mmt_free(mskvalid);
+          avr_pin_name(pinname), pinmask_to_str(valid_pins->mask));
       }
       is_ok = false;
     }
     if(inverse) {
       if(output) {
-        char *mskinvalidinv = pinmask_to_strdup(inverse_used);
         pmsg_error("%s: these pins are not usable as inverse pins for this function: %s\n",
-          avr_pin_name(pinname), mskinvalidinv);
-        mmt_free(mskinvalidinv);
-        char *mskvalidinv = pinmask_to_strdup(valid_pins->inverse);
+          avr_pin_name(pinname), pinmask_to_str(inverse_used));
         pmsg_notice("%s: valid inverse pins for this function are: %s\n",
-          avr_pin_name(pinname), mskvalidinv);
-        mmt_free(mskvalidinv);
+          avr_pin_name(pinname), pinmask_to_str(valid_pins->inverse));
       }
       is_ok = false;
     }
     if(used) {
       if(output) {
-        char *pmsk = pinmask_to_strdup(already_used);
         pmsg_error("%s: these pins are set for other functions too: %s\n",
-          avr_pin_name(pinname), pmsk);
-        mmt_free(pmsk);
+          avr_pin_name(pinname), pinmask_to_str(already_used));
         is_ok = false;
       }
     }
@@ -322,9 +312,9 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""
  *
  * @param[in] pindef the pin definition for which we want the string representation
- * @returns a string that was created by mmt_strdup()
+ * @returns a temporary string that lives in closed-circuit space
  */
-char *pins_to_strdup(const struct pindef_t * const pindef) {
+const char *pins_to_str(const struct pindef_t * const pindef) {
   char buf[6*(PIN_MAX+1)], *p = buf;
 
   *buf = 0;
@@ -337,7 +327,7 @@ char *pins_to_strdup(const struct pindef_t * const pindef) {
     }
   }
 
-  return mmt_strdup(buf);
+  return str_ccstrdup(buf);
 }
 
 /**

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -315,40 +315,6 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
   return rv;
 }
 
-/**
- * This function returns a string of defined pins, eg, ~1,2,~4,~5,7 or " (not used)"
- * Another execution of this function will overwrite the previous result in the static buffer.
- *
- * @param[in] pindef the pin definition for which we want the string representation
- * @returns pointer to a static string.
- */
-const char * pins_to_str(const struct pindef_t * const pindef) {
-  static char buf[(PIN_MAX + 1) * 5]; // should be enough for PIN_MAX=255
-  char *p = buf;
-  int n;
-  int pin;
-  const char * fmt;
-
-  buf[0] = 0;
-  for(pin = PIN_MIN; pin <= PIN_MAX; pin++) {
-    int index = pin / PIN_FIELD_ELEMENT_SIZE;
-    int bit = pin % PIN_FIELD_ELEMENT_SIZE;
-    if(pindef->mask[index] & (1 << bit)) {
-      if(pindef->inverse[index] & (1 << bit)) {
-        fmt = (buf[0] == 0) ? "~%d" : ",~%d";
-      } else {
-        fmt = (buf[0] == 0) ? " %d" : ",%d";
-      }
-      n = sprintf(p, fmt, pin);
-      p += n;
-    }
-  }
-
-  if(buf[0] == 0)
-    return " (not used)";
-
-  return buf;
-}
 
 /**
  * This function returns a string of defined pins, eg, ~1, 2, ~4, ~5, 7 or ""

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -54,7 +54,6 @@ enum {
 static int ppi_shadow_access(const union filedescriptor *fdp, int reg,
 			     unsigned char *v, unsigned char action)
 {
-  static unsigned char shadow[3];
   int shadow_num;
 
   switch (reg) {
@@ -75,14 +74,14 @@ static int ppi_shadow_access(const union filedescriptor *fdp, int reg,
 
   switch (action) {
     case PPI_SHADOWREAD:
-      *v = shadow[shadow_num];
+      *v = cx->ppi_shadow[shadow_num];
       break;
     case PPI_READ:
       DO_PPI_READ(fdp->ifd, reg, v);
-      shadow[shadow_num]=*v;
+      cx->ppi_shadow[shadow_num]=*v;
       break;
     case PPI_WRITE:
-      shadow[shadow_num]=*v;
+      cx->ppi_shadow[shadow_num]=*v;
       DO_PPI_WRITE(fdp->ifd, reg, v);
       break;
   }

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -187,14 +187,14 @@ static void dumpBlock(const char *prefix, const unsigned char *buf, int len)
 
 static const char *usbErrorText(int usbErrno) {
     switch(usbErrno){
-        case USB_ERROR_NONE:    return "Success";
-        case USB_ERROR_ACCESS:  return "Access denied";
-        case USB_ERROR_NOTFOUND:return "Device not found";
-        case USB_ERROR_BUSY:    return "Device is busy";
+        case USB_ERROR_NONE:    return "success";
+        case USB_ERROR_ACCESS:  return "access denied";
+        case USB_ERROR_NOTFOUND:return "device not found";
+        case USB_ERROR_BUSY:    return "device is busy";
         case USB_ERROR_IO:      return "I/O Error";
         default: {
             char *buffer = avr_cc_buffer(32);
-            sprintf(buffer, "Unknown error %d", usbErrno);
+            sprintf(buffer, "unknown error %d", usbErrno);
             return buffer;
         }
     }
@@ -210,7 +210,7 @@ static int avrdoper_open(const char *port, union pinfo pinfo, union filedescript
 
     rval = usbOpenDevice(fdp, USB_VENDOR_ID, vname, USB_PRODUCT_ID, devname, 1);
     if(rval != 0){
-        pmsg_ext_error("%s\n", usbErrorText(rval));
+        pmsg_ext_error("USB %s\n", usbErrorText(rval));
         return -1;
     }
     return 0;
@@ -256,7 +256,7 @@ static int avrdoper_send(const union filedescriptor *fdp, const unsigned char *b
         rval = usbSetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, (char *)buffer,
 			    reportDataSizes[lenIndex] + 2);
         if(rval != 0){
-            pmsg_error("%s\n", usbErrorText(rval));
+            pmsg_error("USB %s\n", usbErrorText(rval));
             return -1;
         }
         buflen -= thisLen;
@@ -281,7 +281,7 @@ static int avrdoperFillBuffer(const union filedescriptor *fdp) {
         usbErr = usbGetReport(fdp, USB_HID_REPORT_TYPE_FEATURE, lenIndex + 1,
 			      (char *)buffer, &len);
         if(usbErr != 0){
-            pmsg_error("%s\n", usbErrorText(usbErr));
+            pmsg_error("USB %s\n", usbErrorText(usbErr));
             return -1;
         }
         msg_trace("Received %d bytes data chunk of total %d\n", len - 2, buffer[1]);

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -185,19 +185,18 @@ static void dumpBlock(const char *prefix, const unsigned char *buf, int len)
     }
 }
 
-static char *usbErrorText(int usbErrno)
-{
-    static char buffer[32];
-
+static const char *usbErrorText(int usbErrno) {
     switch(usbErrno){
         case USB_ERROR_NONE:    return "Success";
         case USB_ERROR_ACCESS:  return "Access denied";
         case USB_ERROR_NOTFOUND:return "Device not found";
         case USB_ERROR_BUSY:    return "Device is busy";
         case USB_ERROR_IO:      return "I/O Error";
-        default:
+        default: {
+            char *buffer = avr_cc_buffer(32);
             sprintf(buffer, "Unknown error %d", usbErrno);
             return buffer;
+        }
     }
 }
 

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -59,9 +59,7 @@ struct baud_mapping {
   speed_t speed;
 };
 
-/* There are a lot more baud rates we could handle, but what's the point? */
-
-static struct baud_mapping baud_lookup_table [] = {
+static const struct baud_mapping baud_lookup_table [] = {
   { 300,    B300 },
   { 600,    B600 },
   { 1200,   B1200 },
@@ -125,24 +123,16 @@ static struct termios original_termios;
 static int saved_original_termios;
 
 static speed_t serial_baud_lookup(long baud, bool *nonstandard) {
-  struct baud_mapping *map = baud_lookup_table;
-
   *nonstandard = false;
 
-  while (map->baud) {
+  for(const struct baud_mapping *map = baud_lookup_table; map->baud; map++)
     if (map->baud == baud)
       return map->speed;
-    map++;
-  }
 
-  /*
-   * If a non-standard BAUD rate is used, issue
-   * a warning (if we are verbose) and return the raw rate
-   */
+  // Return the raw rate when asked for non-standard baud rate
   pmsg_notice2("serial_baud_lookup(): using non-standard baud rate: %ld\n", baud);
 
   *nonstandard = true;
-
   return baud;
 }
 

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -50,7 +50,7 @@ static unsigned char serial_over_ethernet = 0;
 
 /* HANDLE hComPort=INVALID_HANDLE_VALUE; */
 
-static struct baud_mapping baud_lookup_table [] = {
+static const struct baud_mapping baud_lookup_table [] = {
   { 300,    CBR_300 },
   { 600,    CBR_600 },
   { 1200,   CBR_1200 },
@@ -64,20 +64,12 @@ static struct baud_mapping baud_lookup_table [] = {
   { 0,      0 }                 /* Terminator. */
 };
 
-static DWORD serial_baud_lookup(long baud)
-{
-  struct baud_mapping *map = baud_lookup_table;
-
-  while (map->baud) {
+static DWORD serial_baud_lookup(long baud) {
+  for(const struct baud_mapping *map = baud_lookup_table; map->baud; map++)
     if (map->baud == baud)
       return map->speed;
-    map++;
-  }
 
-  /*
-   * If a non-standard BAUD rate is used, issue
-   * a warning (if we are verbose) and return the raw rate
-   */
+  // Return the raw rate when asked for non-standard baud rate
   pmsg_notice2("serial_baud_lookup(): using non-standard baud rate: %ld", baud);
 
   return baud;

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -46,8 +46,6 @@ struct baud_mapping {
   DWORD speed;
 };
 
-static unsigned char serial_over_ethernet = 0;
-
 /* HANDLE hComPort=INVALID_HANDLE_VALUE; */
 
 static const struct baud_mapping baud_lookup_table [] = {
@@ -88,57 +86,55 @@ static BOOL serial_w32SetTimeOut(HANDLE hComPort, DWORD timeout) // in ms
 }
 
 static int ser_setparams(const union filedescriptor *fd, long baud, unsigned long cflags) {
-	if (serial_over_ethernet) {
+	if(cx->ser_serial_over_ethernet)
 		return -ENOTTY;
-	} else {
-		DCB dcb;
-		HANDLE hComPort = (HANDLE)fd->pfd;
 
-		ZeroMemory (&dcb, sizeof(DCB));
-		dcb.DCBlength = sizeof(DCB);
-		dcb.BaudRate = serial_baud_lookup (baud);
-		dcb.fBinary = 1;
-		dcb.fDtrControl = DTR_CONTROL_DISABLE;
-		dcb.fRtsControl = RTS_CONTROL_DISABLE;
-		switch ((cflags & (SERIAL_CS5 | SERIAL_CS6 | SERIAL_CS7 | SERIAL_CS8))) {
-			case SERIAL_CS5:
-				dcb.ByteSize = 5;
-				break;
-			case SERIAL_CS6:
-				dcb.ByteSize = 6;
-				break;
-			case SERIAL_CS7:
-				dcb.ByteSize = 7;
-				break;
-			case SERIAL_CS8:
-				dcb.ByteSize = 8;
-				break;
-		}
-		switch ((cflags & (SERIAL_NO_PARITY | SERIAL_PARENB | SERIAL_PARODD))) {
-			case SERIAL_NO_PARITY:
-				dcb.Parity = NOPARITY;
-				break;
-			case SERIAL_PARENB:
-				dcb.Parity = EVENPARITY;
-				break;
-			case SERIAL_PARODD:
-				dcb.Parity = ODDPARITY;
-				break;
-		}
-		switch ((cflags & (SERIAL_NO_CSTOPB | SERIAL_CSTOPB))) {
-			case SERIAL_NO_CSTOPB:
-				dcb.StopBits = ONESTOPBIT;
-				break;
-			case SERIAL_CSTOPB:
-				dcb.StopBits = TWOSTOPBITS;
-				break;
-		}
+	DCB dcb;
+	HANDLE hComPort = (HANDLE)fd->pfd;
 
-		if (!SetCommState(hComPort, &dcb))
-			return -1;
-
-		return 0;
+	ZeroMemory (&dcb, sizeof(DCB));
+	dcb.DCBlength = sizeof(DCB);
+	dcb.BaudRate = serial_baud_lookup (baud);
+	dcb.fBinary = 1;
+	dcb.fDtrControl = DTR_CONTROL_DISABLE;
+	dcb.fRtsControl = RTS_CONTROL_DISABLE;
+	switch ((cflags & (SERIAL_CS5 | SERIAL_CS6 | SERIAL_CS7 | SERIAL_CS8))) {
+	case SERIAL_CS5:
+		dcb.ByteSize = 5;
+		break;
+	case SERIAL_CS6:
+		dcb.ByteSize = 6;
+		break;
+	case SERIAL_CS7:
+		dcb.ByteSize = 7;
+		break;
+	case SERIAL_CS8:
+		dcb.ByteSize = 8;
+		break;
 	}
+	switch ((cflags & (SERIAL_NO_PARITY | SERIAL_PARENB | SERIAL_PARODD))) {
+	case SERIAL_NO_PARITY:
+		dcb.Parity = NOPARITY;
+		break;
+	case SERIAL_PARENB:
+		dcb.Parity = EVENPARITY;
+		break;
+	case SERIAL_PARODD:
+		dcb.Parity = ODDPARITY;
+		break;
+	}
+	switch ((cflags & (SERIAL_NO_CSTOPB | SERIAL_CSTOPB))) {
+	case SERIAL_NO_CSTOPB:
+		dcb.StopBits = ONESTOPBIT;
+		break;
+	case SERIAL_CSTOPB:
+		dcb.StopBits = TWOSTOPBITS;
+		break;
+	}
+	if (!SetCommState(hComPort, &dcb))
+		return -1;
+
+	return 0;
 }
 
 static int net_open(const char *port, union filedescriptor *fdp) {
@@ -223,7 +219,7 @@ static int net_open(const char *port, union filedescriptor *fdp) {
 
 	fdp->ifd = fd;
 
-	serial_over_ethernet = 1;
+	cx->ser_serial_over_ethernet = 1;
 	return 0;
 }
 
@@ -300,7 +296,7 @@ static int ser_open(const char *port, union pinfo pinfo, union filedescriptor *f
 
 
 static void ser_close(union filedescriptor *fd) {
-	if (serial_over_ethernet) {
+	if (cx->ser_serial_over_ethernet) {
 		closesocket(fd->ifd);
 		WSACleanup();
 	} else {
@@ -313,20 +309,15 @@ static void ser_close(union filedescriptor *fd) {
 }
 
 static int ser_set_dtr_rts(const union filedescriptor *fd, int is_on) {
-	if (serial_over_ethernet) {
+	if(cx->ser_serial_over_ethernet)
 		return 0;
-	} else {
-		HANDLE hComPort=(HANDLE)fd->pfd;
 
-		if (is_on) {
-			EscapeCommFunction(hComPort, SETDTR);
-			EscapeCommFunction(hComPort, SETRTS);
-		} else {
-			EscapeCommFunction(hComPort, CLRDTR);
-			EscapeCommFunction(hComPort, CLRRTS);
-		}
-		return 0;
-	}
+	HANDLE hComPort=(HANDLE)fd->pfd;
+
+	EscapeCommFunction(hComPort, is_on? SETDTR: CLRDTR);
+	EscapeCommFunction(hComPort, is_on? SETRTS: CLRRTS);
+
+	return 0;
 }
 
 static int net_send(const union filedescriptor *fd, const unsigned char *buf, size_t len) {
@@ -370,7 +361,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char *buf, si
 
 
 static int ser_send(const union filedescriptor *fd, const unsigned char *buf, size_t len) {
-	if (serial_over_ethernet)
+	if(cx->ser_serial_over_ethernet)
 		return net_send(fd, buf, len);
 
 	DWORD written;
@@ -481,7 +472,7 @@ reselect:
 }
 
 static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t buflen) {
-	if (serial_over_ethernet)
+	if(cx->ser_serial_over_ethernet)
 		return net_recv(fd, buf, buflen);
 
 	DWORD read;
@@ -603,9 +594,8 @@ static int net_drain(const union filedescriptor *fd, int display) {
 }
 
 static int ser_drain(const union filedescriptor *fd, int display) {
-	if (serial_over_ethernet) {
+	if(cx->ser_serial_over_ethernet)
 		return net_drain(fd, display);
-	}
 
 	// int rc;
 	unsigned char buf[10];

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -72,7 +72,7 @@ static const int serregbits[DB9PINS + 1] =
 { 0, TIOCM_CD, 0, 0, TIOCM_DTR, 0, TIOCM_DSR, TIOCM_RTS, TIOCM_CTS, TIOCM_RI };
 
 #ifdef DEBUG
-static const char *serpins[DB9PINS + 1] =
+static const char * const serpins[DB9PINS + 1] =
   { "NONE", "CD", "RXD", "TXD", "DTR", "GND", "DSR", "RTS", "CTS", "RI" };
 #endif
 

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -44,7 +44,13 @@
 
 #undef DEBUG
 
-static struct termios oldmode;
+struct pdata {
+  struct termios oldmode;
+};
+
+// Use private programmer data as if they were a global structure my
+#define my (*(struct pdata *)(pgm->cookie))
+
 
 /*
   serial port/pin mapping
@@ -243,7 +249,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
     pmsg_ext_error("%s, tcgetattr(): %s\n", port, strerror(errno));
     return(-1);
   }
-  oldmode = mode;
+  my.oldmode = mode;
 
   mode.c_iflag = IGNBRK | IGNPAR;
   mode.c_oflag = 0;
@@ -277,11 +283,20 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 static void serbb_close(PROGRAMMER *pgm) {
   if (pgm->fd.ifd != -1)
   {
-	  (void)tcsetattr(pgm->fd.ifd, TCSANOW, &oldmode);
+	  (void) tcsetattr(pgm->fd.ifd, TCSANOW, &my.oldmode);
 	  pgm->setpin(pgm, PIN_AVR_RESET, 1);
 	  close(pgm->fd.ifd);
   }
   return;
+}
+
+static void serbb_setup(PROGRAMMER *pgm) {
+  pgm->cookie = mmt_malloc(sizeof(struct pdata));
+}
+
+static void serbb_teardown(PROGRAMMER *pgm) {
+  mmt_free(pgm->cookie);
+  pgm->cookie = NULL;
 }
 
 const char serbb_desc[] = "Serial port bitbanging";
@@ -291,6 +306,8 @@ void serbb_initpgm(PROGRAMMER *pgm) {
 
   pgm_fill_old_pins(pgm); // TODO to be removed if old pin data no longer needed
 
+  pgm->setup          = serbb_setup;
+  pgm->teardown       = serbb_teardown;
   pgm->rdy_led        = bitbang_rdy_led;
   pgm->err_led        = bitbang_err_led;
   pgm->pgm_led        = bitbang_pgm_led;

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -62,11 +62,11 @@ static struct termios oldmode;
 
 #define DB9PINS 9
 
-static int serregbits[DB9PINS + 1] =
+static const int serregbits[DB9PINS + 1] =
 { 0, TIOCM_CD, 0, 0, TIOCM_DTR, 0, TIOCM_DSR, TIOCM_RTS, TIOCM_CTS, TIOCM_RI };
 
 #ifdef DEBUG
-static char *serpins[DB9PINS + 1] =
+static const char *serpins[DB9PINS + 1] =
   { "NONE", "CD", "RXD", "TXD", "DTR", "GND", "DSR", "RTS", "CTS", "RI" };
 #endif
 

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -40,8 +40,12 @@
 #include "bitbang.h"
 #include "serbb.h"
 
-/* cached status lines */
-static int dtr, rts, txd;
+struct pdata {
+  int dtr, rts, txd;            // Cached status lines
+};
+
+// Use private programmer data as if they were a global structure my
+#define my (*(struct pdata *)(pgm->cookie))
 
 #define W32SERBUFSIZE 1024
 
@@ -85,13 +89,13 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
         case 3:  /* txd */
                 dwFunc = value? SETBREAK: CLRBREAK;
                 name = value? "SETBREAK": "CLRBREAK";
-                txd = value;
+                my.txd = value;
                 break;
 
         case 4:  /* dtr */
                 dwFunc = value? SETDTR: CLRDTR;
                 name = value? "SETDTR": "CLRDTR";
-                dtr = value;
+                my.dtr = value;
                 break;
 
         case 7:  /* rts */
@@ -191,15 +195,15 @@ static int serbb_getpin(const PROGRAMMER *pgm, int pinfunc) {
         switch (pin)
         {
         case 3: /* txd */
-                rv = txd;
+                rv = my.txd;
                 name = "TXD";
                 break;
         case 4: /* dtr */
-                rv = dtr;
+                rv = my.dtr;
                 name = "DTR";
                 break;
         case 7: /* rts */
-                rv = rts;
+                rv = my.rts;
                 name = "RTS";
                 break;
         default:
@@ -303,7 +307,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
 
         pgm->fd.pfd = (void *)hComPort;
 
-        dtr = rts = txd = 0;
+        my.dtr = my.rts = my.txd = 0;
 
         return 0;
 }
@@ -320,6 +324,15 @@ static void serbb_close(PROGRAMMER *pgm) {
 	hComPort = INVALID_HANDLE_VALUE;
 }
 
+static void serbb_setup(PROGRAMMER *pgm) {
+  pgm->cookie = mmt_malloc(sizeof(struct pdata));
+}
+
+static void serbb_teardown(PROGRAMMER *pgm) {
+  mmt_free(pgm->cookie);
+  pgm->cookie = NULL;
+}
+
 const char serbb_desc[] = "Serial port bitbanging";
 
 void serbb_initpgm(PROGRAMMER *pgm) {
@@ -327,6 +340,8 @@ void serbb_initpgm(PROGRAMMER *pgm) {
 
   pgm_fill_old_pins(pgm); // TODO to be removed if old pin data no longer needed
 
+  pgm->setup          = serbb_setup;
+  pgm->teardown       = serbb_teardown;
   pgm->rdy_led        = bitbang_rdy_led;
   pgm->err_led        = bitbang_err_led;
   pgm->pgm_led        = bitbang_pgm_led;

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -101,6 +101,7 @@ static int serbb_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
         case 7:  /* rts */
                 dwFunc = value? SETRTS: CLRRTS;
                 name = value? "SETRTS": "CLRRTS";
+                my.rts = value;
                 break;
 
         default:

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -217,7 +217,7 @@ static char **sa_list_specs(const SERPORT *sp, int n, int i) {
       if(sa_unique_by_sea(sea, "", sp, n, i))
         Plist[Pi++] = mmt_strdup(id);
       else if(*sn && sa_unique_by_sea(sea, sn, sp, n, i))
-        Plist[Pi++] = str_sprintf("%s:%s", id, sn);
+        Plist[Pi++] = mmt_sprintf("%s:%s", id, sn);
       else if(!via && sa_num_matches_by_sea(sea, "", sp+i, 1))
         via = id;
 
@@ -232,11 +232,11 @@ static char **sa_list_specs(const SERPORT *sp, int n, int i) {
 
   if(Pi == 0 && sp[i].vid) {    // No unique serial adapter, so maybe vid:pid[:sn] works?
     if(sa_unique_by_ids(sp[i].vid, sp[i].pid, "", sp, n, i))
-      Plist[Pi++] = str_sprintf("usb:%04x:%04x", sp[i].vid, sp[i].pid);
+      Plist[Pi++] = mmt_sprintf("usb:%04x:%04x", sp[i].vid, sp[i].pid);
     else if(*sn && sa_unique_by_ids(sp[i].vid, sp[i].pid, sn, sp, n, i))
-      Plist[Pi++] = str_sprintf("usb:%04x:%04x:%s", sp[i].vid, sp[i].pid, sn);
+      Plist[Pi++] = mmt_sprintf("usb:%04x:%04x:%s", sp[i].vid, sp[i].pid, sn);
     else if(via && Pi == 0)
-      Plist[Pi++] = str_sprintf("(via %s serial adapter)", via);
+      Plist[Pi++] = mmt_sprintf("(via %s serial adapter)", via);
   }
 
   Plist[Pi] = NULL;

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1167,7 +1167,7 @@ static size_t csubs(size_t w, unsigned char c1, unsigned char c2) {
   if(w < 8)
     w = 8;
 
-  static size_t wmat[128][128];
+  static size_t wmat[128][128]; // Compute once, read-only cache
   if(!wmat[0][1])               // Initialize weight matrix
     for(size_t k1 = 0; k1 < 128; k1++)
       for(size_t k2 = 0; k2 < 128; k2++)

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -283,6 +283,19 @@ const char *str_ccprintf(const char *fmt, ...) {
   return p;
 }
 
+// Returns a temporary, possibly abbreviated copy of str in closed-circuit space
+const char *str_ccstrdup(const char *str) {
+  size_t size = strlen(str) + 1, avail = sizeof cx->avr_space - AVR_SAFETY_MARGIN;
+  if(size > avail)
+    size = avail;
+  char *ret = avr_cc_buffer(size);
+  strncpy(ret, str, size);
+  ret[size-1] = 0;
+
+  return ret;
+}
+
+
 // Reads a potentially long line and returns it in a mmt_malloc'd buffer
 char *str_fgets(FILE *fp, const char **errpp) {
   int bs = 1023;                // Must be 2^n - 1

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -724,10 +724,11 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
 
       if(is_signed && is_out_of_range)
         Warning("%s out of int%d range, interpreted as %d-byte %lld%sU",
-          stri, sd->size*8, sd->size, sd->ll, sd->size == 4? "L": sd->size==2? "H": "HH");
+          stri, sd->size*8, sd->size, (long long int) sd->ll,
+          sd->size == 4? "L": sd->size==2? "H": "HH");
       else if(is_out_of_range)
         Warning("%s out of uint%d range, interpreted as %d-byte %llu",
-          stri, sd->size*8, sd->size, sd->ull);
+          stri, sd->size*8, sd->size, (long long unsigned int) sd->ull);
       else if(is_outside_int64_t)
         Warning("%s out of int64 range (consider U suffix)", stri);
 

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -570,7 +570,7 @@ unsigned long long int str_ull(const char *str, char **endptr, int base) {
  */
 
 #define Return(...) do { \
-  sd->errstr = str_sprintf(__VA_ARGS__); \
+  sd->errstr = mmt_sprintf(__VA_ARGS__); \
   sd->type = 0; \
   mmt_free(str); \
   return sd; \
@@ -579,7 +579,7 @@ unsigned long long int str_ull(const char *str, char **endptr, int base) {
 #define Warning(...) do { \
   if(sd->warnstr) \
     mmt_free(sd->warnstr); \
-   sd->warnstr = str_sprintf(__VA_ARGS__); \
+   sd->warnstr = mmt_sprintf(__VA_ARGS__); \
 } while (0)
 
 #define sizeforsigned(ll) ( \

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -412,21 +412,12 @@ const char *str_outname(const char *fn) {
   return !fn? "???": strcmp(fn, "-")? fn: "<stdout>";
 }
 
-// Return sth like "[0, 0x1ff]"
-const char *str_interval(int a, int b) {
-  // Cyclic buffer for 20+ temporary interval strings each max 41 bytes at 64-bit int
-  static char space[20*41 + 80], *sp;
-  if(!sp || sp-space > (int) sizeof space - 80)
-    sp = space;
+// Return sth like "[0, 0x1ff]" in closed-circuit space
+const char *str_ccinterval(int a, int b) {
+  char *ret = avr_cc_buffer(45); // Interval strings each max 45 bytes at 64-bit int
 
-  char *ret = sp;
-
-  sprintf(sp, a<16? "[%d": "[0x%x", a);
-  sp += strlen(sp);
-  sprintf(sp, b<16? ", %d]": ", 0x%x]", b);
-
-  // Advance beyond return string in temporary ring buffer
-  sp += strlen(sp)+1;
+  sprintf(ret, a<16? "[%d": "[0x%x", a);
+  sprintf(ret+strlen(ret), b<16? ", %d]": ", 0x%x]", b);
 
   return ret;
 }

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -470,7 +470,7 @@ static int is_mantissa_only(char *p) {
 }
 
 // Return 1 if all n bytes in memory pointed to by p are c, 0 otherwise
-int memall(const void *p, char c, size_t n) {
+int is_memset(const void *p, char c, size_t n) {
   const char *q = (const char *) p;
   return n <= 0 || (*q == c && memcmp(q, q+1, n-1) == 0);
 }

--- a/src/term.c
+++ b/src/term.c
@@ -1890,7 +1890,7 @@ static int cmd_part(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
   else if(onlyvariants)
     avr_variants_display(stdout, p, "");
   else {
-    term_out("%s with programming modes %s\n", p->desc, avr_prog_modes_str(p->prog_modes));
+    term_out("%s with programming modes %s\n", p->desc, str_prog_modes(p->prog_modes));
     avr_mem_display(stdout, p, "");
     avr_variants_display(stdout, p, "");
   }

--- a/src/term.c
+++ b/src/term.c
@@ -211,7 +211,8 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
     int len;
     const AVRMEM *mem;
   } read_mem[32];
-  static int i;
+  static int term_mi;
+  int i = term_mi;
   const char *cmd = tolower(**argv) == 'd'? "dump": "read";
 
   if ((argc < 2 && read_mem[0].mem == NULL) || argc > 4 || (argc > 1 && str_eq(argv[1], "-?"))) {
@@ -266,6 +267,7 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
     pmsg_error("(%s) read_mem[] under-dimensioned; increase and recompile\n", cmd);
     return -1;
   }
+  term_mi = i;
 
   // Get start address if present
   const char *errptr;
@@ -2685,7 +2687,7 @@ static int cmd_include(const PROGRAMMER *pgm, const AVRPART *p, int argc, const 
  *    1 terminate progress bar with \n when finishing at 100 percent
  */
 static void update_progress_tty(int percent, double etime, const char *hdr, int finish) {
-  static char *header;
+  static char *term_header;
   static int term_tty_last, term_tty_todo;
   int i;
 
@@ -2695,16 +2697,16 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
     lmsg_info("");              // Print new line unless already done before
     term_tty_last = 0;
     term_tty_todo = 1;      // OK, we have a header, start reporting
-    if(header)
-      mmt_free(header);
-    header = mmt_strdup(hdr);
+    if(term_header)
+      mmt_free(term_header);
+    term_header = mmt_strdup(hdr);
   }
 
   percent = percent > 100? 100: percent < 0? 0: percent;
 
   if(term_tty_todo) {
-    if(!header)
-      header = mmt_strdup("report");
+    if(!term_header)
+      term_header = mmt_strdup("report");
 
     int showperc = finish >= 0? percent: term_tty_last;
 
@@ -2715,7 +2717,7 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
     hashes[50] = 0;
 
     // Overwrite line using \r
-    msg_info("\r%s | %s | %d%% %0.2f s ", header, hashes, showperc, etime);
+    msg_info("\r%s | %s | %d%% %0.2f s ", term_header, hashes, showperc, etime);
     if(percent == 100) {
       if(finish)
         lmsg_info("");

--- a/src/term.c
+++ b/src/term.c
@@ -965,15 +965,13 @@ typedef struct {                // Context parameters to be passed to functions
 // Cache the contents of the fuse and lock bits memories that a particular Configitem is involved in
 static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const Cfg_t *cci, const char **errpp) {
   const char *err = NULL;
-  char *tofree;
   int islock;
 
   islock = str_starts(cci->memstr, "lock");
   if((islock && cci->t->memoffset != 0) ||
     (!islock && (cci->t->memoffset < 0 || cci->t->memoffset >= (int) (sizeof fl->fuses/sizeof*fl->fuses)))) {
 
-    err = cache_string(tofree = str_sprintf("%s's %s has invalid memoffset %d", p->desc, cci->memstr, cci->t->memoffset));
-    mmt_free(tofree);
+    err = cache_string(str_ccprintf("%s's %s has invalid memoffset %d", p->desc, cci->memstr, cci->t->memoffset));
     goto back;
   }
 
@@ -991,22 +989,19 @@ static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const 
 
   const AVRMEM *mem = avr_locate_mem(p, cci->memstr);
   if(!mem) {
-    err = cache_string(tofree = str_sprintf("memory %s not defined for part %s", cci->memstr, p->desc));
-    mmt_free(tofree);
+    err = cache_string(str_ccprintf("memory %s not defined for part %s", cci->memstr, p->desc));
     goto back;
   }
 
   if((islock && mem->size != 4 && mem->size != 1) || (!islock && mem->size != 2 && mem->size != 1)) {
-    err = cache_string(tofree = str_sprintf("%s's %s memory has unexpected size %d", p->desc, mem->desc, mem->size));
-    mmt_free(tofree);
+    err = cache_string(str_ccprintf("%s's %s memory has unexpected size %d", p->desc, mem->desc, mem->size));
     goto back;
   }
 
   fl_t m = {.i = 0};
   for(int i=0; i<mem->size; i++)
     if(led_read_byte(pgm, p, mem, i, m.b+i) < 0) {
-      err = cache_string(tofree = str_sprintf("cannot read %s's %s memory", p->desc, mem->desc));
-      mmt_free(tofree);
+      err = cache_string(str_ccprintf("cannot read %s's %s memory", p->desc, mem->desc));
       goto back;
     }
 

--- a/src/term.c
+++ b/src/term.c
@@ -1100,8 +1100,8 @@ static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cfg_t *cc, int i,
 }
 
 // Comment printed next to symbolic value
-static char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, int value, Cfg_opts_t o) {
-  static char buf[512], bin[129];
+static const char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, int value, Cfg_opts_t o) {
+  char buf[512], bin[129];
   unsigned u = value, m = cti->mask >> cti->lsh;
   int lsh = cti->lsh;
 
@@ -1135,7 +1135,7 @@ static char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, int va
       strcat(buf+strlen(buf), "factory");
     strcat(buf+strlen(buf), ")");
   }
-  return buf;
+  return str_ccstrdup(buf);
 }
 
 // How a single property is printed

--- a/src/update.c
+++ b/src/update.c
@@ -443,7 +443,7 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd, enum updat
     imsg_info("with %d byte%s in %d section%s within %s\n",
       fs.nbytes, str_plural(fs.nbytes),
       fs.nsections, str_plural(fs.nsections),
-      str_interval(fs.firstaddr, fs.lastaddr));
+      str_ccinterval(fs.firstaddr, fs.lastaddr));
     if(mem->page_size > 1) {
       imsg_info("using %d page%s and %d pad byte%s",
         fs.npages, str_plural(fs.npages),
@@ -471,7 +471,7 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd, enum updat
             imsg_notice2("with %d byte%s in %d section%s within %s\n",
               fs_patched.nbytes, str_plural(fs_patched.nbytes),
               fs_patched.nsections, str_plural(fs_patched.nsections),
-              str_interval(fs_patched.firstaddr, fs_patched.lastaddr));
+              str_ccinterval(fs_patched.firstaddr, fs_patched.lastaddr));
             if(mem->page_size > 1) {
               imsg_notice2("using %d page%s and %d pad byte%s",
                 fs_patched.npages, str_plural(fs_patched.npages),

--- a/src/update.c
+++ b/src/update.c
@@ -267,14 +267,11 @@ static void ioerror(const char *iotype, const UPDATE *upd) {
 
 // Basic checks to reveal serious failure before programming (and on autodetect set format)
 int update_dryrun(const AVRPART *p, UPDATE *upd) {
-  static const char **upd_wrote, **upd_termcmds;
-  static int upd_nfwritten, upd_nterms;
-
   int known, format_detect, ret = LIBAVRDUDE_SUCCESS;
 
   if(upd->cmdline) {            // Todo: parse terminal command line?
-    upd_termcmds = mmt_realloc(upd_termcmds, sizeof(*upd_termcmds) * (upd_nterms+1));
-    upd_termcmds[upd_nterms++] = upd->cmdline;
+    cx->upd_termcmds = mmt_realloc(cx->upd_termcmds, sizeof(*cx->upd_termcmds) * (cx->upd_nterms+1));
+    cx->upd_termcmds[cx->upd_nterms++] = upd->cmdline;
     return 0;
   }
 
@@ -293,16 +290,16 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
   if(upd->op == DEVICE_VERIFY || upd->op == DEVICE_WRITE || upd->format == FMT_AUTO) {
     if(upd->format != FMT_IMM) {
       // Need to read the file: was it written before, so will be known?
-      for(int i = 0; i < upd_nfwritten; i++)
-        if(!upd_wrote || (upd->filename && str_eq(upd_wrote[i], upd->filename)))
+      for(int i = 0; i < cx->upd_nfwritten; i++)
+        if(!cx->upd_wrote || (upd->filename && str_eq(cx->upd_wrote[i], upd->filename)))
           known = 1;
       // Could a -T terminal command have created the file?
-      for(int i = 0; i < upd_nterms; i++)
-        if(!upd_termcmds || (upd->filename && str_contains(upd_termcmds[i], upd->filename)))
+      for(int i = 0; i < cx->upd_nterms; i++)
+        if(!cx->upd_termcmds || (upd->filename && str_contains(cx->upd_termcmds[i], upd->filename)))
           known = 1;
       // Any -t interactive terminal could have created it
-      for(int i = 0; i < upd_nterms; i++)
-        if(!upd_termcmds || str_eq(upd_termcmds[i], "interactive terminal"))
+      for(int i = 0; i < cx->upd_nterms; i++)
+        if(!cx->upd_termcmds || str_eq(cx->upd_termcmds[i], "interactive terminal"))
           known = 1;
 
       errno = 0;
@@ -343,8 +340,8 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
         ret = LIBAVRDUDE_SOFTFAIL;
       } else if(upd->filename) { // Record filename (other than stdout) is available for future reads
         if(!str_eq(upd->filename, "-") &&
-          (upd_wrote = mmt_realloc(upd_wrote, sizeof(*upd_wrote) * (upd_nfwritten+1))))
-          upd_wrote[upd_nfwritten++] = upd->filename;
+          (cx->upd_wrote = mmt_realloc(cx->upd_wrote, sizeof(*cx->upd_wrote) * (cx->upd_nfwritten+1))))
+          cx->upd_wrote[cx->upd_nfwritten++] = upd->filename;
       }
     }
     break;

--- a/src/update.c
+++ b/src/update.c
@@ -133,9 +133,9 @@ void free_update(UPDATE *u) {
 
 char *update_str(const UPDATE *upd) {
   if(upd->cmdline)
-    return str_sprintf("-%c %s",
+    return mmt_sprintf("-%c %s",
       str_eq("interactive terminal", upd->cmdline)? 't': 'T', upd->cmdline);
-  return str_sprintf("-U %s:%c:%s:%c",
+  return mmt_sprintf("-U %s:%c:%s:%c",
     upd->memstr,
     upd->op == DEVICE_READ? 'r': upd->op == DEVICE_WRITE? 'w': 'v',
     upd->filename,

--- a/src/update.c
+++ b/src/update.c
@@ -267,14 +267,14 @@ static void ioerror(const char *iotype, const UPDATE *upd) {
 
 // Basic checks to reveal serious failure before programming (and on autodetect set format)
 int update_dryrun(const AVRPART *p, UPDATE *upd) {
-  static const char **wrote, **termcmds;
-  static int nfwritten, nterms;
+  static const char **upd_wrote, **upd_termcmds;
+  static int upd_nfwritten, upd_nterms;
 
   int known, format_detect, ret = LIBAVRDUDE_SUCCESS;
 
   if(upd->cmdline) {            // Todo: parse terminal command line?
-    termcmds = mmt_realloc(termcmds, sizeof(*termcmds) * (nterms+1));
-    termcmds[nterms++] = upd->cmdline;
+    upd_termcmds = mmt_realloc(upd_termcmds, sizeof(*upd_termcmds) * (upd_nterms+1));
+    upd_termcmds[upd_nterms++] = upd->cmdline;
     return 0;
   }
 
@@ -293,16 +293,16 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
   if(upd->op == DEVICE_VERIFY || upd->op == DEVICE_WRITE || upd->format == FMT_AUTO) {
     if(upd->format != FMT_IMM) {
       // Need to read the file: was it written before, so will be known?
-      for(int i = 0; i < nfwritten; i++)
-        if(!wrote || (upd->filename && str_eq(wrote[i], upd->filename)))
+      for(int i = 0; i < upd_nfwritten; i++)
+        if(!upd_wrote || (upd->filename && str_eq(upd_wrote[i], upd->filename)))
           known = 1;
       // Could a -T terminal command have created the file?
-      for(int i = 0; i < nterms; i++)
-        if(!termcmds || (upd->filename && str_contains(termcmds[i], upd->filename)))
+      for(int i = 0; i < upd_nterms; i++)
+        if(!upd_termcmds || (upd->filename && str_contains(upd_termcmds[i], upd->filename)))
           known = 1;
       // Any -t interactive terminal could have created it
-      for(int i = 0; i < nterms; i++)
-        if(!termcmds || str_eq(termcmds[i], "interactive terminal"))
+      for(int i = 0; i < upd_nterms; i++)
+        if(!upd_termcmds || str_eq(upd_termcmds[i], "interactive terminal"))
           known = 1;
 
       errno = 0;
@@ -342,8 +342,9 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
         ioerror("writeable", upd);
         ret = LIBAVRDUDE_SOFTFAIL;
       } else if(upd->filename) { // Record filename (other than stdout) is available for future reads
-        if(!str_eq(upd->filename, "-") && (wrote = mmt_realloc(wrote, sizeof(*wrote) * (nfwritten+1))))
-          wrote[nfwritten++] = upd->filename;
+        if(!str_eq(upd->filename, "-") &&
+          (upd_wrote = mmt_realloc(upd_wrote, sizeof(*upd_wrote) * (upd_nfwritten+1))))
+          upd_wrote[upd_nfwritten++] = upd->filename;
       }
     }
     break;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2584,7 +2584,7 @@ void urclock_initpgm(PROGRAMMER *pgm) {
   pgm->readonly = urclock_readonly;
   pgm->flash_readhook = urclock_flash_readhook;
 
-  disable_trailing_ff_removal();
+  cx->avr_disableffopt = 1;     // Disable trailing 0xff removal
 #if defined(HAVE_LIBREADLINE)
   pmsg_notice2("libreadline is used; avrdude -t -c urclock should work interactively\n");
 #else

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -372,8 +372,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
  * and transparently issue another USB read request if the buffer is
  * empty and more data are requested.
  */
-static int
-usb_fill_buf(usb_dev_handle *udev, int maxsize, int ep, int use_interrupt_xfer)
+static int usb_fill_buf(usb_dev_handle *udev, int maxsize, int ep, int use_interrupt_xfer)
 {
   int rv;
 


### PR DESCRIPTION
This PR intends to move all static variables used in libavrdude functions into a *single* structure called `cx_t`; the idea is that there is *one* global context pointer `cx_t *cx` that libavrdude applications need to allocate memory for at the beginning of each instantiation. Ideally, one would hide the components of the context structure and write access function that are used in libavrdude functions. However, that ship has sailed given all the explicit PROGRAMMER, AVRPART and AVRMEM structures and the tons of existing direct `->` access to their components. And more importantly, there are a lot of variables to convert (some 111), so writing 222 access functions, one each for get and set, wouldn't be much fun.

@dl8dtl @MCUdude @mcuee Have a look at the commit for the first source file that has been treated that way, `avr.c`, and see what you think. Other than that: it's one down and 34 to do. 