### PR TITLE
Use page erase for UPDI programming

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -472,17 +472,15 @@ arduino.
 .It Fl D
 Disable auto erase for flash.  When the
 .Fl U
-option with flash memory is specified,
+option for writing to any flash memory is specified,
 .Nm
 will perform a chip erase before starting any of the programming
-operations, since it generally is a mistake to program the flash
-without performing an erase first.  This option disables that.
-Auto erase is not used for ATxmega devices as these devices can
-use page erase before writing each page so no explicit chip erase
-is required.
-Note however that any page not affected by the current operation
-will retain its previous contents.
-Setting
+operations, since it generally is a mistake to program the flash without
+performing an erase first.  This option disables that. Auto erase is not
+used for ATxmega parts nor for the UPDI (AVR8X family) parts as these can
+use page erase before writing each page so no explicit chip erase is
+required. Note, however, that any flash page not affected by the current
+operation will retain its previous contents. Setting
 .Fl D
 implies
 .Fl A.
@@ -491,9 +489,9 @@ Causes a chip erase to be executed.  This will reset the contents of the
 flash ROM and EEPROM to the value
 .Ql 0xff ,
 and clear all lock bits.
-Except for ATxmega devices which can use page erase,
-it is basically a prerequisite command before the flash ROM can be
-reprogrammed again.  The only exception would be if the new
+Except for ATxmega and UPDI (AVR8X family) devices, all of which can use
+page erase, it is basically a prerequisite command before the flash ROM
+can be reprogrammed again.  The only exception would be if the new
 contents would exclusively cause bits to be programmed from the value
 .Ql 1
 to
@@ -797,6 +795,7 @@ The available memory types are device-dependent, the actual configuration
 can be viewed with the
 .Cm part
 command in terminal mode.
+.Pp
 Typically, a device's memory configuration at least contains
 the memories
 .Ar flash ,
@@ -812,10 +811,26 @@ memory contains the three device signature bytes, which should
 be, but not always are, unique for the part. The
 .Ar lock
 memory of one or four bytes typically details whether or not external
-reading/writing of the flash memory, or parts of it, is allowed. Parts
-will also typically have fuse bytes, which are read/write memories for
-configuration of the device and calibration memories that typically
-contain read-only factory calibration values.
+reading/writing of the flash memory, or parts of it, is allowed. After
+restricting access via the lock memory, often the only way to unlock
+memory is via a chip erase. Parts will also typically have fuse bytes,
+which are read/write memories for configuration of the device and
+calibration memories that typically contain read-only factory calibration
+values.
+.Pp
+The flash memory, being physically implemented as NOR-memory, is special
+in the sense that it is normally only possible to program bits to change
+from 1 to 0. Before reprogramming takes place normally flash memory has
+to be erased. Older parts would only offer a chip erase to do so, which
+also erases EEPROM unless a fuse configuration preserves its contents. If
+AVRDUDE detects a -U option that writes to a flash memory it will
+automatically trigger a chip erase for these older parts.  ATxmegas or
+UPDI parts (AVR8X family) offer a page erase, and AVRDUDE takes advantage
+of that by erasing pages before programming them unless -e (chip erase) or
+-D (do not erase before writing) was requested. It should be noted that in
+absence of the -e chip erase option any ATxmega or UPDI flash pages not
+affected by the programming will retain their previous content.
+
 .Pp
 Classic devices may have the following memories in addition to eeprom, flash, signature and lock:
 .Bl -tag -width "  calibration" -compact

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -584,30 +584,27 @@ engaged by default when specifying -c arduino.
 
 @item -D
 @cindex Option @code{-D}
-Disable auto erase for flash.  When the -U option with flash memory is 
-specified, avrdude will perform a chip erase before starting any of the 
-programming operations, since it generally is a mistake to program the flash
-without performing an erase first.  This option disables that.
-Auto erase is not used for ATxmega devices as these devices can
-use page erase before writing each page so no explicit chip erase
-is required.
-Note however that any page not affected by the current operation
-will retain its previous contents.
-Setting -D implies -A.
+Disable auto erase for flash.  When the -U  option for writing to any
+flash memory is specified, AVRDUDE will perform a chip erase before
+starting any of the  programming  operations, since it generally is a
+mistake to program the flash without performing an erase first.  This
+option disables that. Auto erase is not used for ATxmega parts nor for the
+UPDI (AVR8X family) parts as these can use page erase before writing each
+page so no explicit chip erase is required. Note, however, that any flash
+page not affected by the current operation will retain its previous
+contents. Setting -D implies -A.
 
 @item -e
 @cindex Option @code{-e}
 Causes a chip erase to be executed.  This will reset the contents of the
