### PR TITLE
Extend elf format for bootrow

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -794,6 +794,10 @@ static int elf_mem_limits(const AVRMEM *mem, const AVRPART *p,
       *lowbound = 0x850000;
       *highbound = 0x85ffff;
       *fileoff = 0;
+    } else if (mem_is_bootrow(mem)) {
+      *lowbound = 0x860000;
+      *highbound = 0x86ffff;
+      *fileoff = 0;
     } else {
       rv = -1;
     }


### PR DESCRIPTION
See [comment](https://github.com/avrdudes/avrdude/issues/1817#issuecomment-2165492852). Is someone is a position to test this? Create an .elf file with bootrow data and try
```
avrdude -U bootrow:w:file.elf
```

