### PR TITLE
Improve signature check for UPDI parts

### DIFF
--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -1071,12 +1071,16 @@ AVRPART *locate_part_by_avr910_devcode(const LISTID parts, int devcode) {
   return NULL;
 }
 
+// Return pointer to first part that has signature sig (unless all 0xff or all 0x00); NULL if no match
 AVRPART *locate_part_by_signature_pm(const LISTID parts, unsigned char *sig, int sigsize, int prog_modes) {
   if(parts && sigsize == 3) {
     for(LNODEID ln=lfirst(parts); ln; ln=lnext(ln)) {
       AVRPART *p = ldata(ln);
-      if(memcmp(p->signature, sig, 3) == 0 && p->prog_modes & prog_modes)
-        return p;
+      if(!*p->id || *p->id == '.') // Skip stump entries
+        continue;
+      if(!is_memset(p->signature, 0xff, 3) && !is_memset(p->signature, 0, 3))
+        if(!memcmp(p->signature, sig, 3) && p->prog_modes & prog_modes)
+          return p;
     }
   }
   return NULL;

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -383,7 +383,7 @@ part_def :
           if(mem_is_signature(m))
             m->type &= ~MEM_IN_SIGROW;
         }
-        if(fileio_mem_offset(current_part, m) == -1U)
+        if(fileio_mem_offset(current_part, m) == ~0U)
           yywarning("revise fileio_mem_offset(), avrdude.conf entry or memory type assignment");
       }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -232,22 +232,22 @@ unsigned fileio_mem_offset(const AVRPART *p, const AVRMEM *mem) {
     mem_is_sib(mem)? MBASE(SIGROW) + 0x1000: // Arbitrary 0x1000 offset in signature section for sib
     mem_is_userrow(mem)? MBASE(USERROW):
     mem_is_bootrow(mem)? MBASE(BOOTROW):
-    -1U;
+    ~0U;
 
-  if(location == -1U)
+  if(location == ~0U)
     pmsg_error("unable to locate %s's %s in multi-memory address space\n", p->desc, mem->desc);
   else if(location >= ANY_MEM_SIZE || location + mem->size > ANY_MEM_SIZE) { // Overflow
     pmsg_error("%s's %s location [0x%06x, 0x%06x] outside flat address space [0, 0x%06x]\n",
       p->desc, mem->desc, location, location + mem->size-1, ANY_MEM_SIZE-1);
-    location = -1U;
+    location = ~0U;
   } else if(location <= MEND(FLASH) && location + mem->size > MEND(FLASH)+1) {
     pmsg_error("%s's %s location [0x%06x, 0x%06x] straddles flash section boundary 0x%06x\n",
       p->desc, mem->desc, location, location + mem->size-1, MEND(FLASH)+1);
-    location = -1U;
+    location = ~0U;
   } else if(location > MEND(FLASH) && location/0x10000 != (location + mem->size-1)/0x10000) {
     pmsg_error("%s's %s memory location [0x%06x, 0x%06x] straddles memory section boundary 0x%02x0000\n",
       p->desc, mem->desc, location, location + mem->size-1, 1+location/0x10000);
-    location = -1U;
+    location = ~0U;
   }
 
   return location;
@@ -465,7 +465,7 @@ static int any2mem(const AVRPART *p, const AVRMEM *mem, const Segment *segp,
   // Compute location for multi-memory file input
   unsigned location = maxsize > MEND(FLASH)+1? fileio_mem_offset(p, mem): 0;
 
-  if(location == -1U)
+  if(location == ~0U)
     return -1;
 
   unsigned ret = 0;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -352,8 +352,7 @@ static int b2ihex(const AVRPART *p, const AVRMEM *mem, const Segment *segp, Sego
         if(name) {
           fprintf(outf, " %s", name);
           if((str_eq(name, "sigrow") || str_eq(name, "signature")) && !nextaddr) {
-            char mculist[1024] = {0};
-            str_mcunames_signature(buf, mculist, sizeof mculist);
+            const char *mculist = str_ccmcunames_signature(buf, PM_ALL);
             if(*mculist)
               fprintf(outf, " (%s)", mculist);
           }
@@ -580,7 +579,7 @@ static int ihex2b(const char *infile, FILE *inf, const AVRPART *p, const AVRMEM 
         if(!ovsigck && nextaddr == mulmem[MULTI_SIGROW].base && ihex.reclen >= 3)
           if(!avr_sig_compatible(p->signature, any->buf+nextaddr)) {
             pmsg_error("signature of %s incompatible with file's (%s)\n", p->desc,
-              str_ccmcunames_signature(any->buf+nextaddr));
+              str_ccmcunames_signature(any->buf+nextaddr, PM_ALL));
             imsg_error("use -F to override this check\n");
             mmt_free(buffer);
             goto error;
@@ -935,7 +934,7 @@ static int srec2b(const char *infile, FILE * inf, const AVRPART *p,
       if(!ovsigck && nextaddr == mulmem[MULTI_SIGROW].base && srec.reclen >= 3)
         if(!avr_sig_compatible(p->signature, any->buf+nextaddr)) {
           pmsg_error("signature of %s incompatible with file's (%s)\n", p->desc,
-            str_ccmcunames_signature(any->buf+nextaddr));
+            str_ccmcunames_signature(any->buf+nextaddr, PM_ALL));
           imsg_error("use -F to override this check\n");
           mmt_free(buffer);
           goto error;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -511,7 +511,7 @@ typedef struct avrmem {
   int initval;                /* factory setting of fuses and lock bits */
   int bitmask;                /* bits used in fuses and lock bits */
   int n_word_writes;          /* TPI only: number words to write at a time */
-  unsigned int offset;        /* offset in IO memory (ATxmega) */
+  unsigned int offset;        /* offset in IO memory (ATxmega, UPDI, some classic memories) */
   int min_write_delay;        /* microseconds */
   int max_write_delay;        /* microseconds */
   int pwroff_after_write;     /* after this memory is written to,
@@ -1524,8 +1524,8 @@ char *str_nexttok(char *buf, const char *delim, char **next);
 const char *str_ccfrq(double f, int n);
 int str_levenshtein(const char *str1, const char *str2, int swap, int subst, int add, int del);
 size_t str_weighted_damerau_levenshtein(const char *str1, const char *str2);
-int str_mcunames_signature(const unsigned char *sigs, char *p, size_t n);
-const char *str_ccmcunames_signature(const unsigned char *sigs);
+int str_mcunames_signature(const unsigned char *sigs, int pm, char *p, size_t n);
+const char *str_ccmcunames_signature(const unsigned char *sigs, int pm);
 
 int led_set(const PROGRAMMER *pgm, int led);
 int led_clr(const PROGRAMMER *pgm, int led);

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1331,9 +1331,8 @@ size_t str_weighted_damerau_levenshtein(const char *s1, const char *s2) {
 
 // Puts a comma-separated list of matching MCU names into array p with n chars space
 int str_mcunames_signature(const unsigned char *sigs, int pm, char *p, size_t n) {
-  int matching = 0, k;
-  const int N = 100;
-  const char *matches[N];
+  const char *matches[100];
+  int matching = 0, k, N = sizeof matches/sizeof*matches;
 
   if(!pm || (pm & PM_ALL) == PM_ALL) // Look up uP table when unrestricted by prog modes
     for(size_t i=0; i < sizeof uP_table/sizeof *uP_table; i++)

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1337,12 +1337,17 @@ int str_mcunames_signature(const unsigned char *sigs, int pm, char *p, size_t n)
 
   if(!pm || (pm & PM_ALL) == PM_ALL) // Look up uP table when unrestricted by prog modes
     for(size_t i=0; i < sizeof uP_table/sizeof *uP_table; i++)
-      if(0 == memcmp(sigs, uP_table[i].sigs, sizeof uP_table->sigs) && matching < N)
-        matches[matching++] = uP_table[i].name;
+      if(!is_memset(uP_table[i].sigs, 0xff, 3) && !is_memset(uP_table[i].sigs, 0, 3))
+        if(0 == memcmp(sigs, uP_table[i].sigs, sizeof uP_table->sigs) && matching < N)
+          matches[matching++] = uP_table[i].name;
 
   for(LNODEID lp = lfirst(part_list); lp; lp = lnext(lp)) {
     AVRPART *pp = ldata(lp);
-    if(0 == memcmp(sigs, pp->signature, 3) && (!pm || (pp->prog_modes & pm))) {
+    if(!*pp->id || *pp->id == '.') // Skip invalid entries
+      continue;
+    if(is_memset(pp->signature, 0xff, 3) || is_memset(pp->signature, 0, 3))
+      continue;
+    if(!memcmp(sigs, pp->signature, 3) && (!pm || (pp->prog_modes & pm))) {
       for(k = 0; k < matching; k++)
         if(str_eq(matches[k], pp->desc))
           break;

--- a/src/update.c
+++ b/src/update.c
@@ -721,7 +721,7 @@ int do_op(const PROGRAMMER *pgm, const AVRPART *p, const UPDATE *upd, enum updat
           continue;
         }
         unsigned off = fileio_mem_offset(p, m);
-        if(off == -1U) {
+        if(off == ~0U) {
           pmsg_warning("cannot map %s to flat address space, skipping ...\n", m_name);
           rwvproblem = 1;
           continue;


### PR DESCRIPTION
Fixes #1813.

Microchip decided to put the `signature` area for UPDI at two different memory offsets, so you now need to know which part you have in order to be able to read the `signature`. This PR checks all different known offsets if an attempt to read a UPDI-part signature draws a blank. It's not fool-proof as, conceivably, if there *was* a valid signature at the wrong location that byte sequence would mistakenly be understood as the signature of the part.

Without this PR:
```
$ avrdude -cserialupdi -p64dd28 -t
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0xffffff (probably .avr8x) (retrying)
avrdude: device signature = 0xffffff (probably .avr8x) (retrying)
avrdude: device signature = 0xffffff (probably .avr8x)
avrdude error: Yikes!  Invalid device signature.
avrdude error: expected signature for AVR64DD28 is 1E 96 1B
        Double check connections and try again, or use -F to override
        this check.


avrdude done.  Thank you.
```

With this PR:
```
$ avrdude -cserialupdi -p64dd28 -t
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 1E 96 22 (AVR64DU28)
avrdude error: expected signature for AVR64DD28 is 1E 96 1B
        double check chip or use -F to override this check

avrdude done.  Thank you.
```

The code graciously assumes Microchip won't create more than ten different regions for signatures within their UPDI series.
