### PR TITLE
Downgrade out-of-range file input errors to warnings on -F

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -258,7 +258,6 @@ static int ihex_readrec(struct ihexsrec *ihex, char * rec) {
   int offset, len;
   char * e;
   unsigned char cksum;
-  int rc;
 
   len    = strlen(rec);
   offset = 1;
@@ -320,9 +319,10 @@ static int ihex_readrec(struct ihexsrec *ihex, char * rec) {
   if (e == buf || *e != 0)
     return -1;
 
-  rc = -cksum & 0x000000ff;
+  pmsg_debug("read ihex record type 0x%02x at 0x%04x with %2d bytes and chksum 0x%02x (0x%02x)\n",
+    ihex->rectyp, ihex->loadofs, ihex->reclen, ihex->cksum, -cksum & 0xff);
 
-  return rc;
+  return -cksum & 0xff;
 }
 
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -415,7 +415,6 @@ static int ihex2b(const char *infile, FILE *inf, const AVRMEM *mem,
             unsigned low = beg - nextaddr;
             if(low < ihex.reclen) { // Clip record
               ihex.reclen -= low;
-              ihex.loadofs += low;
               nextaddr += low;
               below += low;
             } else {            // Nothing to write
@@ -740,7 +739,6 @@ static int srec2b(const char *infile, FILE * inf,
         below = fileoffset - nextaddr;
         if(below < srec.reclen) { // Clip record
           nextaddr += below;
-          srec.loadofs += below;
           srec.reclen -= below;
         } else {                // Ignore record
           srec.reclen = 0;
@@ -763,7 +761,6 @@ static int srec2b(const char *infile, FILE * inf,
           unsigned low = beg - nextaddr;
           if(low < srec.reclen) { // Clip record
             srec.reclen -= low;
-            srec.loadofs += low;
             nextaddr += low;
             below += low;
           } else {              // Nothing to write

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -380,7 +380,7 @@ static int ihex2b(const char *infile, FILE *inf, const AVRMEM *mem,
     unsigned below = 0;
     switch (ihex.rectyp) {
       case 0: /* data record */
-        if (fileoffset != 0 && ihex.loadofs + baseaddr < fileoffset) {
+        if(ihex.loadofs + baseaddr < fileoffset) {
           if(!ovsigck) {
             pmsg_error("address 0x%04x out of range (below fileoffset 0x%x) at line %d of %s\n",
               ihex.loadofs + baseaddr, fileoffset, lineno, infile);

--- a/src/term.c
+++ b/src/term.c
@@ -582,7 +582,7 @@ static int cmd_write(const PROGRAMMER *pgm, const AVRPART *p, int argc, const ch
     pmsg_warning("(write) clipping data to fit into %s %s memory\n", p->desc, mem->desc);
   }
 
-  pmsg_notice2("(write) writing %d byte%s starting from address 0x%02x",
+  pmsg_notice2("(write) writing %d byte%s starting from address 0x%04x",
     len + bytes_grown, str_plural(len + bytes_grown), addr);
   if (write_mode == WRITE_MODE_FILL && filling)
     msg_notice2("; remaining space filled with %s", argv[argc - 2]);


### PR DESCRIPTION
Triggered by #1817 that changed topic.

When .hex or .srec input files have out-of-range records, AVRDUDE exits with an error. This PR changes that behaviour iff `-F` was specified to downgrade this to a warning and clip the respective records or ignore them.

