### PR TITLE
Allow selection of program modes for developer options

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -437,11 +437,11 @@ static void replace_backslashes(char *s)
   }
 }
 
-// Return 2 if str is * or starts with */, 1 if str contains / but is not a valid part, 0 otherwise
+// Return whether a part/programmer string is a developer option and if so which type
 static int dev_opt(const char *str) {
   return
     !str? 0:
-    str_eq(str, "*") || str_starts(str, "*/")? 2:
+    str_eq(str, "*") || str_starts(str, "*/s")? 2: // Print PART DEFINITIONS comment as well
     strchr(str, '/') && !locate_part(part_list, str);
 }
 
@@ -1127,8 +1127,8 @@ int main(int argc, char * argv [])
     pgmid = cache_string(default_programmer);
 
   // Developer options to print parts and/or programmer entries of avrdude.conf
-  int dev_opt_c = dev_opt(pgmid);    // -c <wildcard>/[sSArt]
-  int dev_opt_p = dev_opt(partdesc); // -p <wildcard>/[dsSArcow*t]
+  int dev_opt_c = dev_opt(pgmid);    // -c <wildcard>/[ASsrtiBUPTIJWHQ]
+  int dev_opt_p = dev_opt(partdesc); // -p <wildcard>/[cdoASsrw*tiBUPTIJWHQ]
 
   if(dev_opt_c || dev_opt_p) {  // See -c/h and or -p/h
     dev_output_pgm_part(dev_opt_c, pgmid, dev_opt_p, partdesc);

--- a/src/main.c
+++ b/src/main.c
@@ -1127,7 +1127,7 @@ int main(int argc, char * argv [])
     pgmid = cache_string(default_programmer);
 
   // Developer options to print parts and/or programmer entries of avrdude.conf
-  int dev_opt_c = dev_opt(pgmid);    // -c <wildcard>/[ASsrtiBUPTIJWHQ]
+  int dev_opt_c = dev_opt(pgmid);    // -c <wildcard>/[dASsrtiBUPTIJWHQ]
   int dev_opt_p = dev_opt(partdesc); // -p <wildcard>/[cdoASsrw*tiBUPTIJWHQ]
 
   if(dev_opt_c || dev_opt_p) {  // See -c/h and or -p/h


### PR DESCRIPTION
This PR enables the developer options to apply to a subset of programming modes (be it -p part or -c programmer). This is useful for questions like How many different starting addresses do the `signature` memories of `UPDI` parts have? `/U` restricts to UPDI parts, `/I` to ISP parts and, eg, `/PU` to PDI or UPDI parts.

Examples:
```
avrdude -p*/USt | grep signature.offset | cut -f5 | sort | uniq -c
     14 0x1080
     96 0x1100
```
14 UPDI parts start the `signature` memory at 0x1080 and 96 at `0x1100`. Now you know.

Q: How many ATmega UPDI parts are there? A:
```
avrdude -pATmega*/Ud | wc -l
```

Q: Which programmers can handle PDI parts? A:
```
avrdude -c*/Pd
````

Q: Which other prog mode subsets are there? A:
```
avrdude -p*/? | grep B
```

Only affects developer options, not the core AVRDUDE business. Should be safe to merge