### PR TITLE
Guard serial_number access in usbhid_open() to avoid segfault

### DIFF
--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -97,14 +97,14 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
 
     walk = list;
     while (walk) {
-      pmsg_notice("usbhid_open(): found %ls, serno: %ls\n", walk->product_string, walk->serial_number);
-      size_t slen = wcslen(walk->serial_number);
-      if (slen >= serlen && wcscmp(walk->serial_number + slen - serlen, wserno) == 0)
-      {
-        /* Found matching serial number */
-        break;
+      if(walk->serial_number) {
+        pmsg_notice("usbhid_open(): found %ls, serno: %ls\n", walk->product_string, walk->serial_number);
+        size_t slen = wcslen(walk->serial_number);
+        // Found matching serial number?
+        if (slen >= serlen && wcscmp(walk->serial_number + slen - serlen, wserno) == 0)
+          break;
+        pmsg_debug("usbhid_open(): serial number does not match\n");
       }
-      pmsg_debug("usbhid_open(): serial number does not match\n");
       walk = walk->next;
     }
     if (walk == NULL) {


### PR DESCRIPTION
Unfortunately, I can no longer remember which particular instance lead to the segfault, when I played with a Pro Micro flushed as a programmer, but I could narrow it down to accessing a pointer that a library call returned, so it's reasonable to guard the access.

Should be safe to merge.