### PR TITLE
Alternative fix proposal for #1832

### DIFF
--- a/src/updi_nvm.c
+++ b/src/updi_nvm.c
@@ -157,6 +157,25 @@ int updi_nvm_write_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t ad
   }
 }
 
+int updi_nvm_write_boot_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
+  switch(updi_get_nvm_mode(pgm))
+  {
+    case UPDI_NVM_MODE_V0:
+      return updi_nvm_write_boot_row_V0(pgm, p, address, buffer, size);
+    case UPDI_NVM_MODE_V2:
+      return updi_nvm_write_boot_row_V2(pgm, p, address, buffer, size);
+    case UPDI_NVM_MODE_V3:
+      return updi_nvm_write_boot_row_V3(pgm, p, address, buffer, size);
+    case UPDI_NVM_MODE_V4:
+      return updi_nvm_write_boot_row_V4(pgm, p, address, buffer, size);
+    case UPDI_NVM_MODE_V5:
+      return updi_nvm_write_boot_row_V5(pgm, p, address, buffer, size);
+    default:
+      pmsg_error("invalid NVM Mode %d\n", updi_get_nvm_mode(pgm));
+      return -1;
+  }
+}
+
 int updi_nvm_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
   switch(updi_get_nvm_mode(pgm))
   {

--- a/src/updi_nvm.h
+++ b/src/updi_nvm.h
@@ -39,6 +39,7 @@ int updi_nvm_erase_eeprom(const PROGRAMMER *pgm, const AVRPART *p);
 int updi_nvm_erase_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size);
 int updi_nvm_write_flash(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_user_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_boot_row(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_eeprom(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_fuse(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value);
 int updi_nvm_wait_ready(const PROGRAMMER *pgm, const AVRPART *p);

--- a/src/updi_nvm_v0.c
+++ b/src/updi_nvm_v0.c
@@ -284,9 +284,9 @@ int updi_nvm_write_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
 
 int updi_nvm_write_boot_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
-  Perform write operation as if it was regular flash memory, but ensure page erase/page write command
+  Perform write operation as if it was regular flash memory
 */  
-  return nvm_write_V0(pgm, p, address, buffer, size, USE_WORD_ACCESS, UPDI_V0_NVMCTRL_CTRLA_ERASE_WRITE_PAGE);
+  return nvm_write_V0(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
 int updi_nvm_write_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {

--- a/src/updi_nvm_v0.c
+++ b/src/updi_nvm_v0.c
@@ -282,6 +282,13 @@ int updi_nvm_write_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
   return updi_nvm_write_eeprom_V0(pgm, p, address, buffer, size);
 }
 
+int updi_nvm_write_boot_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
+/*
+  Perform write operation as if it was regular flash memory, but ensure page erase/page write command
+*/  
+  return nvm_write_V0(pgm, p, address, buffer, size, USE_WORD_ACCESS, UPDI_V0_NVMCTRL_CTRLA_ERASE_WRITE_PAGE);
+}
+
 int updi_nvm_write_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):

--- a/src/updi_nvm_v0.h
+++ b/src/updi_nvm_v0.h
@@ -39,6 +39,7 @@ int updi_nvm_erase_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p);
 int updi_nvm_erase_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size);
 int updi_nvm_write_flash_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_user_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_boot_row_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_eeprom_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_fuse_V0(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value);
 int updi_nvm_wait_ready_V0(const PROGRAMMER *pgm, const AVRPART *p);

--- a/src/updi_nvm_v2.c
+++ b/src/updi_nvm_v2.c
@@ -282,6 +282,17 @@ int updi_nvm_write_user_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
   return nvm_write_V2(pgm, p, address, buffer, size, DONT_USE_WORD_ACCESS);
 }
 
+int updi_nvm_write_boot_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
+/*
+  Perform write operation as if it was regular flash memory, but perform erase operation first
+*/
+  if (updi_nvm_erase_flash_page_V2(pgm, p, address) <0) {
+    pmsg_error("Flash page erase failed for bootrow\n");
+    return -1;
+  }
+  return updi_nvm_write_flash_V2(pgm, p, address, buffer, size);
+}
+
 int updi_nvm_write_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):

--- a/src/updi_nvm_v2.c
+++ b/src/updi_nvm_v2.c
@@ -284,13 +284,9 @@ int updi_nvm_write_user_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
 
 int updi_nvm_write_boot_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
-  Perform write operation as if it was regular flash memory, but perform erase operation first
+  Perform write operation as if it was regular flash memory
 */
-  if (updi_nvm_erase_flash_page_V2(pgm, p, address) <0) {
-    pmsg_error("Flash page erase failed for bootrow\n");
-    return -1;
-  }
-  return updi_nvm_write_flash_V2(pgm, p, address, buffer, size);
+  return nvm_write_V2(pgm, p, address, buffer, size, USE_WORD_ACCESS);
 }
 
 int updi_nvm_write_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {

--- a/src/updi_nvm_v2.h
+++ b/src/updi_nvm_v2.h
@@ -39,6 +39,7 @@ int updi_nvm_erase_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p);
 int updi_nvm_erase_user_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size);
 int updi_nvm_write_flash_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_user_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_boot_row_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_eeprom_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_fuse_V2(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value);
 int updi_nvm_wait_ready_V2(const PROGRAMMER *pgm, const AVRPART *p);

--- a/src/updi_nvm_v3.c
+++ b/src/updi_nvm_v3.c
@@ -297,6 +297,13 @@ int updi_nvm_write_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
   return nvm_write_V3(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
+int updi_nvm_write_boot_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
+/*
+  Perform the operation as the regular flash write, but with page erase/page write command 
+*/
+  return nvm_write_V3(pgm, p, address, buffer, size, USE_WORD_ACCESS, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_ERASE_WRITE);
+}
+
 int updi_nvm_write_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):

