### PR TITLE
Prepare for next urboot version

### DIFF
--- a/src/urclock.c
+++ b/src/urclock.c
@@ -544,7 +544,7 @@ static int urclock_flash_readhook(const PROGRAMMER *pgm, const AVRPART *p, const
   const char *fname, int size) { // size is max memory address + 1
 
   int nmdata, maxsize, firstbeg, firstlen;
-  int vecsz = ur.uP.flashsize <= 8192? 2: 4; // Small parts use rjmp, large parts need 4-byte jmp
+  const int vecsz = ur.uP.flashsize <= 8192? 2: 4; // Small parts use rjmp, large a 4-byte jmp
 
   set_date_filename(pgm, fname);
 
@@ -1489,7 +1489,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
           ur.bloptiversion>>8, ur.bloptiversion & 255);
       Return("unknown bootloader ... please specify -xbootsize=<num>\n");
     }
-  } else if(!ur.boothigh) { // Fixme: guess bootloader size from low flash
+  } else if(!ur.boothigh) { // @@@ Fixme: guess bootloader size from low flash
   }
 
 vblvecfound:

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1392,13 +1392,18 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
                   vectnum, ur.xvectornum);
                 imsg_warning("the application might not start correctly\n");
               }
-            } else
+            } else {
               ur.vblvectornum = vectnum;
+              /*
+               * Urboot v8.0 (urver == 0100) onwards no longer supports self-patching
+               * bootloaders. The vbllevel is either 0 (vectnum == 0) or 1 (vectnum > 0).
+               * No longer refer to the capability byte from v8.0 thus freeing 2 bits.
+               */
+              ur.vbllevel = urver <= 077? vectorbl_level_cap(cap): vectnum > 0;
+            }
 
             ur.blurversion = urver;
             ur.bleepromrw = iseeprom_cap(cap);
