### PR TITLE
Differentiate cause when programmer isn't found

### DIFF
--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -708,7 +708,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 	// Todo: use desc and index argument, currently set to NULL and 0
 	err = ftdi_usb_open_desc_index(pdata->ftdic, vid, pid, NULL, serial, 0);
 	if(err) {
-		pmsg_error("error %d occurred: %s\n", err, ftdi_get_error_string(pdata->ftdic));
+		pmsg_error("%s (%d)\n", ftdi_get_error_string(pdata->ftdic), err);
 		// usb_dev is initialized to the last usb device from probing
 		pdata->ftdic->usb_dev = NULL;
 		return err;

--- a/src/main.c
+++ b/src/main.c
@@ -512,7 +512,9 @@ static int suggest_programmers(const char *programmer, LISTID programmers) {
   return n;
 }
 
-static void programmer_not_found(const char *programmer, PROGRAMMER *pgm, int pmode) {
+static void programmer_not_found(const char *programmer, const PROGRAMMER *pgm, const AVRPART *pt) {
+  int pmode = pt? pt->prog_modes: ~0;
+
   if(!programmer || !*programmer) {
     pmsg_error("no programmer has been specified on the command line or in the\n");
     imsg_error("config file(s); specify one using the -c option and try again\n");
@@ -554,9 +556,15 @@ static void programmer_not_found(const char *programmer, PROGRAMMER *pgm, int pm
       }
     }
   } else if(!pgm || !pgm->id || !lsize(pgm->id)) {
-    pmsg_error("cannot find programmer id %s\n", programmer);
-    suggest_programmers(programmer, programmers);
-    msg_info("use -c? to see all possible programmers\n");
+    PROGRAMMER *pg = locate_programmer(programmers, programmer);
+    if(!pgm && pt && pg && !(pg->prog_modes & pmode)) {
+      pmsg_error("programmer %s and part %s have no programming modes in common\n", programmer, pt->desc);
+      msg_info("use -c? -p %s to see all possible programmers for %s\n", pt->desc, pt->desc);
+    } else {
+      pmsg_error("cannot find programmer id %s\n", programmer);
+      suggest_programmers(programmer, programmers);
+      msg_info("use -c? to see all possible programmers\n");
+    }
   } else
     pmsg_error("programmer %s lacks %s setting\n", programmer,
       !pgm->prog_modes? "prog_modes": !pgm->initpgm? "type": "some");
@@ -1153,7 +1161,7 @@ int main(int argc, char * argv [])
       if(pgmid && *pgmid && explicit_c) {
         PROGRAMMER *pgm = locate_programmer_starts_set(programmers, pgmid, &pgmid, NULL);
         if(!pgm || !is_programmer(pgm)) {
-          programmer_not_found(pgmid, pgm, ~0);
+          programmer_not_found(pgmid, pgm, NULL);
           exit(1);
         }
         msg_error("\nValid parts for programmer %s are:\n", pgmid);
@@ -1196,14 +1204,14 @@ int main(int argc, char * argv [])
   msg_notice("\n");
 
   if(!pgmid || !*pgmid) {
-    programmer_not_found(NULL, NULL, ~0);
+    programmer_not_found(NULL, NULL, NULL);
     exit(1);
   }
 
   p = partdesc  && *partdesc? locate_part(part_list, partdesc): NULL;
   pgm = locate_programmer_starts_set(programmers, pgmid, &pgmid, p);
   if (pgm == NULL || !is_programmer(pgm)) {
-    programmer_not_found(pgmid, pgm, p? p->prog_modes: ~0);
+    programmer_not_found(pgmid, pgm, p);
     exit(1);
   }
 


### PR DESCRIPTION
Fixes #1805 

```
$ avrdude -q -c tumpa_jtag -p m328p
avrdude error: programmer tumpa_jtag and part ATmega328P have no programming modes in common
use -c? -p ATmega328P to see all possible programmers for ATmega328P

$ avrdude -qq -c tumpa_jtag -p m2560
avrdude error: device not found (-3)
avrdude error: unable to open port usb for programmer tumpa_jtag
```