--- a/src/updi_nvm_v3.c
+++ b/src/updi_nvm_v3.c
@@ -299,9 +299,9 @@ int updi_nvm_write_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
 
 int updi_nvm_write_boot_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
-  Perform the operation as the regular flash write, but with page erase/page write command 
+  Perform the operation as the regular flash write 
 */
-  return nvm_write_V3(pgm, p, address, buffer, size, USE_WORD_ACCESS, UPDI_V3_NVMCTRL_CTRLA_FLASH_PAGE_ERASE_WRITE);
+  return nvm_write_V3(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
 int updi_nvm_write_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {

--- a/src/updi_nvm_v3.h
+++ b/src/updi_nvm_v3.h
@@ -39,6 +39,7 @@ int updi_nvm_erase_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p);
 int updi_nvm_erase_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size);
 int updi_nvm_write_flash_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_user_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_boot_row_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_eeprom_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_fuse_V3(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value);
 int updi_nvm_wait_ready_V3(const PROGRAMMER *pgm, const AVRPART *p);

--- a/src/updi_nvm_v4.c
+++ b/src/updi_nvm_v4.c
@@ -285,13 +285,9 @@ int updi_nvm_write_user_row_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
 
 int updi_nvm_write_boot_row_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
-  Write it as a regular flash page, but perform page erase first
+  Write it as a regular flash page
 */
-  if (updi_nvm_erase_flash_page_V4(pgm, p, address) <0) {
-    pmsg_error("Flash page erase failed for bootrow\n");
-    return -1;
-  }
-  return updi_nvm_write_flash_V4(pgm, p, address, buffer, size);
+  return nvm_write_V4(pgm, p, address, buffer, size, USE_WORD_ACCESS);
 }
 
 int updi_nvm_write_eeprom_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {

--- a/src/updi_nvm_v4.c
+++ b/src/updi_nvm_v4.c
@@ -283,6 +283,17 @@ int updi_nvm_write_user_row_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
   return nvm_write_V4(pgm, p, address, buffer, size, DONT_USE_WORD_ACCESS);
 }
 
+int updi_nvm_write_boot_row_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
+/*
+  Write it as a regular flash page, but perform page erase first
+*/
+  if (updi_nvm_erase_flash_page_V4(pgm, p, address) <0) {
+    pmsg_error("Flash page erase failed for bootrow\n");
+    return -1;
+  }
+  return updi_nvm_write_flash_V4(pgm, p, address, buffer, size);
+}
+
 int updi_nvm_write_eeprom_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):

--- a/src/updi_nvm_v4.h
+++ b/src/updi_nvm_v4.h
@@ -39,6 +39,7 @@ int updi_nvm_erase_eeprom_V4(const PROGRAMMER *pgm, const AVRPART *p);
 int updi_nvm_erase_user_row_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size);
 int updi_nvm_write_flash_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_user_row_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_boot_row_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_eeprom_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_fuse_V4(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value);
 int updi_nvm_wait_ready_V4(const PROGRAMMER *pgm, const AVRPART *p);

--- a/src/updi_nvm_v5.c
+++ b/src/updi_nvm_v5.c
@@ -298,6 +298,13 @@ int updi_nvm_write_user_row_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
   return nvm_write_V5(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
+int updi_nvm_write_boot_row_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
+/*
+  Perform the operation as the regular flash write, but with page erase/page write command 
+*/
+  return nvm_write_V5(pgm, p, address, buffer, size, USE_WORD_ACCESS, UPDI_V5_NVMCTRL_CTRLA_FLASH_PAGE_ERASE_WRITE);
+}
+
 int updi_nvm_write_eeprom_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
     def write_eeprom(self, address, data):

--- a/src/updi_nvm_v5.c
+++ b/src/updi_nvm_v5.c
@@ -300,9 +300,9 @@ int updi_nvm_write_user_row_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t
 
 int updi_nvm_write_boot_row_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {
 /*
-  Perform the operation as the regular flash write, but with page erase/page write command 
+  Perform the operation as the regular flash write
 */
-  return nvm_write_V5(pgm, p, address, buffer, size, USE_WORD_ACCESS, UPDI_V5_NVMCTRL_CTRLA_FLASH_PAGE_ERASE_WRITE);
+  return nvm_write_V5(pgm, p, address, buffer, size, USE_WORD_ACCESS, USE_DEFAULT_COMMAND);
 }
 
 int updi_nvm_write_eeprom_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size) {

--- a/src/updi_nvm_v5.h
+++ b/src/updi_nvm_v5.h
@@ -39,6 +39,7 @@ int updi_nvm_erase_eeprom_V5(const PROGRAMMER *pgm, const AVRPART *p);
 int updi_nvm_erase_user_row_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint16_t size);
 int updi_nvm_write_flash_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_user_row_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
+int updi_nvm_write_boot_row_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_eeprom_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, unsigned char *buffer, uint16_t size);
 int updi_nvm_write_fuse_V5(const PROGRAMMER *pgm, const AVRPART *p, uint32_t address, uint8_t value);
 int updi_nvm_wait_ready_V5(const PROGRAMMER *pgm, const AVRPART *p);


### PR DESCRIPTION
This is alternative fix for issue #1832, but this one works with multiple bootrow write operations. When possible (v0/v3/v5), it uses NVMCTRL CTRLA page erase/page write operation, and when not available (v2/v4) it performs explicit page erase operation before page write.