### PR TITLE
Rename AVRDUDE symbol names ending in _t

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1528,7 +1528,7 @@ char *dev_prog_modes(int pm) {  // Symbolic C code of prog_modes
 
 
 // Typical order in which memories show in avrdude.conf, runtime adds unknown ones (if any)
-memtable_t avr_mem_order[100] = {
+Memtable avr_mem_order[100] = {
   {"eeprom",      MEM_EEPROM},
   {"flash",       MEM_FLASH | MEM_IN_FLASH},
   {"application", MEM_APPLICATION | MEM_IN_FLASH},

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -363,12 +363,12 @@ typedef struct {
   AVRMEM *mem;
   AVR_Cache *cp;
   int isflash, iseeprom, zopaddr, pgerase;
-} CacheDesc_t;
+} Cache_desc;
 
 
 // Write flash, EEPROM, bootrow and usersig caches to device and free them
 int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
-  CacheDesc_t mems[] = {
+  Cache_desc mems[] = {
     { avr_locate_flash(p), pgm->cp_flash, 1, 0, -1, 0 },
     { avr_locate_eeprom(p), pgm->cp_eeprom, 0, 1, -1, 0 },
     { avr_locate_bootrow(p), pgm->cp_bootrow, 0, 0, -1, 0 },
@@ -689,7 +689,7 @@ int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
 // Erase the chip and set the cache accordingly
 int avr_chip_erase_cached(const PROGRAMMER *pgm, const AVRPART *p) {
-  CacheDesc_t mems[3] = {
+  Cache_desc mems[3] = {
     { avr_locate_flash(p), pgm->cp_flash, 1, 0, -1, 0 },
     { avr_locate_eeprom(p), pgm->cp_eeprom, 0, 1, -1, 0 },
     // bootrow/usersig is unaffected by CE

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -90,7 +90,7 @@ static int write_flush(Avrftdi_data *);
  * returns a human-readable name for a pin number. The name should match with
  * the pin names used in FTDI datasheets.
  */
-static char *ftdi_pin_name(Avrftdi_data *pdata, struct pindef_t pin) {
+static char *ftdi_pin_name(Avrftdi_data *pdata, struct pindef pin) {
 	char *str = pdata->name_str;
 	size_t strsiz = sizeof pdata->name_str;
 
@@ -211,7 +211,7 @@ static int set_pin(const PROGRAMMER *pgm, int pinfunc, int value) {
 		return -1;
 
 	Avrftdi_data *pdata = to_pdata(pgm);
-	struct pindef_t pin = pgm->pin[pinfunc];
+	struct pindef pin = pgm->pin[pinfunc];
 	
 	if (pin.mask[0] == 0) {
 		// ignore not defined pins (might be the led or vcc or buff if not needed)
@@ -507,7 +507,7 @@ static int avrftdi_check_pins_bb(const PROGRAMMER *pgm, bool output) {
 	int valid_mask = ((1 << pdata->pin_limit) - 1);
 
 	pmsg_debug("using valid mask bitbanging: 0x%08x\n", valid_mask);
-	struct pindef_t *valid_pins_p = &pdata->valid_pins;
+	struct pindef *valid_pins_p = &pdata->valid_pins;
 	valid_pins_p->mask[0] = valid_mask;
 	valid_pins_p->inverse[0] = valid_mask ;
 
@@ -530,7 +530,7 @@ static int avrftdi_check_pins_mpsse(const PROGRAMMER *pgm, bool output) {
 
 	Avrftdi_data *pdata = to_pdata(pgm);
 
-	struct pindef_t *valid_pins = pdata->mpsse_pins;
+	struct pindef *valid_pins = pdata->mpsse_pins;
 
 	/* value for 8/12/16 bit wide interface for other pins */
 	int valid_mask = ((1 << pdata->pin_limit) - 1);
@@ -542,7 +542,7 @@ static int avrftdi_check_pins_mpsse(const PROGRAMMER *pgm, bool output) {
 	}
 
 	pmsg_debug("using valid mask mpsse: 0x%08x\n", valid_mask);
-	struct pindef_t *valid_pins_others_p = &pdata->other_pins;
+	struct pindef *valid_pins_others_p = &pdata->other_pins;
 	valid_pins_others_p->mask[0] = valid_mask;
 	valid_pins_others_p->inverse[0] = valid_mask ;
 
@@ -1192,7 +1192,7 @@ static void avrftdi_setup(PROGRAMMER *pgm) {
 
 	/* SCK/SDO/SDI are fixed and not invertible? */
 	/* TODO: inverted SCK/SDI/SDO */
-	const struct pindef_t valid_mpsse_pins[4] = {
+	const struct pindef valid_mpsse_pins[4] = {
 		{{0x01}, {0x00}},
 		{{0x02}, {0x00}},
 		{{0x04}, {0x00}},

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -499,7 +499,7 @@ static int avrftdi_check_pins_bb(const PROGRAMMER *pgm, bool output) {
 	int pin;
 
 	/* pin checklist. */
-	struct pin_checklist_t pin_checklist[N_PINS];
+	Pin_checklist pin_checklist[N_PINS];
 
 	Avrftdi_data *pdata = to_pdata(pgm);
 
@@ -526,7 +526,7 @@ static int avrftdi_check_pins_mpsse(const PROGRAMMER *pgm, bool output) {
 	int pin;
 
 	/* pin checklist. */
-	struct pin_checklist_t pin_checklist[N_PINS];
+	Pin_checklist pin_checklist[N_PINS];
 
 	Avrftdi_data *pdata = to_pdata(pgm);
 

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -95,9 +95,9 @@ typedef struct avrftdi_s {
   uint8_t lext_byte;
 
   char name_str[128];           // Used in ftdi_pin_name()
-  struct pindef_t valid_pins;   // Used in avrftdi_check_pins_bb()
-  struct pindef_t mpsse_pins[4]; // Used in avrftdi_check_pins_mpsse()
-  struct pindef_t other_pins;   // Used in avrftdi_check_pins_mpsse()
+  struct pindef valid_pins;     // Used in avrftdi_check_pins_bb()
+  struct pindef mpsse_pins[4];  // Used in avrftdi_check_pins_mpsse()
+  struct pindef other_pins;     // Used in avrftdi_check_pins_mpsse()
 } Avrftdi_data;
 
 #endif /* DO_NOT_BUILD_AVRFDTI */

--- a/src/avrftdi_private.h
+++ b/src/avrftdi_private.h
@@ -72,7 +72,7 @@ enum jtag_cmd {
 };
 
 #define to_pdata(pgm) \
-  ((avrftdi_t *)((pgm)->cookie))
+  ((Avrftdi_data *)((pgm)->cookie))
 
 typedef struct avrftdi_s {
   /* pointer to struct maintained by libftdi to identify the device */
@@ -98,7 +98,7 @@ typedef struct avrftdi_s {
   struct pindef_t valid_pins;   // Used in avrftdi_check_pins_bb()
   struct pindef_t mpsse_pins[4]; // Used in avrftdi_check_pins_mpsse()
   struct pindef_t other_pins;   // Used in avrftdi_check_pins_mpsse()
-} avrftdi_t;
+} Avrftdi_data;
 
 #endif /* DO_NOT_BUILD_AVRFDTI */
 

--- a/src/avrftdi_tpi.c
+++ b/src/avrftdi_tpi.c
@@ -64,7 +64,7 @@ int
 avrftdi_tpi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 	int ret;
 
-	avrftdi_t* pdata = to_pdata(pgm);
+	Avrftdi_data *pdata = to_pdata(pgm);
 	unsigned char buf[] = { MPSSE_DO_WRITE | MPSSE_WRITE_NEG | MPSSE_LSB, 0x01, 0x00, 0xff, 0xff };
 
 	pmsg_info("Setting /Reset pin low\n");
@@ -132,7 +132,7 @@ static uint16_t tpi_byte2frame(uint8_t byte) {
 	return frame;
 }
 
-static int tpi_frame2byte(uint16_t frame, uint8_t * byte) {
+static int tpi_frame2byte(uint16_t frame, uint8_t *byte) {
 	/* drop idle and start bit(s) */
 	*byte = (frame >> 5) & 0xff;
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -462,10 +462,10 @@ AVRMEM *avr_locate_fuse_by_offset(const AVRPART *p, unsigned int off) {
 }
 
 // Return the first memory that shares the type incl any fuse identified by offset in fuses
-AVRMEM *avr_locate_mem_by_type(const AVRPART *p, memtype_t type) {
+AVRMEM *avr_locate_mem_by_type(const AVRPART *p, Memtype type) {
   AVRMEM *m;
-  memtype_t off = type & MEM_FUSEOFF_MASK;
-  type &= ~(memtype_t) MEM_FUSEOFF_MASK;
+  Memtype off = type & MEM_FUSEOFF_MASK;
+  type &= ~(Memtype) MEM_FUSEOFF_MASK;
 
   if(p && p->mem)
     for(LNODEID ln=lfirst(p->mem); ln; ln=lnext(ln))

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -531,7 +531,7 @@ const char * const *avr_locate_isrtable(const AVRPART *p, int *nip) {
 }
 
 // Return pointer to register file for the part and set number of registers
-const Register_file_t *avr_locate_register_file(const AVRPART *p, int *nrp) {
+const Register_file *avr_locate_register_file(const AVRPART *p, int *nrp) {
   int idx = avr_locate_upidx(p);
   if(idx < 0)
     return NULL;
@@ -556,13 +556,13 @@ const Register_file_t *avr_locate_register_file(const AVRPART *p, int *nrp) {
  * though there are other registers that start with adc, eg, adc.adcsra.
  */
 
-const Register_file_t *avr_locate_register(const Register_file_t *rgf, int nr, const char *reg,
+const Register_file *avr_locate_register(const Register_file *rgf, int nr, const char *reg,
   int (*match)(const char *, const char*)) {
 
   if(!rgf || nr < 1 || !reg || !match)
     return NULL;
 
-  const Register_file_t *ret = NULL;
+  const Register_file *ret = NULL;
   int nmatches = 0, eqmatch = match == str_eq;
 
   for(int i = 0; i < nr; i++) {
@@ -597,10 +597,10 @@ const Register_file_t *avr_locate_register(const Register_file_t *rgf, int nr, c
  * behaviour can be suppressed by specifying a pattern for reg, eg, adc*
  * together with the matching function str_matched_by.
  */
-const Register_file_t **avr_locate_registerlist(const Register_file_t *rgf, int nr, const char *reg,
+const Register_file **avr_locate_registerlist(const Register_file *rgf, int nr, const char *reg,
   int (*match)(const char *, const char*)) {
 
-  const Register_file_t **ret = mmt_malloc(sizeof rgf*(nr>0? nr+1: 1)), **r = ret;
+  const Register_file **ret = mmt_malloc(sizeof rgf*(nr>0? nr+1: 1)), **r = ret;
   int eqmatch = match == str_eq;
 
   if(rgf && reg && match)

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -511,7 +511,7 @@ int avr_locate_upidx(const AVRPART *p) {
 }
 
 // Return pointer to config table for the part and set number of config bitfields
-const Configitem_t *avr_locate_configitems(const AVRPART *p, int *ncp) {
+const Configitem *avr_locate_configitems(const AVRPART *p, int *ncp) {
   int idx = avr_locate_upidx(p);
   if(idx < 0)
     return NULL;
@@ -635,13 +635,13 @@ const Register_file_t **avr_locate_registerlist(const Register_file_t *rgf, int 
  * str_matched_by etc. If name is the full name of a configuration bitfield
  * then a pointer to that is returned irrespective of the matching function.
  */
-const Configitem_t *avr_locate_config(const Configitem_t *cfg, int nc, const char *name,
+const Configitem *avr_locate_config(const Configitem *cfg, int nc, const char *name,
   int (*match)(const char *, const char*)) {
 
   if(!cfg || nc < 1 || !name || !match)
     return NULL;
 
-  const Configitem_t *ret = NULL;
+  const Configitem *ret = NULL;
   int nmatches = 0;
 
   for(int i = 0; i < nc; i++) {
@@ -663,10 +663,10 @@ const Configitem_t *avr_locate_config(const Configitem_t *cfg, int nc, const cha
  * returned list is confined to this specific entry irrespective of the
  * matching function.
  */
-const Configitem_t **avr_locate_configlist(const Configitem_t *cfg, int nc, const char *name,
+const Configitem **avr_locate_configlist(const Configitem *cfg, int nc, const char *name,
   int (*match)(const char *, const char*)) {
 
-  const Configitem_t **ret = mmt_malloc(sizeof cfg*(nc>0? nc+1: 1)), **r = ret;
+  const Configitem **ret = mmt_malloc(sizeof cfg*(nc>0? nc+1: 1)), **r = ret;
 
   if(cfg && name && match) {
     for(int i = 0; i < nc; i++)
@@ -684,19 +684,19 @@ const Configitem_t **avr_locate_configlist(const Configitem_t *cfg, int nc, cons
   return ret;
 }
 
-// Return memory associated with config item and fill in pointer to Configitem_t record
+// Return memory associated with config item and fill in pointer to Configitem record
 static AVRMEM *avr_locate_config_mem_c_value(const PROGRAMMER *pgm, const AVRPART *p,
-  const char *cname, const Configitem_t **cp, int *valp) {
+  const char *cname, const Configitem **cp, int *valp) {
 
   int nc = 0;
-  const Configitem_t *cfg = avr_locate_configitems(p, &nc);
+  const Configitem *cfg = avr_locate_configitems(p, &nc);
 
   if(!cfg || nc < 1) {
     pmsg_error("avrintel.c does not hold configuration information for %s\n", p->desc);
     return NULL;
   }
 
-  const Configitem_t *c = avr_locate_config(cfg, nc, cname, str_contains);
+  const Configitem *c = avr_locate_config(cfg, nc, cname, str_contains);
   if(!c) {
     pmsg_error("%s does not have a unique config item matched by %s\n", p->desc, cname);
     return NULL;
@@ -729,7 +729,7 @@ static AVRMEM *avr_locate_config_mem_c_value(const PROGRAMMER *pgm, const AVRPAR
 
 // Initialise *valuep with configuration value of named configuration bitfield
 int avr_get_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int *valuep) {
-  const Configitem_t *c;
+  const Configitem *c;
   int fusel;
 
   if(!avr_locate_config_mem_c_value(pgm, p, cname, &c, &fusel))
@@ -742,7 +742,7 @@ int avr_get_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cn
 // Set configuration value of named configuration bitfield to value
 int avr_set_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int value) {
   AVRMEM *mem;
-  const Configitem_t *c;
+  const Configitem *c;
   int fusel;
 
   if(!(mem=avr_locate_config_mem_c_value(pgm, p, cname, &c, &fusel)))

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -333,7 +333,7 @@ static int ch341a_spi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd, unsig
 }
 
 
-static int ch341a_spi_chip_erase(const struct programmer_t *pgm, const AVRPART *p) {
+static int ch341a_spi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char cmd[4];
   unsigned char res[4];
 
@@ -477,12 +477,12 @@ void ch341a_initpgm(PROGRAMMER *pgm) {
 // ----------------------------------------------------------------------
 #else // !defined(HAVE_LIBUSB_1_0)
 
-static int ch341a_nousb_open(struct programmer_t *pgm, const char *name) {
+static int ch341a_nousb_open(PROGRAMMER *pgm, const char *name) {
   pmsg_error("no usb support, please compile again with libusb installed\n");
   return -1;
 }
 
-void ch341a_initpgm(PROGRAMMER * pgm) {
+void ch341a_initpgm(PROGRAMMER *pgm) {
   strcpy(pgm->type, "ch341a");
   pgm->open = ch341a_nousb_open;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -66,7 +66,7 @@ extern char *yytext;
 #define mem_comp_desc(x, type)  { #x, COMP_AVRMEM, offsetof(AVRMEM, x), sizeof(((AVRMEM *) NULL)->x), type }
 
 // Component description for config_gram.y, will be sorted appropriately on first use
-Component_t avr_comp[] = {
+Component avr_comp[] = {
   // PROGRAMMER
   pgm_comp_desc(desc, COMP_STRING),
   pgm_comp_desc(prog_modes, COMP_INT),
@@ -822,22 +822,22 @@ char *cfg_escape(const char *s) {
 
 
 static int cmp_comp(const void *v1, const void *v2) {
-  const Component_t *c1 = v1, *c2 = v2;
+  const Component *c1 = v1, *c2 = v2;
   int ret = strcmp(c1->name, c2->name);
 
   return ret? ret: c1->strct - c2->strct;
 }
 
-Component_t *cfg_comp_search(const char *name, int strct) {
-  Component_t key;
+Component *cfg_comp_search(const char *name, int strct) {
+  Component key;
 
   if(!cx->cfg_init_search++)
-    qsort(avr_comp, sizeof avr_comp/sizeof*avr_comp, sizeof(Component_t), cmp_comp);
+    qsort(avr_comp, sizeof avr_comp/sizeof*avr_comp, sizeof(Component), cmp_comp);
 
 
   key.name = name;
   key.strct = strct;
-  return bsearch(&key, avr_comp, sizeof avr_comp/sizeof*avr_comp, sizeof(Component_t), cmp_comp);
+  return bsearch(&key, avr_comp, sizeof avr_comp/sizeof*avr_comp, sizeof(Component), cmp_comp);
 }
 
 
@@ -881,7 +881,7 @@ const char *cfg_comp_type(int type) {
 
 
 // Used by config_gram.y to assign a component in one of the relevant structures with a value
-void cfg_assign(char *sp, int strct, Component_t *cp, VALUE *v) {
+void cfg_assign(char *sp, int strct, Component *cp, VALUE *v) {
   const char *str;
   int num;
 

--- a/src/config.c
+++ b/src/config.c
@@ -46,20 +46,20 @@ double default_bitclock;
 char const *default_linuxgpio;
 int allow_subshells;
 
-LISTID       string_list;
-LISTID       number_list;
-PROGRAMMER * current_prog;
-AVRPART    * current_part;
-AVRMEM     * current_mem;
-int          current_strct;
-LISTID       part_list;
-LISTID       programmers;
-bool         is_alias;
+LISTID      string_list;
+LISTID      number_list;
+PROGRAMMER *current_prog;
+AVRPART    *current_part;
+AVRMEM     *current_mem;
+int         current_strct;
+LISTID      part_list;
+LISTID      programmers;
+bool        is_alias;
 
-int    cfg_lineno;
-char * cfg_infile;
+int   cfg_lineno;
+char *cfg_infile;
 
-extern char * yytext;
+extern char *yytext;
 
 #define pgm_comp_desc(x, type)  { #x, COMP_PROGRAMMER, offsetof(PROGRAMMER, x), sizeof(((PROGRAMMER *) NULL)->x), type }
 #define part_comp_desc(x, type) { #x, COMP_AVRPART, offsetof(AVRPART, x), sizeof(((AVRPART *) NULL)->x), type }
@@ -228,8 +228,7 @@ int yywrap()
 }
 
 
-int yyerror(char * errmsg, ...)
-{
+int yyerror(char *errmsg, ...) {
   va_list args;
 
   char message[512];
@@ -245,8 +244,7 @@ int yyerror(char * errmsg, ...)
 }
 
 
-int yywarning(char * errmsg, ...)
-{
+int yywarning(char *errmsg, ...) {
   va_list args;
 
   char message[512];
@@ -262,15 +260,14 @@ int yywarning(char * errmsg, ...)
 }
 
 
-TOKEN * new_token(int primary) {
-  TOKEN * tkn = (TOKEN *) mmt_malloc(sizeof(TOKEN));
+TOKEN *new_token(int primary) {
+  TOKEN *tkn = (TOKEN *) mmt_malloc(sizeof(TOKEN));
   tkn->primary = primary;
   return tkn;
 }
 
 
-void free_token(TOKEN * tkn)
-{
+void free_token(TOKEN *tkn) {
   if (tkn) {
     switch (tkn->value.type) {
       case V_STR:
@@ -287,7 +284,7 @@ void free_token(TOKEN * tkn)
 
 void free_tokens(int n, ...)
 {
-  TOKEN * t;
+  TOKEN *t;
   va_list ap;
 
   va_start(ap, n);
@@ -302,7 +299,7 @@ void free_tokens(int n, ...)
 
 TOKEN *new_number(const char *text) {
   const char *errstr;
-  struct token_t *tkn = new_token(TKN_NUMBER);
+  TOKEN *tkn = new_token(TKN_NUMBER);
   tkn->value.type   = V_NUM;
   tkn->value.number = str_int(text, STR_INT32, &errstr);
   if(errstr) {
@@ -320,7 +317,7 @@ TOKEN *new_number(const char *text) {
 
 TOKEN *new_number_real(const char *text) {
   char *endptr;
-  struct token_t * tkn = new_token(TKN_NUMBER);
+  TOKEN *tkn = new_token(TKN_NUMBER);
   tkn->value.type   = V_NUM_REAL;
   tkn->value.number_real = strtod(text, &endptr);
   if(endptr == text || *endptr) {
@@ -337,7 +334,7 @@ TOKEN *new_number_real(const char *text) {
 }
 
 TOKEN *new_constant(const char *con) {
-  struct token_t *tkn = new_token(TKN_NUMBER);
+  TOKEN *tkn = new_token(TKN_NUMBER);
   int assigned = 1;
 
   tkn->value.type = V_NUM;
@@ -380,7 +377,7 @@ TOKEN *new_constant(const char *con) {
 }
 
 TOKEN *new_string(const char *text) {
-  struct token_t *tkn = new_token(TKN_STRING);
+  TOKEN *tkn = new_token(TKN_STRING);
   tkn->value.type   = V_STR;
   tkn->value.string = mmt_strdup(text);
 
@@ -397,8 +394,7 @@ TOKEN *new_keyword(int primary) {
 }
 
 
-void print_token(TOKEN * tkn)
-{
+void print_token(TOKEN *tkn) {
   if (!tkn)
     return;
 
@@ -438,9 +434,8 @@ void pyytext(void)
 extern int yylex_destroy(void);
 #endif
 
-int read_config(const char * file)
-{
-  FILE * f;
+int read_config(const char *file) {
+  FILE *f;
   int r;
 
   if(!(cfg_infile = realpath(file, NULL))) {

--- a/src/config.h
+++ b/src/config.h
@@ -62,7 +62,7 @@ typedef struct {                // Description of a component in a structure
   const char *name;             // Component name
   int strct;                    // Structure, eg, COMP_AVRPART
   int offset, size, type;       // Location, size and type within structure
-} Component_t;
+} Component;
 
 
 enum {                          // Value types for VALUE struct
@@ -79,7 +79,7 @@ typedef struct {
     int     number;
     double  number_real;
     char   *string;
-    Component_t *comp;
+    Component *comp;
   };
 } VALUE;
 
@@ -152,13 +152,13 @@ LISTID cfg_move_comments(void);
 
 void cfg_pop_comms(void);
 
-Component_t *cfg_comp_search(const char *name, int strct);
+Component *cfg_comp_search(const char *name, int strct);
 
 const char *cfg_v_type(int type);
 
 const char *cfg_strct_name(int strct);
 
-void cfg_assign(char *sp, int strct, Component_t *cp, VALUE *v);
+void cfg_assign(char *sp, int strct, Component *cp, VALUE *v);
 
 void cfg_update_mcuid(AVRPART *part);
 

--- a/src/config.h
+++ b/src/config.h
@@ -73,7 +73,7 @@ enum {                          // Value types for VALUE struct
   V_COMPONENT,
 };
 
-typedef struct value_t {
+typedef struct {
   int type;
   union {
     int     number;

--- a/src/config.h
+++ b/src/config.h
@@ -74,33 +74,33 @@ enum {                          // Value types for VALUE struct
 };
 
 typedef struct value_t {
-  int      type;
+  int type;
   union {
-    int      number;
-    double   number_real;
-    char   * string;
+    int     number;
+    double  number_real;
+    char   *string;
     Component_t *comp;
   };
 } VALUE;
 
 
-typedef struct token_t {
+typedef struct token {
   int primary;
   VALUE value;
 } TOKEN;
-typedef struct token_t *token_p;
+typedef struct token *token_p;
 
 
-extern FILE       * yyin;
-extern PROGRAMMER * current_prog;
-extern AVRPART    * current_part;
-extern AVRMEM     * current_mem;
-extern int          current_strct;
-extern int          cfg_lineno;
-extern char       * cfg_infile;
-extern LISTID       string_list;
-extern LISTID       number_list;
-extern bool         is_alias; // current entry is alias
+extern FILE       *yyin;
+extern PROGRAMMER *current_prog;
+extern AVRPART    *current_part;
+extern AVRMEM     *current_mem;
+extern int         current_strct;
+extern int         cfg_lineno;
+extern char       *cfg_infile;
+extern LISTID      string_list;
+extern LISTID      number_list;
+extern bool        is_alias; // current entry is alias
 
 
 #if !defined(HAS_YYSTYPE)

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -459,7 +459,7 @@ prog_parm_type:
 
 prog_parm_type_id:
   TKN_STRING        {
-  const struct programmer_type_t * pgm_type = locate_programmer_type($1->value.string);
+  const PROGRAMMER_TYPE *pgm_type = locate_programmer_type($1->value.string);
     if (pgm_type == NULL) {
         yyerror("programmer type %s not found", $1->value.string);
         free_token($1); 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1175,7 +1175,7 @@ static void dev_pgm_raw(const PROGRAMMER *pgm) {
 }
 
 
-static const char *connstr(conntype_t conntype) {
+static const char *connstr(Conntype conntype) {
   switch(conntype) {
   case CONNTYPE_LINUXGPIO: return "linuxgpio";
   case CONNTYPE_PARALLEL: return "parallel";

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -191,7 +191,7 @@ static void dryrun_enable(PROGRAMMER *pgm, const AVRPART *p) {
         }
       } else if(mem_is_io(m)) { // Initialise reset values (if known)
         int nr;
-        const Register_file_t *rf = avr_locate_register_file(p, &nr);
+        const Register_file *rf = avr_locate_register_file(p, &nr);
         if(rf)
           for(int i = 0; i < nr; i++)
             if(rf[i].initval != -1 && rf[i].size > 0 && rf[i].size < 5)

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -47,11 +47,11 @@ typedef enum {
   DRY_NOBOOTLOADER,             // No bootloader, taking to an ordinary programmer
   DRY_TOP,                      // Bootloader and it sits at top of flash
   DRY_BOTTOM,                   // Bootloader sits at bottom of flash (UPDI parts)
-} dry_prog_t;
+} Dry_prog;
 
 typedef struct {
   AVRPART *dp;
-  dry_prog_t bl;                // Bootloader and, if so, at top/bottom of flash?
+  Dry_prog bl;                  // Bootloader and, if so, at top/bottom of flash?
   int blsize;                   // Bootloader size min(flash size/4, 512)
 } dryrun_t;
 

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -53,10 +53,10 @@ typedef struct {
   AVRPART *dp;
   Dry_prog bl;                  // Bootloader and, if so, at top/bottom of flash?
   int blsize;                   // Bootloader size min(flash size/4, 512)
-} dryrun_t;
+} Dryrun_data;
 
 // Use private programmer data as if they were a global structure dry
-#define dry (*(dryrun_t *)(pgm->cookie))
+#define dry (*(Dryrun_data *)(pgm->cookie))
 
 #define Return(...) do { pmsg_error(__VA_ARGS__); msg_error("\n"); return -1; } while (0)
 
@@ -535,7 +535,7 @@ static int dryrun_readonly(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 static void dryrun_setup(PROGRAMMER *pgm) {
   pmsg_debug("%s()\n", __func__);
   // Allocate dry
-  pgm->cookie = mmt_malloc(sizeof(dryrun_t));
+  pgm->cookie = mmt_malloc(sizeof(Dryrun_data));
 }
 
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -153,7 +153,7 @@ FILEFMT fileio_format(char c) {
 typedef enum {
   FIRST_SEG = 1,
   LAST_SEG  = 2,
-} Segorder_t;
+} Segorder;
 
 
 static void print_ihex_extended_addr(int n_64k, FILE *outf) {
@@ -176,7 +176,7 @@ static void print_ihex_extended_addr(int n_64k, FILE *outf) {
  * Return the maximum memory address within mem->buf that was read from
  * plus one. If an error occurs, return -1.
  */
-static int b2ihex(const unsigned char *buf, const Segment_t *segp, Segorder_t where,
+static int b2ihex(const unsigned char *buf, const Segment_t *segp, Segorder where,
   int recsize, int startaddr, const char *outfile_unused, FILE *outf,
   FILEFMT ffmt) {
 
@@ -458,7 +458,7 @@ static unsigned int cksum_srec(const unsigned char *buf, int n, unsigned addr, i
 
 
 // Binary to Motorola S-Record, see https://en.wikipedia.org/wiki/SREC_(file_format)
-static int b2srec(const AVRMEM *mem, const Segment_t *segp, Segorder_t where,
+static int b2srec(const AVRMEM *mem, const Segment_t *segp, Segorder where,
   int recsize, int startaddr, const char *outfile_unused, FILE *outf) {
 
   const unsigned char *buf;
@@ -1079,7 +1079,7 @@ static int fileio_imm(struct fioparms *fio, const char *fname, FILE *f_unused,
 
 
 static int fileio_ihex(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const Segment_t *segp, FILEFMT ffmt, Segorder_t where) {
+  const AVRMEM *mem, const Segment_t *segp, FILEFMT ffmt, Segorder where) {
 
   int rc;
 
@@ -1102,7 +1102,7 @@ static int fileio_ihex(struct fioparms *fio, const char *filename, FILE *f,
 
 
 static int fileio_srec(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const Segment_t *segp, Segorder_t where) {
+  const AVRMEM *mem, const Segment_t *segp, Segorder where) {
 
   int rc;
 
@@ -1540,7 +1540,7 @@ static int fileio_segments_normalise(int oprwv, const char *filename, FILEFMT fo
     if(fio.op == FIO_READ) // Fill unspecified memory in segment
       memset(mem->buf+addr, 0xff, len);
     memset(mem->tags+addr, 0, len);
-    Segorder_t where = 0;
+    Segorder where = 0;
 
     if(i == 0)
       where |= FIRST_SEG;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -176,7 +176,7 @@ static void print_ihex_extended_addr(int n_64k, FILE *outf) {
  * Return the maximum memory address within mem->buf that was read from
  * plus one. If an error occurs, return -1.
  */
-static int b2ihex(const unsigned char *buf, const Segment_t *segp, Segorder where,
+static int b2ihex(const unsigned char *buf, const Segment *segp, Segorder where,
   int recsize, int startaddr, const char *outfile_unused, FILE *outf,
   FILEFMT ffmt) {
 
@@ -339,7 +339,7 @@ static int ihex_readrec(struct ihexsrec *ihex, char * rec) {
  * plus one. If an error occurs, return -1.
  */
 static int ihex2b(const char *infile, FILE *inf, const AVRMEM *mem,
-  const Segment_t *segp, unsigned int fileoffset, FILEFMT ffmt) {
+  const Segment *segp, unsigned int fileoffset, FILEFMT ffmt) {
 
   const char *errstr;
   unsigned int nextaddr, baseaddr, maxaddr;
@@ -458,7 +458,7 @@ static unsigned int cksum_srec(const unsigned char *buf, int n, unsigned addr, i
 
 
 // Binary to Motorola S-Record, see https://en.wikipedia.org/wiki/SREC_(file_format)
-static int b2srec(const AVRMEM *mem, const Segment_t *segp, Segorder where,
+static int b2srec(const AVRMEM *mem, const Segment *segp, Segorder where,
   int recsize, int startaddr, const char *outfile_unused, FILE *outf) {
 
   const unsigned char *buf;
@@ -609,7 +609,7 @@ static int srec_readrec(struct ihexsrec *srec, char *rec) {
 
 // Motorola S-Record to binary
 static int srec2b(const char *infile, FILE * inf,
-  const AVRMEM *mem, const Segment_t *segp, unsigned int fileoffset) {
+  const AVRMEM *mem, const Segment *segp, unsigned int fileoffset) {
 
   const char *errstr;
   unsigned int nextaddr, maxaddr;
@@ -805,7 +805,7 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
 
 // ELF format to binary (the memory segment to read into is ignored)
 static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
-  const AVRPART *p, const Segment_t *segp_unused, unsigned int fileoffset_unused) {
+  const AVRPART *p, const Segment *segp_unused, unsigned int fileoffset_unused) {
 
   Elf *e;
   int rv = 0, size = 0;
@@ -1012,7 +1012,7 @@ done:
 
 // Read/write binary files and return highest memory addr set + 1
 static int fileio_rbin(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const Segment_t *segp) {
+  const AVRMEM *mem, const Segment *segp) {
 
   int rc;
   switch (fio->op) {
@@ -1040,7 +1040,7 @@ static int fileio_rbin(struct fioparms *fio, const char *filename, FILE *f,
 
 
 static int fileio_imm(struct fioparms *fio, const char *fname, FILE *f_unused,
- const AVRMEM *mem, const Segment_t *segp) {
+ const AVRMEM *mem, const Segment *segp) {
 
   char *tok, *p, *line;
   const char *errstr;
@@ -1079,7 +1079,7 @@ static int fileio_imm(struct fioparms *fio, const char *fname, FILE *f_unused,
 
 
 static int fileio_ihex(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const Segment_t *segp, FILEFMT ffmt, Segorder where) {
+  const AVRMEM *mem, const Segment *segp, FILEFMT ffmt, Segorder where) {
 
   int rc;
 
@@ -1102,7 +1102,7 @@ static int fileio_ihex(struct fioparms *fio, const char *filename, FILE *f,
 
 
 static int fileio_srec(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const Segment_t *segp, Segorder where) {
+  const AVRMEM *mem, const Segment *segp, Segorder where) {
 
   int rc;
 
@@ -1126,7 +1126,7 @@ static int fileio_srec(struct fioparms *fio, const char *filename, FILE *f,
 
 #ifdef HAVE_LIBELF
 static int fileio_elf(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const AVRPART *p, const Segment_t *segp) {
+  const AVRMEM *mem, const AVRPART *p, const Segment *segp) {
 
   int rc;
 
@@ -1150,7 +1150,7 @@ static int fileio_elf(struct fioparms *fio, const char *filename, FILE *f,
 #endif
 
 
-static int b2num(const char *filename, FILE *f, const AVRMEM *mem, const Segment_t *segp, FILEFMT fmt) {
+static int b2num(const char *filename, FILE *f, const AVRMEM *mem, const Segment *segp, FILEFMT fmt) {
   const char *prefix;
   int base;
 
@@ -1214,7 +1214,7 @@ static int b2num(const char *filename, FILE *f, const AVRMEM *mem, const Segment
 }
 
 
-static int num2b(const char *filename, FILE *f, const AVRMEM *mem, const Segment_t *segp) {
+static int num2b(const char *filename, FILE *f, const AVRMEM *mem, const Segment *segp) {
   const char *geterr = NULL;
   char *line;
   int n = segp->addr, end = segp->addr + segp->len;
@@ -1250,7 +1250,7 @@ static int num2b(const char *filename, FILE *f, const AVRMEM *mem, const Segment
 
 
 static int fileio_num(struct fioparms *fio, const char *filename, FILE *f,
-  const AVRMEM *mem, const Segment_t *segp, FILEFMT fmt) {
+  const AVRMEM *mem, const Segment *segp, FILEFMT fmt) {
 
   switch (fio->op) {
     case FIO_WRITE:
@@ -1422,13 +1422,13 @@ int fileio(int op, const char *filename, FILEFMT format,
   if(size < 0 || op == FIO_READ || op == FIO_READ_FOR_VERIFY)
     size = mem->size;
 
-  const Segment_t seg = {0, size};
+  const Segment seg = {0, size};
   return fileio_segments(op, filename, format, p, mem, 1, &seg);
 }
 
 
 // Normalise segment address and length to be non-negative
-int segment_normalise(const AVRMEM *mem, Segment_t *segp) {
+int segment_normalise(const AVRMEM *mem, Segment *segp) {
   int addr = segp->addr, len = segp->len, maxsize = mem->size;
   int digits = maxsize > 0x10000? 5: 4;
 
@@ -1458,7 +1458,7 @@ int segment_normalise(const AVRMEM *mem, Segment_t *segp) {
 
 
 static int fileio_segments_normalise(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, const AVRMEM *mem, int n, Segment_t *seglist) {
+  const AVRPART *p, const AVRMEM *mem, int n, Segment *seglist) {
 
   int op, rc;
   FILE * f;
@@ -1609,9 +1609,9 @@ static int fileio_segments_normalise(int oprwv, const char *filename, FILEFMT fo
 }
 
 int fileio_segments(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, const AVRMEM *mem, int n, const Segment_t *list) {
+  const AVRPART *p, const AVRMEM *mem, int n, const Segment *list) {
 
-  Segment_t *seglist = mmt_malloc(n*sizeof*seglist);
+  Segment *seglist = mmt_malloc(n*sizeof*seglist);
   memcpy(seglist, list, n*sizeof*seglist);
   int ret = fileio_segments_normalise(oprwv, filename, format, p, mem, n, seglist);
   mmt_free(seglist);

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -806,7 +806,7 @@ static int ft245r_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
 /* lower 8 pins are accepted, they might be also inverted */
 static const struct pindef valid_pins = {{0xff}, {0xff}};
 
-static const struct pin_checklist_t pin_checklist[] = {
+static const Pin_checklist pin_checklist[] = {
     { PIN_AVR_SCK, 1, &valid_pins},
     { PIN_AVR_SDO, 1, &valid_pins},
     { PIN_AVR_SDI, 1, &valid_pins},

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -804,7 +804,7 @@ static int ft245r_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
 }
 
 /* lower 8 pins are accepted, they might be also inverted */
-static const struct pindef_t valid_pins = {{0xff}, {0xff}} ;
+static const struct pindef valid_pins = {{0xff}, {0xff}};
 
 static const struct pin_checklist_t pin_checklist[] = {
     { PIN_AVR_SCK, 1, &valid_pins},

--- a/src/leds.c
+++ b/src/leds.c
@@ -59,7 +59,7 @@
 #define CHECK               15 // Check LED needs changing
 
 // Keep track of LED status and set LED 0 .. LED_N-1 physically on or off
-static void led_direct(const PROGRAMMER *pgm, leds_t *ls, int led, int what) {
+static void led_direct(const PROGRAMMER *pgm, Leds *ls, int led, int what) {
   if(what ^ !!(ls->phy & (1<<led))) {
     switch(led) {
     case LED_RDY:
@@ -82,7 +82,7 @@ static void led_direct(const PROGRAMMER *pgm, leds_t *ls, int led, int what) {
 }
 
 // Physical level of LED setting, deal with max blinking frequency LED_FMAX
-static void led_physical(const PROGRAMMER *pgm, leds_t *ls, int led, int what) {
+static void led_physical(const PROGRAMMER *pgm, Leds *ls, int led, int what) {
   if(led < 0 || led >= LED_N) // Sanity
     return;
 
@@ -125,7 +125,7 @@ static void led_physical(const PROGRAMMER *pgm, leds_t *ls, int led, int what) {
 // Logical level of setting LEDs, passes on to physical level
 int led_set(const PROGRAMMER *pgm, int led) {
   // leds should always be allocated, but if not use dummy
-  leds_t sanity = { 0, 0, 0, 0, 0, {0, } }, *ls = pgm->leds? pgm->leds: &sanity;
+  Leds sanity = { 0, 0, 0, 0, 0, {0, } }, *ls = pgm->leds? pgm->leds: &sanity;
   int what = led >= 0 && led < LED_N && !(ls->now & (1<<led))? TON: CHECK;
 
   switch(led) {
@@ -174,7 +174,7 @@ int led_clr(const PROGRAMMER *pgm, int led) {
   }
 
   // pgm->leds should always be allocated, but if not use dummy
-  leds_t sanity = { 0, 0, 0, 0, 0, {0, } }, *ls = pgm->leds? pgm->leds: &sanity;
+  Leds sanity = { 0, 0, 0, 0, 0, {0, } }, *ls = pgm->leds? pgm->leds: &sanity;
   int what = ls->now & (1<<led)? TOFF: CHECK;
 
   // Record logical level

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -159,7 +159,7 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
   paged | size | num_pages | initval | bitmask | n_word_writes | offset | min_write_delay | max_write_delay | pwroff_after_write |
   readback_p1 | readback_p2 | mode | delay | blocksize | readsize ) {
   /* struct components for PROGRAMMER, AVRPART and AVRMEM */
-  Component_t *cp = cfg_comp_search(yytext, current_strct);
+  Component *cp = cfg_comp_search(yytext, current_strct);
   if(!cp) {
     yyerror("unknown component %s in %s", yytext, cfg_strct_name(current_strct));
     return YYERRCODE;

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -12,7 +12,7 @@
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * v 1.3
- * 08.05.2024
+ * 20.05.2024
  *
  */
 
@@ -27,19 +27,19 @@ typedef struct {
   int value;                    // Value (to be shifted into mask position)
   const char *label;            // Symbolic label for this config item
   const char *vcomment;         // Expanded semantic comment
-} Valueitem_t;
+} Configvalue;
 
 typedef struct {
   const char *name;             // Name of this configuration item
   int nvalues;                  // Number of (symbolic) values
-  const Valueitem_t *vlist;     // Pointer to nvalues value items
+  const Configvalue *vlist;     // Pointer to nvalues value items
   const char *memstr;           // Fuse/Lock memory for this configuration
   int memoffset;                // Byte offset within fuses (always 0 for lock)
   int mask;                     // Bit mask of fuse/lock memory
   int lsh;                      // Values need shifting left by lsh to be in mask
   int initval;                  // Factory default, to be shifted into mask position
   const char *ccomment;         // Expanded semantic name for this configuration item
-} Configitem_t;
+} Configitem;
 
 typedef struct {
   const char *reg;              // Name of I/O register
@@ -48,7 +48,7 @@ typedef struct {
   int mask;                     // Bit mask for register, if any (-1 means none/unknown)
   int initval;                  // Reset value, if any (-1 means none/unknown)
   const char *caption;          // Expanded semantic name
-} Register_file_t;
+} Register_file;
 
 typedef struct {                // Value of -1 typically means unknown
   const char *name;             // Name of part
@@ -70,10 +70,10 @@ typedef struct {                // Value of -1 typically means unknown
   uint8_t ninterrupts;          // Number of vectors in interrupt vector table
   const char * const *isrtable; // Interrupt vector table vector names
   uint8_t nconfigs;             // Number of configuration bitfields in fuses/locks
-  const Configitem_t *cfgtable; // Configuration bitfield table
+  const Configitem *cfgtable;   // Configuration bitfield table
   uint16_t nregisters;          // Number of I/O registers
-  const Register_file_t *regf;  // Register file
-} uPcore_t;
+  const Register_file *regf;    // Register file
+} Avrintel;
 
 #define F_AVR8L               1 // TPI programming, ATtiny(4|5|9|10|20|40|102|104)
 #define F_AVR8                2 // ISP programming with SPI, "classic" AVRs
@@ -82,7 +82,7 @@ typedef struct {                // Value of -1 typically means unknown
 
 #define UB_N_MCU           2040 // mcuid is in 0..2039
 
-extern const uPcore_t uP_table[394];
+extern const Avrintel uP_table[394];
 
 
 // MCU id: running number in arbitrary order; once assigned never change for backward compatibility
@@ -1745,54 +1745,54 @@ extern const char * const    vtab_avr128db64[65];
 
 // Configuration table names
 
-extern const Configitem_t    cfgtab_atmega328[14];
+extern const Configitem    cfgtab_atmega328[14];
 #define cfgtab_atmega328p    cfgtab_atmega328
 #define cfgtab_ata6614q      cfgtab_atmega328
 
-extern const Configitem_t    cfgtab_atmega16m1[17];
+extern const Configitem    cfgtab_atmega16m1[17];
 
-extern const Configitem_t    cfgtab_atmega16hva2[9];
+extern const Configitem    cfgtab_atmega16hva2[9];
 
-extern const Configitem_t    cfgtab_atmega32hvbrevb[12];
+extern const Configitem    cfgtab_atmega32hvbrevb[12];
 
-extern const Configitem_t    cfgtab_atmega64hve[13];
+extern const Configitem    cfgtab_atmega64hve[13];
 
-extern const Configitem_t    cfgtab_atmega328pb[15];
+extern const Configitem    cfgtab_atmega328pb[15];
 
-extern const Configitem_t    cfgtab_atmega8515[13];
+extern const Configitem    cfgtab_atmega8515[13];
 
-extern const Configitem_t    cfgtab_attiny102[5];
+extern const Configitem    cfgtab_attiny102[5];
 #define cfgtab_attiny104     cfgtab_attiny102
 
-extern const Configitem_t    cfgtab_attiny28[3];
+extern const Configitem    cfgtab_attiny28[3];
 
-extern const Configitem_t    cfgtab_attiny441[14];
+extern const Configitem    cfgtab_attiny441[14];
 #define cfgtab_attiny841     cfgtab_attiny441
 
-extern const Configitem_t    cfgtab_at90pwm2[18];
+extern const Configitem    cfgtab_at90pwm2[18];
 #define cfgtab_at90pwm3      cfgtab_at90pwm2
 
-extern const Configitem_t    cfgtab_at90pwm81[19];
+extern const Configitem    cfgtab_at90pwm81[19];
 #define cfgtab_at90pwm161    cfgtab_at90pwm81
 
-extern const Configitem_t    cfgtab_at90can128[15];
+extern const Configitem    cfgtab_at90can128[15];
 
-extern const Configitem_t    cfgtab_at90usb162[15];
+extern const Configitem    cfgtab_at90usb162[15];
 #define cfgtab_atmega16u2    cfgtab_at90usb162
 #define cfgtab_at90usb82     cfgtab_at90usb162
 
-extern const Configitem_t    cfgtab_at90s1200[3];
+extern const Configitem    cfgtab_at90s1200[3];
 
-extern const Configitem_t    cfgtab_at90s2313[3];
+extern const Configitem    cfgtab_at90s2313[3];
 #define cfgtab_at90s4414     cfgtab_at90s2313
 #define cfgtab_at90s4434     cfgtab_at90s2313
 #define cfgtab_at90s8515     cfgtab_at90s2313
 #define cfgtab_at90s8535     cfgtab_at90s2313
 
-extern const Configitem_t    cfgtab_ata5700m322[9];
+extern const Configitem    cfgtab_ata5700m322[9];
 #define cfgtab_ata5702m322   cfgtab_ata5700m322
 
-extern const Configitem_t    cfgtab_ata5781[11];
+extern const Configitem    cfgtab_ata5781[11];
 #define cfgtab_ata5782       cfgtab_ata5781
 #define cfgtab_ata5783       cfgtab_ata5781
 #define cfgtab_ata5831       cfgtab_ata5781
@@ -1803,17 +1803,17 @@ extern const Configitem_t    cfgtab_ata5781[11];
 #define cfgtab_ata8510       cfgtab_ata5781
 #define cfgtab_ata8515       cfgtab_ata5781
 
-extern const Configitem_t    cfgtab_ata5790[11];
+extern const Configitem    cfgtab_ata5790[11];
 #define cfgtab_ata5791       cfgtab_ata5790
 
-extern const Configitem_t    cfgtab_ata6285[17];
+extern const Configitem    cfgtab_ata6285[17];
 #define cfgtab_ata6286       cfgtab_ata6285
 
-extern const Configitem_t    cfgtab_atxmega16e5[17];
+extern const Configitem    cfgtab_atxmega16e5[17];
 #define cfgtab_atxmega8e5    cfgtab_atxmega16e5
 #define cfgtab_atxmega32e5   cfgtab_atxmega16e5
 
-extern const Configitem_t    cfgtab_atxmega128a3[16];
+extern const Configitem    cfgtab_atxmega128a3[16];
 #define cfgtab_atxmega64a1   cfgtab_atxmega128a3
 #define cfgtab_atxmega64a3   cfgtab_atxmega128a3
 #define cfgtab_atxmega128a1  cfgtab_atxmega128a3
@@ -1822,7 +1822,7 @@ extern const Configitem_t    cfgtab_atxmega128a3[16];
 #define cfgtab_atxmega256a3  cfgtab_atxmega128a3
 #define cfgtab_atxmega256a3b cfgtab_atxmega128a3
 
-extern const Configitem_t    cfgtab_atxmega128a3u[17];
+extern const Configitem    cfgtab_atxmega128a3u[17];
 #define cfgtab_atxmega16a4u  cfgtab_atxmega128a3u
 #define cfgtab_atxmega32a4u  cfgtab_atxmega128a3u
 #define cfgtab_atxmega64a1u  cfgtab_atxmega128a3u
@@ -1834,7 +1834,7 @@ extern const Configitem_t    cfgtab_atxmega128a3u[17];
 #define cfgtab_atxmega256a3bu cfgtab_atxmega128a3u
 #define cfgtab_atxmega256a3u cfgtab_atxmega128a3u
 
-extern const Configitem_t    cfgtab_attiny204[23];
+extern const Configitem    cfgtab_attiny204[23];
 #define cfgtab_attiny202     cfgtab_attiny204
 #define cfgtab_attiny212     cfgtab_attiny204
 #define cfgtab_attiny214     cfgtab_attiny204
@@ -1854,7 +1854,7 @@ extern const Configitem_t    cfgtab_attiny204[23];
 #define cfgtab_attiny3216    cfgtab_attiny204
 #define cfgtab_attiny3217    cfgtab_attiny204
 
-extern const Configitem_t    cfgtab_attiny1624[16];
+extern const Configitem    cfgtab_attiny1624[16];
 #define cfgtab_attiny424     cfgtab_attiny1624
 #define cfgtab_attiny426     cfgtab_attiny1624
 #define cfgtab_attiny427     cfgtab_attiny1624
@@ -1867,7 +1867,7 @@ extern const Configitem_t    cfgtab_attiny1624[16];
 #define cfgtab_attiny3226    cfgtab_attiny1624
 #define cfgtab_attiny3227    cfgtab_attiny1624
 
-extern const Configitem_t    cfgtab_avr32dd14[17];
+extern const Configitem    cfgtab_avr32dd14[17];
 #define cfgtab_avr16dd14     cfgtab_avr32dd14
 #define cfgtab_avr16dd20     cfgtab_avr32dd14
 #define cfgtab_avr16dd28     cfgtab_avr32dd14
@@ -1880,7 +1880,7 @@ extern const Configitem_t    cfgtab_avr32dd14[17];
 #define cfgtab_avr64dd28     cfgtab_avr32dd14
 #define cfgtab_avr64dd32     cfgtab_avr32dd14
 
-extern const Configitem_t    cfgtab_avr64ea48[16];
+extern const Configitem    cfgtab_avr64ea48[16];
 #define cfgtab_avr16ea28     cfgtab_avr64ea48
 #define cfgtab_avr16ea32     cfgtab_avr64ea48
 #define cfgtab_avr16ea48     cfgtab_avr64ea48
@@ -1890,48 +1890,48 @@ extern const Configitem_t    cfgtab_avr64ea48[16];
 #define cfgtab_avr64ea28     cfgtab_avr64ea48
 #define cfgtab_avr64ea32     cfgtab_avr64ea48
 
-extern const Configitem_t    cfgtab_atmega103comp[15];
+extern const Configitem    cfgtab_atmega103comp[15];
 
-extern const Configitem_t    cfgtab_at90scr100h[13];
+extern const Configitem    cfgtab_at90scr100h[13];
 #define cfgtab_at90scr100    cfgtab_at90scr100h
 
-extern const Configitem_t    cfgtab_atmega161comp[15];
+extern const Configitem    cfgtab_atmega161comp[15];
 
-extern const Configitem_t    cfgtab_at90s8535comp[13];
+extern const Configitem    cfgtab_at90s8535comp[13];
 
-extern const Configitem_t    cfgtab_attiny4[4];
+extern const Configitem    cfgtab_attiny4[4];
 #define cfgtab_attiny5       cfgtab_attiny4
 #define cfgtab_attiny9       cfgtab_attiny4
 #define cfgtab_attiny10      cfgtab_attiny4
 
-extern const Configitem_t    cfgtab_attiny20[5];
+extern const Configitem    cfgtab_attiny20[5];
 #define cfgtab_attiny40      cfgtab_attiny20
 
-extern const Configitem_t    cfgtab_attiny11[4];
+extern const Configitem    cfgtab_attiny11[4];
 
-extern const Configitem_t    cfgtab_attiny12[6];
+extern const Configitem    cfgtab_attiny12[6];
 
-extern const Configitem_t    cfgtab_attiny13[10];
+extern const Configitem    cfgtab_attiny13[10];
 #define cfgtab_attiny13a     cfgtab_attiny13
 
-extern const Configitem_t    cfgtab_attiny15[6];
+extern const Configitem    cfgtab_attiny15[6];
 
-extern const Configitem_t    cfgtab_attiny22[3];
+extern const Configitem    cfgtab_attiny22[3];
 
-extern const Configitem_t    cfgtab_attiny24[11];
+extern const Configitem    cfgtab_attiny24[11];
 #define cfgtab_attiny24a     cfgtab_attiny24
 #define cfgtab_attiny44      cfgtab_attiny24
 #define cfgtab_attiny44a     cfgtab_attiny24
 #define cfgtab_attiny84      cfgtab_attiny24
 #define cfgtab_attiny84a     cfgtab_attiny24
 
-extern const Configitem_t    cfgtab_attiny25[11];
+extern const Configitem    cfgtab_attiny25[11];
 #define cfgtab_attiny45      cfgtab_attiny25
 #define cfgtab_attiny85      cfgtab_attiny25
 
-extern const Configitem_t    cfgtab_attiny26[8];
+extern const Configitem    cfgtab_attiny26[8];
 
-extern const Configitem_t    cfgtab_attiny43u[11];
+extern const Configitem    cfgtab_attiny43u[11];
 #define cfgtab_attiny261     cfgtab_attiny43u
 #define cfgtab_attiny261a    cfgtab_attiny43u
 #define cfgtab_attiny461     cfgtab_attiny43u
@@ -1939,10 +1939,10 @@ extern const Configitem_t    cfgtab_attiny43u[11];
 #define cfgtab_attiny861     cfgtab_attiny43u
 #define cfgtab_attiny861a    cfgtab_attiny43u
 
-extern const Configitem_t    cfgtab_attiny48[11];
+extern const Configitem    cfgtab_attiny48[11];
 #define cfgtab_attiny88      cfgtab_attiny48
 
-extern const Configitem_t    cfgtab_attiny87[11];
+extern const Configitem    cfgtab_attiny87[11];
 #define cfgtab_attiny167     cfgtab_attiny87
 #define cfgtab_ata5272       cfgtab_attiny87
 #define cfgtab_ata5505       cfgtab_attiny87
@@ -1950,96 +1950,96 @@ extern const Configitem_t    cfgtab_attiny87[11];
 #define cfgtab_ata6617c      cfgtab_attiny87
 #define cfgtab_ata664251     cfgtab_attiny87
 
-extern const Configitem_t    cfgtab_attiny828[16];
+extern const Configitem    cfgtab_attiny828[16];
 #define cfgtab_attiny828r    cfgtab_attiny828
 
-extern const Configitem_t    cfgtab_attiny1634[13];
+extern const Configitem    cfgtab_attiny1634[13];
 #define cfgtab_attiny1634r   cfgtab_attiny1634
 
-extern const Configitem_t    cfgtab_attiny2313[11];
+extern const Configitem    cfgtab_attiny2313[11];
 
-extern const Configitem_t    cfgtab_attiny2313a[11];
+extern const Configitem    cfgtab_attiny2313a[11];
 #define cfgtab_attiny4313    cfgtab_attiny2313a
 
-extern const Configitem_t    cfgtab_atmega8[13];
+extern const Configitem    cfgtab_atmega8[13];
 #define cfgtab_atmega8a      cfgtab_atmega8
 
-extern const Configitem_t    cfgtab_atmega8hva[7];
+extern const Configitem    cfgtab_atmega8hva[7];
 #define cfgtab_atmega16hva   cfgtab_atmega8hva
 
-extern const Configitem_t    cfgtab_atmega8u2[15];
+extern const Configitem    cfgtab_atmega8u2[15];
 
-extern const Configitem_t    cfgtab_atmega16[13];
+extern const Configitem    cfgtab_atmega16[13];
 #define cfgtab_atmega16a     cfgtab_atmega16
 
-extern const Configitem_t    cfgtab_atmega16hvb[12];
+extern const Configitem    cfgtab_atmega16hvb[12];
 
-extern const Configitem_t    cfgtab_atmega16hvbrevb[12];
+extern const Configitem    cfgtab_atmega16hvbrevb[12];
 
-extern const Configitem_t    cfgtab_atmega16u4[15];
+extern const Configitem    cfgtab_atmega16u4[15];
 
-extern const Configitem_t    cfgtab_atmega32[13];
+extern const Configitem    cfgtab_atmega32[13];
 #define cfgtab_atmega32a     cfgtab_atmega32
 
-extern const Configitem_t    cfgtab_atmega32hvb[12];
+extern const Configitem    cfgtab_atmega32hvb[12];
 
-extern const Configitem_t    cfgtab_atmega32c1[17];
+extern const Configitem    cfgtab_atmega32c1[17];
 #define cfgtab_atmega32m1    cfgtab_atmega32c1
 
-extern const Configitem_t    cfgtab_atmega32u2[15];
+extern const Configitem    cfgtab_atmega32u2[15];
 
-extern const Configitem_t    cfgtab_atmega32u4[15];
+extern const Configitem    cfgtab_atmega32u4[15];
 
-extern const Configitem_t    cfgtab_atmega32u6[15];
+extern const Configitem    cfgtab_atmega32u6[15];
 
-extern const Configitem_t    cfgtab_atmega48[11];
+extern const Configitem    cfgtab_atmega48[11];
 #define cfgtab_atmega48a     cfgtab_atmega48
 #define cfgtab_atmega48p     cfgtab_atmega48
 #define cfgtab_atmega48pa    cfgtab_atmega48
 
-extern const Configitem_t    cfgtab_atmega48pb[11];
+extern const Configitem    cfgtab_atmega48pb[11];
 
-extern const Configitem_t    cfgtab_atmega64[15];
+extern const Configitem    cfgtab_atmega64[15];
 #define cfgtab_atmega64a     cfgtab_atmega64
 
-extern const Configitem_t    cfgtab_atmega64c1[17];
+extern const Configitem    cfgtab_atmega64c1[17];
 #define cfgtab_atmega64m1    cfgtab_atmega64c1
 
-extern const Configitem_t    cfgtab_atmega64hve2[13];
+extern const Configitem    cfgtab_atmega64hve2[13];
 #define cfgtab_atmega32hve2  cfgtab_atmega64hve2
 
-extern const Configitem_t    cfgtab_atmega64rfr2[14];
+extern const Configitem    cfgtab_atmega64rfr2[14];
 #define cfgtab_atmega644rfr2 cfgtab_atmega64rfr2
 
-extern const Configitem_t    cfgtab_atmega88[14];
+extern const Configitem    cfgtab_atmega88[14];
 #define cfgtab_atmega88a     cfgtab_atmega88
 #define cfgtab_atmega88p     cfgtab_atmega88
 #define cfgtab_atmega88pa    cfgtab_atmega88
 #define cfgtab_ata6612c      cfgtab_atmega88
 
-extern const Configitem_t    cfgtab_atmega88pb[14];
+extern const Configitem    cfgtab_atmega88pb[14];
 
-extern const Configitem_t    cfgtab_atmega103[4];
+extern const Configitem    cfgtab_atmega103[4];
 
-extern const Configitem_t    cfgtab_atmega128[15];
+extern const Configitem    cfgtab_atmega128[15];
 #define cfgtab_atmega128a    cfgtab_atmega128
 
-extern const Configitem_t    cfgtab_atmega128rfa1[14];
+extern const Configitem    cfgtab_atmega128rfa1[14];
 
-extern const Configitem_t    cfgtab_atmega128rfr2[14];
+extern const Configitem    cfgtab_atmega128rfr2[14];
 #define cfgtab_atmega1284rfr2 cfgtab_atmega128rfr2
 
-extern const Configitem_t    cfgtab_atmega161[7];
+extern const Configitem    cfgtab_atmega161[7];
 
-extern const Configitem_t    cfgtab_atmega162[15];
+extern const Configitem    cfgtab_atmega162[15];
 
-extern const Configitem_t    cfgtab_atmega163[9];
+extern const Configitem    cfgtab_atmega163[9];
 
-extern const Configitem_t    cfgtab_atmega164a[14];
+extern const Configitem    cfgtab_atmega164a[14];
 #define cfgtab_atmega164p    cfgtab_atmega164a
 #define cfgtab_atmega164pa   cfgtab_atmega164a
 
-extern const Configitem_t    cfgtab_atmega165[15];
+extern const Configitem    cfgtab_atmega165[15];
 #define cfgtab_atmega165a    cfgtab_atmega165
 #define cfgtab_atmega165p    cfgtab_atmega165
 #define cfgtab_atmega165pa   cfgtab_atmega165
@@ -2048,26 +2048,26 @@ extern const Configitem_t    cfgtab_atmega165[15];
 #define cfgtab_atmega169p    cfgtab_atmega165
 #define cfgtab_atmega169pa   cfgtab_atmega165
 
-extern const Configitem_t    cfgtab_atmega168[14];
+extern const Configitem    cfgtab_atmega168[14];
 #define cfgtab_atmega168a    cfgtab_atmega168
 #define cfgtab_atmega168p    cfgtab_atmega168
 #define cfgtab_atmega168pa   cfgtab_atmega168
 #define cfgtab_ata6613c      cfgtab_atmega168
 
-extern const Configitem_t    cfgtab_atmega168pb[14];
+extern const Configitem    cfgtab_atmega168pb[14];
 
-extern const Configitem_t    cfgtab_atmega256rfr2[14];
+extern const Configitem    cfgtab_atmega256rfr2[14];
 #define cfgtab_atmega2564rfr2 cfgtab_atmega256rfr2
 
-extern const Configitem_t    cfgtab_atmega323[12];
+extern const Configitem    cfgtab_atmega323[12];
 
-extern const Configitem_t    cfgtab_atmega324a[14];
+extern const Configitem    cfgtab_atmega324a[14];
 #define cfgtab_atmega324p    cfgtab_atmega324a
 #define cfgtab_atmega324pa   cfgtab_atmega324a
 
-extern const Configitem_t    cfgtab_atmega324pb[15];
+extern const Configitem    cfgtab_atmega324pb[15];
 
-extern const Configitem_t    cfgtab_atmega325[15];
+extern const Configitem    cfgtab_atmega325[15];
 #define cfgtab_atmega325a    cfgtab_atmega325
 #define cfgtab_atmega325p    cfgtab_atmega325
 #define cfgtab_atmega325pa   cfgtab_atmega325
@@ -2084,16 +2084,16 @@ extern const Configitem_t    cfgtab_atmega325[15];
 #define cfgtab_atmega3290p   cfgtab_atmega325
 #define cfgtab_atmega3290pa  cfgtab_atmega325
 
-extern const Configitem_t    cfgtab_atmega406[10];
+extern const Configitem    cfgtab_atmega406[10];
 
-extern const Configitem_t    cfgtab_atmega640[14];
+extern const Configitem    cfgtab_atmega640[14];
 
-extern const Configitem_t    cfgtab_atmega644[14];
+extern const Configitem    cfgtab_atmega644[14];
 #define cfgtab_atmega644a    cfgtab_atmega644
 #define cfgtab_atmega644p    cfgtab_atmega644
 #define cfgtab_atmega644pa   cfgtab_atmega644
 
-extern const Configitem_t    cfgtab_atmega645[15];
+extern const Configitem    cfgtab_atmega645[15];
 #define cfgtab_atmega645a    cfgtab_atmega645
 #define cfgtab_atmega645p    cfgtab_atmega645
 #define cfgtab_atmega649     cfgtab_atmega645
@@ -2106,58 +2106,58 @@ extern const Configitem_t    cfgtab_atmega645[15];
 #define cfgtab_atmega6490a   cfgtab_atmega645
 #define cfgtab_atmega6490p   cfgtab_atmega645
 
-extern const Configitem_t    cfgtab_atmega1280[14];
+extern const Configitem    cfgtab_atmega1280[14];
 #define cfgtab_atmega1281    cfgtab_atmega1280
 
-extern const Configitem_t    cfgtab_atmega1284[14];
+extern const Configitem    cfgtab_atmega1284[14];
 #define cfgtab_atmega1284p   cfgtab_atmega1284
 
-extern const Configitem_t    cfgtab_atmega2560[14];
+extern const Configitem    cfgtab_atmega2560[14];
 #define cfgtab_atmega2561    cfgtab_atmega2560
 
-extern const Configitem_t    cfgtab_atmega8535[13];
+extern const Configitem    cfgtab_atmega8535[13];
 
-extern const Configitem_t    cfgtab_at90pwm1[17];
+extern const Configitem    cfgtab_at90pwm1[17];
 
-extern const Configitem_t    cfgtab_at90pwm2b[18];
+extern const Configitem    cfgtab_at90pwm2b[18];
 #define cfgtab_at90pwm3b     cfgtab_at90pwm2b
 
-extern const Configitem_t    cfgtab_at90can32[15];
+extern const Configitem    cfgtab_at90can32[15];
 
-extern const Configitem_t    cfgtab_at90can64[15];
+extern const Configitem    cfgtab_at90can64[15];
 
-extern const Configitem_t    cfgtab_at90pwm216[18];
+extern const Configitem    cfgtab_at90pwm216[18];
 
-extern const Configitem_t    cfgtab_at90pwm316[18];
+extern const Configitem    cfgtab_at90pwm316[18];
 
-extern const Configitem_t    cfgtab_at90usb646[15];
+extern const Configitem    cfgtab_at90usb646[15];
 #define cfgtab_at90usb647    cfgtab_at90usb646
 
-extern const Configitem_t    cfgtab_at90usb1286[15];
+extern const Configitem    cfgtab_at90usb1286[15];
 #define cfgtab_at90usb1287   cfgtab_at90usb1286
 
-extern const Configitem_t    cfgtab_at90s2323[3];
+extern const Configitem    cfgtab_at90s2323[3];
 
-extern const Configitem_t    cfgtab_at90s2333[5];
+extern const Configitem    cfgtab_at90s2333[5];
 
-extern const Configitem_t    cfgtab_at90s2343[3];
+extern const Configitem    cfgtab_at90s2343[3];
 
-extern const Configitem_t    cfgtab_at90s4433[5];
+extern const Configitem    cfgtab_at90s4433[5];
 
-extern const Configitem_t    cfgtab_at90s8515comp[13];
+extern const Configitem    cfgtab_at90s8515comp[13];
 
-extern const Configitem_t    cfgtab_ata5787[11];
+extern const Configitem    cfgtab_ata5787[11];
 #define cfgtab_ata5835       cfgtab_ata5787
 
-extern const Configitem_t    cfgtab_ata5790n[10];
+extern const Configitem    cfgtab_ata5790n[10];
 #define cfgtab_ata5795       cfgtab_ata5790n
 
-extern const Configitem_t    cfgtab_ata6289[17];
+extern const Configitem    cfgtab_ata6289[17];
 
-extern const Configitem_t    cfgtab_atxmega16a4[16];
+extern const Configitem    cfgtab_atxmega16a4[16];
 #define cfgtab_atxmega32a4   cfgtab_atxmega16a4
 
-extern const Configitem_t    cfgtab_atxmega16c4[15];
+extern const Configitem    cfgtab_atxmega16c4[15];
 #define cfgtab_atxmega16d4   cfgtab_atxmega16c4
 #define cfgtab_atxmega32c3   cfgtab_atxmega16c4
 #define cfgtab_atxmega32d3   cfgtab_atxmega16c4
@@ -2176,21 +2176,21 @@ extern const Configitem_t    cfgtab_atxmega16c4[15];
 #define cfgtab_atxmega384c3  cfgtab_atxmega16c4
 #define cfgtab_atxmega384d3  cfgtab_atxmega16c4
 
-extern const Configitem_t    cfgtab_atxmega64b1[17];
+extern const Configitem    cfgtab_atxmega64b1[17];
 #define cfgtab_atxmega64b3   cfgtab_atxmega64b1
 #define cfgtab_atxmega128b1  cfgtab_atxmega64b1
 #define cfgtab_atxmega128b3  cfgtab_atxmega64b1
 
-extern const Configitem_t    cfgtab_attiny416auto[23];
+extern const Configitem    cfgtab_attiny416auto[23];
 
-extern const Configitem_t    cfgtab_attiny804[15];
+extern const Configitem    cfgtab_attiny804[15];
 #define cfgtab_attiny806     cfgtab_attiny804
 #define cfgtab_attiny807     cfgtab_attiny804
 #define cfgtab_attiny1604    cfgtab_attiny804
 #define cfgtab_attiny1606    cfgtab_attiny804
 #define cfgtab_attiny1607    cfgtab_attiny804
 
-extern const Configitem_t    cfgtab_atmega808[15];
+extern const Configitem    cfgtab_atmega808[15];
 #define cfgtab_atmega809     cfgtab_atmega808
 #define cfgtab_atmega1608    cfgtab_atmega808
 #define cfgtab_atmega1609    cfgtab_atmega808
@@ -2199,7 +2199,7 @@ extern const Configitem_t    cfgtab_atmega808[15];
 #define cfgtab_atmega4808    cfgtab_atmega808
 #define cfgtab_atmega4809    cfgtab_atmega808
 
-extern const Configitem_t    cfgtab_avr16du14[20];
+extern const Configitem    cfgtab_avr16du14[20];
 #define cfgtab_avr16du20     cfgtab_avr16du14
 #define cfgtab_avr16du28     cfgtab_avr16du14
 #define cfgtab_avr16du32     cfgtab_avr16du14
@@ -2210,12 +2210,12 @@ extern const Configitem_t    cfgtab_avr16du14[20];
 #define cfgtab_avr64du28     cfgtab_avr16du14
 #define cfgtab_avr64du32     cfgtab_avr16du14
 
-extern const Configitem_t    cfgtab_avr16eb14[18];
+extern const Configitem    cfgtab_avr16eb14[18];
 #define cfgtab_avr16eb20     cfgtab_avr16eb14
 #define cfgtab_avr16eb28     cfgtab_avr16eb14
 #define cfgtab_avr16eb32     cfgtab_avr16eb14
 
-extern const Configitem_t    cfgtab_avr32da28[15];
+extern const Configitem    cfgtab_avr32da28[15];
 #define cfgtab_avr32da32     cfgtab_avr32da28
 #define cfgtab_avr32da48     cfgtab_avr32da28
 #define cfgtab_avr64da28     cfgtab_avr32da28
@@ -2227,7 +2227,7 @@ extern const Configitem_t    cfgtab_avr32da28[15];
 #define cfgtab_avr128da48    cfgtab_avr32da28
 #define cfgtab_avr128da64    cfgtab_avr32da28
 
-extern const Configitem_t    cfgtab_avr32db28[16];
+extern const Configitem    cfgtab_avr32db28[16];
 #define cfgtab_avr32db32     cfgtab_avr32db28
 #define cfgtab_avr32db48     cfgtab_avr32db28
 #define cfgtab_avr64db28     cfgtab_avr32db28
@@ -2241,74 +2241,74 @@ extern const Configitem_t    cfgtab_avr32db28[16];
 
 // I/O Register files
 
-extern const Register_file_t rgftab_atmega328[81];
+extern const Register_file rgftab_atmega328[81];
 #define rgftab_atmega328p    rgftab_atmega328
 
-extern const Register_file_t rgftab_atmega16m1[136];
+extern const Register_file rgftab_atmega16m1[136];
 #define rgftab_atmega32m1    rgftab_atmega16m1
 
-extern const Register_file_t rgftab_atmega32hvbrevb[91];
+extern const Register_file rgftab_atmega32hvbrevb[91];
 #define rgftab_atmega16hvb   rgftab_atmega32hvbrevb
 #define rgftab_atmega16hvbrevb rgftab_atmega32hvbrevb
 #define rgftab_atmega32hvb   rgftab_atmega32hvbrevb
 
-extern const Register_file_t rgftab_atmega328pb[123];
+extern const Register_file rgftab_atmega328pb[123];
 
-extern const Register_file_t rgftab_atmega8515[52];
+extern const Register_file rgftab_atmega8515[52];
 
-extern const Register_file_t rgftab_attiny102[55];
+extern const Register_file rgftab_attiny102[55];
 #define rgftab_attiny104     rgftab_attiny102
 
-extern const Register_file_t rgftab_attiny28[20];
+extern const Register_file rgftab_attiny28[20];
 
-extern const Register_file_t rgftab_attiny441[101];
+extern const Register_file rgftab_attiny441[101];
 #define rgftab_attiny841     rgftab_attiny441
 
-extern const Register_file_t rgftab_at90pwm81[84];
+extern const Register_file rgftab_at90pwm81[84];
 
-extern const Register_file_t rgftab_at90can128[137];
+extern const Register_file rgftab_at90can128[137];
 #define rgftab_at90can32     rgftab_at90can128
 #define rgftab_at90can64     rgftab_at90can128
 
-extern const Register_file_t rgftab_at90usb162[92];
+extern const Register_file rgftab_at90usb162[92];
 #define rgftab_at90usb82     rgftab_at90usb162
 
-extern const Register_file_t rgftab_ata5700m322[337];
+extern const Register_file rgftab_ata5700m322[337];
 
-extern const Register_file_t rgftab_ata5781[262];
+extern const Register_file rgftab_ata5781[262];
 #define rgftab_ata5782       rgftab_ata5781
 #define rgftab_ata5783       rgftab_ata5781
 #define rgftab_ata8210       rgftab_ata5781
 #define rgftab_ata8215       rgftab_ata5781
 
-extern const Register_file_t rgftab_ata5790[112];
+extern const Register_file rgftab_ata5790[112];
 
-extern const Register_file_t rgftab_ata6285[79];
+extern const Register_file rgftab_ata6285[79];
 #define rgftab_ata6286       rgftab_ata6285
 
-extern const Register_file_t rgftab_atxmega16e5[438];
+extern const Register_file rgftab_atxmega16e5[438];
 #define rgftab_atxmega8e5    rgftab_atxmega16e5
 #define rgftab_atxmega32e5   rgftab_atxmega16e5
 
-extern const Register_file_t rgftab_atxmega128a3[680];
+extern const Register_file rgftab_atxmega128a3[680];
 #define rgftab_atxmega64a3   rgftab_atxmega128a3
 #define rgftab_atxmega192a3  rgftab_atxmega128a3
 #define rgftab_atxmega256a3  rgftab_atxmega128a3
 
-extern const Register_file_t rgftab_atxmega128a3u[792];
+extern const Register_file rgftab_atxmega128a3u[792];
 #define rgftab_atxmega64a3u  rgftab_atxmega128a3u
 #define rgftab_atxmega192a3u rgftab_atxmega128a3u
 #define rgftab_atxmega256a3u rgftab_atxmega128a3u
 
-extern const Register_file_t rgftab_attiny204[235];
+extern const Register_file rgftab_attiny204[235];
 #define rgftab_attiny404     rgftab_attiny204
 
-extern const Register_file_t rgftab_attiny1624[307];
+extern const Register_file rgftab_attiny1624[307];
 #define rgftab_attiny424     rgftab_attiny1624
 #define rgftab_attiny824     rgftab_attiny1624
 #define rgftab_attiny3224    rgftab_attiny1624
 
-extern const Register_file_t rgftab_avr32dd14[401];
+extern const Register_file rgftab_avr32dd14[401];
 #define rgftab_avr16dd14     rgftab_avr32dd14
 #define rgftab_avr16dd20     rgftab_avr32dd14
 #define rgftab_avr16dd28     rgftab_avr32dd14
@@ -2321,118 +2321,118 @@ extern const Register_file_t rgftab_avr32dd14[401];
 #define rgftab_avr64dd28     rgftab_avr32dd14
 #define rgftab_avr64dd32     rgftab_avr32dd14
 
-extern const Register_file_t rgftab_avr64ea48[502];
+extern const Register_file rgftab_avr64ea48[502];
 #define rgftab_avr16ea48     rgftab_avr64ea48
 #define rgftab_avr32ea48     rgftab_avr64ea48
 
-extern const Register_file_t rgftab_attiny4[36];
+extern const Register_file rgftab_attiny4[36];
 #define rgftab_attiny9       rgftab_attiny4
 
-extern const Register_file_t rgftab_attiny5[41];
+extern const Register_file rgftab_attiny5[41];
 #define rgftab_attiny10      rgftab_attiny5
 
-extern const Register_file_t rgftab_attiny20[61];
+extern const Register_file rgftab_attiny20[61];
 
-extern const Register_file_t rgftab_attiny40[63];
+extern const Register_file rgftab_attiny40[63];
 
-extern const Register_file_t rgftab_attiny11[14];
+extern const Register_file rgftab_attiny11[14];
 
-extern const Register_file_t rgftab_attiny12[18];
+extern const Register_file rgftab_attiny12[18];
 
-extern const Register_file_t rgftab_attiny13[35];
+extern const Register_file rgftab_attiny13[35];
 
-extern const Register_file_t rgftab_attiny13a[37];
+extern const Register_file rgftab_attiny13a[37];
 
-extern const Register_file_t rgftab_attiny15[28];
+extern const Register_file rgftab_attiny15[28];
 
-extern const Register_file_t rgftab_attiny24[55];
+extern const Register_file rgftab_attiny24[55];
 #define rgftab_attiny24a     rgftab_attiny24
 
-extern const Register_file_t rgftab_attiny25[55];
+extern const Register_file rgftab_attiny25[55];
 
-extern const Register_file_t rgftab_attiny26[37];
+extern const Register_file rgftab_attiny26[37];
 
-extern const Register_file_t rgftab_attiny43u[54];
+extern const Register_file rgftab_attiny43u[54];
 
-extern const Register_file_t rgftab_attiny44[55];
+extern const Register_file rgftab_attiny44[55];
 #define rgftab_attiny44a     rgftab_attiny44
 
-extern const Register_file_t rgftab_attiny45[55];
+extern const Register_file rgftab_attiny45[55];
 #define rgftab_attiny85      rgftab_attiny45
 
-extern const Register_file_t rgftab_attiny48[74];
+extern const Register_file rgftab_attiny48[74];
 
-extern const Register_file_t rgftab_attiny84[55];
+extern const Register_file rgftab_attiny84[55];
 #define rgftab_attiny84a     rgftab_attiny84
 
-extern const Register_file_t rgftab_attiny87[80];
+extern const Register_file rgftab_attiny87[80];
 #define rgftab_attiny167     rgftab_attiny87
 
-extern const Register_file_t rgftab_attiny88[74];
+extern const Register_file rgftab_attiny88[74];
 
-extern const Register_file_t rgftab_attiny261[63];
+extern const Register_file rgftab_attiny261[63];
 #define rgftab_attiny261a    rgftab_attiny261
 
-extern const Register_file_t rgftab_attiny461[63];
+extern const Register_file rgftab_attiny461[63];
 #define rgftab_attiny461a    rgftab_attiny461
 
-extern const Register_file_t rgftab_attiny828[94];
+extern const Register_file rgftab_attiny828[94];
 
-extern const Register_file_t rgftab_attiny861[63];
+extern const Register_file rgftab_attiny861[63];
 #define rgftab_attiny861a    rgftab_attiny861
 
-extern const Register_file_t rgftab_attiny1634[89];
+extern const Register_file rgftab_attiny1634[89];
 
-extern const Register_file_t rgftab_attiny2313[54];
+extern const Register_file rgftab_attiny2313[54];
 
-extern const Register_file_t rgftab_attiny2313a[58];
+extern const Register_file rgftab_attiny2313a[58];
 
-extern const Register_file_t rgftab_attiny4313[58];
+extern const Register_file rgftab_attiny4313[58];
 
-extern const Register_file_t rgftab_atmega8[61];
+extern const Register_file rgftab_atmega8[61];
 #define rgftab_atmega8a      rgftab_atmega8
 
-extern const Register_file_t rgftab_atmega8hva[74];
+extern const Register_file rgftab_atmega8hva[74];
 #define rgftab_atmega16hva   rgftab_atmega8hva
 
-extern const Register_file_t rgftab_atmega8u2[92];
+extern const Register_file rgftab_atmega8u2[92];
 #define rgftab_atmega16u2    rgftab_atmega8u2
 #define rgftab_atmega32u2    rgftab_atmega8u2
 
-extern const Register_file_t rgftab_atmega16[70];
+extern const Register_file rgftab_atmega16[70];
 
-extern const Register_file_t rgftab_atmega16a[70];
+extern const Register_file rgftab_atmega16a[70];
 
-extern const Register_file_t rgftab_atmega16u4[139];
+extern const Register_file rgftab_atmega16u4[139];
 #define rgftab_atmega32u4    rgftab_atmega16u4
 
-extern const Register_file_t rgftab_atmega32[68];
+extern const Register_file rgftab_atmega32[68];
 
-extern const Register_file_t rgftab_atmega32a[66];
+extern const Register_file rgftab_atmega32a[66];
 
-extern const Register_file_t rgftab_atmega32c1[117];
+extern const Register_file rgftab_atmega32c1[117];
 
-extern const Register_file_t rgftab_atmega48[81];
+extern const Register_file rgftab_atmega48[81];
 #define rgftab_atmega48p     rgftab_atmega48
 
-extern const Register_file_t rgftab_atmega48a[82];
+extern const Register_file rgftab_atmega48a[82];
 #define rgftab_atmega48pa    rgftab_atmega48a
 
-extern const Register_file_t rgftab_atmega48pb[95];
+extern const Register_file rgftab_atmega48pb[95];
 
-extern const Register_file_t rgftab_atmega64[103];
+extern const Register_file rgftab_atmega64[103];
 #define rgftab_atmega64a     rgftab_atmega64
 
-extern const Register_file_t rgftab_atmega64c1[122];
+extern const Register_file rgftab_atmega64c1[122];
 
-extern const Register_file_t rgftab_atmega64m1[136];
+extern const Register_file rgftab_atmega64m1[136];
 
-extern const Register_file_t rgftab_atmega64hve2[89];
+extern const Register_file rgftab_atmega64hve2[89];
 
-extern const Register_file_t rgftab_atmega64rfr2[269];
+extern const Register_file rgftab_atmega64rfr2[269];
 #define rgftab_atmega644rfr2 rgftab_atmega64rfr2
 
-extern const Register_file_t rgftab_atmega88[81];
+extern const Register_file rgftab_atmega88[81];
 #define rgftab_atmega88a     rgftab_atmega88
 #define rgftab_atmega88p     rgftab_atmega88
 #define rgftab_atmega88pa    rgftab_atmega88
@@ -2441,222 +2441,222 @@ extern const Register_file_t rgftab_atmega88[81];
 #define rgftab_atmega168p    rgftab_atmega88
 #define rgftab_atmega168pa   rgftab_atmega88
 
-extern const Register_file_t rgftab_atmega88pb[95];
+extern const Register_file rgftab_atmega88pb[95];
 #define rgftab_atmega168pb   rgftab_atmega88pb
 
-extern const Register_file_t rgftab_atmega128[103];
+extern const Register_file rgftab_atmega128[103];
 
-extern const Register_file_t rgftab_atmega128a[103];
+extern const Register_file rgftab_atmega128a[103];
 
-extern const Register_file_t rgftab_atmega128rfa1[237];
+extern const Register_file rgftab_atmega128rfa1[237];
 
-extern const Register_file_t rgftab_atmega128rfr2[270];
+extern const Register_file rgftab_atmega128rfr2[270];
 #define rgftab_atmega1284rfr2 rgftab_atmega128rfr2
 
-extern const Register_file_t rgftab_atmega162[79];
+extern const Register_file rgftab_atmega162[79];
 
-extern const Register_file_t rgftab_atmega164a[96];
+extern const Register_file rgftab_atmega164a[96];
 #define rgftab_atmega164p    rgftab_atmega164a
 #define rgftab_atmega164pa   rgftab_atmega164a
 #define rgftab_atmega324a    rgftab_atmega164a
 #define rgftab_atmega324p    rgftab_atmega164a
 #define rgftab_atmega324pa   rgftab_atmega164a
 
-extern const Register_file_t rgftab_atmega165a[86];
+extern const Register_file rgftab_atmega165a[86];
 #define rgftab_atmega165p    rgftab_atmega165a
 #define rgftab_atmega165pa   rgftab_atmega165a
 
-extern const Register_file_t rgftab_atmega169a[106];
+extern const Register_file rgftab_atmega169a[106];
 #define rgftab_atmega169p    rgftab_atmega169a
 #define rgftab_atmega169pa   rgftab_atmega169a
 
-extern const Register_file_t rgftab_atmega256rfr2[271];
+extern const Register_file rgftab_atmega256rfr2[271];
 
-extern const Register_file_t rgftab_atmega324pb[134];
+extern const Register_file rgftab_atmega324pb[134];
 
-extern const Register_file_t rgftab_atmega325[86];
+extern const Register_file rgftab_atmega325[86];
 #define rgftab_atmega325a    rgftab_atmega325
 #define rgftab_atmega325p    rgftab_atmega325
 #define rgftab_atmega325pa   rgftab_atmega325
 
-extern const Register_file_t rgftab_atmega329[106];
+extern const Register_file rgftab_atmega329[106];
 
-extern const Register_file_t rgftab_atmega329a[106];
+extern const Register_file rgftab_atmega329a[106];
 #define rgftab_atmega329pa   rgftab_atmega329a
 
-extern const Register_file_t rgftab_atmega329p[106];
+extern const Register_file rgftab_atmega329p[106];
 
-extern const Register_file_t rgftab_atmega406[79];
+extern const Register_file rgftab_atmega406[79];
 
-extern const Register_file_t rgftab_atmega640[160];
+extern const Register_file rgftab_atmega640[160];
 
-extern const Register_file_t rgftab_atmega644[88];
+extern const Register_file rgftab_atmega644[88];
 
-extern const Register_file_t rgftab_atmega644a[93];
+extern const Register_file rgftab_atmega644a[93];
 #define rgftab_atmega644p    rgftab_atmega644a
 #define rgftab_atmega644pa   rgftab_atmega644a
 
-extern const Register_file_t rgftab_atmega645[86];
+extern const Register_file rgftab_atmega645[86];
 #define rgftab_atmega645a    rgftab_atmega645
 #define rgftab_atmega645p    rgftab_atmega645
 
-extern const Register_file_t rgftab_atmega649[106];
+extern const Register_file rgftab_atmega649[106];
 #define rgftab_atmega649a    rgftab_atmega649
 #define rgftab_atmega649p    rgftab_atmega649
 
-extern const Register_file_t rgftab_atmega1280[161];
+extern const Register_file rgftab_atmega1280[161];
 #define rgftab_atmega2560    rgftab_atmega1280
 
-extern const Register_file_t rgftab_atmega1281[138];
+extern const Register_file rgftab_atmega1281[138];
 
-extern const Register_file_t rgftab_atmega1284[104];
+extern const Register_file rgftab_atmega1284[104];
 #define rgftab_atmega1284p   rgftab_atmega1284
 
-extern const Register_file_t rgftab_atmega2561[139];
+extern const Register_file rgftab_atmega2561[139];
 
-extern const Register_file_t rgftab_atmega2564rfr2[271];
+extern const Register_file rgftab_atmega2564rfr2[271];
 
-extern const Register_file_t rgftab_atmega3250[94];
+extern const Register_file rgftab_atmega3250[94];
 #define rgftab_atmega3250a   rgftab_atmega3250
 #define rgftab_atmega3250p   rgftab_atmega3250
 #define rgftab_atmega3250pa  rgftab_atmega3250
 
-extern const Register_file_t rgftab_atmega3290[118];
+extern const Register_file rgftab_atmega3290[118];
 #define rgftab_atmega3290a   rgftab_atmega3290
 
-extern const Register_file_t rgftab_atmega3290p[118];
+extern const Register_file rgftab_atmega3290p[118];
 
-extern const Register_file_t rgftab_atmega3290pa[118];
+extern const Register_file rgftab_atmega3290pa[118];
 
-extern const Register_file_t rgftab_atmega6450[94];
+extern const Register_file rgftab_atmega6450[94];
 #define rgftab_atmega6450a   rgftab_atmega6450
 #define rgftab_atmega6450p   rgftab_atmega6450
 
-extern const Register_file_t rgftab_atmega6490[118];
+extern const Register_file rgftab_atmega6490[118];
 #define rgftab_atmega6490a   rgftab_atmega6490
 #define rgftab_atmega6490p   rgftab_atmega6490
 
-extern const Register_file_t rgftab_atmega8535[67];
+extern const Register_file rgftab_atmega8535[67];
 
-extern const Register_file_t rgftab_at90pwm1[92];
+extern const Register_file rgftab_at90pwm1[92];
 
-extern const Register_file_t rgftab_at90pwm2b[100];
+extern const Register_file rgftab_at90pwm2b[100];
 
-extern const Register_file_t rgftab_at90pwm3[115];
+extern const Register_file rgftab_at90pwm3[115];
 
-extern const Register_file_t rgftab_at90pwm3b[115];
+extern const Register_file rgftab_at90pwm3b[115];
 
-extern const Register_file_t rgftab_at90pwm161[86];
+extern const Register_file rgftab_at90pwm161[86];
 
-extern const Register_file_t rgftab_at90pwm216[102];
+extern const Register_file rgftab_at90pwm216[102];
 
-extern const Register_file_t rgftab_at90pwm316[117];
+extern const Register_file rgftab_at90pwm316[117];
 
-extern const Register_file_t rgftab_at90usb646[157];
+extern const Register_file rgftab_at90usb646[157];
 #define rgftab_at90usb647    rgftab_at90usb646
 #define rgftab_at90usb1287   rgftab_at90usb646
 
-extern const Register_file_t rgftab_at90usb1286[132];
+extern const Register_file rgftab_at90usb1286[132];
 
-extern const Register_file_t rgftab_ata5272[80];
+extern const Register_file rgftab_ata5272[80];
 #define rgftab_ata5505       rgftab_ata5272
 
-extern const Register_file_t rgftab_ata5702m322[378];
+extern const Register_file rgftab_ata5702m322[378];
 
-extern const Register_file_t rgftab_ata5787[292];
+extern const Register_file rgftab_ata5787[292];
 
-extern const Register_file_t rgftab_ata5790n[117];
+extern const Register_file rgftab_ata5790n[117];
 #define rgftab_ata5791       rgftab_ata5790n
 
-extern const Register_file_t rgftab_ata5795[84];
+extern const Register_file rgftab_ata5795[84];
 
-extern const Register_file_t rgftab_ata5831[279];
+extern const Register_file rgftab_ata5831[279];
 #define rgftab_ata5832       rgftab_ata5831
 #define rgftab_ata5833       rgftab_ata5831
 #define rgftab_ata8510       rgftab_ata5831
 #define rgftab_ata8515       rgftab_ata5831
 
-extern const Register_file_t rgftab_ata5835[307];
+extern const Register_file rgftab_ata5835[307];
 
-extern const Register_file_t rgftab_ata6612c[81];
+extern const Register_file rgftab_ata6612c[81];
 #define rgftab_ata6613c      rgftab_ata6612c
 
-extern const Register_file_t rgftab_ata6614q[81];
+extern const Register_file rgftab_ata6614q[81];
 
-extern const Register_file_t rgftab_ata6616c[81];
+extern const Register_file rgftab_ata6616c[81];
 #define rgftab_ata6617c      rgftab_ata6616c
 #define rgftab_ata664251     rgftab_ata6616c
 
-extern const Register_file_t rgftab_atxmega16a4[553];
+extern const Register_file rgftab_atxmega16a4[553];
 #define rgftab_atxmega32a4   rgftab_atxmega16a4
 
-extern const Register_file_t rgftab_atxmega16a4u[630];
+extern const Register_file rgftab_atxmega16a4u[630];
 #define rgftab_atxmega32a4u  rgftab_atxmega16a4u
 
-extern const Register_file_t rgftab_atxmega16c4[482];
+extern const Register_file rgftab_atxmega16c4[482];
 #define rgftab_atxmega32c4   rgftab_atxmega16c4
 
-extern const Register_file_t rgftab_atxmega16d4[460];
+extern const Register_file rgftab_atxmega16d4[460];
 #define rgftab_atxmega32d4   rgftab_atxmega16d4
 
-extern const Register_file_t rgftab_atxmega32c3[569];
+extern const Register_file rgftab_atxmega32c3[569];
 #define rgftab_atxmega64c3   rgftab_atxmega32c3
 #define rgftab_atxmega128c3  rgftab_atxmega32c3
 #define rgftab_atxmega192c3  rgftab_atxmega32c3
 #define rgftab_atxmega256c3  rgftab_atxmega32c3
 
-extern const Register_file_t rgftab_atxmega32d3[567];
+extern const Register_file rgftab_atxmega32d3[567];
 #define rgftab_atxmega64d3   rgftab_atxmega32d3
 #define rgftab_atxmega128d3  rgftab_atxmega32d3
 #define rgftab_atxmega192d3  rgftab_atxmega32d3
 #define rgftab_atxmega256d3  rgftab_atxmega32d3
 
-extern const Register_file_t rgftab_atxmega64a1[814];
+extern const Register_file rgftab_atxmega64a1[814];
 #define rgftab_atxmega128a1  rgftab_atxmega64a1
 
-extern const Register_file_t rgftab_atxmega64a1u[943];
+extern const Register_file rgftab_atxmega64a1u[943];
 #define rgftab_atxmega128a1u rgftab_atxmega64a1u
 
-extern const Register_file_t rgftab_atxmega64b1[574];
+extern const Register_file rgftab_atxmega64b1[574];
 #define rgftab_atxmega128b1  rgftab_atxmega64b1
 
-extern const Register_file_t rgftab_atxmega64b3[458];
+extern const Register_file rgftab_atxmega64b3[458];
 #define rgftab_atxmega128b3  rgftab_atxmega64b3
 
-extern const Register_file_t rgftab_atxmega64a4u[632];
+extern const Register_file rgftab_atxmega64a4u[632];
 #define rgftab_atxmega128a4u rgftab_atxmega64a4u
 
-extern const Register_file_t rgftab_atxmega64d4[460];
+extern const Register_file rgftab_atxmega64d4[460];
 #define rgftab_atxmega128d4  rgftab_atxmega64d4
 
-extern const Register_file_t rgftab_atxmega256a3b[665];
+extern const Register_file rgftab_atxmega256a3b[665];
 
-extern const Register_file_t rgftab_atxmega256a3bu[780];
+extern const Register_file rgftab_atxmega256a3bu[780];
 
-extern const Register_file_t rgftab_atxmega384c3[603];
+extern const Register_file rgftab_atxmega384c3[603];
 
-extern const Register_file_t rgftab_atxmega384d3[560];
+extern const Register_file rgftab_atxmega384d3[560];
 
-extern const Register_file_t rgftab_attiny202[217];
+extern const Register_file rgftab_attiny202[217];
 #define rgftab_attiny402     rgftab_attiny202
 
-extern const Register_file_t rgftab_attiny212[247];
+extern const Register_file rgftab_attiny212[247];
 #define rgftab_attiny412     rgftab_attiny212
 
-extern const Register_file_t rgftab_attiny214[265];
+extern const Register_file rgftab_attiny214[265];
 #define rgftab_attiny414     rgftab_attiny214
 
-extern const Register_file_t rgftab_attiny406[253];
+extern const Register_file rgftab_attiny406[253];
 
-extern const Register_file_t rgftab_attiny416[283];
+extern const Register_file rgftab_attiny416[283];
 
-extern const Register_file_t rgftab_attiny416auto[283];
+extern const Register_file rgftab_attiny416auto[283];
 
-extern const Register_file_t rgftab_attiny417[283];
+extern const Register_file rgftab_attiny417[283];
 #define rgftab_attiny816     rgftab_attiny417
 #define rgftab_attiny817     rgftab_attiny417
 
-extern const Register_file_t rgftab_attiny426[308];
+extern const Register_file rgftab_attiny426[308];
 #define rgftab_attiny427     rgftab_attiny426
 #define rgftab_attiny826     rgftab_attiny426
 #define rgftab_attiny827     rgftab_attiny426
@@ -2665,41 +2665,41 @@ extern const Register_file_t rgftab_attiny426[308];
 #define rgftab_attiny3226    rgftab_attiny426
 #define rgftab_attiny3227    rgftab_attiny426
 
-extern const Register_file_t rgftab_attiny804[255];
+extern const Register_file rgftab_attiny804[255];
 #define rgftab_attiny806     rgftab_attiny804
 #define rgftab_attiny807     rgftab_attiny804
 #define rgftab_attiny1604    rgftab_attiny804
 #define rgftab_attiny1606    rgftab_attiny804
 #define rgftab_attiny1607    rgftab_attiny804
 
-extern const Register_file_t rgftab_attiny814[265];
+extern const Register_file rgftab_attiny814[265];
 
-extern const Register_file_t rgftab_attiny1614[308];
+extern const Register_file rgftab_attiny1614[308];
 
-extern const Register_file_t rgftab_attiny1616[326];
+extern const Register_file rgftab_attiny1616[326];
 #define rgftab_attiny1617    rgftab_attiny1616
 
-extern const Register_file_t rgftab_attiny3216[326];
+extern const Register_file rgftab_attiny3216[326];
 #define rgftab_attiny3217    rgftab_attiny3216
 
-extern const Register_file_t rgftab_atmega808[406];
+extern const Register_file rgftab_atmega808[406];
 #define rgftab_atmega1608    rgftab_atmega808
 
-extern const Register_file_t rgftab_atmega809[432];
+extern const Register_file rgftab_atmega809[432];
 #define rgftab_atmega1609    rgftab_atmega809
 
-extern const Register_file_t rgftab_atmega3208[406];
+extern const Register_file rgftab_atmega3208[406];
 #define rgftab_atmega4808    rgftab_atmega3208
 
-extern const Register_file_t rgftab_atmega3209[432];
+extern const Register_file rgftab_atmega3209[432];
 #define rgftab_atmega4809    rgftab_atmega3209
 
-extern const Register_file_t rgftab_avr16du14[371];
+extern const Register_file rgftab_avr16du14[371];
 #define rgftab_avr32du14     rgftab_avr16du14
 
-extern const Register_file_t rgftab_avr16eb14[391];
+extern const Register_file rgftab_avr16eb14[391];
 
-extern const Register_file_t rgftab_avr16du20[372];
+extern const Register_file rgftab_avr16du20[372];
 #define rgftab_avr16du28     rgftab_avr16du20
 #define rgftab_avr16du32     rgftab_avr16du20
 #define rgftab_avr32du20     rgftab_avr16du20
@@ -2708,53 +2708,60 @@ extern const Register_file_t rgftab_avr16du20[372];
 #define rgftab_avr64du28     rgftab_avr16du20
 #define rgftab_avr64du32     rgftab_avr16du20
 
-extern const Register_file_t rgftab_avr16eb20[393];
+extern const Register_file rgftab_avr16eb20[393];
 #define rgftab_avr16eb28     rgftab_avr16eb20
 #define rgftab_avr16eb32     rgftab_avr16eb20
 
-extern const Register_file_t rgftab_avr16ea28[402];
+extern const Register_file rgftab_avr16ea28[402];
 #define rgftab_avr16ea32     rgftab_avr16ea28
 #define rgftab_avr32ea28     rgftab_avr16ea28
 #define rgftab_avr32ea32     rgftab_avr16ea28
 #define rgftab_avr64ea28     rgftab_avr16ea28
 #define rgftab_avr64ea32     rgftab_avr16ea28
 
-extern const Register_file_t rgftab_avr32da28[432];
+extern const Register_file rgftab_avr32da28[432];
 
-extern const Register_file_t rgftab_avr32db28[462];
+extern const Register_file rgftab_avr32db28[462];
 #define rgftab_avr64db28     rgftab_avr32db28
 #define rgftab_avr128db28    rgftab_avr32db28
 
-extern const Register_file_t rgftab_avr32da32[447];
+extern const Register_file rgftab_avr32da32[447];
 
-extern const Register_file_t rgftab_avr32db32[477];
+extern const Register_file rgftab_avr32db32[477];
 #define rgftab_avr64db32     rgftab_avr32db32
 #define rgftab_avr128db32    rgftab_avr32db32
 
-extern const Register_file_t rgftab_avr32da48[600];
+extern const Register_file rgftab_avr32da48[600];
 
-extern const Register_file_t rgftab_avr32db48[643];
+extern const Register_file rgftab_avr32db48[643];
 #define rgftab_avr64db48     rgftab_avr32db48
 #define rgftab_avr128db48    rgftab_avr32db48
 
-extern const Register_file_t rgftab_avr64da28[433];
+extern const Register_file rgftab_avr64da28[433];
 #define rgftab_avr128da28    rgftab_avr64da28
 
-extern const Register_file_t rgftab_avr64da32[448];
+extern const Register_file rgftab_avr64da32[448];
 #define rgftab_avr128da32    rgftab_avr64da32
 
-extern const Register_file_t rgftab_avr64da48[601];
+extern const Register_file rgftab_avr64da48[601];
 #define rgftab_avr128da48    rgftab_avr64da48
 
-extern const Register_file_t rgftab_avr64da64[659];
+extern const Register_file rgftab_avr64da64[659];
 #define rgftab_avr128da64    rgftab_avr64da64
 
-extern const Register_file_t rgftab_avr64db64[698];
+extern const Register_file rgftab_avr64db64[698];
 #define rgftab_avr128db64    rgftab_avr64db64
 
 int upidxmcuid(int mcuid);
 int upidxsig(const uint8_t *sigs);
 int upidxname(const char *name);
 int upmatchingsig(uint8_t sigs[3], char *p, size_t n);
+
+#ifndef TO_BE_DEPRECATED_IN_2026
+typedef Configvalue Valueitem_t;
+typedef Configitem Configitem_t;
+typedef Register_file Register_file_t;
+typedef Avrintel uPcore_t;
+#endif
 
 #endif

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -2759,7 +2759,7 @@ int upmatchingsig(uint8_t sigs[3], char *p, size_t n);
 
 #ifndef TO_BE_DEPRECATED_IN_2026
 typedef Configvalue Configvalue;
-typedef Configitem Configitem_t;
+typedef Configitem Configitem;
 typedef Register_file Register_file_t;
 typedef Avrintel Avrintel;
 #endif

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -2757,11 +2757,4 @@ int upidxsig(const uint8_t *sigs);
 int upidxname(const char *name);
 int upmatchingsig(uint8_t sigs[3], char *p, size_t n);
 
-#ifndef TO_BE_DEPRECATED_IN_2026
-typedef Configvalue Valueitem_t;
-typedef Configitem Configitem_t;
-typedef Register_file Register_file_t;
-typedef Avrintel uPcore_t;
-#endif
-
 #endif

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -2761,7 +2761,7 @@ int upmatchingsig(uint8_t sigs[3], char *p, size_t n);
 typedef Configvalue Valueitem_t;
 typedef Configitem Configitem_t;
 typedef Register_file Register_file_t;
-typedef Avrintel uPcore_t;
+typedef Avrintel Avrintel;
 #endif
 
 #endif

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -2758,10 +2758,10 @@ int upidxname(const char *name);
 int upmatchingsig(uint8_t sigs[3], char *p, size_t n);
 
 #ifndef TO_BE_DEPRECATED_IN_2026
-typedef Configvalue Configvalue;
-typedef Configitem Configitem;
-typedef Register_file Register_file;
-typedef Avrintel Avrintel;
+typedef Configvalue Valueitem_t;
+typedef Configitem Configitem_t;
+typedef Register_file Register_file_t;
+typedef Avrintel uPcore_t;
 #endif
 
 #endif

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -2758,7 +2758,7 @@ int upidxname(const char *name);
 int upmatchingsig(uint8_t sigs[3], char *p, size_t n);
 
 #ifndef TO_BE_DEPRECATED_IN_2026
-typedef Configvalue Valueitem_t;
+typedef Configvalue Configvalue;
 typedef Configitem Configitem_t;
 typedef Register_file Register_file_t;
 typedef Avrintel Avrintel;

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -2760,7 +2760,7 @@ int upmatchingsig(uint8_t sigs[3], char *p, size_t n);
 #ifndef TO_BE_DEPRECATED_IN_2026
 typedef Configvalue Configvalue;
 typedef Configitem Configitem;
-typedef Register_file Register_file_t;
+typedef Register_file Register_file;
 typedef Avrintel Avrintel;
 #endif
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -702,14 +702,14 @@ void pin_set_value(struct pindef_t * const pindef, const int pin, const bool inv
  */
 void pin_clear_all(struct pindef_t * const pindef);
 
-struct programmer_t; /* forward declaration */
+typedef struct programmer_t PROGRAMMER; // Forward declaration
 
 /**
  * Convert for given programmer new pin definitions to old pin definitions.
  *
  * @param[inout] pgm programmer whose pins shall be converted.
  */
-int pgm_fill_old_pins(struct programmer_t * const pgm);
+int pgm_fill_old_pins(PROGRAMMER * const pgm);
 
 /**
  * This function checks all pin of pgm against the constraints given in the checklist.
@@ -729,7 +729,7 @@ int pgm_fill_old_pins(struct programmer_t * const pgm);
  * @param[in] output false suppresses error messages to the user
  * @returns 0 if all pin definitions are valid, -1 otherwise
  */
-int pins_check(const struct programmer_t * const pgm, const struct pin_checklist_t * const checklist, const int size, const bool output);
+int pins_check(const PROGRAMMER * const pgm, const struct pin_checklist_t * const checklist, const int size, const bool output);
 
 /**
  * Returns the name of the pin as string.
@@ -937,7 +937,7 @@ typedef struct {
 typedef struct programmer_t {
   LISTID id;
   const char *desc;
-  void (*initpgm)(struct programmer_t *pgm); // Sets up the AVRDUDE programmer
+  void (*initpgm)(PROGRAMMER *pgm); // Sets up the AVRDUDE programmer
   LISTID comments;              // Used by developer options -c*/[ASsr...]
   const char *parent_id;        // Used by developer options
   int prog_modes;               // Programming interfaces, see #define PM_...
@@ -969,76 +969,63 @@ typedef struct programmer_t {
   double bitclock;              // JTAG ICE clock period in microseconds
   leds_t *leds;                 // State of LEDs as tracked by led_...()  functions in leds.c
 
-  int  (*rdy_led)        (const struct programmer_t *pgm, int value);
-  int  (*err_led)        (const struct programmer_t *pgm, int value);
-  int  (*pgm_led)        (const struct programmer_t *pgm, int value);
-  int  (*vfy_led)        (const struct programmer_t *pgm, int value);
-  int  (*initialize)     (const struct programmer_t *pgm, const AVRPART *p); // Sets up the physical programmer
-  void (*display)        (const struct programmer_t *pgm, const char *p);
-  void (*enable)         (struct programmer_t *pgm, const AVRPART *p);
-  void (*disable)        (const struct programmer_t *pgm);
-  void (*powerup)        (const struct programmer_t *pgm);
-  void (*powerdown)      (const struct programmer_t *pgm);
-  int  (*program_enable) (const struct programmer_t *pgm, const AVRPART *p);
-  int  (*chip_erase)     (const struct programmer_t *pgm, const AVRPART *p);
-  int  (*unlock)         (const struct programmer_t *pgm, const AVRPART *p);
-  int  (*cmd)            (const struct programmer_t *pgm, const unsigned char *cmd,
-                          unsigned char *res);
-  int  (*cmd_tpi)        (const struct programmer_t *pgm, const unsigned char *cmd,
-                          int cmd_len, unsigned char res[], int res_len);
-  int  (*spi)            (const struct programmer_t *pgm, const unsigned char *cmd,
-                          unsigned char *res, int count);
-  int  (*open)           (struct programmer_t *pgm, const char *port);
-  void (*close)          (struct programmer_t *pgm);
-  int  (*paged_write)    (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned int page_size, unsigned int baseaddr,
-                          unsigned int n_bytes);
-  int  (*paged_load)     (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned int page_size, unsigned int baseaddr,
-                          unsigned int n_bytes);
-  int  (*page_erase)     (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned int baseaddr);
-  void (*write_setup)    (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m);
-  int  (*write_byte)     (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned long addr, unsigned char value);
-  int  (*read_byte)      (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned long addr, unsigned char *value);
-  int  (*read_sig_bytes) (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m);
-  int  (*read_sib)       (const struct programmer_t *pgm, const AVRPART *p, char *sib);
-  int  (*read_chip_rev)  (const struct programmer_t *pgm, const AVRPART *p, unsigned char *chip_rev);
-  int  (*term_keep_alive)(const struct programmer_t *pgm, const AVRPART *p);
-  int  (*end_programming)(const struct programmer_t *pgm, const AVRPART *p);
+  int  (*rdy_led)        (const PROGRAMMER *pgm, int value);
+  int  (*err_led)        (const PROGRAMMER *pgm, int value);
+  int  (*pgm_led)        (const PROGRAMMER *pgm, int value);
+  int  (*vfy_led)        (const PROGRAMMER *pgm, int value);
+  int  (*initialize)     (const PROGRAMMER *pgm, const AVRPART *p); // Sets up the physical programmer
+  void (*display)        (const PROGRAMMER *pgm, const char *p);
+  void (*enable)         (PROGRAMMER *pgm, const AVRPART *p);
+  void (*disable)        (const PROGRAMMER *pgm);
+  void (*powerup)        (const PROGRAMMER *pgm);
+  void (*powerdown)      (const PROGRAMMER *pgm);
+  int  (*program_enable) (const PROGRAMMER *pgm, const AVRPART *p);
+  int  (*chip_erase)     (const PROGRAMMER *pgm, const AVRPART *p);
+  int  (*unlock)         (const PROGRAMMER *pgm, const AVRPART *p);
+  int  (*cmd)            (const PROGRAMMER *pgm, const unsigned char *cmd, unsigned char *res);
+  int  (*cmd_tpi)        (const PROGRAMMER *pgm, const unsigned char *cmd, int cmd_len, unsigned char *res, int res_len);
+  int  (*spi)            (const PROGRAMMER *pgm, const unsigned char *cmd, unsigned char *res, int count);
+  int  (*open)           (PROGRAMMER *pgm, const char *port);
+  void (*close)          (PROGRAMMER *pgm);
+  int  (*paged_write)    (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int pg_size, unsigned int addr, unsigned int n);
+  int  (*paged_load)     (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int pg_size, unsigned int addr, unsigned int n);
+  int  (*page_erase)     (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int addr);
+  void (*write_setup)    (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);
+  int  (*write_byte)     (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr, unsigned char value);
+  int  (*read_byte)      (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr, unsigned char *value);
+  int  (*read_sig_bytes) (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);
+  int  (*read_sib)       (const PROGRAMMER *pgm, const AVRPART *p, char *sib);
+  int  (*read_chip_rev)  (const PROGRAMMER *pgm, const AVRPART *p, unsigned char *chip_rev);
+  int  (*term_keep_alive)(const PROGRAMMER *pgm, const AVRPART *p);
+  int  (*end_programming)(const PROGRAMMER *pgm, const AVRPART *p);
 
-  void (*print_parms)    (const struct programmer_t *pgm, FILE *fp);
-  int  (*set_vtarget)    (const struct programmer_t *pgm, double v);
-  int  (*get_vtarget)    (const struct programmer_t *pgm, double *v);
-  int  (*set_varef)      (const struct programmer_t *pgm, unsigned int chan, double v);
-  int  (*get_varef)      (const struct programmer_t *pgm, unsigned int chan, double *v);
-  int  (*set_fosc)       (const struct programmer_t *pgm, double v);
-  int  (*get_fosc)       (const struct programmer_t *pgm, double *v);
-  int  (*set_sck_period) (const struct programmer_t *pgm, double v);
-  int  (*get_sck_period) (const struct programmer_t *pgm, double *v);
-  int  (*setpin)         (const struct programmer_t *pgm, int pinfunc, int value);
-  int  (*getpin)         (const struct programmer_t *pgm, int pinfunc);
-  int  (*highpulsepin)   (const struct programmer_t *pgm, int pinfunc);
-  int  (*parseexitspecs) (struct programmer_t *pgm, const char *s);
-  int  (*perform_osccal) (const struct programmer_t *pgm);
-  int  (*parseextparams) (const struct programmer_t *pgm, const LISTID xparams);
-  void (*setup)          (struct programmer_t *pgm);
-  void (*teardown)       (struct programmer_t *pgm);
-  int  (*flash_readhook) (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *flm, const char *fname, int size);
+  void (*print_parms)    (const PROGRAMMER *pgm, FILE *fp);
+  int  (*set_vtarget)    (const PROGRAMMER *pgm, double v);
+  int  (*get_vtarget)    (const PROGRAMMER *pgm, double *v);
+  int  (*set_varef)      (const PROGRAMMER *pgm, unsigned int chan, double v);
+  int  (*get_varef)      (const PROGRAMMER *pgm, unsigned int chan, double *v);
+  int  (*set_fosc)       (const PROGRAMMER *pgm, double v);
+  int  (*get_fosc)       (const PROGRAMMER *pgm, double *v);
+  int  (*set_sck_period) (const PROGRAMMER *pgm, double v);
+  int  (*get_sck_period) (const PROGRAMMER *pgm, double *v);
+  int  (*setpin)         (const PROGRAMMER *pgm, int pinfunc, int value);
+  int  (*getpin)         (const PROGRAMMER *pgm, int pinfunc);
+  int  (*highpulsepin)   (const PROGRAMMER *pgm, int pinfunc);
+  int  (*parseexitspecs) (PROGRAMMER *pgm, const char *s);
+  int  (*perform_osccal) (const PROGRAMMER *pgm);
+  int  (*parseextparams) (const PROGRAMMER *pgm, const LISTID xparams);
+  void (*setup)          (PROGRAMMER *pgm);
+  void (*teardown)       (PROGRAMMER *pgm);
+  int  (*flash_readhook) (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *flm, const char *fname, int size);
+
   // Cached r/w API for terminal reads/writes
-  int (*write_byte_cached)(const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned long addr, unsigned char value);
-  int (*read_byte_cached)(const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned long addr, unsigned char *value);
-  int (*chip_erase_cached)(const struct programmer_t *pgm, const AVRPART *p);
-  int (*page_erase_cached)(const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned int baseaddr);
-  int (*readonly)        (const struct programmer_t *pgm, const AVRPART *p, const AVRMEM *m,
-                          unsigned int addr);
-  int (*flush_cache)     (const struct programmer_t *pgm, const AVRPART *p);
-  int (*reset_cache)     (const struct programmer_t *pgm, const AVRPART *p);
+  int (*write_byte_cached)(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr, unsigned char value);
+  int (*read_byte_cached)(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr, unsigned char *value);
+  int (*chip_erase_cached)(const PROGRAMMER *pgm, const AVRPART *p);
+  int (*page_erase_cached)(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int addr);
+  int (*readonly)        (const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int addr);
+  int (*flush_cache)     (const PROGRAMMER *pgm, const AVRPART *p);
+  int (*reset_cache)     (const PROGRAMMER *pgm, const AVRPART *p);
   AVR_Cache *cp_flash, *cp_eeprom, *cp_bootrow, *cp_usersig;
 
   const char *config_file;      // Config file where defined
@@ -1184,7 +1171,7 @@ int avr_is_and(const unsigned char *s1, const unsigned char *s2, const unsigned 
 int avr_read_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned long addr, unsigned char *value);
 int avr_write_byte_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned long addr, unsigned char data);
 int avr_chip_erase_cached(const PROGRAMMER *pgm, const AVRPART *p);
-int avr_page_erase_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned int baseaddr);
+int avr_page_erase_cached(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, unsigned int addr);
 int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p);
 int avr_reset_cache(const PROGRAMMER *pgm, const AVRPART *p);
 
@@ -1326,7 +1313,7 @@ int update_dryrun(const AVRPART *p, UPDATE *upd);
 
 typedef struct programmer_type_t {
   const char * const id;
-  void (*initpgm)(struct programmer_t *pgm);
+  void (*initpgm)(PROGRAMMER *pgm);
   const char * const desc;
 } PROGRAMMER_TYPE;
 
@@ -1336,7 +1323,7 @@ extern "C" {
 
 const PROGRAMMER_TYPE *locate_programmer_type(const char *id);
 
-const char *locate_programmer_type_id(void (*initpgm)(struct programmer_t *pgm));
+const char *locate_programmer_type_id(void (*initpgm)(PROGRAMMER *pgm));
 
 typedef void (*walk_programmer_types_cb)(const char *id, const char *desc,
                                     void *cookie);
@@ -1511,16 +1498,11 @@ size_t str_weighted_damerau_levenshtein(const char *str1, const char *str2);
 int led_set(const PROGRAMMER *pgm, int led);
 int led_clr(const PROGRAMMER *pgm, int led);
 int led_chip_erase(const PROGRAMMER *pgm, const AVRPART *p);
-int led_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
-  unsigned long addr, unsigned char value);
-int led_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
-  unsigned long addr, unsigned char *value);
-int led_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
-  unsigned int page_size, unsigned int baseaddr, unsigned int n_bytes);
-int led_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
-  unsigned int page_size, unsigned int baseaddr, unsigned int n_bytes);
-int led_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m,
-  unsigned int baseaddr);
+int led_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr, unsigned char value);
+int led_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned long addr, unsigned char *value);
+int led_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int page_size, unsigned int addr, unsigned int n);
+int led_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int page_size, unsigned int addr, unsigned int n);
+int led_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, unsigned int addr);
 
 int terminal_mode(const PROGRAMMER *pgm, const AVRPART *p);
 int terminal_mode_noninteractive(const PROGRAMMER *pgm, const AVRPART *p);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -891,7 +891,7 @@ typedef enum {
   EXIT_RESET_UNSPEC,
   EXIT_RESET_ENABLED,
   EXIT_RESET_DISABLED
-} exit_reset_t;
+} Exit_reset;
 
 typedef enum {
   EXIT_DATAHIGH_UNSPEC,
@@ -960,7 +960,7 @@ typedef struct programmer {
   const char *port;
   unsigned int pinno[N_PINS];   // TODO to be removed if old pin data no longer needed
   exit_vcc_t exit_vcc;          // Should these be set in avrdude.conf?
-  exit_reset_t exit_reset;
+  Exit_reset exit_reset;
   Exit_datahigh exit_datahigh;
   int ppidata;
   int ppictrl;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -51,7 +51,7 @@
  * compiled from source together with the application.
  */
 
-typedef uint32_t pinmask_t;
+typedef uint32_t Pinmask;
 /*
  * Values returned by library functions.
  * Some library functions also return a count, i.e. a positive
@@ -627,7 +627,7 @@ enum {
 #endif
 
 /** Number of pins in each element of the bitfield */
-#define PIN_FIELD_ELEMENT_SIZE (sizeof(pinmask_t) * 8)
+#define PIN_FIELD_ELEMENT_SIZE (sizeof(Pinmask) * 8)
 /** Numer of elements to store the complete bitfield of all pins */
 #define PIN_FIELD_SIZE ((PIN_MAX+1 + PIN_FIELD_ELEMENT_SIZE-1)/PIN_FIELD_ELEMENT_SIZE)
 
@@ -673,8 +673,8 @@ enum {
  * Data structure to hold used pins by logical function (PIN_AVR_*, ...)
  */
 struct pindef {
-  pinmask_t mask[PIN_FIELD_SIZE]; ///< bitfield of used pins
-  pinmask_t inverse[PIN_FIELD_SIZE]; ///< bitfield of inverse/normal usage of used pins
+  Pinmask mask[PIN_FIELD_SIZE]; ///< bitfield of used pins
+  Pinmask inverse[PIN_FIELD_SIZE]; ///< bitfield of inverse/normal usage of used pins
 };
 
 /**
@@ -762,7 +762,7 @@ const char *pins_to_str(const struct pindef * const pindef);
  * @param[in] pinmask the pin mask for which we want the string representation
  * @returns a temporary string that lives in closed-circuit space
  */
-const char *pinmask_to_str(const pinmask_t * const pinmask);
+const char *pinmask_to_str(const Pinmask * const pinmask);
 
 /* formerly serial.h */
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -924,7 +924,7 @@ typedef enum {
 typedef struct {
   int now, chg, phy, end, set;  // LED states (current, change needed next period, physical, at end, ever set)
   unsigned long ms[LED_N];      // Time in ms after last physical change
-} leds_t;
+} Leds;
 
 /*
  * Any changes in PROGRAMMER, please also ensure changes are made in
@@ -959,7 +959,7 @@ typedef struct programmer {
   char type[PGM_TYPELEN];
   const char *port;
   unsigned int pinno[N_PINS];   // TODO to be removed if old pin data no longer needed
-  Exit_vcc exit_vcc;          // Should these be set in avrdude.conf?
+  Exit_vcc exit_vcc;            // Should these be set in avrdude.conf?
   Exit_reset exit_reset;
   Exit_datahigh exit_datahigh;
   int ppidata;
@@ -967,7 +967,7 @@ typedef struct programmer {
   int ispdelay;                 // ISP clock delay
   int page_size;                // Page size if the programmer supports paged write/load
   double bitclock;              // JTAG ICE clock period in microseconds
-  leds_t *leds;                 // State of LEDs as tracked by led_...()  functions in leds.c
+  Leds *leds;                   // State of LEDs as tracked by led_...()  functions in leds.c
 
   int  (*rdy_led)        (const PROGRAMMER *pgm, int value);
   int  (*err_led)        (const PROGRAMMER *pgm, int value);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1624,5 +1624,16 @@ int win_set_path(char *path, int n, const char *file);
 
 #endif  /* WIN32 */
 
+#ifndef TO_BE_DEPRECATED_IN_2026
+typedef Pinmask pinmask_t;
+typedef Conntype conntype_t;
+typedef Exit_datahigh exit_datahigh_t;
+typedef Exit_reset exit_reset_t;
+typedef Exit_vcc exit_vcc_t;
+typedef Leds leds_t;
+typedef Memtable memtable_t;
+typedef Memtype memtype_t;
+typedef Segment Segment_t;
+#endif
 
 #endif  /* libavrdude_h */

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -351,10 +351,10 @@ typedef struct avrpart {
 } AVRPART;
 
 
-typedef unsigned int memtype_t;
+typedef unsigned int Memtype;
 typedef struct {
   const char *str;
-  memtype_t type;
+  Memtype type;
 } Memtable;
 
 // The least significant 4 bits of type are the offset of a fuse in fuses mem
@@ -497,7 +497,7 @@ typedef struct {
 
 typedef struct avrmem {
   const char *desc;           /* memory description ("flash", "eeprom", etc) */
-  memtype_t type;             /* internally used type, cannot be set in conf files */
+  Memtype type;               /* Internally used type, cannot be set in conf files */
   LISTID comments;            // Used by developer options -p*/[ASsr...]
   int paged;                  /* 16-bit page addressed, e.g., ATmega flash but not EEPROM */
   int size;                   /* total memory size in bytes */
@@ -562,7 +562,7 @@ void     avr_free_memalias(AVRMEM_ALIAS * m);
 AVRMEM * avr_locate_mem(const AVRPART *p, const char *desc);
 AVRMEM * avr_locate_mem_noalias(const AVRPART *p, const char *desc);
 AVRMEM * avr_locate_fuse_by_offset(const AVRPART *p, unsigned int off);
-AVRMEM * avr_locate_mem_by_type(const AVRPART *p, memtype_t type);
+AVRMEM * avr_locate_mem_by_type(const AVRPART *p, Memtype type);
 unsigned int avr_data_offset(const AVRPART *p);
 AVRMEM_ALIAS * avr_locate_memalias(const AVRPART *p, const char *desc);
 AVRMEM_ALIAS * avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -189,7 +189,7 @@ enum { /* these are assigned to reset_disposition of AVRPART */
   RESET_IO            /* reset pin might be configured as an I/O pin */
 };
 
-enum ctl_stack_t {
+enum ctl_stack {
   CTL_STACK_NONE,     /* no control stack defined */
   CTL_STACK_PP,	      /* parallel programming control stack */
   CTL_STACK_HVSP      /* high voltage serial programming control stack */
@@ -300,7 +300,7 @@ typedef struct avrpart {
   int           postdelay;
   int           pollmethod;
 
-  enum ctl_stack_t ctl_stack_type;  /* what to use the ctl stack for */
+  enum ctl_stack ctl_stack_type;  /* what to use the ctl stack for */
   unsigned char controlstack[CTL_STACK_SIZE]; /* stk500v2 PP/HVSP ctl stack */
   unsigned char flash_instr[FLASH_INSTR_SIZE]; /* flash instructions (debugWire, JTAG) */
   unsigned char eeprom_instr[EEPROM_INSTR_SIZE]; /* EEPROM instructions (debugWire, JTAG) */

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -355,7 +355,7 @@ typedef unsigned int memtype_t;
 typedef struct {
   const char *str;
   memtype_t type;
-} memtable_t;
+} Memtable;
 
 // The least significant 4 bits of type are the offset of a fuse in fuses mem
 #define MEM_FUSEOFF_MASK     15 // Mask for offset
@@ -1082,7 +1082,7 @@ void sort_programmers(LISTID programmers);
 typedef void (*FP_UpdateProgress)(int percent, double etime, const char *hdr, int finish);
 
 extern struct avrpart parts[];
-extern memtable_t avr_mem_order[100];
+extern Memtable avr_mem_order[100];
 
 extern FP_UpdateProgress update_progress;
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -680,11 +680,11 @@ struct pindef {
 /**
  * Data structure to define a checklist of valid pins for each function.
  */
-struct pin_checklist_t {
+typedef struct pin_checklist {
   int pinname; ///< logical pinname eg. PIN_AVR_SCK
   int mandatory; ///< is this a mandatory pin
   const struct pindef *valid_pins; ///< mask defines allowed pins, inverse define is they might be used inverted
-};
+} Pin_checklist;
 
 /**
  * Adds a pin in the pin definition as normal or inverse pin.
@@ -729,7 +729,7 @@ int pgm_fill_old_pins(PROGRAMMER * const pgm);
  * @param[in] output false suppresses error messages to the user
  * @returns 0 if all pin definitions are valid, -1 otherwise
  */
-int pins_check(const PROGRAMMER * const pgm, const struct pin_checklist_t * const checklist, const int size, const bool output);
+int pins_check(const PROGRAMMER * const pgm, const Pin_checklist * const checklist, const int size, const bool output);
 
 /**
  * Returns the name of the pin as string.

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -672,7 +672,7 @@ enum {
 /**
  * Data structure to hold used pins by logical function (PIN_AVR_*, ...)
  */
-struct pindef_t {
+struct pindef {
   pinmask_t mask[PIN_FIELD_SIZE]; ///< bitfield of used pins
   pinmask_t inverse[PIN_FIELD_SIZE]; ///< bitfield of inverse/normal usage of used pins
 };
@@ -683,7 +683,7 @@ struct pindef_t {
 struct pin_checklist_t {
   int pinname; ///< logical pinname eg. PIN_AVR_SCK
   int mandatory; ///< is this a mandatory pin
-  const struct pindef_t* valid_pins; ///< mask defines allowed pins, inverse define is they might be used inverted
+  const struct pindef *valid_pins; ///< mask defines allowed pins, inverse define is they might be used inverted
 };
 
 /**
@@ -693,14 +693,14 @@ struct pin_checklist_t {
  * @param[in] pin number of pin [0..PIN_MAX]
  * @param[in] inverse inverse (true) or normal (false) pin
  */
-void pin_set_value(struct pindef_t * const pindef, const int pin, const bool inverse);
+void pin_set_value(struct pindef * const pindef, const int pin, const bool inverse);
 
 /**
  * Clear all defined pins in pindef.
  *
  * @param[out] pindef pin definition to clear
  */
-void pin_clear_all(struct pindef_t * const pindef);
+void pin_clear_all(struct pindef * const pindef);
 
 typedef struct programmer PROGRAMMER; // Forward declaration
 
@@ -753,7 +753,7 @@ const char * avr_pin_lcname(int pinname);
  * @param[in] pindef the pin definition for which we want the string representation
  * @returns a temporary string that lives in closed-circuit space
  */
-const char *pins_to_str(const struct pindef_t * const pindef);
+const char *pins_to_str(const struct pindef * const pindef);
 
 /**
  * This function returns a string representation of pins in the mask, eg, 1, 3, 5-7, 9, 12
@@ -943,7 +943,7 @@ typedef struct programmer {
   int prog_modes;               // Programming interfaces, see #define PM_...
   int is_serialadapter;         // Programmer is also a serialadapter
   int extra_features;
-  struct pindef_t pin[N_PINS];
+  struct pindef pin[N_PINS];
   conntype_t conntype;
   int baudrate;
   int usbvid;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -897,7 +897,7 @@ typedef enum {
   EXIT_DATAHIGH_UNSPEC,
   EXIT_DATAHIGH_ENABLED,
   EXIT_DATAHIGH_DISABLED
-} exit_datahigh_t;
+} Exit_datahigh;
 
 typedef enum {
   CONNTYPE_PARALLEL,
@@ -961,7 +961,7 @@ typedef struct programmer {
   unsigned int pinno[N_PINS];   // TODO to be removed if old pin data no longer needed
   exit_vcc_t exit_vcc;          // Should these be set in avrdude.conf?
   exit_reset_t exit_reset;
-  exit_datahigh_t exit_datahigh;
+  Exit_datahigh exit_datahigh;
   int ppidata;
   int ppictrl;
   int ispdelay;                 // ISP clock delay

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1311,7 +1311,7 @@ int update_dryrun(const AVRPART *p, UPDATE *upd);
 
 /*LISTID programmer_types;*/
 
-typedef struct programmer_type_t {
+typedef struct programmer_type {
   const char * const id;
   void (*initpgm)(PROGRAMMER *pgm);
   const char * const desc;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -257,7 +257,7 @@ typedef struct opcode {
 /*
  * Any changes in AVRPART or AVRMEM, please also ensure changes are made in
  *  - lexer.l
- *  - Either Component_t avr_comp[] of config.c or in config_gram.y
+ *  - Either Component avr_comp[] of config.c or in config_gram.y
  *  - dev_part_strct() in developer_opts.c
  *  - avr_new_part() and/or avr_new_mem() in avrpart.c for
  *    initialisation; note that all const char * must be initialised with ""
@@ -929,7 +929,7 @@ typedef struct {
 /*
  * Any changes in PROGRAMMER, please also ensure changes are made in
  *  - lexer.l
- *  - Either Component_t avr_comp[] of config.c or config_gram.y
+ *  - Either Component avr_comp[] of config.c or config_gram.y
  *  - dev_pgm_strct() in developer_opts.c
  *  - pgm_new() in pgm.c for initialisation; note that all const char * must
  *    be initialised with ""

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1429,16 +1429,16 @@ extern "C" {
 #endif
 
 int avr_locate_upidx(const AVRPART *p);
-const Configitem_t *avr_locate_configitems(const AVRPART *p, int *ncp);
+const Configitem *avr_locate_configitems(const AVRPART *p, int *ncp);
 const char * const *avr_locate_isrtable(const AVRPART *p, int *nip);
 const Register_file_t *avr_locate_register_file(const AVRPART *p, int *nrp);
 const Register_file_t *avr_locate_register(const Register_file_t *rgf, int nr, const char *reg,
  int (*match)(const char *, const char*));
 const Register_file_t **avr_locate_registerlist(const Register_file_t *rgf, int nr, const char *reg,
  int (*match)(const char *, const char*));
-const Configitem_t *avr_locate_config(const Configitem_t *cfg, int nc, const char *name,
+const Configitem *avr_locate_config(const Configitem *cfg, int nc, const char *name,
   int (*match)(const char *, const char*));
-const Configitem_t **avr_locate_configlist(const Configitem_t *cfg, int nc, const char *name,
+const Configitem **avr_locate_configlist(const Configitem *cfg, int nc, const char *name,
   int (*match)(const char *, const char*));
 int avr_get_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int *valuep);
 int avr_set_config_value(const PROGRAMMER *pgm, const AVRPART *p, const char *cname, int value);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -702,7 +702,7 @@ void pin_set_value(struct pindef_t * const pindef, const int pin, const bool inv
  */
 void pin_clear_all(struct pindef_t * const pindef);
 
-typedef struct programmer_t PROGRAMMER; // Forward declaration
+typedef struct programmer PROGRAMMER; // Forward declaration
 
 /**
  * Convert for given programmer new pin definitions to old pin definitions.
@@ -934,7 +934,7 @@ typedef struct {
  *  - pgm_new() in pgm.c for initialisation; note that all const char * must
  *    be initialised with ""
  */
-typedef struct programmer_t {
+typedef struct programmer {
   LISTID id;
   const char *desc;
   void (*initpgm)(PROGRAMMER *pgm); // Sets up the AVRDUDE programmer

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1208,7 +1208,7 @@ struct fioparms {
 
 typedef struct {
   int addr, len;
-} Segment_t;
+} Segment;
 
 enum {
   FIO_READ,
@@ -1235,10 +1235,10 @@ int fileio_fmt_autodetect(const char *fname);
 int fileio(int oprwv, const char *filename, FILEFMT format,
   const AVRPART *p, const char *memstr, int size);
 
-int segment_normalise(const AVRMEM *mem, Segment_t *segp);
+int segment_normalise(const AVRMEM *mem, Segment *segp);
 
 int fileio_segments(int oprwv, const char *filename, FILEFMT format,
-  const AVRPART *p, const AVRMEM *mem, int n, const Segment_t *seglist);
+  const AVRPART *p, const AVRMEM *mem, int n, const Segment *seglist);
 
 #ifdef __cplusplus
 }

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1261,7 +1261,7 @@ enum updateflags {
 };
 
 
-typedef struct update_t {
+typedef struct update {
   const char *cmdline;          // -T line is stored here and takes precedence if it exists
   char *memstr;                 // Memory name for -U
   int   op;                     // Symbolic memory operation DEVICE_... for -U

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -905,7 +905,7 @@ typedef enum {
   CONNTYPE_USB,
   CONNTYPE_SPI,
   CONNTYPE_LINUXGPIO
-} conntype_t;
+} Conntype;
 
 
 #define LED_N                 4 // Max number of LEDs driven by programmers
@@ -944,7 +944,7 @@ typedef struct programmer {
   int is_serialadapter;         // Programmer is also a serialadapter
   int extra_features;
   struct pindef pin[N_PINS];
-  conntype_t conntype;
+  Conntype conntype;
   int baudrate;
   int usbvid;
   LISTID usbpid;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -885,7 +885,7 @@ typedef enum {
   EXIT_VCC_UNSPEC,
   EXIT_VCC_ENABLED,
   EXIT_VCC_DISABLED
-} exit_vcc_t;
+} Exit_vcc;
 
 typedef enum {
   EXIT_RESET_UNSPEC,
@@ -959,7 +959,7 @@ typedef struct programmer {
   char type[PGM_TYPELEN];
   const char *port;
   unsigned int pinno[N_PINS];   // TODO to be removed if old pin data no longer needed
-  exit_vcc_t exit_vcc;          // Should these be set in avrdude.conf?
+  Exit_vcc exit_vcc;          // Should these be set in avrdude.conf?
   Exit_reset exit_reset;
   Exit_datahigh exit_datahigh;
   int ppidata;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1431,10 +1431,10 @@ extern "C" {
 int avr_locate_upidx(const AVRPART *p);
 const Configitem *avr_locate_configitems(const AVRPART *p, int *ncp);
 const char * const *avr_locate_isrtable(const AVRPART *p, int *nip);
-const Register_file_t *avr_locate_register_file(const AVRPART *p, int *nrp);
-const Register_file_t *avr_locate_register(const Register_file_t *rgf, int nr, const char *reg,
+const Register_file *avr_locate_register_file(const AVRPART *p, int *nrp);
+const Register_file *avr_locate_register(const Register_file *rgf, int nr, const char *reg,
  int (*match)(const char *, const char*));
-const Register_file_t **avr_locate_registerlist(const Register_file_t *rgf, int nr, const char *reg,
+const Register_file **avr_locate_registerlist(const Register_file *rgf, int nr, const char *reg,
  int (*match)(const char *, const char*));
 const Configitem *avr_locate_config(const Configitem *cfg, int nc, const char *name,
   int (*match)(const char *, const char*));

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1625,6 +1625,49 @@ int win_set_path(char *path, int n, const char *file);
 #endif  /* WIN32 */
 
 #ifndef TO_BE_DEPRECATED_IN_2026
+
+/*
+ * AVRDUDE type names ending in _t have been renamed, as POSIX reserves
+ * all of these. Below typedefs that give access to some of these _t names
+ * but will be withdrawn in future. If you want to update your project
+ * code that uses libavrdude feel free to copy and paste the lines below
+ * into a file avrdude_t.sed and execute in your code directory
+ *
+ * $ sed -i -f avrdude_t.sed *.{c,h,cpp,hpp,l,y}
+ *
+
+s/\btypedef struct programmer_t\b/typedef struct programmer/g
+s/\bstruct programmer_t\b/PROGRAMMER/g
+s/\bprogrammer_t\b/programmer/g
+s/\bprogrammer_type_t\b/programmer_type/g
+s/\bctl_stack_t\b/ctl_stack/g
+s/\bpindef_t\b/pindef/g
+s/\bpin_checklist_t\b/Pin_checklist/g
+s/\bpinmask_t\b/Pinmask/g
+s/\bupdate_t\b/update/g
+s/\buPcore_t\b/Avrintel/g
+s/\bComponent_t\b/Component/g
+s/\bValueitem_t\b/Configvalue/g
+s/\bConfigitem_t\b/Configitem/g
+s/\bRegister_file_t\b/Register_file/g
+s/\bconntype_t\b/Conntype/g
+s/\bexit_datahigh_t\b/Exit_datahigh/g
+s/\bexit_reset_t\b/Exit_reset/g
+s/\bexit_vcc_t\b/Exit_vcc/g
+s/\bleds_t\b/Leds/g
+s/\bmemtable_t\b/Memtable/g
+s/\bmemtype_t\b/Memtype/g
+s/\bSegment_t\b/Segment/g
+
+ *
+ */
+
+typedef Configvalue Valueitem_t;
+typedef Configitem Configitem_t;
+typedef Register_file Register_file_t;
+typedef Avrintel uPcore_t;
+
+typedef Pin_checklist pin_checklist_t;
 typedef Pinmask pinmask_t;
 typedef Conntype conntype_t;
 typedef Exit_datahigh exit_datahigh_t;
@@ -1634,6 +1677,7 @@ typedef Leds leds_t;
 typedef Memtable memtable_t;
 typedef Memtype memtype_t;
 typedef Segment Segment_t;
+
 #endif
 
 #endif  /* libavrdude_h */

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -75,12 +75,11 @@
 #define MICRONUCLEUS_DEFAULT_TIMEOUT 500
 #define MICRONUCLEUS_MAX_MAJOR_VERSION 2
 
-#define PDATA(pgm) ((pdata_t*)(pgm->cookie))
+#define PDATA(pgm) ((struct pdata *)(pgm->cookie))
 
 //-----------------------------------------------------------------------------
 
-typedef struct pdata
-{
+struct pdata {
     usb_dev_handle* usb_handle;
     // Extended parameters
     bool wait_until_device_present;
@@ -102,7 +101,7 @@ typedef struct pdata
     uint16_t user_reset_vector; // reset vector of user program
     bool write_last_page;       // last page already programmed
     bool start_program;         // require start after flash
-} pdata_t;
+};
 
 //-----------------------------------------------------------------------------
 
@@ -111,8 +110,7 @@ static void delay_ms(uint32_t duration)
     usleep(duration * 1000);
 }
 
-static int micronucleus_check_connection(pdata_t* pdata)
-{
+static int micronucleus_check_connection(struct pdata *pdata) {
     if (pdata->major_version >= 2)
     {
         uint8_t buffer[6] = { 0 };
@@ -139,8 +137,7 @@ static int micronucleus_check_connection(pdata_t* pdata)
     }
 }
 
-static bool micronucleus_is_device_responsive(pdata_t* pdata, struct usb_device* device)
-{
+static bool micronucleus_is_device_responsive(struct pdata *pdata, struct usb_device *device) {
     pdata->usb_handle = usb_open(device);
     if (pdata->usb_handle == NULL)
     {
@@ -155,8 +152,7 @@ static bool micronucleus_is_device_responsive(pdata_t* pdata, struct usb_device*
     return result >= 0;
 }
 
-static int micronucleus_reconnect(pdata_t* pdata)
-{
+static int micronucleus_reconnect(struct pdata *pdata) {
     struct usb_device* device = usb_device(pdata->usb_handle);
 
     usb_close(pdata->usb_handle);
@@ -176,8 +172,7 @@ static int micronucleus_reconnect(pdata_t* pdata)
     return -1;
 }
 
-static int micronucleus_get_bootloader_info_v1(pdata_t* pdata)
-{
+static int micronucleus_get_bootloader_info_v1(struct pdata *pdata) {
     uint8_t buffer[4] = { 0 };
     int result = usb_control_msg(
         pdata->usb_handle,
@@ -243,8 +238,7 @@ static int micronucleus_get_bootloader_info_v1(pdata_t* pdata)
     return 0;
 }
 
-static int micronucleus_get_bootloader_info_v2(pdata_t* pdata)
-{
+static int micronucleus_get_bootloader_info_v2(struct pdata *pdata) {
     uint8_t buffer[6] = { 0 };
     int result = usb_control_msg(
         pdata->usb_handle,
@@ -284,8 +278,7 @@ static int micronucleus_get_bootloader_info_v2(pdata_t* pdata)
     return 0;
 }
 
-static int micronucleus_get_bootloader_info(pdata_t* pdata)
-{
+static int micronucleus_get_bootloader_info(struct pdata *pdata) {
     if (pdata->major_version >= 2)
     {
         return micronucleus_get_bootloader_info_v2(pdata);
@@ -296,8 +289,7 @@ static int micronucleus_get_bootloader_info(pdata_t* pdata)
     }
 }
 
-static void micronucleus_dump_device_info(pdata_t* pdata)
-{
+static void micronucleus_dump_device_info(struct pdata *pdata) {
     pmsg_notice("Bootloader version: %d.%d\n", pdata->major_version, pdata->minor_version);
     imsg_notice("Available flash size: %u\n", pdata->flash_size);
     imsg_notice("Page size: %u\n", pdata->page_size);
@@ -308,8 +300,7 @@ static void micronucleus_dump_device_info(pdata_t* pdata)
     imsg_notice("Signature2: 0x%02X\n", pdata->signature2);
 }
 
-static int micronucleus_erase_device(pdata_t* pdata)
-{
+static int micronucleus_erase_device(struct pdata *pdata) {
     pmsg_debug("micronucleus_erase_device()\n");
 
     int result = usb_control_msg(
@@ -351,8 +342,7 @@ static int micronucleus_erase_device(pdata_t* pdata)
     return 0;
 }
 
-static int micronucleus_patch_reset_vector(pdata_t* pdata, uint8_t* buffer)
-{
+static int micronucleus_patch_reset_vector(struct pdata *pdata, uint8_t *buffer) {
     // Save user reset vector.
     uint16_t word0 = (buffer[1] << 8) | buffer[0];
     uint16_t word1 = (buffer[3] << 8) | buffer[2];
@@ -394,8 +384,7 @@ static int micronucleus_patch_reset_vector(pdata_t* pdata, uint8_t* buffer)
     return 0;
 }
 
-static void micronucleus_patch_user_vector(pdata_t* pdata, uint8_t* buffer)
-{
+static void micronucleus_patch_user_vector(struct pdata *pdata, uint8_t *buffer) {
     uint16_t user_reset_addr = pdata->bootloader_start - 4;
     uint16_t address = pdata->bootloader_start - pdata->page_size;
     if (user_reset_addr > 0x2000)
@@ -416,8 +405,7 @@ static void micronucleus_patch_user_vector(pdata_t* pdata, uint8_t* buffer)
     }
 }
 
-static int micronucleus_write_page_v1(pdata_t* pdata, uint32_t address, uint8_t* buffer, uint32_t size)
-{
+static int micronucleus_write_page_v1(struct pdata *pdata, uint32_t address, uint8_t *buffer, uint32_t size) {
     int result = usb_control_msg(
         pdata->usb_handle,
         USB_ENDPOINT_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
@@ -434,8 +422,7 @@ static int micronucleus_write_page_v1(pdata_t* pdata, uint32_t address, uint8_t*
     return 0;
 }
 
-static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t* buffer, uint32_t size)
-{
+static int micronucleus_write_page_v2(struct pdata *pdata, uint32_t address, uint8_t *buffer, uint32_t size) {
     int result = usb_control_msg(
         pdata->usb_handle,
         USB_ENDPOINT_OUT | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
@@ -470,8 +457,7 @@ static int micronucleus_write_page_v2(pdata_t* pdata, uint32_t address, uint8_t*
     return 0;
 }
 
-static int micronucleus_write_page(pdata_t* pdata, uint32_t address, uint8_t* buffer, uint32_t size)
-{
+static int micronucleus_write_page(struct pdata *pdata, uint32_t address, uint8_t *buffer, uint32_t size) {
     pmsg_debug("micronucleus_write_page(address=0x%04X, size=%d)\n", address, size);
 
     if (address == 0)
@@ -522,8 +508,7 @@ static int micronucleus_write_page(pdata_t* pdata, uint32_t address, uint8_t* bu
     return 0;
 }
 
-static int micronucleus_start(pdata_t* pdata)
-{
+static int micronucleus_start(struct pdata *pdata) {
     pmsg_debug("micronucleus_start()\n");
 
     int result = usb_control_msg(
@@ -546,7 +531,7 @@ static int micronucleus_start(pdata_t* pdata)
 
 static void micronucleus_setup(PROGRAMMER *pgm) {
     pmsg_debug("micronucleus_setup()\n");
-    pgm->cookie = mmt_malloc(sizeof(pdata_t));
+    pgm->cookie = mmt_malloc(sizeof(struct pdata));
 }
 
 static void micronucleus_teardown(PROGRAMMER* pgm) {
@@ -558,7 +543,7 @@ static void micronucleus_teardown(PROGRAMMER* pgm) {
 static int micronucleus_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_debug("micronucleus_initialize()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
 
     int result = micronucleus_get_bootloader_info(pdata);
     if (result < 0)
@@ -580,7 +565,7 @@ static void micronucleus_powerup(const PROGRAMMER *pgm) {
 static void micronucleus_powerdown(const PROGRAMMER *pgm) {
     pmsg_debug("micronucleus_powerdown()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     if (pdata->write_last_page)
     {
         pdata->write_last_page = false;
@@ -621,7 +606,7 @@ static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, 
         return -1;
     }
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     mem->buf[0] = 0x1E;
     mem->buf[1] = pdata->signature1;
     mem->buf[2] = pdata->signature2;
@@ -631,14 +616,14 @@ static int micronucleus_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, 
 static int micronucleus_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_debug("micronucleus_chip_erase()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     return micronucleus_erase_device(pdata);
 }
 
 static int micronucleus_open(PROGRAMMER* pgm, const char *port) {
     pmsg_debug("micronucleus_open(\"%s\")\n", port);
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     const char *bus_name = NULL;
     char* dev_name = NULL;
 
@@ -790,7 +775,7 @@ static void micronucleus_close(PROGRAMMER* pgm)
 {
     pmsg_debug("micronucleus_close()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     if (pdata->usb_handle != NULL)
     {
         usb_close(pdata->usb_handle);
@@ -838,7 +823,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 
     if (mem_is_flash(mem))
     {
-        pdata_t* pdata = PDATA(pgm);
+        struct pdata *pdata = PDATA(pgm);
 
         if (n_bytes > page_size)
         {
@@ -886,7 +871,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
 static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
     pmsg_debug("micronucleus_parseextparams()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     for (LNODEID node = lfirst(xparams); node != NULL; node = lnext(node))
     {
         const char* param = ldata(node);

--- a/src/par.c
+++ b/src/par.c
@@ -44,14 +44,14 @@
 
 #if HAVE_PARPORT
 
-struct ppipins_t {
+struct ppipins {
   int pin;
   int reg;
   int bit;
   int inverted;
 };
 
-static const struct ppipins_t ppipins[] = {
+static const struct ppipins ppipins[] = {
   {  1, PPICTRL,   0x01, 1 },
   {  2, PPIDATA,   0x01, 0 },
   {  3, PPIDATA,   0x02, 0 },
@@ -71,7 +71,7 @@ static const struct ppipins_t ppipins[] = {
   { 17, PPICTRL,   0x08, 1 }
 };
 
-#define NPINS (sizeof(ppipins)/sizeof(struct ppipins_t))
+#define NPINS (sizeof(ppipins)/sizeof(struct ppipins))
 
 static int par_setpin_internal(const PROGRAMMER *pgm, int pin, int value) {
   int inverted;

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -407,7 +407,7 @@ void sort_programmers(LISTID programmers)
 }
 
 
-// Soft assignment: some struct programmer_t entries can be both programmers and serial adapters
+// Soft assignment: some PROGRAMMER entries can be both programmers and serial adapters
 int is_programmer(const PROGRAMMER *p) {
  return p && p->id && lsize(p->id) && p->prog_modes && p->initpgm;
 }

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -169,7 +169,7 @@ PROGRAMMER *pgm_new(void) {
     pin_clear_all(&(pgm->pin[i]));
   }
 
-  pgm->leds = mmt_malloc(sizeof(leds_t));
+  pgm->leds = mmt_malloc(sizeof(Leds));
 
   pgm_init_functions(pgm);
 
@@ -218,7 +218,7 @@ PROGRAMMER *pgm_dup(const PROGRAMMER *src) {
     if(pgm->cp_usersig)
       mmt_free(pgm->cp_usersig);
 
-    leds_t *ls = pgm->leds;
+    Leds *ls = pgm->leds;
     memcpy(pgm, src, sizeof(*pgm));
     if(ls && src->leds)
       memcpy(ls, src->leds, sizeof *ls);

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -217,7 +217,7 @@ const char *pinmask_to_str(const Pinmask * const pinmask) {
  * @param[in] size the number of entries in checklist
  * @returns 0 if all pin definitions are valid, -1 otherwise
  */
-int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const checklist, const int size, const bool output) {
+int pins_check(const PROGRAMMER *const pgm, const Pin_checklist *const checklist, const int size, const bool output) {
   static const struct pindef no_valid_pins = {{0}, {0}}; // default value if check list does not contain anything else
   int rv = 0; // return value
   int pinname; // loop counter through pinnames

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -34,7 +34,7 @@
  * @param[in] pin number of pin [0..PIN_MAX]
  * @param[in] inverse inverse (true) or normal (false) pin
  */
-void pin_set_value(struct pindef_t * const pindef, const int pin, const bool inverse) {
+void pin_set_value(struct pindef * const pindef, const int pin, const bool inverse) {
 
   pindef->mask[pin / PIN_FIELD_ELEMENT_SIZE] |= 1 << (pin % PIN_FIELD_ELEMENT_SIZE);
   if(inverse) {
@@ -49,8 +49,8 @@ void pin_set_value(struct pindef_t * const pindef, const int pin, const bool inv
  *
  * @param[out] pindef pin definition to clear
  */
-void pin_clear_all(struct pindef_t * const pindef) {
-  memset(pindef, 0, sizeof(struct pindef_t));
+void pin_clear_all(struct pindef * const pindef) {
+  memset(pindef, 0, sizeof(struct pindef));
 }
 
 /**
@@ -59,7 +59,7 @@ void pin_clear_all(struct pindef_t * const pindef) {
  * @param[in] pindef new pin definition structure
  * @param[out] pinno old pin definition integer
  */
-static int pin_fill_old_pinno(const struct pindef_t * const pindef, unsigned int * const pinno) {
+static int pin_fill_old_pinno(const struct pindef * const pindef, unsigned int * const pinno) {
   bool found = false;
   int i;
   for(i = 0; i <= PIN_MAX; i++) {
@@ -84,7 +84,7 @@ static int pin_fill_old_pinno(const struct pindef_t * const pindef, unsigned int
  * @param[in] pindef new pin definition structure
  * @param[out] pinno old pin definition integer
  */
-static int pin_fill_old_pinlist(const struct pindef_t * const pindef, unsigned int * const pinno) {
+static int pin_fill_old_pinlist(const struct pindef * const pindef, unsigned int * const pinno) {
   for(size_t i = 0; i < PIN_FIELD_SIZE; i++) {
     if(i == 0) {
       if((pindef->mask[i] & ~PIN_MASK) != 0) {
@@ -218,7 +218,7 @@ const char *pinmask_to_str(const pinmask_t * const pinmask) {
  * @returns 0 if all pin definitions are valid, -1 otherwise
  */
 int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const checklist, const int size, const bool output) {
-  static const struct pindef_t no_valid_pins = {{0}, {0}}; // default value if check list does not contain anything else
+  static const struct pindef no_valid_pins = {{0}, {0}}; // default value if check list does not contain anything else
   int rv = 0; // return value
   int pinname; // loop counter through pinnames
   pinmask_t already_used_all[PIN_FIELD_SIZE] = {0}; // collect pin definitions of all pin names for check of double use
@@ -232,7 +232,7 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     pinmask_t invalid_used[PIN_FIELD_SIZE] = {0};
     pinmask_t inverse_used[PIN_FIELD_SIZE] = {0};
     pinmask_t already_used[PIN_FIELD_SIZE] = {0};
-    const struct pindef_t * valid_pins = &no_valid_pins;
+    const struct pindef * valid_pins = &no_valid_pins;
     bool is_mandatory = false;
     bool is_ok = true;
     //find corresponding check pattern
@@ -314,7 +314,7 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
  * @param[in] pindef the pin definition for which we want the string representation
  * @returns a temporary string that lives in closed-circuit space
  */
-const char *pins_to_str(const struct pindef_t * const pindef) {
+const char *pins_to_str(const struct pindef * const pindef) {
   char buf[6*(PIN_MAX+1)], *p = buf;
 
   *buf = 0;

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -158,7 +158,7 @@ int pgm_fill_old_pins(PROGRAMMER * const pgm) {
  * @param[in] pinmask the pin mask for which we want the string representation
  * @returns a temporary string that lives in closed-circuit space
  */
-const char *pinmask_to_str(const pinmask_t * const pinmask) {
+const char *pinmask_to_str(const Pinmask * const pinmask) {
   char buf[6 * (PIN_MAX + 1)];
   char *p = buf;
   int n;
@@ -221,7 +221,7 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
   static const struct pindef no_valid_pins = {{0}, {0}}; // default value if check list does not contain anything else
   int rv = 0; // return value
   int pinname; // loop counter through pinnames
-  pinmask_t already_used_all[PIN_FIELD_SIZE] = {0}; // collect pin definitions of all pin names for check of double use
+  Pinmask already_used_all[PIN_FIELD_SIZE] = {0}; // collect pin definitions of all pin names for check of double use
   // loop over all possible pinnames
   for(pinname = 0; pinname < N_PINS; pinname++) {
     bool used = false;
@@ -229,9 +229,9 @@ int pins_check(const PROGRAMMER *const pgm, const struct pin_checklist_t *const 
     bool inverse = false;
     int index;
     bool mandatory_used = false;
-    pinmask_t invalid_used[PIN_FIELD_SIZE] = {0};
-    pinmask_t inverse_used[PIN_FIELD_SIZE] = {0};
-    pinmask_t already_used[PIN_FIELD_SIZE] = {0};
+    Pinmask invalid_used[PIN_FIELD_SIZE] = {0};
+    Pinmask inverse_used[PIN_FIELD_SIZE] = {0};
+    Pinmask already_used[PIN_FIELD_SIZE] = {0};
     const struct pindef * valid_pins = &no_valid_pins;
     bool is_mandatory = false;
     bool is_ok = true;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2081,22 +2081,22 @@ static void scratchmonkey_led_state(const PROGRAMMER *pgm, int flag, int value) 
   stk500v2_setparm_real(pgm, PARAM_SCRATCHMONKEY_STATUS_LEDS, PDATA(pgm)->scratchmonkey_leds);
 }
 
-static int scratchmonkey_rdy_led(const struct programmer_t *pgm, int value) {
+static int scratchmonkey_rdy_led(const PROGRAMMER *pgm, int value) {
   scratchmonkey_led_state(pgm, SCRATCHMONKEY_RDY_LED, value);
   return 0;
 }
 
-static int scratchmonkey_err_led(const struct programmer_t *pgm, int value) {
+static int scratchmonkey_err_led(const PROGRAMMER *pgm, int value) {
   scratchmonkey_led_state(pgm, SCRATCHMONKEY_ERR_LED, value);
   return 0;
 }
 
-static int scratchmonkey_pgm_led(const struct programmer_t *pgm, int value) {
+static int scratchmonkey_pgm_led(const PROGRAMMER *pgm, int value) {
   scratchmonkey_led_state(pgm, SCRATCHMONKEY_PGM_LED, value);
   return 0;
 }
 
-static int scratchmonkey_vfy_led(const struct programmer_t *pgm, int value) {
+static int scratchmonkey_vfy_led(const PROGRAMMER *pgm, int value) {
   scratchmonkey_led_state(pgm, SCRATCHMONKEY_VFY_LED, value);
   return 0;
 }

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -642,7 +642,7 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
 
   // Try integers and assign data size
   if(type & STR_INTEGER) {
-    bool is_big_endian, is_signed = 0, is_outside_int64_t = 0, is_out_of_range = 0;
+    bool is_big_endian, is_signed = 0, is_outside_int64 = 0, is_out_of_range = 0;
     char *stri = str;
 
     while(isspace(*stri & 0xff))
@@ -684,9 +684,9 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
 
           if(is_signed) {       // Is input in range for int64_t?
             if(*stri == '-' && (sd->ull == ~(~0ULL>>1) || sd->ll > 0))
-              is_outside_int64_t = 1;
+              is_outside_int64 = 1;
             if(*stri != '-' && sd->ll < 0)
-              is_outside_int64_t = 1;
+              is_outside_int64 = 1;
           }
 
           // Set size
@@ -699,7 +699,7 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
             } else if(is_signed) {
               // Smallest size that fits signed or unsigned (asymmetric to meet user expectation)
               sd->size =
-                is_outside_int64_t? 8:
+                is_outside_int64? 8:
                 sd->ll < INT32_MIN || sd->ll > (long long) UINT32_MAX? 8:
                 sd->ll < INT16_MIN || sd->ll > (long long) UINT16_MAX? 4:
                 sd->ll < INT8_MIN  || sd->ll > (long long) UINT8_MAX? 2: 1;
@@ -760,7 +760,7 @@ Str2data *str_todata(const char *s, int type, const AVRPART *part, const char *m
       else if(is_out_of_range)
         Warning("%s out of uint%d range, interpreted as %d-byte %llu",
           stri, sd->size*8, sd->size, (long long unsigned int) sd->ull);
-      else if(is_outside_int64_t)
+      else if(is_outside_int64)
         Warning("%s out of int64 range (consider U suffix)", stri);
 
       sd->type = STR_INTEGER;

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -59,12 +59,11 @@
 
 #define TEENSY_CONNECT_WAIT 100
 
-#define PDATA(pgm) ((pdata_t*)(pgm->cookie))
+#define PDATA(pgm) ((struct pdata *)(pgm->cookie))
 
 //-----------------------------------------------------------------------------
 
-typedef struct pdata
-{
+struct pdata {
     hid_device* hid_handle;
     uint16_t hid_usage;
     // Extended parameters
@@ -78,7 +77,7 @@ typedef struct pdata
     // State
     bool erase_flash;
     bool reboot;
-} pdata_t;
+};
 
 //-----------------------------------------------------------------------------
 
@@ -87,7 +86,7 @@ static void delay_ms(uint32_t duration)
     usleep(duration * 1000);
 }
 
-static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
+static int teensy_get_bootloader_info(struct pdata *pdata, const AVRPART *p) {
     switch (pdata->hid_usage)
     {
     case 0x19:
@@ -156,8 +155,7 @@ static int teensy_get_bootloader_info(pdata_t* pdata, const AVRPART* p) {
     return 0;
 }
 
-static void teensy_dump_device_info(pdata_t* pdata)
-{
+static void teensy_dump_device_info(struct pdata *pdata) {
     pmsg_notice("HID usage: 0x%02X\n", pdata->hid_usage);
     pmsg_notice("Board: %s\n", pdata->board);
     pmsg_notice("Available flash size: %u\n", pdata->flash_size);
@@ -166,8 +164,7 @@ static void teensy_dump_device_info(pdata_t* pdata)
       pdata->sig_bytes[0], pdata->sig_bytes[1], pdata->sig_bytes[2]);
 }
 
-static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* buffer, uint32_t size, bool suppress_warning)
-{
+static int teensy_write_page(struct pdata *pdata, uint32_t address, const uint8_t *buffer, uint32_t size, bool suppress_warning) {
     pmsg_debug("teensy_write_page(address=0x%06X, size=%d)\n", address, size);
 
     if (size > pdata->page_size)
@@ -211,16 +208,14 @@ static int teensy_write_page(pdata_t* pdata, uint32_t address, const uint8_t* bu
     return 0;
 }
 
-static int teensy_erase_flash(pdata_t* pdata)
-{
+static int teensy_erase_flash(struct pdata *pdata) {
     pmsg_debug("teensy_erase_flash()\n");
 
     // Write a dummy page at address 0 to explicitly erase the flash.
     return teensy_write_page(pdata, 0, NULL, 0, false);
 }
 
-static int teensy_reboot(pdata_t* pdata)
-{
+static int teensy_reboot(struct pdata *pdata) {
     pmsg_debug("teensy_reboot()\n");
 
     // Write a dummy page at address -1 to reboot the Teensy.
@@ -231,7 +226,7 @@ static int teensy_reboot(pdata_t* pdata)
 
 static void teensy_setup(PROGRAMMER *pgm) {
     pmsg_debug("teensy_setup()\n");
-    pgm->cookie = mmt_malloc(sizeof(pdata_t));
+    pgm->cookie = mmt_malloc(sizeof(struct pdata));
 }
 
 static void teensy_teardown(PROGRAMMER *pgm) {
@@ -243,7 +238,7 @@ static void teensy_teardown(PROGRAMMER *pgm) {
 static int teensy_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_debug("teensy_initialize()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
 
     int result = teensy_get_bootloader_info(pdata, p);
     if (result < 0)
@@ -265,7 +260,7 @@ static void teensy_powerup(const PROGRAMMER *pgm) {
 static void teensy_powerdown(const PROGRAMMER *pgm) {
     pmsg_debug("teensy_powerdown()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
 
     if (pdata->erase_flash)
     {
@@ -302,7 +297,7 @@ static int teensy_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
         return -1;
     }
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     memcpy(mem->buf, pdata->sig_bytes, sizeof(pdata->sig_bytes));
 
     return 0;
@@ -311,7 +306,7 @@ static int teensy_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
 static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_debug("teensy_chip_erase()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
 
     // Schedule a chip erase, either at first write or on powerdown.
     pdata->erase_flash = true;
@@ -322,7 +317,7 @@ static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int teensy_open(PROGRAMMER *pgm, const char *port) {
     pmsg_debug("teensy_open(\"%s\")\n", port);
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     const char *bus_name = NULL;
     char* dev_name = NULL;
 
@@ -438,7 +433,7 @@ static void teensy_close(PROGRAMMER* pgm)
 {
     pmsg_debug("teensy_close()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     if (pdata->hid_handle != NULL)
     {
         hid_close(pdata->hid_handle);
@@ -486,7 +481,7 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
     if (mem_is_flash(mem))
     {
-        pdata_t* pdata = PDATA(pgm);
+        struct pdata *pdata = PDATA(pgm);
 
         if (n_bytes > page_size)
         {
@@ -537,7 +532,7 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
     pmsg_debug("teensy_parseextparams()\n");
 
-    pdata_t* pdata = PDATA(pgm);
+    struct pdata *pdata = PDATA(pgm);
     for (LNODEID node = lfirst(xparams); node != NULL; node = lnext(node))
     {
         const char* param = ldata(node);

--- a/src/term.c
+++ b/src/term.c
@@ -958,7 +958,7 @@ typedef struct {
 
 typedef struct {                // Context parameters to be passed to functions
   int verb, allscript, flheaders, allv, vmax, printfactory;
-} Cfg_opts_t;
+} Cfg_opts;
 
 // Cache the contents of the fuse and lock bits memories that a particular Configitem is involved in
 static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const Cfg_t *cci, const char **errpp) {
@@ -1098,7 +1098,7 @@ static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cfg_t *cc, int i,
 }
 
 // Comment printed next to symbolic value
-static const char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, int value, Cfg_opts_t o) {
+static const char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, int value, Cfg_opts o) {
   char buf[512], bin[129];
   unsigned u = value, m = cti->mask >> cti->lsh;
   int lsh = cti->lsh;
@@ -1137,14 +1137,14 @@ static const char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, 
 }
 
 // How a single property is printed
-static void printoneproperty(Cfg_t *cc, int ii, const Valueitem_t *vp, int llen, const char *vstr, Cfg_opts_t o) {
+static void printoneproperty(Cfg_t *cc, int ii, const Valueitem_t *vp, int llen, const char *vstr, Cfg_opts o) {
   int value = vp? vp->value: cc[ii].val;
   term_out("%s %s=%-*s # %s\n", vp && cc[ii].val != vp->value? "# conf": "config",
     cc[ii].t->name, llen, vstr, valuecomment(cc[ii].t, vp, value, o));
 }
 
 // Prints a list of all possible values (o.allv) or just the one proporty cc[ii]
-static void printproperty(Cfg_t *cc, int ii, Cfg_opts_t o) {
+static void printproperty(Cfg_t *cc, int ii, Cfg_opts o) {
   const Valueitem_t *vt = cc[ii].t->vlist, *vp;
   int nv = cc[ii].t->nvalues;
   const char *ccom = cc->t[ii].ccomment, *col = strchr(ccom, ':');
@@ -1209,7 +1209,7 @@ static void printproperty(Cfg_t *cc, int ii, Cfg_opts_t o) {
 }
 
 // Print the fuse/lock bits header (-f, o.flheaders)
-static void printfuse(Cfg_t *cc, int ii, Flock_t *fc, int nf, int printed, Cfg_opts_t o) {
+static void printfuse(Cfg_t *cc, int ii, Flock_t *fc, int nf, int printed, Cfg_opts o) {
   char buf[512];
   int fj;
   for(fj=0; fj<nf; fj++)
@@ -1238,7 +1238,7 @@ static void printfuse(Cfg_t *cc, int ii, Flock_t *fc, int nf, int printed, Cfg_o
 
 // Show or change configuration properties of the part
 static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
-  Cfg_opts_t o = { 0 };
+  Cfg_opts o = { 0 };
   int help = 0, invalid = 0, itemac=1;
 
   for(int ai = 0; --argc > 0; ) { // Simple option parsing

--- a/src/term.c
+++ b/src/term.c
@@ -954,14 +954,14 @@ typedef struct {
   const char *alt;              // Set when memstr is an alias
   int match;                    // Matched by user request
   int ok, val, initval;         // Has value val been read OK? Initval == -1 if not known
-} Cfg_t;
+} Cnfg;
 
 typedef struct {                // Context parameters to be passed to functions
   int verb, allscript, flheaders, allv, vmax, printfactory;
 } Cfg_opts;
 
 // Cache the contents of the fuse and lock bits memories that a particular Configitem is involved in
-static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const Cfg_t *cci, const char **errpp) {
+static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const Cnfg *cci, const char **errpp) {
   const char *err = NULL;
   int islock;
 
@@ -1022,7 +1022,7 @@ back:
   return err? -1: 0;
 }
 
-static int setmatches(const char *str, int n, Cfg_t *cc) {
+static int setmatches(const char *str, int n, Cnfg *cc) {
   int matches = 0;
 
   if(!*str)
@@ -1075,7 +1075,7 @@ typedef struct {                // Fuse/lock properties of the part
 
 
 // Fill in cc record with the actual value of the relevant fuse
-static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cfg_t *cc, int i,
+static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cnfg *cc, int i,
   Fusel_t *fuselp, Flock_t *fc, int nf) {
 
   // Load current value of this config item
@@ -1137,14 +1137,14 @@ static const char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, 
 }
 
 // How a single property is printed
-static void printoneproperty(Cfg_t *cc, int ii, const Valueitem_t *vp, int llen, const char *vstr, Cfg_opts o) {
+static void printoneproperty(Cnfg *cc, int ii, const Valueitem_t *vp, int llen, const char *vstr, Cfg_opts o) {
   int value = vp? vp->value: cc[ii].val;
   term_out("%s %s=%-*s # %s\n", vp && cc[ii].val != vp->value? "# conf": "config",
     cc[ii].t->name, llen, vstr, valuecomment(cc[ii].t, vp, value, o));
 }
 
 // Prints a list of all possible values (o.allv) or just the one proporty cc[ii]
-static void printproperty(Cfg_t *cc, int ii, Cfg_opts o) {
+static void printproperty(Cnfg *cc, int ii, Cfg_opts o) {
   const Valueitem_t *vt = cc[ii].t->vlist, *vp;
   int nv = cc[ii].t->nvalues;
   const char *ccom = cc->t[ii].ccomment, *col = strchr(ccom, ':');
@@ -1209,7 +1209,7 @@ static void printproperty(Cfg_t *cc, int ii, Cfg_opts o) {
 }
 
 // Print the fuse/lock bits header (-f, o.flheaders)
-static void printfuse(Cfg_t *cc, int ii, Flock_t *fc, int nf, int printed, Cfg_opts o) {
+static void printfuse(Cnfg *cc, int ii, Flock_t *fc, int nf, int printed, Cfg_opts o) {
   char buf[512];
   int fj;
   for(fj=0; fj<nf; fj++)
@@ -1317,7 +1317,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
   Fusel_t fusel;                // Copy of fuses and lock bits
   const Valueitem_t *vt;        // Pointer to symbolic labels and associated values
   int nv;                       // Number of symbolic labels
-  Cfg_t *cc;                    // Current configuration; cc[] and ct[] are parallel arrays
+  Cnfg *cc;                     // Current configuration; cc[] and ct[] are parallel arrays
   Flock_t *fc;                  // Current fuse and lock bits memories
   int nf = 0;                   // Number of involved fuse and lock bits memories
 
@@ -1434,7 +1434,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
   }
 
   // ci is fixed now: save what we have for sanity check
-  Cfg_t safecc = cc[ci];
+  Cnfg safecc = cc[ci];
 
   nv = ct[ci].nvalues;
   vt = ct[ci].vlist;

--- a/src/term.c
+++ b/src/term.c
@@ -1047,7 +1047,7 @@ static int setmatches(const char *str, int n, Cnfg *cc) {
   return matches;
 }
 
-static int getvalidx(const char *str, int n, const Valueitem_t *vt) {
+static int getvalidx(const char *str, int n, const Configvalue *vt) {
   int hold, matches = 0;
 
   if(!*str)
@@ -1098,7 +1098,7 @@ static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cnfg *cc, int i,
 }
 
 // Comment printed next to symbolic value
-static const char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, int value, Cfg_opts o) {
+static const char *valuecomment(const Configitem_t *cti, const Configvalue *vp, int value, Cfg_opts o) {
   char buf[512], bin[129];
   unsigned u = value, m = cti->mask >> cti->lsh;
   int lsh = cti->lsh;
@@ -1137,7 +1137,7 @@ static const char *valuecomment(const Configitem_t *cti, const Valueitem_t *vp, 
 }
 
 // How a single property is printed
-static void printoneproperty(Cnfg *cc, int ii, const Valueitem_t *vp, int llen, const char *vstr, Cfg_opts o) {
+static void printoneproperty(Cnfg *cc, int ii, const Configvalue *vp, int llen, const char *vstr, Cfg_opts o) {
   int value = vp? vp->value: cc[ii].val;
   term_out("%s %s=%-*s # %s\n", vp && cc[ii].val != vp->value? "# conf": "config",
     cc[ii].t->name, llen, vstr, valuecomment(cc[ii].t, vp, value, o));
@@ -1145,7 +1145,7 @@ static void printoneproperty(Cnfg *cc, int ii, const Valueitem_t *vp, int llen, 
 
 // Prints a list of all possible values (o.allv) or just the one proporty cc[ii]
 static void printproperty(Cnfg *cc, int ii, Cfg_opts o) {
-  const Valueitem_t *vt = cc[ii].t->vlist, *vp;
+  const Configvalue *vt = cc[ii].t->vlist, *vp;
   int nv = cc[ii].t->nvalues;
   const char *ccom = cc->t[ii].ccomment, *col = strchr(ccom, ':');
   char buf[32];
@@ -1315,7 +1315,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
   const Configitem_t *ct;       // Configuration bitfield table
   int nc;                       // Number of config properties, some may not be available
   Part_FL fusel;                // Copy of fuses and lock bits
-  const Valueitem_t *vt;        // Pointer to symbolic labels and associated values
+  const Configvalue *vt;        // Pointer to symbolic labels and associated values
   int nv;                       // Number of symbolic labels
   Cnfg *cc;                     // Current configuration; cc[] and ct[] are parallel arrays
   FL_item *fc;                  // Current fuse and lock bits memories

--- a/src/term.c
+++ b/src/term.c
@@ -938,7 +938,7 @@ static const int MAX_PAD = 10;  // Align value labels if their length difference
 typedef union {                 // Lock memory can be 1 or 4 bytes
   uint8_t b[4];
   uint32_t i;
-} fl_t;
+} Intbytes;
 
 typedef struct {                // Fuses and lock bits
   uint16_t fuses[16];           // pdicfg fuse has two bytes
@@ -996,7 +996,7 @@ static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const 
     goto back;
   }
 
-  fl_t m = {.i = 0};
+  Intbytes m = {.i = 0};
   for(int i=0; i<mem->size; i++)
     if(led_read_byte(pgm, p, mem, i, m.b+i) < 0) {
       err = cache_string(str_ccprintf("cannot read %s's %s memory", p->desc, mem->desc));
@@ -1510,7 +1510,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
     goto finished;
   }
 
-  fl_t towrite;
+  Intbytes towrite;
   towrite.i = (fusel.current & ~ct[ci].mask) | (toassign<<ct[ci].lsh);
   const AVRMEM *mem = avr_locate_mem(p, cc[ci].memstr);
   if(!mem) {

--- a/src/term.c
+++ b/src/term.c
@@ -1071,12 +1071,12 @@ typedef struct {                // Fuse/lock properties of the part
   const char *memstr;
   int mask;
   int value;
-} Flock_t;
+} FL_item;
 
 
 // Fill in cc record with the actual value of the relevant fuse
 static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cnfg *cc, int i,
-  Fusel_t *fuselp, Flock_t *fc, int nf) {
+  Fusel_t *fuselp, FL_item *fc, int nf) {
 
   // Load current value of this config item
   const char *errstr = NULL;
@@ -1209,7 +1209,7 @@ static void printproperty(Cnfg *cc, int ii, Cfg_opts o) {
 }
 
 // Print the fuse/lock bits header (-f, o.flheaders)
-static void printfuse(Cnfg *cc, int ii, Flock_t *fc, int nf, int printed, Cfg_opts o) {
+static void printfuse(Cnfg *cc, int ii, FL_item *fc, int nf, int printed, Cfg_opts o) {
   char buf[512];
   int fj;
   for(fj=0; fj<nf; fj++)
@@ -1318,7 +1318,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
   const Valueitem_t *vt;        // Pointer to symbolic labels and associated values
   int nv;                       // Number of symbolic labels
   Cnfg *cc;                     // Current configuration; cc[] and ct[] are parallel arrays
-  Flock_t *fc;                  // Current fuse and lock bits memories
+  FL_item *fc;                  // Current fuse and lock bits memories
   int nf = 0;                   // Number of involved fuse and lock bits memories
 
   memset(&fusel, 0, sizeof fusel);

--- a/src/term.c
+++ b/src/term.c
@@ -949,7 +949,7 @@ typedef struct {                // Fuses and lock bits
 } Part_FL;
 
 typedef struct {
-  const Configitem_t *t;        // Configuration bitfield table
+  const Configitem *t;        // Configuration bitfield table
   const char *memstr;           // Memory name but could also be "lockbits"
   const char *alt;              // Set when memstr is an alias
   int match;                    // Matched by user request
@@ -1098,7 +1098,7 @@ static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cnfg *cc, int i,
 }
 
 // Comment printed next to symbolic value
-static const char *valuecomment(const Configitem_t *cti, const Configvalue *vp, int value, Cfg_opts o) {
+static const char *valuecomment(const Configitem *cti, const Configvalue *vp, int value, Cfg_opts o) {
   char buf[512], bin[129];
   unsigned u = value, m = cti->mask >> cti->lsh;
   int lsh = cti->lsh;
@@ -1312,7 +1312,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
   }
 
   int idx = -1;                 // Index in uP_table[]
-  const Configitem_t *ct;       // Configuration bitfield table
+  const Configitem *ct;       // Configuration bitfield table
   int nc;                       // Number of config properties, some may not be available
   Part_FL fusel;                // Copy of fuses and lock bits
   const Configvalue *vt;        // Pointer to symbolic labels and associated values

--- a/src/term.c
+++ b/src/term.c
@@ -1727,7 +1727,7 @@ static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, const 
 
   int do_read = p->prog_modes & (PM_UPDI | PM_PDI);
   int nr;
-  const Register_file_t *rf = avr_locate_register_file(p, &nr);
+  const Register_file *rf = avr_locate_register_file(p, &nr);
 
   if(!rf || nr <= 0) {
     pmsg_error("(regfile) .atdf file not published for %s: unknown register file\n", p->desc);
@@ -1739,7 +1739,7 @@ static int cmd_regfile(const PROGRAMMER *pgm, const AVRPART *p, int argc, const 
     *rhs++ = 0;                 // Terminate lhs
 
   // Create mmt_malloc'd NULL-terminated list of register pointers
-  const Register_file_t *r, **rl, **rlist;
+  const Register_file *r, **rl, **rlist;
   rlist = avr_locate_registerlist(rf, nr, reg, str_is_pattern(reg)? str_matched_by: str_contains);
 
   if(rhs) {                     // Write to single register

--- a/src/term.c
+++ b/src/term.c
@@ -663,7 +663,7 @@ static int cmd_save(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
 
   mem = avr_dup_mem(omem);
   int n = argc > 3? (argc-3)/2: 1;
-  Segment_t *seglist = mmt_malloc(n*sizeof*seglist);
+  Segment *seglist = mmt_malloc(n*sizeof*seglist);
 
   int ret = -1;
 

--- a/src/term.c
+++ b/src/term.c
@@ -946,7 +946,7 @@ typedef struct {                // Fuses and lock bits
   int fread[16], lread;
   int islock;
   uint32_t current;
-} Fusel_t;
+} Part_FL;
 
 typedef struct {
   const Configitem_t *t;        // Configuration bitfield table
@@ -961,7 +961,7 @@ typedef struct {                // Context parameters to be passed to functions
 } Cfg_opts;
 
 // Cache the contents of the fuse and lock bits memories that a particular Configitem is involved in
-static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Fusel_t *fl, const Cnfg *cci, const char **errpp) {
+static int getfusel(const PROGRAMMER *pgm, const AVRPART *p, Part_FL *fl, const Cnfg *cci, const char **errpp) {
   const char *err = NULL;
   int islock;
 
@@ -1076,7 +1076,7 @@ typedef struct {                // Fuse/lock properties of the part
 
 // Fill in cc record with the actual value of the relevant fuse
 static int gatherval(const PROGRAMMER *pgm, const AVRPART *p, Cnfg *cc, int i,
-  Fusel_t *fuselp, FL_item *fc, int nf) {
+  Part_FL *fuselp, FL_item *fc, int nf) {
 
   // Load current value of this config item
   const char *errstr = NULL;
@@ -1314,7 +1314,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
   int idx = -1;                 // Index in uP_table[]
   const Configitem_t *ct;       // Configuration bitfield table
   int nc;                       // Number of config properties, some may not be available
-  Fusel_t fusel;                // Copy of fuses and lock bits
+  Part_FL fusel;                // Copy of fuses and lock bits
   const Valueitem_t *vt;        // Pointer to symbolic labels and associated values
   int nv;                       // Number of symbolic labels
   Cnfg *cc;                     // Current configuration; cc[] and ct[] are parallel arrays

--- a/src/term.c
+++ b/src/term.c
@@ -365,7 +365,7 @@ static size_t maxstrlen(int argc, const char **argv) {
 typedef enum {
   WRITE_MODE_STANDARD = 0,
   WRITE_MODE_FILL     = 1,
-} Write_mode_t;
+} Write_mode;
 
 static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if (argc < 3 || (argc > 1 && str_eq(argv[1], "-?"))) {
@@ -418,7 +418,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, const ch
   }
 
   int i;
-  int write_mode;               // Operation mode, standard or fill
+  Write_mode write_mode;        // Operation mode, standard or fill
   int start_offset;             // Which argc argument
   int len;                      // Number of bytes to write to memory
   const char *memstr = argv[1]; // Memory name string

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -324,10 +324,10 @@ typedef struct {
 
   char title[254];              // Use instead of filename for metadata - same size as filename
   char iddesc[64];              // Location of Urclock ID, eg F.12324.6 or E.-4.4 (default E.257.6)
-} Urclock_t;
+} Urclock_data;
 
 // Use private programmer data as if they were a global structure ur
-#define ur (*(Urclock_t *)(pgm->cookie))
+#define ur (*(Urclock_data *)(pgm->cookie))
 
 #define Return(...) do { pmsg_error(__VA_ARGS__); msg_error("\n"); return -1; } while (0)
 
@@ -2552,7 +2552,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
 
 static void urclock_setup(PROGRAMMER *pgm) {
   // Allocate ur
-  pgm->cookie = mmt_malloc(sizeof(Urclock_t));
+  pgm->cookie = mmt_malloc(sizeof(Urclock_data));
 
   ur.xvectornum    = -1;        // Initialise, to ascertain whether user had set to 0
   ur.ext_addr_byte = 0xff;      // So first memory address will load extended address

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -251,7 +251,7 @@ typedef struct {
 
   unsigned char ext_addr_byte;  // Ext-addr byte for STK500v1 protocol and MCUs with > 128k
 
-  uPcore_t uP;                  // Info about the connected processor (copied from uP_table)
+  Avrintel uP;                  // Info about the connected processor (copied from uP_table)
 
   bool initialised;             // Is this structure initialised?
   bool bleepromrw;              // Bootloader has EEPROM r/w support

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2419,9 +2419,7 @@ static void urclock_display(const PROGRAMMER *pgm, const char *p_unused) {
 
 
 // Return whether an address is write protected
-static int urclock_readonly(const struct programmer_t *pgm, const AVRPART *p_unused,
-  const AVRMEM *mem, unsigned int addr) {
-
+static int urclock_readonly(const PROGRAMMER *pgm, const AVRPART *p_unused, const AVRMEM *mem, unsigned int addr) {
   if(mem_is_in_flash(mem)) {
     if(addr > (unsigned int) ur.pfend)
       return 1;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1092,10 +1092,10 @@ static uint32_t jenkins_hash(const uint8_t* key, size_t length) {
 typedef struct {
   uint16_t sz, ee;
   uint32_t h256, hash;
-} Blhash_t;
+} Bl_hash;
 
 static int cmpblhash(const void *va, const void *vb) {
-  const Blhash_t *a = va, *b = vb;
+  const Bl_hash *a = va, *b = vb;
   return a->sz > b->sz? 1: a->sz < b->sz? -1: a->hash > b->hash? 1: a->hash < b->hash? -1: 0;
 }
 
@@ -1103,7 +1103,7 @@ static void guessblstart(const PROGRAMMER *pgm, const AVRPART *p) {
   if(ur.urprotocol && !(ur.urfeatures & UB_READ_FLASH)) // Cannot read flash
     return;
 
-  Blhash_t blist[] = {
+  Bl_hash blist[] = {
     // From https://github.com/arduino/ArduinoCore-avr/tree/master/bootloaders
     { 1024, 0, 0x35445c45, 0x9ef77953 }, // ATmegaBOOT-prod-firmware-2009-11-07.hex
     { 1024, 0, 0x32b1376c, 0xceba80bb }, // ATmegaBOOT.hex

--- a/src/urclock.h
+++ b/src/urclock.h
@@ -21,8 +21,16 @@
 #ifndef urclock_h__
 #define urclock_h__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern const char urclock_desc[];
 void urclock_initpgm (PROGRAMMER *pgm);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -934,7 +934,7 @@ static int usbasp_spi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 }
 
 /* The list of SCK frequencies in Hz supported by USBasp */
-static const struct sckoptions_t usbaspSCKoptions[] = {
+static const struct sckoptions usbaspSCKoptions[] = {
   { USBASP_ISP_SCK_3000, 3000000 },
   { USBASP_ISP_SCK_1500, 1500000 },
   { USBASP_ISP_SCK_750, 750000 },

--- a/src/usbasp.h
+++ b/src/usbasp.h
@@ -115,7 +115,7 @@
 #define NVMCMD_WORD_WRITE    0x1D
 
 
-typedef struct sckoptions_t {
+typedef struct sckoptions {
   int id;
   double frequency;
 } CLOCKOPTIONS;


### PR DESCRIPTION
Posix reserves all type names ending in `_t`, so our use was *verboten*. For the time being I have left type names in `libavrdude`, as changing these creates real work for all their users. What do you think @ndim, @dl8dtl, @MCUdude, @mcuee?