### PR TITLE
Improve error handling when Avrdude is built without libserialport

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1413,9 +1413,11 @@ int main(int argc, char * argv [])
     pmsg_error("unable to open port %s for programmer %s\n", port, pgmid);
 skipopen:
     if (print_ports && pgm->conntype == CONNTYPE_SERIAL) {
+#ifdef HAVE_LIBSERIALPORT
       list_available_serialports(programmers);
       if(touch_1200bps == 1)
         pmsg_info("alternatively, try -rr or -rrr for longer delays\n");
+#endif
     }
     exitrc = 1;
     pgm->ppidata = 0; /* clear all bits at exit */

--- a/src/main.c
+++ b/src/main.c
@@ -1331,6 +1331,7 @@ int main(int argc, char * argv [])
     // Use libserialport to find the actual serial port
     ser = locate_programmer(programmers, port_tok[0]);
     if (is_serialadapter(ser)) {
+#ifdef HAVE_LIBSERIALPORT
       int rv = setport_from_serialadapter(&port, ser, port_tok[1]);
       if (rv == -1) {
         pmsg_warning("serial adapter %s", port_tok[0]);
@@ -1344,6 +1345,7 @@ int main(int argc, char * argv [])
         print_ports = false;
       if(rv)
         ser = NULL;
+#endif
     } else if(str_eq(port_tok[0], DEFAULT_USB)) {
       // Port or usb:[vid]:[pid]
       int vid, pid;


### PR DESCRIPTION
This is just a tiny tweak to improve the error message that gets printed when Avrdude is built without libserialport.
It's not all that elegant, so if someone has other suggestions, please let me know!

Without this PR:

```
$ ./avrdude -cjtag2updi -patmega4809 -P /dev/cu.usbmodem14101 -r
avrdude error: avrdude built without libserialport support; please compile again with libserialport installed
avrdude error: avrdude built without libserialport support; please compile again with libserialport installed
avrdude: alternatively, try -rr or -rrr for longer delays

avrdude done.  Thank you.
```

With this PR:

```
$ ./avrdude -cjtag2updi -patmega4809 -P /dev/cu.usbmodem14101 -r
avrdude error: avrdude built without libserialport support; please compile again with libserialport installed

avrdude done.  Thank you.
```