-flash and EEPROM to the value `0xff', and clear all lock bits.
-Except for ATxmega devices which can use page erase,
-it is basically a
-prerequisite command before the flash can be reprogrammed again.
-The only exception would be if the new contents would exclusively cause
-bits to be programmed from the value `1' to `0'.  Note that in order
-to reprogram EERPOM cells, no explicit prior chip erase is required
-since the MCU provides an auto-erase cycle in that case before
+flash and EEPROM to the value `0xff', and clear all lock bits. Except for
+ATxmega and UPDI (AVR8X family) devices, all of which can use page erase,
+it is basically a prerequisite command before the flash ROM can be
+reprogrammed again.  The only exception would be if the new contents would
+exclusively cause bits to be programmed from the value `1' to `0'. Note
+that in order to reprogram EERPOM cells, no explicit prior chip erase is
+required since the MCU provides an auto-erase cycle in that case before
 programming the cell.
-
 
 @item -E @var{exitspec}[,@dots{}]
 @cindex Option @code{-E} @var{exitspec}[,@dots{}]
@@ -860,9 +857,24 @@ is sometimes known as @code{lockbits}. The signature memory contains the
 three device signature bytes, which should be, but not always are, unique
 for the part. The @code{lock} memory of one or four bytes typically
 details whether or not external reading/writing of the flash memory, or
-parts of it, is allowed. Parts will also typically have fuse bytes, which
-are read/write memories for configuration of the device and calibration
-memories that typically contain read-only factory calibration values.
+parts of it, is allowed. After restricting access via the lock memory,
+often the only way to unlock memory is via a chip erase.  Parts will also
+typically have fuse bytes, which are read/write memories for configuration
+of the device and calibration memories that typically contain read-only
+factory calibration values.
+
+The flash memory, being physically implemented as NOR-memory, is special
+in the sense that it is normally only possible to program bits to change
+from 1 to 0. Before reprogramming takes place normally flash memory has to
+be erased. Older parts would only offer a chip erase to do so, which also
+erases EEPROM unless a fuse configuration preserves its contents. If
+AVRDUDE detects a -U option that writes to a flash memory it will
+automatically trigger a chip erase for these older parts.  ATxmegas or
+UPDI parts (AVR8X family) offer a page erase, and AVRDUDE takes advantage
+of that by erasing pages before programming them unless -e (chip erase) or
+-D (do not erase before writing) was requested. It should be noted that in
+absence of the -e chip erase option any ATxmega or UPDI flash pages not
+affected by the programming will retain their previous content.
 
 Classic devices may have the following memories in addition to
 @code{eeprom}, @code{flash}, @code{signature} and @code{lock}:


### PR DESCRIPTION
This PR makes AVRDUDE use page erase for UPDI parts.

Traditionally, AVRDUDE has used page erase for XMEGAs in favour of chip erase unless the user decided to go for `-e`: https://github.com/avrdudes/avrdude/blob/42c984c9e83190f3d882799ee1c4a5fed94475bf/src/main.c#L1684-L1687

The main change is to use `(PM_PDI | PM_UPDI)` instead of `PM_PDI` the remainder being documentation and clarification. A secondary change is to switch off trailing 0xff optimisation when page erase is used over chip erase, the reason being that in the rare *but possible* case of an application having `0xff` data storage at its end that must not be cut off in absence of a CE. (Not doing so has been a bug for XMEGA programming.)

Apart from the fact that it makes sense to program UPDI flash using page erase, it greatly simplifies the treatment of the new `bootrow` memory (AVR-DU and AVR-EB parts) that needs erasing before writing. Whilst @dbuchwald has offered a PR where `bootrow` is page erased before writing (thanks!), the same work would need to be done for all other UPDI programmers:
```
$ avrdude -p 64du28 -c? |& grep -v via.boot | grep -v serialupdi

Valid programmers for part AVR64DU28 are:
  atmelice_updi      = Atmel-ICE (ARM/AVR) via UPDI
  dryrun             = Emulates programming without a programmer via UPDI
  jtag2updi          = JTAGv2 to UPDI bridge via UPDI
  nanoevery          = JTAGv2 to UPDI bridge via UPDI
  jtag3updi          = Atmel AVR JTAGICE3 via UPDI
  pickit4_updi       = MPLAB(R) PICkit 4 via UPDI
  pkobn_updi         = Curiosity nano (nEDBG) via UPDI
  powerdebugger_updi = Atmel PowerDebugger (ARM/AVR) via UPDI
  snap_updi          = MPLAB(R) SNAP via UPDI
  xplainedmini_updi  = Atmel AVR XplainedMini via UPDI
  xplainedpro_updi   = Atmel AVR XplainedPro via UPDI
```

In absence of -e the new method leaves the contents of not programmed UPDI flash pages as before. However, the user will be informed that no CE happens:
```
$ avrdude -c serialupdi -p 64du28 -U flash:w:'"@ @ @"':m 
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9622 (probably 64du28)
avrdude: NOT erasing chip as page erase will be used for new flash/bootrow contents
avrdude: reading 6 bytes for flash from input file "@ @ @"
         in 1 section [0, 5]: 1 page and 506 pad bytes
         writing 6 bytes to flash ...
         writing | ################################################## | 100% 0.20 s 
         reading | ################################################## | 100% 0.07 s 
         6 bytes of flash verified

avrdude done.  Thank you.
```