### PR TITLE
Add developer options /vcr to explore software compatibility of parts

### DIFF
--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -849,7 +849,7 @@ static int prog_modes_in_flags(int prog_modes, const char *flags) {
   return (prog_modes == 0 && quirky) || !pm || (prog_modes & pm);
 }
 
-// -p <wildcard>/[cdoASsrw*tiBUPTIJWHQ]
+// -p <wildcard>/[dsASReow*tiBUPTIJWHQ]
 void dev_output_part_defs(char *partdesc) {
   bool cmdok, waits, opspi, descs, astrc, strct, cmpst, injct, raw, all, tsv;
   char *flags;
@@ -862,27 +862,27 @@ void dev_output_part_defs(char *partdesc) {
   if(!flags && str_eq(partdesc, "*")) // Treat -p * as if it was -p */s
     flags = "s";
 
-  if(!*flags || !strchr("cdoASsrw*tiBUPTIJWHQ", *flags)) {
+  if(!*flags || !strchr("dsASReow*tiBUPTIJWHQ", *flags)) {
     dev_info("%s: flags for developer option -p <wildcard>/<flags> not recognised\n", progname);
     dev_info(
       "Wildcard examples (these need protecting in the shell through quoting):\n"
-      "         * all known parts\n"
-      "  ATtiny10 just this part\n"
-      "  *32[0-9] matches ATmega329, ATmega325 and ATmega328\n"
-      "      *32? matches ATmega329, ATmega32A, ATmega325 and ATmega328\n"
+      "          * all known parts\n"
+      "   ATtiny10 just this part\n"
+      "   *32[0-9] matches ATmega329, ATmega325 and ATmega328\n"
+      "       *32? matches ATmega329, ATmega32A, ATmega325 and ATmega328\n"
       "Flags (one or more of the characters below):\n"
-      "         d  description of core part features\n"
-      "         A  show entries of avrdude.conf parts with all values\n"
-      "         S  show entries of avrdude.conf parts with necessary values\n"
-      "         s  show short entries of avrdude.conf parts using parent\n"
-      "         r  show entries of avrdude.conf parts as raw dump\n"
-      "         c  check and report errors in address bits of SPI commands\n"
-      "         o  opcodes for SPI programming parts and memories\n"
-      "         w  wd_... constants for ISP parts\n"
-      "         *  as first character: all of the above except s and S\n"
-      " BUPTIJWHQ  only Bootloader/UPDI/PDI/TPI/ISP/JTAG/debugWire/HV/quirky MUCs\n"
-      "         t  use tab separated values as much as possible\n"
-      "         i  inject assignments from source code table\n"
+      "          d  description of core part features\n"
+      "          s  show short entries of avrdude.conf parts using parent\n"
+      "          A  show entries of avrdude.conf parts with all values\n"
+      "          S  show entries of avrdude.conf parts with necessary values\n"
+      "          R  show entries of avrdude.conf parts as raw dump\n"
+      "          e  check and report errors in address bits of SPI commands\n"
+      "          o  opcodes for SPI programming parts and memories\n"
+      "          w  wd_... constants for ISP parts\n"
+      "          *  as first character: all of the above except s and S\n"
+      "  BUPTIJWHQ  only Bootloader/UPDI/PDI/TPI/ISP/JTAG/debugWire/HV/quirky MUCs\n"
+      "          t  use tab separated values as much as possible\n"
+      "          i  inject assignments from source code table\n"
       "Examples:\n"
       "  $ avrdude -p ATmega328P/s\n"
       "  $ avrdude -p m328*/st | grep chip_erase_delay\n"
@@ -901,12 +901,12 @@ void dev_output_part_defs(char *partdesc) {
   }
 
   all = *flags == '*';
-  cmdok = all || !!strchr(flags, 'c');
+  cmdok = all || !!strchr(flags, 'e');
   descs = all || !!strchr(flags, 'd');
   opspi = all || !!strchr(flags, 'o');
   waits = all || !!strchr(flags, 'w');
   astrc = all || !!strchr(flags, 'A');
-  raw   = all || !!strchr(flags, 'r');
+  raw   = all || !!strchr(flags, 'R');
   strct = !!strchr(flags, 'S');
   cmpst = !!strchr(flags, 's');
   tsv   = !!strchr(flags, 't');

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1135,7 +1135,7 @@ void dev_output_part_defs(char *partdesc) {
 
       if(vtabs && (up = silent_locate_uP(p)) && up->isrtable)
         for(int i=0; i < up->ninterrupts; i++)
-          dev_info("%s\t%3d\t%s\n", p->desc, i, up->isrtable[i]);
+          dev_info(".vtab\t%s\t%d\t%s\n", p->desc, i, up->isrtable[i]);
 
       if(confs && (up = silent_locate_uP(p)) && up->cfgtable)
         for(int i=0; i < up->nconfigs; i++) {
@@ -1146,15 +1146,15 @@ void dev_output_part_defs(char *partdesc) {
               n &= n-1;
             n = 1<<c;
           }
-          dev_info("%s\t%3d\t%s\n", p->desc, n, cp->name);
+          dev_info(".cfgt\t%s\t%d\t%s\n", p->desc, n, cp->name);
           if(cp->vlist && verbose)
             for(int k=0; k < cp->nvalues; k++)
-              dev_info("%s\t\tvalue\t%3d\t%s\n", p->desc, cp->vlist[k].value, cp->vlist[k].label);
+              dev_info(".cfgv\t%s\t\tvalue\t%d\t%s\n", p->desc, cp->vlist[k].value, cp->vlist[k].label);
         }
 
       if(regis && (up = silent_locate_uP(p)) && up->regf)
         for(int i=0; i < up->nregisters; i++)
-          dev_info("%s\t0x%02x\t%d\t%s\n", p->desc, up->regf[i].addr, up->regf[i].size, up->regf[i].reg);
+          dev_info(".regf\t%s\t0x%02x\t%d\t%s\n", p->desc, up->regf[i].addr, up->regf[i].size, up->regf[i].reg);
     }
 
     if(opspi) {

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -214,6 +214,9 @@ static char *dev_sprintf(const char *fmt, ...) {
 
 static int dev_nprinted;
 
+#if defined(__GNUC__)
+   __attribute__ ((format (printf, 2, 3)))
+#endif
 int dev_message(int msglvl, const char *fmt, ...) {
   va_list ap;
   int rc = 0;
@@ -530,7 +533,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
 
     if(!cp || !dev_has_subsstr_comms(cp->comms, del)) {
       dev_info("%s\n", del);
-      dev_info("# %.*s\n", strlen(descstr)-2, descstr+1); // Remove double quotes
+      dev_info("# %.*s\n", (int) strlen(descstr)-2, descstr+1); // Remove double quotes
       dev_info("%s\n\n", del);
     }
     if(cp)
@@ -689,7 +692,7 @@ static void dev_part_strct(const AVRPART *p, bool tsv, const AVRPART *base, bool
     bm = base? dev_locate_mem(base, avr_mem_order[mi].str): NULL;
 
     if(!m && bm && !tsv)
-      dev_info("\n    memory \"%s\" %*s= NULL;\n", bm->desc, 13 > strlen(bm->desc)? 13-strlen(bm->desc): 0, "");
+      dev_info("\n    memory \"%s\" %*s= NULL;\n", bm->desc, 13 > strlen(bm->desc)? 13 - (int) strlen(bm->desc): 0, "");
 
     if(!m)
       continue;
@@ -1298,7 +1301,7 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
         if(!firstid)
           dev_info("/");
         firstid = 0;
-        dev_info("%s", ldata(ln));
+        dev_info("%s", (char *) ldata(ln));
       }
       dev_info("\n%s\n\n", del);
     }
@@ -1307,9 +1310,9 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
 
     const char *prog_sea = is_programmer(pgm)? "programmer": is_serialadapter(pgm)? "serialadapter": "programmer";
     if(pgm->parent_id && *pgm->parent_id)
-      dev_info("%s parent \"%s\" # %s\n", prog_sea, pgm->parent_id, ldata(lfirst(pgm->id)));
+      dev_info("%s parent \"%s\" # %s\n", prog_sea, pgm->parent_id, (char *) ldata(lfirst(pgm->id)));
     else
-      dev_info("%s # %s\n", prog_sea, ldata(lfirst(pgm->id)));
+      dev_info("%s # %s\n", prog_sea, (char *) ldata(lfirst(pgm->id)));
   }
 
   if(tsv)

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -834,6 +834,7 @@ static int prog_modes_in_flags(int prog_modes, const char *flags) {
   for(const char *p = flags; *p; p++)
     switch(*p) {
     case 'B': pm |= PM_SPM; break;
+    case 'C': pm |= PM_TPI | PM_ISP | PM_HVSP | PM_HVPP | PM_debugWIRE | PM_JTAG | PM_JTAGmkI; break;
     case 'U': pm |= PM_UPDI; break;
     case 'P': pm |= PM_PDI; break;
     case 'T': pm |= PM_TPI; break;
@@ -849,7 +850,7 @@ static int prog_modes_in_flags(int prog_modes, const char *flags) {
   return (prog_modes == 0 && quirky) || !pm || (prog_modes & pm);
 }
 
-// -p <wildcard>/[dsASReow*tiBUPTIJWHQ]
+// -p <wildcard>/[dsASReow*tiBCUPTIJWHQ]
 void dev_output_part_defs(char *partdesc) {
   bool cmdok, waits, opspi, descs, astrc, strct, cmpst, injct, raw, all, tsv;
   char *flags;
@@ -862,7 +863,7 @@ void dev_output_part_defs(char *partdesc) {
   if(!flags && str_eq(partdesc, "*")) // Treat -p * as if it was -p */s
     flags = "s";
 
-  if(!*flags || !strchr("dsASReow*tiBUPTIJWHQ", *flags)) {
+  if(!*flags || !strchr("dsASReow*tiBCUPTIJWHQ", *flags)) {
     dev_info("%s: flags for developer option -p <wildcard>/<flags> not recognised\n", progname);
     dev_info(
       "Wildcard examples (these need protecting in the shell through quoting):\n"
@@ -880,7 +881,7 @@ void dev_output_part_defs(char *partdesc) {
       "          o  opcodes for SPI programming parts and memories\n"
       "          w  wd_... constants for ISP parts\n"
       "          *  as first character: all of the above except s and S\n"
-      "  BUPTIJWHQ  only Bootloader/UPDI/PDI/TPI/ISP/JTAG/debugWire/HV/quirky MUCs\n"
+      " BCUPTIJWHQ  only Boot/Classic/UPDI/PDI/TPI/ISP/JTAG/debugWire/HV/quirky MUCs\n"
       "          t  use tab separated values as much as possible\n"
       "          i  inject assignments from source code table\n"
       "Examples:\n"


### PR DESCRIPTION
This PR adds developer options to print 
 - Interrupt vector names (`-p part/v`)
 - Configuration options (`-p part/c` and `-v -p part/c` to show the list of admissible values)
 - Register file `-p part/r`

The output can be used to judge to which degree two parts are software-compatible, defined as same memory sizes, same interrupt vectors and same register files. For example, the `AVR16EB14` and `AVR16EB20` are SW-compatible as long as the following two registers are not used:

```
$ avrdude -qq -p16eb14/vcr -v | cut -f3- >/tmp/16eb14
$ avrdude -qq -p16eb20/vcr -v | cut -f3- >/tmp/16eb20
$ diff /tmp/16eb*
340a341,342
> 0x5e8	1	portmux.tcbroutea
> 0x5ea	1	portmux.acroutea
```

A similar exerise with `m324pa` and `m324pb` shows that the `pb` part has more timers and peripherals than the `pa` (and which ones) and, hence, more interrupt vectors and registers to deal with these. As the interrupt vectors and registers otherwise remain at the same position it is reasonable to assume that a program for the `pa` might work on the `pb`, but not vice versa.