-            if(!ur.vbllevel)        // Unless manually overwritten
-              ur.vbllevel = vectorbl_level_cap(cap);
           }
         }
       }

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -922,8 +922,11 @@ static void urbootPutVersion(const PROGRAMMER *pgm, char *buf, uint16_t ver, uin
     buf += strlen(buf);
     *buf++ = (hi < 077 && (type & UR_PGMWRITEPAGE)) || (hi >= 077 && rjmpwp != ret_opcode)? 'w': '-';
     *buf++ = type & UR_EEPROM? 'e': '-';
-    if(hi >= 076) {             // From urboot version 7.6 URPROTOCOL has its own bit
-      *buf++ = type & UR_URPROTOCOL? 'u': 's';
+    if(hi >= 076) {
+      if(hi > 077)              // From version 8.0 it's always urprotocol
+        *buf++ = type & UR_EXPEDITE? 'U': 'u';
+      else
+        *buf++ = type & UR_URPROTOCOL? 'u': 's';
       *buf++ = type & UR_DUAL? 'd': '-';
     } else {
       *buf++ = '-';             // Dummy bit
@@ -931,7 +934,7 @@ static void urbootPutVersion(const PROGRAMMER *pgm, char *buf, uint16_t ver, uin
       // D = Dual boot with SE & SPI restoration, d = dual boot with SE, f = dual boot only
       *buf++ = flags==3? 'D': flags==2? 'd': flags? 'f': '-';
     }
-    flags = (type/UR_VBL) & 3;
+    flags = (type/(UR_VBLMASK & -UR_VBLMASK)) & (hi > 077? 1: 3); // Only use 1 bit for v8.0+
     // V = VBL, patch & verify, v = VBL, patch only, j = VBL, jump only
     *buf++ = flags==3? 'V': flags==2? 'v': flags? 'j': 'h';
     *buf++ = hi < 077? (type & UR_PROTECTME? 'p': '-'): (type & UR_PROTECTME? 'P': 'p');

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1363,7 +1363,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
         ur.blurversion = urver;
         ur.bleepromrw = iseeprom_cap(cap);
         if(!ur.vbllevel)        // Unless manually overwritten
-          ur.vbllevel = vectorbl_level_cap(cap);
+          ur.vbllevel = vectorbl_level077_cap(cap);
       } else {                  // Urboot v7.5+ encodes bootloader size and vector number
         int blsize = numpags*flm->page_size;
         // Size of urboot bootloader should be in [64, 2048] (in v7.6 these are 224-512 bytes)
@@ -1399,7 +1399,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
                * bootloaders. The vbllevel is either 0 (vectnum == 0) or 1 (vectnum > 0).
                * No longer refer to the capability byte from v8.0 thus freeing 2 bits.
                */
-              ur.vbllevel = urver <= 077? vectorbl_level_cap(cap): vectnum > 0;
+              ur.vbllevel = urver <= 077? vectorbl_level077_cap(cap): vectnum > 0;
             }
 
             ur.blurversion = urver;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1349,9 +1349,9 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
     if((rc = ur_readEF(pgm, p, spc, flm->size-6, 6, 'F')))
       return rc;
 
-    // In a urboot bootloader (v7.2 onwards) these six are as follows
-    uint8_t numpags = spc[0];   // Actually, these two only exist from v7.5 onwards
-    uint8_t vectnum = spc[1];
+    // In a urboot bootloader these six (v7.5 onwards) are as follows
+    uint8_t numpags = spc[0] & 0x7f; // Number of bootloader pages (undefined before v7.5)
+    uint8_t vectnum = spc[1] & 0x7f; // Vector number for application start (undefined before v7.5)
     rjmpwp = buf2uint16(spc+2); // rjmp to bootloader pgm_write_page() or ret opcode
     uint8_t cap = spc[4];       // Capability byte
     uint8_t urver = spc[5];     // Urboot version (low three bits are minor version: 076 is v7.6)

--- a/src/urclock_private.h
+++ b/src/urclock_private.h
@@ -18,8 +18,8 @@
 
 /* $Id$ */
 
-#ifndef urclock_private_h__
-#define urclock_private_h__
+#ifndef urclock_private_h
+#define urclock_private_h
 
 // EEPROM or flash cache for bytewise access
 typedef struct {
@@ -92,14 +92,15 @@ typedef struct {
 #define UR_PGMWRITEPAGE     128 // pgm_write_page() can be called from application at FLASHEND+1-4
 #define UR_AUTOBAUD         128 // Bootloader has autobaud detection (from  v7.7)
 #define UR_EEPROM            64 // EEPROM read/write support
-#define UR_URPROTOCOL        32 // Bootloader uses urprotocol that requires avrdude -c urclock
+#define UR_URPROTOCOL        32 // Using urprotocol (v7.6 and v7.7 only)
 #define UR_DUAL              16 // Dual boot
-#define UR_VBLMASK           12 // Vector bootloader bits
+#define UR_VBLMASK           12 // Vector bootloader bits (up to v7.7 only)
 #define UR_VBLPATCHVERIFY    12 // Patch reset/interrupt vectors and show original ones on verify
 #define UR_VBLPATCH           8 // Patch reset/interrupt vectors only (expect an error on verify)
 #define UR_VBL                4 // Merely start application via interrupt vector instead of reset
 #define UR_NO_VBL             0 // Not a vector bootloader, must set fuses to HW bootloader support
 #define UR_PROTECTME          2 // Bootloader safeguards against overwriting itself
+#define UR_PROTECTRESET       2 // Bootloader safeguards against overwriting itself and reset
 #define UR_RESETFLAGS         1 // Load reset flags into register R2 before starting application
 #define UR_HAS_CE             1 // Bootloader has Chip Erase (from v7.7)
 
@@ -116,39 +117,56 @@ typedef struct {
   (uint8_t) (_vh >= 072 && _vh != 0xff? _vh: 0); })
 
 #define vercapis(capver, mask)  ({ uint16_t _vi = capver; !!(capabilities_cv(_vi) & (mask)); })
-#define ispgmwritepage_cv(capver) vercapis(capver, UR_PGMWRITEPAGE) // up to v7.6
-#define isautobaud_cv(capver)     vercapis(capver, UR_AUTOBAUD)     // from v7.7
-#define iseeprom_cv(capver)       vercapis(capver, UR_EEPROM)
-#define isurprotocol_cv(capver)   vercapis(capver, UR_URPROTOCOL)
-#define isdual_cv(capver)         vercapis(capver, UR_DUAL)
-#define isvectorbl_cv(capver)     vercapis(capver, UR_VBLMASK)
-#define isprotectme_cv(capver)    vercapis(capver, UR_PROTECTME)
-#define isresetflags_cv(capver)   vercapis(capver, UR_RESETFLAGS)   // up to v7.6
-#define ishas_ce_cv(capver)       vercapis(capver, UR_HAS_CE)       // from v7.7
+#define isautobaud_cv(capver)        vercapis(capver, UR_AUTOBAUD)     // from v7.7
+#define iseeprom_cv(capver)          vercapis(capver, UR_EEPROM)
+#define isdual_cv(capver)            vercapis(capver, UR_DUAL)
+#define isprotectreset_cv(capver)    vercapis(capver, UR_PROTECTRESET) // from 7.7
+#define ishas_ce_cv(capver)          vercapis(capver, UR_HAS_CE)       // from v7.7
+
+// Up to v7.7
+#define isurprotocol077_cv(capver)   vercapis(capver, UR_URPROTOCOL)
+#define isvectorbl077_cv(capver)     vercapis(capver, UR_VBLMASK)
+
+// Up to v7.6
+#define ispgmwritepage076_cv(capver) vercapis(capver, UR_PGMWRITEPAGE)
+#define isprotectme076_cv(capver)    vercapis(capver, UR_PROTECTME)
+#define isresetflags076_cv(capver)   vercapis(capver, UR_RESETFLAGS)
+
 
 // Capability bits incl position
-#define pgmwritepage_bit_cap(cap) ((cap) & UR_PGMWRITEPAGE) // up to v7.6
-#define autibaud_bit_cap(cap)     ((cap) & UR_AUTOBAUD)     // from v7.7
-#define eeprom_bit_cap(cap)       ((cap) & UR_EEPROM)
-#define dual_bit_cap(cap)         ((cap) & UR_DUAL)
-#define vector_bits_cap(cap)      ((cap) & UR_VBLMASK))
-#define protectme_bit_cap(cap)    ((cap) & UR_PROTECTME)
-#define urprotocol_bit_cap(cap)   ((cap) & UR_URPROTOCOL)
-#define resetflags_bit_cap(cap)   ((cap) & UR_RESETFLAGS)  // up to v7.6
-#define has_ce_bit_cap(cap)       ((cap) & UR_HAS_CE)      // from v7.7
+#define autobaud_bit_cap(cap)        ((cap) & UR_AUTOBAUD)     // from v7.7
+#define eeprom_bit_cap(cap)          ((cap) & UR_EEPROM)
+#define dual_bit_cap(cap)            ((cap) & UR_DUAL)
+#define protectreset_bit_cap(cap)    ((cap) & UR_PROTECTRESET) // from v7.7
+#define has_ce_bit_cap(cap)          ((cap) & UR_HAS_CE)       // from v7.7
+
+// Up to v7.7
+#define urprotocol077_bit_cap(cap)   ((cap) & UR_URPROTOCOL)
+#define vector077_bits_cap(cap)      ((cap) & UR_VBLMASK))
+
+// Up to v7.6
+#define pgmwritepage076_bit_cap(cap) ((cap) & UR_PGMWRITEPAGE)
+#define protectme076_bit_cap(cap)    ((cap) & UR_PROTECTME)
+#define resetflags076_bit_cap(cap)   ((cap) & UR_RESETFLAGS)
+
 
 // Boolean capabilities
-#define ispgmwritepage_cap(cap) (!!((cap) & UR_PGMWRITEPAGE)) // up to v7.6
-#define isautobaud_cap(cap)     (!!((cap) & UR_AUTOBAUD))     // from v7.7
-#define iseeprom_cap(cap)       (!!((cap) & UR_EEPROM))
-#define isdual_cap(cap)         (!!((cap) & UR_DUAL))
-#define isvectorbl_cap(cap)     (!!((cap) & UR_VBLMASK)))
-#define isprotectme_cap(cap)    (!!((cap) & UR_PROTECTME))
-#define isurprotocol_cap(cap)   (!!((cap) & UR_URPROTOCOL))
-#define isresetflags_cap(cap)   (!!((cap) & UR_RESETFLAGS))   // up to v7.6
-#define ishas_ce_cap(cap)       (!!((cap) & UR_HAS_CE))       // from v7.7
+#define isautobaud_cap(cap)        (!!((cap) & UR_AUTOBAUD))     // from v7.7
+#define iseeprom_cap(cap)          (!!((cap) & UR_EEPROM))
+#define isdual_cap(cap)            (!!((cap) & UR_DUAL))
+#define isprotectreset_cap(cap)    (!!((cap) & UR_PROTECTRESET)) // from v7.7
+#define ishas_ce_cap(cap)          (!!((cap) & UR_HAS_CE))       // from v7.7
 
-// Capability levels 0, 1, 2 or 3
-#define vectorbl_level_cap(cap) (((cap) & UR_VBLMASK)/UR_VBL)
+// Up to v7.7
+#define isurprotocol077_cap(cap)   (!!((cap) & UR_URPROTOCOL))
+#define isvectorbl077_cap(cap)     (!!((cap) & UR_VBLMASK)))
+
+// Up to v7.6
+#define ispgmwritepage076_cap(cap) (!!((cap) & UR_PGMWRITEPAGE))
+#define isprotectme076_cap(cap)    (!!((cap) & UR_PROTECTME))
+#define isresetflags076_cap(cap)   (!!((cap) & UR_RESETFLAGS))
+
+// Capability levels 0, 1, 2 or 3 (only for bootloaders up to v7.7)
+#define vectorbl_level077_cap(cap) (((cap) & UR_VBLMASK)/(UR_VBLMASK & -UR_VBLMASK))
 
 #endif

--- a/src/urclock_private.h
+++ b/src/urclock_private.h
@@ -90,9 +90,10 @@ typedef struct {
 
 // Capability byte of bootloader from version 7.2 onwards
 #define UR_PGMWRITEPAGE     128 // pgm_write_page() can be called from application at FLASHEND+1-4
-#define UR_AUTOBAUD         128 // Bootloader has autobaud detection (from  v7.7)
+#define UR_AUTOBAUD         128 // Bootloader has autobaud detection (from v7.7)
 #define UR_EEPROM            64 // EEPROM read/write support
 #define UR_URPROTOCOL        32 // Using urprotocol (v7.6 and v7.7 only)
+#define UR_EXPEDITE          32 // Check need to write flash first (from v8.0)
 #define UR_DUAL              16 // Dual boot
 #define UR_VBLMASK           12 // Vector bootloader bits (up to v7.7 only)
 #define UR_VBLPATCHVERIFY    12 // Patch reset/interrupt vectors and show original ones on verify


### PR DESCRIPTION
Some small code changes in anticipation of a new release of urboot bootloaders later this year. Only affects `-c urclock`; tested and should be safe to merge.