### PR TITLE
Extended parameters (`-x` and `-E`) improvements

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -37,6 +37,45 @@
 #include "stk500.h"
 #include "arduino.h"
 
+static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
+  const char *extended_param;
+  int attempts;
+  int rv = 0;
+
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    extended_param = ldata(ln);
+
+    if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
+      PDATA(pgm)->retry_attempts = attempts;
+      pmsg_info("setting number of retry attempts to %d\n", attempts);
+      continue;
+    }
+
+    if(str_starts(extended_param, "no_autoreset")) {
+      if(!str_eq(extended_param, "no_autoreset")) {
+        pmsg_error("invalid -xno_autoreset value %s. Use -xno_autoreset\n", extended_param);
+        rv = -1;
+        break;
+      }
+      PDATA(pgm)->autoreset = false;
+      continue;
+    }
+
+    if (str_eq(extended_param, "help")) {
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
+      msg_error("  -xattempts=<arg> Specify no. connection retry attempts\n");
+      msg_error("  -xno_autoreset   Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
+      msg_error("  -xhelp           Show this help menu and exit\n");
+      return LIBAVRDUDE_EXIT;
+    }
+
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
+    rv = -1;
+  }
+
+  return rv;
+}
+
 /* read signature bytes - arduino version */
 static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m) {
   unsigned char buf[32];
@@ -85,28 +124,28 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
-  // This code assumes a negative-logic USB to TTL serial adapter
-  // Set RTS/DTR high to discharge the series-capacitor, if present
-  serial_set_dtr_rts(&pgm->fd, 0);
-  /*
-   * Long wait needed for optiboot: otherwise the second of two bootloader
-   * calls in quick succession fails:
-   *
-   * avrdude -c arduino -qqp m328p -U x.hex; avrdude -c arduino -qqp m328p -U x.hex
-   */
-  usleep(250 * 1000);
-  // Pull the RTS/DTR line low to reset AVR
-  serial_set_dtr_rts(&pgm->fd, 1);
-  // Max 100 us: charging a cap longer creates a high reset spike above Vcc
-  usleep(100);
-  // Set the RTS/DTR line back to high, so direct connection to reset works
-  serial_set_dtr_rts(&pgm->fd, 0);
+  if(PDATA(pgm)->autoreset) {
+    // This code assumes a negative-logic USB to TTL serial adapter
+    // Set RTS/DTR high to discharge the series-capacitor, if present
+    serial_set_dtr_rts(&pgm->fd, 0);
+    /*
+    * Long wait needed for optiboot: otherwise the second of two bootloader
+    * calls in quick succession fails:
+    *
+    * avrdude -c arduino -qqp m328p -U x.hex; avrdude -c arduino -qqp m328p -U x.hex
+    */
+    usleep(250 * 1000);
+    // Pull the RTS/DTR line low to reset AVR
+    serial_set_dtr_rts(&pgm->fd, 1);
+    // Max 100 us: charging a cap longer creates a high reset spike above Vcc
+    usleep(100);
+    // Set the RTS/DTR line back to high, so direct connection to reset works
+    serial_set_dtr_rts(&pgm->fd, 0);
 
-  usleep(100 * 1000);
+    usleep(100 * 1000);
+  }
 
-  /*
-   * drain any extraneous input
-   */
+  // Drain any extraneous input
   stk500_drain(pgm, 0);
 
   if (stk500_getsync(pgm) < 0)
@@ -115,7 +154,7 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
   return 0;
 }
 
-static void arduino_close(PROGRAMMER * pgm)
+static void arduino_close(PROGRAMMER *pgm)
 {
   serial_close(&pgm->fd);
   pgm->fd.ifd = -1;
@@ -131,9 +170,12 @@ void arduino_initpgm(PROGRAMMER *pgm) {
   stk500_initpgm(pgm);
 
   strcpy(pgm->type, "Arduino");
+  PDATA(&pgm)->autoreset = true; // Auto-reset enabled by default
+
   pgm->read_sig_bytes = arduino_read_sig_bytes;
   pgm->open = arduino_open;
   pgm->close = arduino_close;
+  pgm->parseextparams = arduino_parseextparms;
 
   cx->avr_disableffopt = 1;     // Disable trailing 0xff removal
 }

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -45,7 +45,7 @@ static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
 
-    if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
+    if (sscanf(extended_param, "attempts=%i", &attempts) == 1) {
       PDATA(pgm)->retry_attempts = attempts;
       pmsg_info("setting number of retry attempts to %d\n", attempts);
       continue;

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -38,13 +38,12 @@
 #include "arduino.h"
 
 static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  const char *extended_param;
   int attempts;
   int rv = 0;
   bool help = 0;
 
   for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+    const char *extended_param = ldata(ln);
 
     if (sscanf(extended_param, "attempts=%i", &attempts) == 1) {
       PDATA(pgm)->retry_attempts = attempts;

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -40,7 +40,7 @@
 static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   const char *extended_param;
   int attempts;
-  int rv = 0;
+  int rv = 0, help = 0;
 
   for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
@@ -57,17 +57,20 @@ static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xattempts=<n> Specify the number <n> of connection retry attempts\n");
-      msg_error("  -xnoautoreset  Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
-      msg_error("  -xhelp         Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;
+      help = 1;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter %s\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xattempts=<n> Specify the number <n> of connection retry attempts\n");
+    msg_error("  -xnoautoreset  Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
+    msg_error("  -xhelp         Show this help menu and exit\n");
+    return rv;
   }
-
   return rv;
 }
 

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -162,10 +162,7 @@ void arduino_initpgm(PROGRAMMER *pgm) {
      and the DTR signal is set when opening the serial port
      for the Auto-Reset feature */
   stk500_initpgm(pgm);
-
   strcpy(pgm->type, "Arduino");
-  PDATA(&pgm)->autoreset = true; // Auto-reset enabled by default
-
   pgm->read_sig_bytes = arduino_read_sig_bytes;
   pgm->open = arduino_open;
   pgm->close = arduino_close;

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -62,13 +62,13 @@ static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xattempts=<n> Specify the number <n> of connection retry attempts\n");
-    msg_error("  -xnoautoreset  Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
-    msg_error("  -xhelp         Show this help menu and exit\n");
+    msg_error("  -x attempts=<n> Specify the number <n> of connection retry attempts\n");
+    msg_error("  -x noautoreset  Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
+    msg_error("  -x help         Show this help menu and exit\n");
     return rv;
   }
   return rv;

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -40,7 +40,8 @@
 static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   const char *extended_param;
   int attempts;
-  int rv = 0, help = 0;
+  int rv = 0;
+  bool help = 0;
 
   for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
@@ -57,7 +58,7 @@ static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if (str_eq(extended_param, "help")) {
-      help = 1;
+      help = true;
       rv = LIBAVRDUDE_EXIT;
     }
 

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -51,25 +51,20 @@ static int arduino_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
 
-    if(str_starts(extended_param, "no_autoreset")) {
-      if(!str_eq(extended_param, "no_autoreset")) {
-        pmsg_error("invalid -xno_autoreset value %s. Use -xno_autoreset\n", extended_param);
-        rv = -1;
-        break;
-      }
+    if(str_eq(extended_param, "noautoreset")) {
       PDATA(pgm)->autoreset = false;
       continue;
     }
 
     if (str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xattempts=<arg> Specify no. connection retry attempts\n");
-      msg_error("  -xno_autoreset   Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
-      msg_error("  -xhelp           Show this help menu and exit\n");
+      msg_error("  -xattempts=<n> Specify the number <n> of connection retry attempts\n");
+      msg_error("  -xnoautoreset  Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
+      msg_error("  -xhelp         Show this help menu and exit\n");
       return LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter %s\n", extended_param);
     rv = -1;
   }
 
@@ -154,8 +149,7 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
   return 0;
 }
 
-static void arduino_close(PROGRAMMER *pgm)
-{
+static void arduino_close(PROGRAMMER *pgm) {
   serial_close(&pgm->fd);
   pgm->fd.ifd = -1;
 }

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -308,12 +308,11 @@ static int avr910_cmd(const PROGRAMMER *pgm, const unsigned char *cmd,
 
 
 static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rv = 0;
+  bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (str_starts(extended_param, "devcode=")) {
       int devcode;
@@ -335,15 +334,19 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xdevcode=<arg> Override device code\n");
-      msg_error("  -xno_blockmode  Disable default checking for block transfer capability\n");
-      msg_error("  -xhelp          Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xdevcode=<arg> Override device code\n");
+    msg_error("  -xno_blockmode  Disable default checking for block transfer capability\n");
+    msg_error("  -xhelp          Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -318,9 +318,9 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int devcode;
       if (sscanf(extended_param, "devcode=%i", &devcode) != 1 ||
 	  devcode <= 0 || devcode > 255) {
-        pmsg_error("invalid devcode '%s'\n", extended_param);
+        pmsg_error("invalid device code in -x %s\n", extended_param);
         rv = -1;
-        continue;
+        break;
       }
       pmsg_notice2("avr910_parseextparms(): devcode overwritten as 0x%02x\n", devcode);
       PDATA(pgm)->devcode = devcode;
@@ -339,13 +339,13 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xdevcode=<arg> Override device code\n");
-    msg_error("  -xno_blockmode  Disable default checking for block transfer capability\n");
-    msg_error("  -xhelp          Show this help menu and exit\n");
+    msg_error("  -x devcode=<n>   Set device code to <n> (0x.. hex, 0... oct or dec)\n");
+    msg_error("  -x no_blockmode  Disable default checking for block transfer capability\n");
+    msg_error("  -x help          Show this help menu and exit\n");
     return rv;
   }
 

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1652,14 +1652,14 @@ Other JTAG units might require a different bit shift count.
 .sp 0.5
 High-voltage UPDI programming is used to enable a UPDI pin that has previously
 been set to RESET or GPIO mode. Use
-.Ar -xhvupdi
+.Ar -x hvupdi
 to enable high-voltage UPDI initialization for targets that supports this.
 .It Ar vtarg=VALUE, vtarg
 .Nm Power Debugger only
 .sp 0.5
 The voltage generator can be enabled by setting a target voltage.
 The current set-voltage can be read by
-.Ar -xvtarg
+.Ar -x vtarg
 alone.
 .It Ar help
 Show help menu and exit.
@@ -1672,9 +1672,9 @@ Switch programmer to AVR or PIC mode, then exit: the PICkit 4 and MPLAB SNAP
 programmer can only be utilised by
 .Nm
 when in AVR mode. Use
-.Ar -xmode=avr
+.Ar -x mode=avr
 for switching to AVR mode, or
-.Ar -xmode=pic
+.Ar -x mode=pic
 for switching to PIC mode.
 .It Ar help
 Show help menu and exit.
@@ -1684,7 +1684,7 @@ Show help menu and exit.
 .It Ar suffer=VALUE, suffer
 The SUFFER register allows the user to modify the behavior of the on-board mEDBG.
 The current state can be read by
-.Ar -xsuffer
+.Ar -x suffer
 alone.
 .Bl -tag -offset indent -width indent
 .It Bit 7 ARDUINO:
@@ -1704,7 +1704,7 @@ Fuses are safe-masked when bit sent to 1. Fuses are unprotected when set to 0
 .It Ar vtarg_switch=VALUE, vtarg_switch
 The on-board target voltage switch can be turned on or off by writing a 1 or
 a 0. The current state can be read by
-.Ar -xvtarg_switch
+.Ar -x vtarg_switch
 alone.
 Note that the target power switch will always be on after a power cycle.
 Also note that the smaller Xplained Nano boards does not have a target power switch.
@@ -1716,7 +1716,7 @@ Show help menu and exit.
 .It Ar vtarg=VALUE, vtarg
 The generated on-board target voltage can be changed by specifying a new voltage.
 The current set-voltage can be read by
-.Ar -xvtarg
+.Ar -x vtarg
 alone.
 .It Ar help
 Show help menu and exit.
@@ -1727,16 +1727,16 @@ Show help menu and exit.
 .It Ar vtarg=VALUE, vtarg
 The generated on-board target voltage can be changed by specifying a new voltage.
 The current set-voltage can be read by
-.Ar -xvtarg
+.Ar -x vtarg
 alone.
 .It Ar fosc=VALUE[MHz|M|kHz|k|Hz|H], fosc
 Set the programmable oscillator frequency. The current frequency can be read by
-.Ar -xfosc
+.Ar -x fosc
 alone.
 .It Ar varef=VALUE, varef
 The generated on-board analog reference voltage can be changed by specifying
 a new reference voltage. The current reference voltage can be read by
-.Ar -xvaref
+.Ar -x varef
 alone.
 .It Ar varef[0,1]=VALUE, varef[0,1]
 .Nm STK600 only
@@ -1744,9 +1744,9 @@ alone.
 The generated on-board analog reference voltage for channel 0 or channel 1 can
 be changed by specifying a new reference voltage.
 The current reference voltage can be read by
-.Ar -xvaref0
+.Ar -x varef0
 or
-.Ar -xvaref1
+.Ar -x varef1
 alone.
 .It Ar attemps[=<1..99>]
 .Nm STK500V1 only
@@ -1797,7 +1797,7 @@ Show help menu and exit.
 .It Ar Urclock
 .Bl -tag -offset indent -width indent
 .It Ar showall
-Show all info for the connected part, then exit. The -xshow... options
+Show all info for the connected part, then exit. The -x show... options
 below can be used to assemble a bespoke response consisting of a subset
 (or only one item) of all available relevant information about the
 connected part and bootloader.
@@ -1806,7 +1806,7 @@ Show a unique Urclock ID stored in either flash or EEPROM of the MCU, then exit.
 .It Ar id=<E|F>.<addr>.<len>
 Historically, the Urclock ID was a six-byte unique little-endian number
 stored in Urclock boards at EEPROM address 257. The location of this
-number can be set by the -xid=<E|F>.<addr>.<len> extended parameter. E
+number can be set by the -x id=<E|F>.<addr>.<len> extended parameter. E
 stands for EEPROM and F stands for flash. A negative address addr counts
 from the end of EEPROM and flash, respectively. The length len of the
 Urclock ID can be between 1 and 8 bytes.
@@ -1847,7 +1847,7 @@ i.e., typically top of flash, so the urclock programmer can look up the
 bootloader size itself. In backward-compatibility mode, when programming
 via other bootloaders, this option can be used to tell the programmer the
 size, and therefore the location, of the bootloader.
-.It Ar vectornum=<arg>
+.It Ar vectornum=<n>
 Manual override for vector number. Urboot bootloaders put the vector
 number used by a vector bootloader into a table at the top of flash, so
 this option is normally not needed for urboot bootloaders. However, it is
@@ -1872,7 +1872,7 @@ Upload unchanged flash input files and trim below the bootloader if
 needed. This is most useful when one has a backup of the full flash and
 wants to play that back onto the device. No metadata are written in this
 case and no vector patching happens either if it is a vector bootloader.
-However, for vector bootloaders, even under the option -xrestore an
+However, for vector bootloaders, even under the option -x restore an
 input file will not be uploaded for which the reset vector does not point
 to the vector bootloader. This is to avoid writing an input file to the
 device that would render the vector bootloader not functional as it would
@@ -1897,12 +1897,12 @@ indicate there are no further metadata available. In absence of
 -xnometadata, the default for the urclock programmer is to write as much
 metadata (filename, data and store information) as the size of the
 uploaded application and the other extended options allow. The subtle
-difference between -xnometadata and -xnostore is that the latter always
+difference between -x nometadata and -x nostore is that the latter always
 explicitly stores in flash that no further metadata are available, so that
 a such prepared flash can always be queried with
 .Nm
--xshowall. In contrast to this, it cannot be guaranteed that a -xshowall
-query on flash prepared with -xnometadata yields useful results.
+-xshowall. In contrast to this, it cannot be guaranteed that a -x showall
+query on flash prepared with -x nometadata yields useful results.
 .It Ar delay=<n>
 Add a <n> ms delay after reset. This can be useful if a board takes a
 particularly long time to exit from external reset. <n> can be negative,
@@ -1911,7 +1911,7 @@ shortened accordingly.
 .It Ar strict
 Urclock has a faster, but slightly different strategy than -c arduino to
 synchronise with the bootloader; some stk500v1 bootloaders cannot cope
-with this, and they need the -xstrict option.
+with this, and they need the -x strict option.
 .It Ar help
 Show help menu and exit.
 .El

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1815,7 +1815,7 @@ Show the last-modified date of the input file for the flash application,
 then exit. If the input file was stdin, the date will be that of the
 programming.  Date and filename are part of the metadata that the urclock
 programmer stores by default in high flash just under the bootloader; see also
--xnometadata.
+-x nometadata.
 .It Ar showfilename
 Show the input filename (or title) of the last flash writing session, then exit.
 .It Ar title=<string>
@@ -1894,14 +1894,14 @@ Do not support any metadata. The full flash besides the bootloader is
 available for the application. If the application is smaller than the
 available space then a metadata code byte 0xff is stored nevertheless to
 indicate there are no further metadata available. In absence of
--xnometadata, the default for the urclock programmer is to write as much
+-x nometadata, the default for the urclock programmer is to write as much
 metadata (filename, data and store information) as the size of the
 uploaded application and the other extended options allow. The subtle
 difference between -x nometadata and -x nostore is that the latter always
 explicitly stores in flash that no further metadata are available, so that
 a such prepared flash can always be queried with
 .Nm
--xshowall. In contrast to this, it cannot be guaranteed that a -x showall
+-x showall. In contrast to this, it cannot be guaranteed that a -x showall
 query on flash prepared with -x nometadata yields useful results.
 .It Ar delay=<n>
 Add a <n> ms delay after reset. This can be useful if a board takes a

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -689,7 +689,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 	else if (pgm->usbdev[0] == 'b' || pgm->usbdev[0] == 'B')
 		interface = INTERFACE_B;
 	else {
-		pmsg_warning("invalid interface '%s'. Setting to Interface A\n", pgm->usbdev);
+		pmsg_warning("invalid interface %s; setting to Interface A\n", pgm->usbdev);
 		interface = INTERFACE_A;
 	}
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -288,17 +288,18 @@ static void buspirate_dummy_6(const PROGRAMMER *pgm, const char *p) {
 
 /* ====== Config / parameters handling functions ====== */
 static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-	LNODEID ln;
-	const char *extended_param;
+	int rv = 0;
 	char reset[10];
 	char *preset = reset; /* for strtok() */
 	unsigned int spifreq;
 	unsigned int rawfreq;
 	unsigned int cpufreq;
 	int serial_recv_timeout;
+	bool help = false;
 
-	for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-		extended_param = ldata(ln);
+	for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+		const char *extended_param = ldata(ln);
+
 		if (str_eq(extended_param, "ascii")) {
 			PDATA(pgm)->flag |= BP_FLAG_XPARM_FORCE_ASCII;
 			continue;
@@ -318,11 +319,13 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 			if (spifreq & (~0x07)) {
 				pmsg_error("spifreq must be between 0 and 7\n");
 				imsg_error("see BusPirate manual for details\n");
-				return -1;
+				rv = -1;
+				break;
 			}
 			if (PDATA(pgm)->flag & BP_FLAG_XPARM_RAWFREQ) {
 				pmsg_error("set either spifreq or rawfreq\n");
-				return -1;
+				rv = -1;
+				break;
 			}
 			PDATA(pgm)->flag |=  BP_FLAG_XPARM_SPIFREQ;
 			PDATA(pgm)->spifreq = spifreq;
@@ -332,11 +335,13 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 		if (sscanf(extended_param, "rawfreq=%u", &rawfreq) == 1) {
 			if (rawfreq >= 4) {
 				pmsg_error("rawfreq must be between 0 and 3\n");
-				return -1;
+				rv = -1;
+				break;
 			}
 			if (PDATA(pgm)->flag & BP_FLAG_XPARM_SPIFREQ) {
 				pmsg_error("set either spifreq or rawfreq\n");
-				return -1;
+				rv = -1;
+				break;
 			}
 			PDATA(pgm)->flag |=  BP_FLAG_XPARM_RAWFREQ;
 			PDATA(pgm)->spifreq = rawfreq;
@@ -348,7 +353,8 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 			if (cpufreq < 125 || cpufreq > 4000) {
 				pmsg_error("cpufreq must be between 125 and 4000 kHz\n");
 				imsg_error("see BusPirate manual for details\n");
-				return -1;
+				rv = -1;
+				break;
 			}
 			PDATA(pgm)->cpufreq = cpufreq;
 			PDATA(pgm)->flag |= BP_FLAG_XPARM_CPUFREQ;
@@ -367,7 +373,8 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 					PDATA(pgm)->reset |= BP_RESET_AUX2;
 				else {
 					pmsg_error("reset must be either CS or AUX\n");
-					return -1;
+					rv = -1;
+				  break;
 				}
 			}
 			PDATA(pgm)->flag |= BP_FLAG_XPARM_RESET;
@@ -387,33 +394,38 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 		if (sscanf(extended_param, "serial_recv_timeout=%d", &serial_recv_timeout) == 1) {
 			if (serial_recv_timeout < 1) {
 				pmsg_error("serial_recv_timeout must be greater 0\n");
-				return -1;
+				rv = -1;
+				break;
 			}
 			PDATA(pgm)->serial_recv_timeout = serial_recv_timeout;
 			continue;
 		}
 
 		if (str_eq(extended_param, "help")) {
-			msg_error("%s -c %s extended options:\n", progname, pgmid);
-			msg_error("  -xreset=cs,aux,aux2         Override default reset pin\n");
-			msg_error("  -xspifreq=<0..7>            Set binary SPI mode speed\n");
-			msg_error("  -xrawfreq=<0..3>            Set \"raw-wire\" SPI mode speed\n");
-			msg_error("  -xascii                     Use ASCII protocol between BP and Avrdude\n");
-			msg_error("  -xnopagedwrite              Disable page write functionality\n");
-			msg_error("  -xnopagedread               Disable page read functionality\n");
-			msg_error("  -xcpufreq=<125..4000>       Set the AUX pin to output a frequency to n [kHz]\n");
-			msg_error("  -xserial_recv_timeout=<arg> Set serial receive timeout to <arg> [ms]\n");
-			msg_error("  -xpullups                   Enable internal pull-ups\n");
-			msg_error("  -xhiz                       SPI HiZ mode (open collector)\n");
-			msg_error("  -xhelp                      Show this help menu and exit\n");
-			return LIBAVRDUDE_EXIT;;
+			help = true;
+			rv = LIBAVRDUDE_EXIT;
 		}
 
-		pmsg_error("do not understand extended param '%s'\n", extended_param);
-		return -1;
+		if (!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+		}
+		msg_error("%s -c %s extended options:\n", progname, pgmid);
+		msg_error("  -xreset=cs,aux,aux2         Override default reset pin\n");
+		msg_error("  -xspifreq=<0..7>            Set binary SPI mode speed\n");
+		msg_error("  -xrawfreq=<0..3>            Set \"raw-wire\" SPI mode speed\n");
+		msg_error("  -xascii                     Use ASCII protocol between BP and Avrdude\n");
+		msg_error("  -xnopagedwrite              Disable page write functionality\n");
+		msg_error("  -xnopagedread               Disable page read functionality\n");
+		msg_error("  -xcpufreq=<125..4000>       Set the AUX pin to output a frequency to n [kHz]\n");
+		msg_error("  -xserial_recv_timeout=<arg> Set serial receive timeout to <arg> [ms]\n");
+		msg_error("  -xpullups                   Enable internal pull-ups\n");
+		msg_error("  -xhiz                       SPI HiZ mode (open collector)\n");
+		msg_error("  -xhelp                      Show this help menu and exit\n");
+		return rv;
 	}
 
-	return 0;
+	return rv;
 }
 
 static int buspirate_verifyconfig(const PROGRAMMER *pgm) {

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -372,7 +372,7 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 				else if (str_caseeq(resetpin, "aux2"))
 					PDATA(pgm)->reset |= BP_RESET_AUX2;
 				else {
-					pmsg_error("-xreset= value must be either CS, AUX or AUX2\n");
+					pmsg_error("-x reset= value must be either CS, AUX or AUX2\n");
 					rv = -1;
 					break;
 				}

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -372,9 +372,9 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 				else if (str_caseeq(resetpin, "aux2"))
 					PDATA(pgm)->reset |= BP_RESET_AUX2;
 				else {
-					pmsg_error("reset must be either CS or AUX\n");
+					pmsg_error("-xreset= value must be either CS, AUX or AUX2\n");
 					rv = -1;
-				  break;
+					break;
 				}
 			}
 			PDATA(pgm)->flag |= BP_FLAG_XPARM_RESET;
@@ -407,21 +407,21 @@ static int buspirate_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 		}
 
 		if (!help) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
-      rv = -1;
+			pmsg_error("invalid extended parameter -x %s\n", extended_param);
+			rv = -1;
 		}
 		msg_error("%s -c %s extended options:\n", progname, pgmid);
-		msg_error("  -xreset=cs,aux,aux2         Override default reset pin\n");
-		msg_error("  -xspifreq=<0..7>            Set binary SPI mode speed\n");
-		msg_error("  -xrawfreq=<0..3>            Set \"raw-wire\" SPI mode speed\n");
-		msg_error("  -xascii                     Use ASCII protocol between BP and Avrdude\n");
-		msg_error("  -xnopagedwrite              Disable page write functionality\n");
-		msg_error("  -xnopagedread               Disable page read functionality\n");
-		msg_error("  -xcpufreq=<125..4000>       Set the AUX pin to output a frequency to n [kHz]\n");
-		msg_error("  -xserial_recv_timeout=<arg> Set serial receive timeout to <arg> [ms]\n");
-		msg_error("  -xpullups                   Enable internal pull-ups\n");
-		msg_error("  -xhiz                       SPI HiZ mode (open collector)\n");
-		msg_error("  -xhelp                      Show this help menu and exit\n");
+		msg_error("  -x reset=[cs|aux|aux2]     Override default reset pin\n");
+		msg_error("  -x spifreq=<0..7>          Set binary SPI mode speed\n");
+		msg_error("  -x rawfreq=<0..3>          Set \"raw-wire\" SPI mode speed\n");
+		msg_error("  -x ascii                   Use ASCII protocol between BP and Avrdude\n");
+		msg_error("  -x nopagedwrite            Disable page write functionality\n");
+		msg_error("  -x nopagedread             Disable page read functionality\n");
+		msg_error("  -x cpufreq=<125..4000>     Set the AUX pin to output a frequency to <n> kHz\n");
+		msg_error("  -x serial_recv_timeout=<n> Set serial receive timeout to <n> ms\n");
+		msg_error("  -x pullups                 Enable internal pull-ups\n");
+		msg_error("  -x hiz                     SPI HiZ mode (open collector)\n");
+		msg_error("  -x help                    Show this help menu and exit\n");
 		return rv;
 	}
 
@@ -560,7 +560,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 	memset(buf, 0, sizeof(buf));
 	buspirate_recv_bin(pgm, buf, 5);
 	if (sscanf((const char*)buf, "BBIO%1d", &PDATA(pgm)->binmode_version) != 1) {
-		pmsg_error("binary mode not confirmed: '%s'\n", buf);
+		pmsg_error("binary mode not confirmed: %s\n", buf);
 		buspirate_reset_from_binmode(pgm);
 		return -1;
 	}
@@ -598,7 +598,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm)
 	memset(buf, 0, sizeof(buf));
 	buspirate_recv_bin(pgm, buf, 4);
 	if (sscanf((const char*)buf, submode.entered_format, &PDATA(pgm)->submode_version) != 1) {
-		pmsg_error("%s mode not confirmed: '%s'\n", submode.name, buf);
+		pmsg_error("%s mode not confirmed: %s\n", submode.name, buf);
 		buspirate_reset_from_binmode(pgm);
 		return -1;
 	}
@@ -1193,7 +1193,7 @@ static void buspirate_bb_enable(PROGRAMMER *pgm, const AVRPART *p) {
 	memset(buf, 0, sizeof(buf));
 	buspirate_recv_bin(pgm, buf, 5);
 	if (sscanf((char*)buf, "BBIO%1d", &PDATA(pgm)->binmode_version) != 1) {
-		pmsg_error("binary mode not confirmed: '%s'\n", buf);
+		pmsg_error("binary mode not confirmed: %s\n", buf);
 		buspirate_reset_from_binmode(pgm);
 		return;
 	}

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -60,6 +60,7 @@ struct pdata
   int ctype;                    // Cache one byte for flash
   unsigned char cvalue;
   unsigned long caddr;
+  bool autoreset;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))
@@ -361,9 +362,8 @@ static void butterfly_enable(PROGRAMMER *pgm, const AVRPART *p) {
 static int butterfly_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   pgm->port = port;
-  /*
-   *  If baudrate was not specified use 19200 Baud
-   */
+
+  // If baudrate was not specified use 19200 Baud
   if(pgm->baudrate == 0) {
     pgm->baudrate = 19200;
   }
@@ -373,9 +373,22 @@ static int butterfly_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
-  /*
-   * drain any extraneous input
-   */
+  if(PDATA(pgm)->autoreset) {
+    // This code assumes a negative-logic USB to TTL serial adapter
+    // Set RTS/DTR high to discharge the series-capacitor, if present
+    imsg_notice2("Toggling the DTR/RTS lines to trigger a hardware reset\n");
+    serial_set_dtr_rts(&pgm->fd, 0);
+    usleep(250 * 1000);
+    // Pull the RTS/DTR line low to reset AVR
+    serial_set_dtr_rts(&pgm->fd, 1);
+    // Max 100 us: charging a cap longer creates a high reset spike above Vcc
+    usleep(100);
+    // Set the RTS/DTR line back to high, so direct connection to reset works
+    serial_set_dtr_rts(&pgm->fd, 0);
+    usleep(100 * 1000);
+  }
+
+  // Drain any extraneous input
   (void) butterfly_drain(pgm, 0);
 
   return 0;
@@ -681,6 +694,37 @@ static int butterfly_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, con
   return 3;
 }
 
+static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
+  const char *extended_param;
+  int rv = 0;
+
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    extended_param = ldata(ln);
+
+    if(str_starts(extended_param, "autoreset")) {
+      if(!str_eq(extended_param, "autoreset")) {
+        pmsg_error("invalid -xautoreset value %s. Use -xautoreset\n", extended_param);
+        rv = -1;
+        break;
+      }
+      PDATA(pgm)->autoreset = true;
+      continue;
+    }
+
+    if (str_eq(extended_param, "help")) {
+      msg_error("%s -c %s extended options:\n", progname, pgmid);
+      msg_error("  -xautoreset Toggle RTS/DTR lines on port open to issue a hardware reset\n");
+      msg_error("  -xhelp      Show this help menu and exit\n");
+      exit(0);
+    }
+
+    pmsg_error("invalid extended parameter '%s'\n", extended_param);
+    rv = -1;
+  }
+
+  return rv;
+}
+
 const char butterfly_desc[] = "Atmel Butterfly evaluation board; Atmel AppNotes AVR109, AVR911";
 
 void butterfly_initpgm(PROGRAMMER *pgm) {
@@ -714,7 +758,7 @@ void butterfly_initpgm(PROGRAMMER *pgm) {
   pgm->paged_load = butterfly_paged_load;
 
   pgm->read_sig_bytes = butterfly_read_sig_bytes;
-
+  pgm->parseextparams = butterfly_parseextparms;
   pgm->setup          = butterfly_setup;
   pgm->teardown       = butterfly_teardown;
   pgm->flag = 0;

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -696,7 +696,7 @@ static int butterfly_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, con
 
 static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   const char *extended_param;
-  int rv = 0;
+  int rv = 0, help = 0;
 
   for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
@@ -707,14 +707,18 @@ static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
     }
 
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xautoreset Toggle RTS/DTR lines on port open to issue a hardware reset\n");
-      msg_error("  -xhelp      Show this help menu and exit\n");
-      exit(0);
+      help = 1;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter %s\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xautoreset Toggle RTS/DTR lines on port open to issue a hardware reset\n");
+    msg_error("  -xhelp      Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -696,7 +696,8 @@ static int butterfly_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, con
 
 static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   const char *extended_param;
-  int rv = 0, help = 0;
+  int rv = 0;
+  bool help = 0;
 
   for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
@@ -707,7 +708,7 @@ static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
     }
 
     if (str_eq(extended_param, "help")) {
-      help = 1;
+      help = true;
       rv = LIBAVRDUDE_EXIT;
     }
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -701,12 +701,7 @@ static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
   for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
 
-    if(str_starts(extended_param, "autoreset")) {
-      if(!str_eq(extended_param, "autoreset")) {
-        pmsg_error("invalid -xautoreset value %s. Use -xautoreset\n", extended_param);
-        rv = -1;
-        break;
-      }
+    if(str_eq(extended_param, "autoreset")) {
       PDATA(pgm)->autoreset = true;
       continue;
     }
@@ -718,7 +713,7 @@ static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
       exit(0);
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter %s\n", extended_param);
     rv = -1;
   }
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -713,12 +713,12 @@ static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xautoreset Toggle RTS/DTR lines on port open to issue a hardware reset\n");
-    msg_error("  -xhelp      Show this help menu and exit\n");
+    msg_error("  -x autoreset  Toggle RTS/DTR lines on port open to issue a hardware reset\n");
+    msg_error("  -x help       Show this help menu and exit\n");
     return rv;
   }
 

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1222,14 +1222,14 @@ Other JTAG units might require a different bit shift count.
 @var{Power Debugger and Pickit 4 only}
 @*
 High-voltage UPDI programming is used to enable a UPDI pin that has previously
-been set to RESET or GPIO mode. Use @samp{-xhvupdi} to enable high-voltage UPDI
+been set to RESET or GPIO mode. Use @samp{-x hvupdi} to enable high-voltage UPDI
 initialization for supported targets.
 
 @item @samp{vtarg=VALUE, vtarg}
 @var{Power Debugger only}
 @*
 The voltage generator can be enabled by setting a target voltage.
-The current set-voltage can be read by @samp{-xvtarg} alone.
+The current set-voltage can be read by @samp{-x vtarg} alone.
 
 @item @samp{help}
 Show help menu and exit.
@@ -1245,7 +1245,7 @@ The PICkit 4 and MPLAB SNAP programmers accept the following extended parameters
 @item @samp{mode=avr,pic}
 Switch programmer to AVR or PIC mode, then exit: the PICkit 4 and MPLAB SNAP
 programmer can only be utilised by Avrdude when in AVR mode.
-Use @samp{-xmode=avr} for switching to AVR mode, or @samp{-xmode=pic}
+Use @samp{-x mode=avr} for switching to AVR mode, or @samp{-x mode=pic}
 for switching to PIC mode.
 @item @samp{help}
 Show help menu and exit.
@@ -1260,7 +1260,7 @@ following extended parameters:
 @table @code
 @item @samp{suffer=VALUE}, @samp{suffer}
 The SUFFER register allows the user to modify the behavior of the on-board mEDBG.
-The current state can be read by @samp{-xsuffer} alone.
+The current state can be read by @samp{-x suffer} alone.
 @table @code
 @item Bit 7 ARDUINO:
 Adds control of extra LEDs when set to 0
@@ -1278,7 +1278,7 @@ Fuses are safe-masked when bit sent to 1. Fuses are unprotected when set to 0
 @table @code
 @item @samp{vtarg_switch=VALUE}, @samp{vtarg_switch}
 The on-board target voltage switch can be turned on or off by writing a 1 or
-a 0. The current state can be read by @samp{-xvtarg_switch} alone.
+a 0. The current state can be read by @samp{-x vtarg_switch} alone.
 Note that the target power switch will always be on after a power cycle.
 Also note that the smaller Xplained Nano boards does not have a target power switch.
 
@@ -1293,7 +1293,7 @@ The Curiosity Nano board accepts the following extended parameter:
 @table @code
 @item @samp{vtarg=VALUE, vtarg}
 The generated on-board target voltage can be changed by specifying a new voltage.
-The current set-voltage can be read by @samp{-xvtarg} alone.
+The current set-voltage can be read by @samp{-x vtarg} alone.
 @item @samp{help}
 Show help menu and exit.
 @end table
@@ -1307,21 +1307,21 @@ The STK500 and STK600 boards accept the following extended parameters:
 @table @code
 @item @samp{vtarg=VALUE, vtarg}
 The generated on-board target voltage can be changed by specifying a new voltage.
-The current set-voltage can be read by @samp{-xvtarg} alone.
+The current set-voltage can be read by @samp{-x vtarg} alone.
 @item @samp{fosc=VALUE[MHz|M|kHz|k|Hz|H], fosc}
 Set the programmable oscillator frequency in MHz, kHz or Hz.
-The current frequency can be read by @samp{-xfosc} alone.
+The current frequency can be read by @samp{-x fosc} alone.
 @item @samp{varef=VALUE, varef}
 The generated on-board analog reference voltage can be changed by specifying
 a new reference voltage. The current reference voltage can be read by
-@samp{-xvaref} alone.
+@samp{-x varef} alone.
 @item @samp{varef[0,1]=VALUE, varef[0,1]}
 @var{STK600 only}
 @*
 The generated on-board analog reference voltage for channel 0 or channel 1 can
 be changed by specifying a new reference voltage.
-The current reference voltage can be read by @samp{-xvaref0} or
-@samp{-xvaref1} alone.
+The current reference voltage can be read by @samp{-x varef0} or
+@samp{-x varef1} alone.
 @item @samp{attemps[=<1..99>]}
 @var{STK500V1 only}
 @*
@@ -1374,7 +1374,7 @@ Show help menu and exit.
 The urclock programmer type accepts the following extended parameters:
 @table @code
 @item @samp{showall}
-Show all info for the connected part, then exit. The @code{-xshow...} options
+Show all info for the connected part, then exit. The @code{-x show...} options
 below can be used to assemble a bespoke response consisting of a subset
 (or only one item) of all available relevant information about the
 connected part and bootloader.
@@ -1383,7 +1383,7 @@ Show a unique Urclock ID stored in either flash or EEPROM of the MCU, then exit.
 @item @samp{id=<E|F>.<addr>.<len>}
 Historically, the Urclock ID was a six-byte unique little-endian number
 stored in Urclock boards at EEPROM address 257. The location of this
-number can be set by the @code{-xid=<E|F>.<addr>.<len>} extended parameter. @code{E}
+number can be set by the @code{-x id=<E|F>.<addr>.<len>} extended parameter. @code{E}
 stands for EEPROM and @code{F} stands for flash. A negative address addr counts
 from the end of EEPROM and flash, respectively. The length len of the
 Urclock ID can be between 1 and 8 bytes.
@@ -1392,7 +1392,7 @@ Show the last-modified date of the input file for the flash application,
 then exit. If the input file was stdin, the date will be that of the
 programming. Date and filename are part of the metadata that the urclock
 programmer stores by default in high flash just under the bootloader; see also
-@code{-xnometadata}.
+@code{-x nometadata}.
 @item @samp{showfilename}
 Show the input filename (or title) of the last flash writing session, then exit.
 @item @samp{title=<string>}
@@ -1449,7 +1449,7 @@ Upload unchanged flash input files and trim below the bootloader if
 needed. This is most useful when one has a backup of the full flash and
 wants to play that back onto the device. No metadata are written in this
 case and no vector patching happens either if it is a vector bootloader.
-However, for vector bootloaders, even under the option @code{-xrestore} an
+However, for vector bootloaders, even under the option @code{-x restore} an
 input file will not be uploaded for which the reset vector does not point
 to the vector bootloader. This is to avoid writing an input file to the
 device that would render the vector bootloader not functional as it would
@@ -1471,14 +1471,14 @@ Do not support any metadata. The full flash besides the bootloader is
 available for the application. If the application is smaller than the
 available space then a metadata code byte @code{0xff} is stored
 nevertheless to indicate there are no further metadata available. In
-absence of @code{-xnometadata}, the default for the urclock programmer is
+absence of @code{-x nometadata}, the default for the urclock programmer is
 to write as much metadata (filename, data and store information) as the
 size of the uploaded application and the other extended options allow. The
-subtle difference between @code{-xnometadata} and @code{-xnostore} is that
+subtle difference between @code{-x nometadata} and @code{-x nostore} is that
 the latter always explicitly stores in flash that no further metadata are
 available, so that a such prepared flash can always be queried with
 @code{avrdude -x showall}. In contrast to this, it cannot be guaranteed
-that a @code{-x showall} query on flash prepared with @code{-xnometadata}
+that a @code{-x showall} query on flash prepared with @code{-x nometadata}
 yields useful results.
 @item @samp{delay=<n>}
 Add a <n> ms delay after reset. This can be useful if a board takes a
@@ -1488,7 +1488,7 @@ shortened accordingly.
 @item @samp{strict}
 Urclock has a faster, but slightly different strategy than -c arduino to
 synchronise with the bootloader; some stk500v1 bootloaders cannot cope
-with this, and they need the @code{-xstrict} option.
+with this, and they need the @code{-x strict} option.
 @item @samp{help}
 Show help menu and exit.
 @end table

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1424,7 +1424,7 @@ i.e., typically top of flash, so the urclock programmer can look up the
 bootloader size itself. In backward-compatibility mode, when programming
 via other bootloaders, this option can be used to tell the programmer the
 size, and therefore the location, of the bootloader.
-@item @samp{vectornum=<arg>}
+@item @samp{vectornum=<n>}
 Manual override for vector number. Urboot bootloaders put the vector
 number used by a vector bootloader into a table at the top of flash, so
 this option is normally not needed for urboot bootloaders. However, it is
@@ -1477,8 +1477,8 @@ size of the uploaded application and the other extended options allow. The
 subtle difference between @code{-xnometadata} and @code{-xnostore} is that
 the latter always explicitly stores in flash that no further metadata are
 available, so that a such prepared flash can always be queried with
-@code{avrdude -xshowall}. In contrast to this, it cannot be guaranteed
-that a @code{-xshowall} query on flash prepared with @code{-xnometadata}
+@code{avrdude -x showall}. In contrast to this, it cannot be guaranteed
+that a @code{-x showall} query on flash prepared with @code{-xnometadata}
 yields useful results.
 @item @samp{delay=<n>}
 Add a <n> ms delay after reset. This can be useful if a board takes a
@@ -2165,7 +2165,7 @@ Valid programmers for part AVR32EA32 are:
 @smallexample
 @cartouche
 
-$avrdude -qq -curclock -P/dev/ttyUSB0 -pattiny13 -xshowdate -xshowfilename
+$avrdude -qq -curclock -P/dev/ttyUSB0 -pattiny13 -x showdate -x showfilename
 
 2023-05-19 11.13 blink.hex
 

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -1067,18 +1067,18 @@ static int dryrun_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if(!help) {
-      pmsg_error("invalid extended parameter '%s'\n", xpara);
+      pmsg_error("invalid extended parameter -x %s\n", xpara);
       rc = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xinit     Initialise memories with human-readable patterns (1, 2, 3)\n");
-    msg_error("  -xrandom   Initialise memories with random code/values (1, 3)\n");
-    msg_error("  -xseed=<n> Seed random number generator with <n>, default time(NULL)\n");
-    msg_error("  -xhelp     Show this help menu and exit\n");
+    msg_error("  -x init     Initialise memories with human-readable patterns (1, 2, 3)\n");
+    msg_error("  -x random   Initialise memories with random code/values (1, 3)\n");
+    msg_error("  -x seed=<n> Seed random number generator with <n>, n>0, default time(NULL)\n");
+    msg_error("  -x help     Show this help menu and exit\n");
     msg_error("Notes:\n");
-    msg_error("  (1) -xinit and -xrandom randomly configure flash wrt boot/data/code length\n");
+    msg_error("  (1) -x init and -x random randomly configure flash wrt boot/data/code length\n");
     msg_error("  (2) Patterns can best be seen with fixed-width font on -U flash:r:-:I\n");
-    msg_error("  (3) Choose, eg, -xseed=1 for reproducible flash configuration and output\n");
+    msg_error("  (3) Choose, eg, -x seed=1 for reproducible flash configuration and output\n");
     return rc;
   }
 

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -1036,42 +1036,53 @@ static void dryrun_teardown(PROGRAMMER *pgm) {
 
 
 static int dryrun_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) {
+  int rc = 0;
+  bool help = false;
+
   for(LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     const char *xpara = ldata(ln);
 
     if(str_starts(xpara, "init")) {
       dry.init = 1;
       continue;
-    } else if(str_starts(xpara, "random")) {
+    }
+    if(str_starts(xpara, "random")) {
       dry.random = 1;
       continue;
-    } else if(str_starts(xpara, "seed=")) {
+    }
+    if(str_starts(xpara, "seed=")) {
       const char *errptr;
       int seed = str_int(strchr(xpara, '=')+1, STR_INT32, &errptr);
       if(errptr) {
         pmsg_error("cannot parse %s seed value: %s\n", xpara, errptr);
-        return -1;
+        rc = -1;
+        break;
       }
       dry.seed = seed;
       continue;
-    } else if(str_eq(xpara, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xinit     Initialise memories with human-readable patterns (1, 2, 3)\n");
-      msg_error("  -xrandom   Initialise memories with random code/values (1, 3)\n");
-      msg_error("  -xseed=<n> Seed random number generator with <n>, default time(NULL)\n");
-      msg_error("  -xhelp     Show this help menu and exit\n");
-      msg_error("Notes:\n");
-      msg_error("  (1) -xinit and -xrandom randomly configure flash wrt boot/data/code length\n");
-      msg_error("  (2) Patterns can best be seen with fixed-width font on -U flash:r:-:I\n");
-      msg_error("  (3) Choose, eg, -xseed=1 for reproducible flash configuration and output\n");
-      return LIBAVRDUDE_EXIT;
+    }
+    if(str_eq(xpara, "help")) {
+      help = true;
+      rc = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", xpara);
-    return -1;
+    if(!help) {
+      pmsg_error("invalid extended parameter '%s'\n", xpara);
+      rc = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xinit     Initialise memories with human-readable patterns (1, 2, 3)\n");
+    msg_error("  -xrandom   Initialise memories with random code/values (1, 3)\n");
+    msg_error("  -xseed=<n> Seed random number generator with <n>, default time(NULL)\n");
+    msg_error("  -xhelp     Show this help menu and exit\n");
+    msg_error("Notes:\n");
+    msg_error("  (1) -xinit and -xrandom randomly configure flash wrt boot/data/code length\n");
+    msg_error("  (2) Patterns can best be seen with fixed-width font on -U flash:r:-:I\n");
+    msg_error("  (3) Choose, eg, -xseed=1 for reproducible flash configuration and output\n");
+    return rc;
   }
 
-  return 0;
+  return rc;
 }
 
 const char dryrun_desc[] = "Dryrun programmer for testing avrdude";

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -494,6 +494,8 @@ static int flip2_paged_write(const PROGRAMMER *pgm, const AVRPART *part, const A
 // Parse the -E option flag
 static int flip2_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
   char *cp, *s, *str = mmt_strdup(sp);
+  int rv = 0;
+  bool help = false;
 
   s = str;
   while ((cp = strtok(s, ","))) {
@@ -506,12 +508,25 @@ static int flip2_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
       pgm->exit_reset = EXIT_RESET_DISABLED;
       continue;
     }
+    if (str_eq(cp, "help")) {
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
+    }
+
+    if (!help) {
+      pmsg_error("invalid exitspec parameter -E %s\n", cp);
+      rv = -1;
+    }
+    msg_error("%s -c %s exitspec parameter options:\n", progname, pgmid);
+    msg_error("  -E reset   Application will not start automatically after programming session\n");
+    msg_error("  -E noreset Application will start automatically after programming session\n");
+    msg_error("  -E help    Show this help menu and exit\n");
     mmt_free(str);
-    return -1;
+    return rv;
   }
 
   mmt_free(str);
-  return 0;
+  return rv;
 }
 
 static int flip2_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *part, const AVRMEM *mem) {

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -378,7 +378,7 @@ static int ft245r_set_bitclock(const PROGRAMMER *pgm) {
 
     r = ftdi_set_baudrate(my.handle, ftdi_rate);
     if (r) {
-        msg_error("set baudrate %d failed with error '%s'\n", rate, ftdi_get_error_string (my.handle));
+        msg_error("setting baudrate %d failed with error %s\n", rate, ftdi_get_error_string (my.handle));
         return -1;
     }
     return 0;
@@ -854,7 +854,7 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
 
     // if something went wrong before abort with helpful message
     if (devnum < 0) {
-      pmsg_error("invalid portname '%s': use^ 'ft[0-9]+' or serial number\n", port);
+      pmsg_error("invalid port name %s: use ft[0-9]+ or serial number\n", port);
       return -1;
     }
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1456,12 +1456,11 @@ static void jtag3_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rv = 0;
+  bool help = false;
 
-  for(ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for(LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if(str_starts(extended_param, "jtagchain=") && (pgm->prog_modes & (PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG))) {
       unsigned int ub, ua, bb, ba;
@@ -1602,31 +1601,35 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if(str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      if(str_eq(pgm->type, "JTAGICE3"))
-        msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
-      if(lsize(pgm->hvupdi_support) > 1)
-        msg_error("  -xhvupdi                Enable high-voltage UPDI initialization\n");
-      if(pgm->extra_features & HAS_SUFFER) {
-        msg_error("  -xsuffer                Read SUFFER register value\n");
-        msg_error("  -xsuffer=<arg>          Set SUFFER register value\n");
-      }
-      if(pgm->extra_features & HAS_VTARG_SWITCH) {
-        msg_error("  -xvtarg_switch          Read on-board target voltage switch state\n");
-        msg_error("  -xvtarg_switch=<0..1>   Set on-board target voltage switch state\n");
-      }
-      if(pgm->extra_features & HAS_VTARG_ADJ) {
-        msg_error("  -xvtarg                 Read on-board target supply voltage\n");
-        msg_error("  -xvtarg=<arg>           Set on-board target supply voltage\n");
-      }
-      if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
-        msg_error("  -xmode=avr|pic          Set programmer to AVR or PIC mode, then exit\n");
-      msg_error  ("  -xhelp                  Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter %s\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    if(str_eq(pgm->type, "JTAGICE3"))
+      msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
+    if(lsize(pgm->hvupdi_support) > 1)
+      msg_error("  -xhvupdi                Enable high-voltage UPDI initialization\n");
+    if(pgm->extra_features & HAS_SUFFER) {
+      msg_error("  -xsuffer                Read SUFFER register value\n");
+      msg_error("  -xsuffer=<arg>          Set SUFFER register value\n");
+    }
+    if(pgm->extra_features & HAS_VTARG_SWITCH) {
+      msg_error("  -xvtarg_switch          Read on-board target voltage switch state\n");
+      msg_error("  -xvtarg_switch=<0..1>   Set on-board target voltage switch state\n");
+    }
+    if(pgm->extra_features & HAS_VTARG_ADJ) {
+      msg_error("  -xvtarg                 Read on-board target supply voltage\n");
+      msg_error("  -xvtarg=<arg>           Set on-board target supply voltage\n");
+    }
+    if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
+      msg_error("  -xmode=avr|pic          Set programmer to AVR or PIC mode, then exit\n");
+    msg_error  ("  -xhelp                  Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1610,9 +1610,10 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    if(str_eq(pgm->type, "JTAGICE3"))
+    if(str_eq(pgm->type, "JTAGICE3")) {
       msg_error("  -x jtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
-      msg_error("               UB/UA = units before/after, BB/BA = bits before/after\n");
+      msg_error("                           UB/UA = units before/after, BB/BA = bits before/after\n");
+    }
     if(lsize(pgm->hvupdi_support) > 1)
       msg_error("  -x hvupdi                Enable high-voltage UPDI initialization\n");
     if(pgm->extra_features & HAS_SUFFER) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1465,7 +1465,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     if(str_starts(extended_param, "jtagchain=") && (pgm->prog_modes & (PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG))) {
       unsigned int ub, ua, bb, ba;
       if(sscanf(extended_param, "jtagchain=%u,%u,%u,%u", &ub, &ua, &bb, &ba) != 4) {
-        pmsg_error("invalid JTAG chain %s\n", extended_param);
+        pmsg_error("invalid JTAG chain in -x %s\n", extended_param);
         rv = -1;
         break;
       }
@@ -1491,7 +1491,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
         break;
       }
       if(!str_eq(extended_param, "hvupdi")) {
-        pmsg_error("invalid -xhvupdi value %s. Use -xhvupdi\n", extended_param);
+        pmsg_error("invalid assignment in -x %s; use -x hvupdi\n", extended_param);
         rv = -1;
         break;
       }
@@ -1510,13 +1510,13 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
         // Set SUFFER value
         if(str_starts(extended_param, "suffer=")) {
           if(sscanf(extended_param, "suffer=%hhi", PDATA(pgm)->suffer_data+1) < 1) {
-            pmsg_error("invalid -xsuffer=<value> %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
           if((PDATA(pgm)->suffer_data[1] & 0x78) != 0x78) {
             PDATA(pgm)->suffer_data[1] |= 0x78;
-            pmsg_info("setting -xsuffer=0x%02x so that reserved bits 3..6 are set\n",
+            pmsg_info("setting -x suffer=0x%02x so that reserved bits 3..6 are set\n",
               PDATA(pgm)->suffer_data[1]);
           }
           PDATA(pgm)->suffer_set = true;
@@ -1527,7 +1527,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
           PDATA(pgm)->suffer_get = true;
           continue;
         }
-        pmsg_error("invalid suffer setting %s. Use -xsuffer or -xsuffer=<arg>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x suffer or -x suffer=<n>\n", extended_param);
         rv = -1;
         break;
       }
@@ -1539,7 +1539,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
         if(str_starts(extended_param, "vtarg_switch=")) {
           int sscanf_success = sscanf(extended_param, "vtarg_switch=%hhi", PDATA(pgm)->vtarg_switch_data+1);
           if(sscanf_success < 1 || PDATA(pgm)->vtarg_switch_data[1] > 1) {
-            pmsg_error("invalid vtarg_switch value %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
@@ -1551,7 +1551,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
           PDATA(pgm)->vtarg_switch_get = true;
           continue;
         }
-        pmsg_error("invalid vtarg_switch setting %s. Use -xvtarg_switch or -xvtarg_switch=<0..1>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x vtarg_switch or -x vtarg_switch=<0..1>\n", extended_param);
         rv = -1;
         break;
       }
@@ -1565,7 +1565,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
           int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
           PDATA(pgm)->vtarg_data = (double)((int)(vtarg_set_val * 100 + .5)) / 100;
           if(sscanf_success < 1 || vtarg_set_val < 0) {
-            pmsg_error("invalid vtarg value %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
@@ -1577,7 +1577,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
           PDATA(pgm)->vtarg_get = true;
           continue;
         }
-        pmsg_error("invalid vtarg setting %s. Use -xvtarg or -xvtarg=<arg>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x vtarg or -x vtarg=<dbl>\n", extended_param);
         rv = -1;
         break;
       }
@@ -1595,7 +1595,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
         PDATA(pgm)->pk4_snap_mode = PK4_SNAP_MODE_PIC;
         continue;
       }
-      pmsg_error("invalid mode setting %s. Use -xmode=avr or -xmode=pic\n", extended_param);
+      pmsg_error("invalid setting in -x %s; use -x mode=avr or -x mode=pic\n", extended_param);
       rv = -1;
       break;
     }
@@ -1606,29 +1606,30 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
     if(str_eq(pgm->type, "JTAGICE3"))
-      msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
+      msg_error("  -x jtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
+      msg_error("               UB/UA = units before/after, BB/BA = bits before/after\n");
     if(lsize(pgm->hvupdi_support) > 1)
-      msg_error("  -xhvupdi                Enable high-voltage UPDI initialization\n");
+      msg_error("  -x hvupdi                Enable high-voltage UPDI initialization\n");
     if(pgm->extra_features & HAS_SUFFER) {
-      msg_error("  -xsuffer                Read SUFFER register value\n");
-      msg_error("  -xsuffer=<arg>          Set SUFFER register value\n");
+      msg_error("  -x suffer                Read SUFFER register value\n");
+      msg_error("  -x suffer=<n>            Set SUFFER register to <n> (0x.. hex, 0.. oct or dec)\n");
     }
     if(pgm->extra_features & HAS_VTARG_SWITCH) {
-      msg_error("  -xvtarg_switch          Read on-board target voltage switch state\n");
-      msg_error("  -xvtarg_switch=<0..1>   Set on-board target voltage switch state\n");
+      msg_error("  -x vtarg_switch          Read on-board target voltage switch state\n");
+      msg_error("  -x vtarg_switch=<0..1>   Set on-board target voltage switch state\n");
     }
     if(pgm->extra_features & HAS_VTARG_ADJ) {
-      msg_error("  -xvtarg                 Read on-board target supply voltage\n");
-      msg_error("  -xvtarg=<arg>           Set on-board target supply voltage\n");
+      msg_error("  -x vtarg                 Read on-board target supply voltage\n");
+      msg_error("  -x vtarg=<dbl>           Set on-board target supply voltage to <dbl> V\n");
     }
     if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
-      msg_error("  -xmode=avr|pic          Set programmer to AVR or PIC mode, then exit\n");
-    msg_error  ("  -xhelp                  Show this help menu and exit\n");
+      msg_error("  -x mode=avr|pic          Set programmer to AVR or PIC mode, then exit\n");
+    msg_error  ("  -x help                  Show this help menu and exit\n");
     return rv;
   }
 
@@ -1725,7 +1726,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
             imsg_error("please run Avrdude again to continue the session\n\n");
           } else {
             imsg_error("to switch into AVR mode try\n");
-            imsg_error("avrdude -c%s -p%s -P%s -xmode=avr\n", pgmid, partdesc, port);
+            imsg_error("avrdude -c%s -p%s -P%s -x mode=avr\n", pgmid, partdesc, port);
           }
           serial_close(&pgm->fd);
           return LIBAVRDUDE_EXIT;;
@@ -1751,7 +1752,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
   }
 
   if (mode_switch == PK4_SNAP_MODE_AVR)
-    pmsg_warning("programmer is already in AVR mode. Ignoring -xmode");
+    pmsg_warning("programmer is already in AVR mode, ignoring -x mode");
 
   // The event EP has been deleted by usb_open(), so we are
   // running on a CMSIS-DAP device, using EDBG protocol

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1341,10 +1341,10 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     const char *extended_param = ldata(ln);
 
     if (pgm->flag & PGM_FL_IS_JTAG) {
-      if (str_eq(extended_param, "jtagchain=")) {
+      if (str_starts(extended_param, "jtagchain=")) {
         unsigned int ub, ua, bb, ba;
         if (sscanf(extended_param, "jtagchain=%u,%u,%u,%u", &ub, &ua, &bb, &ba) != 4) {
-          pmsg_error("invalid JTAG chain '%s'\n", extended_param);
+          pmsg_error("invalid JTAG chain in -x %s\n", extended_param);
           rv = -1;
           continue;
         }
@@ -1381,14 +1381,14 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     if (pgm->flag & PGM_FL_IS_JTAG)
-      msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
+      msg_error("  -x jtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
     if (pgm->flag & PGM_FL_IS_PDI)
-      msg_error("  -xrtsdtr=low,high       Force RTS/DTR lines low or high state during programming\n");
-    msg_error(  "  -xhelp                  Show this help menu and exit\n");
+      msg_error("  -x rtsdtr=low,high       Force RTS/DTR lines low or high state during programming\n");
+    msg_error(  "  -x help                  Show this help menu and exit\n");
     return rv;
   }
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1376,7 +1376,7 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     }
 
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
+      help = true;
       rv = LIBAVRDUDE_EXIT;
     }
 
@@ -1384,6 +1384,7 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
     if (pgm->flag & PGM_FL_IS_JTAG)
       msg_error("  -x jtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
     if (pgm->flag & PGM_FL_IS_PDI)

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1334,12 +1334,11 @@ static void jtagmkII_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rv = 0;
+  bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (pgm->flag & PGM_FL_IS_JTAG) {
       if (str_eq(extended_param, "jtagchain=")) {
@@ -1356,7 +1355,6 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         PDATA(pgm)->jtagchain[1] = ua;
         PDATA(pgm)->jtagchain[2] = bb;
         PDATA(pgm)->jtagchain[3] = ba;
-
         continue;
       }
     }
@@ -1370,7 +1368,8 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           PDATA(pgm)->rts_mode = RTS_MODE_HIGH;
         } else {
           pmsg_error("RTS/DTR mode must be LOW or HIGH\n");
-          return -1;
+          rv = -1;
+          break;
         }
         continue;
       }
@@ -1378,16 +1377,19 @@ static int jtagmkII_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
 
     if (str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
-      if (pgm->flag & PGM_FL_IS_JTAG)
-        msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
-      if (pgm->flag & PGM_FL_IS_PDI)
-        msg_error("  -xrtsdtr=low,high       Force RTS/DTR lines low or high state during programming\n");
-      msg_error(  "  -xhelp                  Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      rv = -1;
+    }
+    if (pgm->flag & PGM_FL_IS_JTAG)
+      msg_error("  -xjtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
+    if (pgm->flag & PGM_FL_IS_PDI)
+      msg_error("  -xrtsdtr=low,high       Force RTS/DTR lines low or high state during programming\n");
+    msg_error(  "  -xhelp                  Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -381,6 +381,8 @@ static int linuxspi_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
 static int linuxspi_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
     char *cp, *s, *str = mmt_strdup(sp);
+    int rv = 0;
+    bool help = false;
 
     s = str;
     while ((cp = strtok(s, ","))) {
@@ -393,12 +395,25 @@ static int linuxspi_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
             pgm->exit_reset = EXIT_RESET_DISABLED;
             continue;
         }
+        if (str_eq(cp, "help")) {
+            help = true;
+            rv = LIBAVRDUDE_EXIT;
+        }
+
+        if (!help) {
+            pmsg_error("invalid exitspec parameter -E %s\n", cp);
+            rv = -1;
+        }
+        msg_error("%s -c %s exitspec parameter options:\n", progname, pgmid);
+        msg_error("  -E reset   Programmer will keep the reset line low after programming session\n");
+        msg_error("  -E noreset Programmer will not keep the reset line low after programming session\n");
+        msg_error("  -E help    Show this help menu and exit\n");
         mmt_free(str);
-        return -1;
+        return rv;
     }
 
     mmt_free(str);
-    return 0;
+    return rv;
 }
 
 static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) {

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -402,26 +402,30 @@ static int linuxspi_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
 }
 
 static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rc = 0;
+  bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (str_eq(extended_param, "disable_no_cs")) {
       my.disable_no_cs = 1;
       continue;
     }
+
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xdisable_no_cs Do not use the SPI_NO_CS bit for the SPI driver\n");
-      msg_error("  -xhelp          Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;
+      help = true;
+      rc = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
-    rc = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      rc = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xdisable_no_cs Do not use the SPI_NO_CS bit for the SPI driver\n");
+    msg_error("  -xhelp          Show this help menu and exit\n");
+    return rc;
   }
 
   return rc;

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -419,12 +419,12 @@ static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rc = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xdisable_no_cs Do not use the SPI_NO_CS bit for the SPI driver\n");
-    msg_error("  -xhelp          Show this help menu and exit\n");
+    msg_error("  -x disable_no_cs Do not use the SPI_NO_CS bit for the SPI driver\n");
+    msg_error("  -x help          Show this help menu and exit\n");
     return rc;
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -252,7 +252,7 @@ static void usage(void)
     "  -n                     Do not write to the device whilst processing -U\n"
     "  -V                     Do not automatically verify during -U\n"
     "  -E <exitsp>[,<exitsp>] List programmer exit specifications\n"
-    "  -x <extended_param>    Pass <extended_param> to programmer, see -xhelp\n"
+    "  -x <extended_param>    Pass <extended_param> to programmer, see -x help\n"
     "  -v                     Verbose output; -v -v for more\n"
     "  -q                     Quell progress output; -q -q for less\n"
     "  -l logfile             Use logfile rather than stderr for diagnostics\n"
@@ -900,7 +900,7 @@ int main(int argc, char * argv [])
       case 'U':
         upd = parse_op(optarg);
         if (upd == NULL) {
-          pmsg_error("unable to parse update operation '%s'\n", optarg);
+          pmsg_error("unable to parse update operation %s\n", optarg);
           exit(1);
         }
         ladd(updates, upd);
@@ -1248,7 +1248,7 @@ int main(int argc, char * argv [])
         const char *extended_param = ldata(ln);
         if (str_eq(extended_param, "help")) {
           msg_error("%s -c %s extended options:\n", progname, pgmid);
-          msg_error("  -xhelp    Show this help menu and exit\n");
+          msg_error("  -x help  Show this help menu and exit\n");
           exit(0);
         }
         else
@@ -1259,7 +1259,7 @@ int main(int argc, char * argv [])
       if(rc == LIBAVRDUDE_EXIT)
         exit(0);
       if(rc < 0) {
-        pmsg_error("unable to parse extended parameter list\n");
+        pmsg_error("unable to parse list of -x parameters\n");
         exit(1);
       }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -1440,11 +1440,14 @@ skipopen:
     if (pgm->parseexitspecs == NULL) {
       pmsg_warning("-E option not supported by this programmer type\n");
       exitspecs = NULL;
-    }
-    else if (pgm->parseexitspecs(pgm, exitspecs) < 0) {
-      usage();
-      exitrc = 1;
-      goto main_exit;
+    } else {
+      int rc = pgm->parseexitspecs(pgm, exitspecs);
+      if(rc == LIBAVRDUDE_EXIT)
+        exit(0);
+      if(rc < 0) {
+        pmsg_error("unable to parse list of -E parameters\n");
+        exit(1);
+      }
     }
   }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -900,13 +900,13 @@ static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xpara
 
         if (!help)
         {
-            pmsg_error("invalid extended parameter '%s'\n", extended_param);
+            pmsg_error("invalid extended parameter -x %s\n", extended_param);
             rv = -1;
         }
         msg_error("%s -c %s extended options:\n", progname, pgmid);
-        msg_error("  -xwait       Wait for the device to be plugged in if not connected\n");
-        msg_error("  -xwait=<arg> Wait <arg> [s] for the device to be plugged in if not connected\n");
-        msg_error("  -xhelp       Show this help menu and exit\n");
+        msg_error("  -x wait     Wait for the device to be plugged in if not connected\n");
+        msg_error("  -x wait=<n> Wait <n> s for the device to be plugged in if not connected\n");
+        msg_error("  -x help     Show this help menu and exit\n");
         return rv;
     }
 

--- a/src/par.c
+++ b/src/par.c
@@ -335,36 +335,59 @@ static void par_close(PROGRAMMER *pgm) {
  */
 static int par_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
   char *cp, *s, *str = mmt_strdup(sp);
+  int rv = 0;
+  bool help = false;
 
   s = str;
   while((cp = strtok(s, ","))) {
-    if(str_eq(cp, "reset"))
+    s = NULL;
+    if(str_eq(cp, "reset")) {
       pgm->exit_reset = EXIT_RESET_ENABLED;
-
-    else if(str_eq(cp, "noreset"))
-      pgm->exit_reset = EXIT_RESET_DISABLED;
-
-    else if(str_eq(cp, "vcc"))
-      pgm->exit_vcc = EXIT_VCC_ENABLED;
-
-    else if(str_eq(cp, "novcc"))
-      pgm->exit_vcc = EXIT_VCC_DISABLED;
-
-    else if(str_eq(cp, "d_high"))
-      pgm->exit_datahigh = EXIT_DATAHIGH_ENABLED;
-
-    else if(str_eq(cp, "d_low"))
-      pgm->exit_datahigh = EXIT_DATAHIGH_DISABLED;
-
-    else {
-      mmt_free(str);
-      return -1;
+      continue;
     }
-    s = NULL; // Only call strtok() once with the actual string
+    if(str_eq(cp, "noreset")) {
+      pgm->exit_reset = EXIT_RESET_DISABLED;
+      continue;
+    }
+    if(str_eq(cp, "vcc")) {
+      pgm->exit_vcc = EXIT_VCC_ENABLED;
+      continue;
+    }
+    if(str_eq(cp, "novcc")) {
+      pgm->exit_vcc = EXIT_VCC_DISABLED;
+      continue;
+    }
+    if(str_eq(cp, "d_high")) {
+      pgm->exit_datahigh = EXIT_DATAHIGH_ENABLED;
+      continue;
+    }
+    if(str_eq(cp, "d_low")) {
+      pgm->exit_datahigh = EXIT_DATAHIGH_DISABLED;
+      continue;
+    }
+    if (str_eq(cp, "help")) {
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
+    }
+
+    if (!help) {
+      pmsg_error("invalid exitspec parameter -E %s\n", cp);
+      rv = -1;
+    }
+    msg_error("%s -c %s exitspec parameter options:\n", progname, pgmid);
+    msg_error("  -E reset   Programmer will keep the reset line low after programming session\n");
+    msg_error("  -E noreset Programmer will not keep the reset line low after programming session\n");
+    msg_error("  -E vcc     Programmer VCC pin(s) remain active after programming session\n");
+    msg_error("  -E novcc   Programmer VCC pin(s) turned off after programming session\n");
+    msg_error("  -E d_high  Set all 8 programmer data pins high after programming session\n");
+    msg_error("  -E d_low   Set all 8 programmer data pins low after programming session\n");
+    msg_error("  -E help    Show this help menu and exit\n");
+    mmt_free(str);
+    return rv;
   }
 
   mmt_free(str);
-  return 0;
+  return rv;
 }
 
 void par_initpgm(PROGRAMMER *pgm) {

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1156,15 +1156,15 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int clock_rate;
             if (sscanf(extended_param, "clockrate=%i", &clock_rate) != 1 || clock_rate <= 0)
             {
-                pmsg_error("invalid clockrate '%s'\n", extended_param);
+                pmsg_error("invalid clock rate in -x %s\n", extended_param);
                 rv = -1;
-                continue;
+                break;
             }
 
             int clock_period = MIN(1000000 / clock_rate, 255);    // max period is 255
             clock_rate = (int)(1000000 / (clock_period + 5e-7));    // assume highest speed is 2MHz - should probably check this
 
-            pmsg_notice2("pickit2_parseextparms(): clockrate set to 0x%02x\n", clock_rate);
+            pmsg_notice2("%s(): effective clock rate set to 0x%02x\n", __func__, clock_rate);
             PDATA(pgm)->clock_period = clock_period;
             continue;
         }
@@ -1174,12 +1174,12 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
             int timeout;
             if (sscanf(extended_param, "timeout=%i", &timeout) != 1 || timeout <= 0)
             {
-                pmsg_error("invalid timeout '%s'\n", extended_param);
+                pmsg_error("invalid timeout in -x %s\n", extended_param);
                 rv = -1;
-                continue;
+                break;
             }
 
-            pmsg_notice2("pickit2_parseextparms(): usb timeout set to 0x%02x\n", timeout);
+            pmsg_notice2("%s(): usb timeout set to 0x%02x\n", __func__, timeout);
             PDATA(pgm)->transaction_timeout = timeout;
             continue;
         }
@@ -1192,13 +1192,13 @@ static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
 
         if (!help)
         {
-            pmsg_error("invalid extended parameter '%s'\n", extended_param);
+            pmsg_error("invalid extended parameter -x %s\n", extended_param);
             rv = -1;
         }
         msg_error("%s -c %s extended options:\n", progname, pgmid);
-        msg_error("  -xclockrate=<arg> Set the SPI clocking rate in <arg> [Hz]\n");
-        msg_error("  -xtimeout=<arg>   Set the timeout for USB read/write to <arg> [ms]\n");
-        msg_error("  -xhelp            Show this help menu and exit\n");
+        msg_error("  -x clockrate=<n> Set the SPI clock rate to <n> Hz\n");
+        msg_error("  -x timeout=<n>   Set the timeout for USB read/write to <n> ms\n");
+        msg_error("  -x help          Show this help menu and exit\n");
         return rv;
     }
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1145,7 +1145,7 @@ static int pickit2_read_report(const PROGRAMMER *pgm, unsigned char report[65]) 
 
 static int  pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) {
     int rv = 0;
-    bool help = true;
+    bool help = false;
 
     for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln))
     {

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -1027,7 +1027,7 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
       } else if (str_caseeq(rts_mode, "high")) {
         updi_set_rts_mode(pgm, RTS_MODE_HIGH);
       } else {
-        pmsg_error("RTS/DTR mode must be LOW or HIGH\n");
+        pmsg_error("-xrtsdtr=<mode>: RTS/DTR mode must be LOW or HIGH\n");
         rv = -1;
         break;
       }
@@ -1040,12 +1040,12 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xrtsdtr=low,high Force RTS/DTR lines low or high state during programming\n");
-    msg_error("  -xhelp            Show this help menu and exit\n");
+    msg_error("  -x rtsdtr=[low|high] Set RTS/DTR lines low/high during programming\n");
+    msg_error("  -x help              Show this help menu and exit\n");
     return rv;
   }
 

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -1027,7 +1027,7 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
       } else if (str_caseeq(rts_mode, "high")) {
         updi_set_rts_mode(pgm, RTS_MODE_HIGH);
       } else {
-        pmsg_error("-xrtsdtr=<mode>: RTS/DTR mode must be LOW or HIGH\n");
+        pmsg_error("-x rtsdtr=<mode>: RTS/DTR mode must be LOW or HIGH\n");
         rv = -1;
         break;
       }

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -1014,13 +1014,12 @@ static int serialupdi_read_sib(const PROGRAMMER *pgm, const AVRPART *p, char *si
 }
 
 static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   char rts_mode[5];
   int rv = 0;
+  bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (sscanf(extended_param, "rtsdtr=%4s", rts_mode) == 1) {
       if (str_caseeq(rts_mode, "low")) {
@@ -1029,19 +1028,25 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
         updi_set_rts_mode(pgm, RTS_MODE_HIGH);
       } else {
         pmsg_error("RTS/DTR mode must be LOW or HIGH\n");
-        return -1;
+        rv = -1;
+        break;
       }
       continue;
     }
+
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xrtsdtr=low,high Force RTS/DTR lines low or high state during programming\n");
-      msg_error("  -xhelp            Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xrtsdtr=low,high Force RTS/DTR lines low or high state during programming\n");
+    msg_error("  -xhelp            Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -482,7 +482,7 @@ static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
 
     if(str_eq(extended_param, "help")) {
       help = true;
-      return LIBAVRDUDE_EXIT;
+      rv = LIBAVRDUDE_EXIT;
     }
 
     if(!help) {

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -462,12 +462,11 @@ static int serprog_get_sck_period(const PROGRAMMER *pgm, double *v) {
 }
 
 static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rv = 0;
+  bool help = true;
 
-  for(ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for(LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if(str_starts(extended_param, "cs=")) {
       unsigned int cs;
@@ -482,14 +481,18 @@ static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
     }
 
     if(str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -x cs=<n> Sets the chip select line to CS<n> for supported programmers\n");
-      msg_error("  -x help   Show this help menu and exit\n");
+      help = true;
       return LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter -x %s\n", extended_param);
-    rv = -1;
+    if(!help) {
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -x cs=<n> Sets the chip select line to CS<n> for supported programmers\n");
+    msg_error("  -x help   Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -463,7 +463,7 @@ static int serprog_get_sck_period(const PROGRAMMER *pgm, double *v) {
 
 static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) {
   int rv = 0;
-  bool help = true;
+  bool help = false;
 
   for(LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
     const char *extended_param = ldata(ln);

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -473,8 +473,9 @@ static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
       unsigned int cs;
 
       if(sscanf(extended_param, "cs=%u", &cs) != 1) {
-        pmsg_error("invalid chip select '%s'\n", extended_param);
+        pmsg_error("invalid chip select in -x %s\n", extended_param);
         rv = -1;
+        break;
       }
       my.cs = cs;
       continue;
@@ -482,12 +483,12 @@ static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
 
     if(str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xcs=cs_num    Sets the chip select (CS) to use on supported programmers\n");
-      msg_error("  -xhelp         Show this help menu and exit\n");
+      msg_error("  -x cs=<n> Sets the chip select line to CS<n> for supported programmers\n");
+      msg_error("  -x help   Show this help menu and exit\n");
       return LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter -x %s\n", extended_param);
     rv = -1;
   }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1580,7 +1580,7 @@ static void stk500_setup(PROGRAMMER *pgm) {
   else
     PDATA(pgm)->xtal = STK500_XTAL;
   // The -c arduino programmer has auto-reset enabled be default
-  if (str_eq(pgmid, "arduino"))
+  if (str_eq(pgm->type, "Arduino"))
     PDATA(pgm)->autoreset = true;
 }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -644,7 +644,8 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param;
   int attempts;
-  int rv = 0, help = 0;
+  int rv = 0;
+  bool help = false;
 
   for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
@@ -782,7 +783,7 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     else if (str_eq(extended_param, "help")) {
-      help = 1;
+      help = true;
       rv =  LIBAVRDUDE_EXIT;
     }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -650,7 +650,7 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
    for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
      extended_param = ldata(ln);
 
-    if (sscanf(extended_param, "attempts=%2d", &attempts) == 1) {
+    if (sscanf(extended_param, "attempts=%i", &attempts) == 1) {
       PDATA(pgm)->retry_attempts = attempts;
       pmsg_info("setting number of retry attempts to %d\n", attempts);
       continue;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -640,15 +640,14 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   return pgm->program_enable(pgm, p);
 }
 
-static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
- {
-   LNODEID ln;
-   const char *extended_param;
-   int attempts;
-   int rv = 0;
+static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
+  LNODEID ln;
+  const char *extended_param;
+  int attempts;
+  int rv = 0, help = 0;
 
-   for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-     extended_param = ldata(ln);
+  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    extended_param = ldata(ln);
 
     if (sscanf(extended_param, "attempts=%i", &attempts) == 1) {
       PDATA(pgm)->retry_attempts = attempts;
@@ -783,33 +782,37 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
     }
 
     else if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xattempts=<n>        Specify the number <n> of connection retry attempts\n");
-      if (pgm->extra_features & HAS_VTARG_READ) {
-        msg_error("  -xvtarg               Read target supply voltage\n");
-      }
-      if (pgm->extra_features & HAS_VTARG_ADJ) {
-        msg_error("  -xvtarg=<arg>         Set target supply voltage\n");
-      }
-      if (pgm->extra_features & HAS_VAREF_ADJ) {
-        msg_error("  -xvaref               Read analog reference voltage\n");
-        msg_error("  -xvaref=<arg>         Set analog reference voltage\n");
-      }
-      if (pgm->extra_features & HAS_FOSC_ADJ) {
-        msg_error("  -xfosc                Read oscillator clock frequency\n");
-        msg_error("  -xfosc=<arg>[M|k]|off Set oscillator clock frequency\n");
-      }
-      msg_error("  -xxtal=<arg>[M|k]     Set programmer xtal frequency\n");
-      msg_error("  -xhelp                Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      help = 1;
+      rv =  LIBAVRDUDE_EXIT;
     }
 
-     pmsg_error("invalid extended parameter %s\n", extended_param);
-     rv = -1;
-   }
+    if (!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xattempts=<n>        Specify the number <n> of connection retry attempts\n");
+    if (pgm->extra_features & HAS_VTARG_READ) {
+      msg_error("  -xvtarg               Read target supply voltage\n");
+    }
+    if (pgm->extra_features & HAS_VTARG_ADJ) {
+      msg_error("  -xvtarg=<arg>         Set target supply voltage\n");
+    }
+    if (pgm->extra_features & HAS_VAREF_ADJ) {
+      msg_error("  -xvaref               Read analog reference voltage\n");
+      msg_error("  -xvaref=<arg>         Set analog reference voltage\n");
+    }
+    if (pgm->extra_features & HAS_FOSC_ADJ) {
+      msg_error("  -xfosc                Read oscillator clock frequency\n");
+      msg_error("  -xfosc=<arg>[M|k]|off Set oscillator clock frequency\n");
+    }
+    msg_error("  -xxtal=<arg>[M|k]     Set programmer xtal frequency\n");
+    msg_error("  -xhelp                Show this help menu and exit\n");
+    return rv;
+  }
 
-   return rv;
- }
+  return rv;
+}
 
 static void stk500_disable(const PROGRAMMER *pgm) {
   unsigned char buf[16];

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -784,7 +784,7 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 
     else if (str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xattempts=<arg>      Specify no. connection retry attempts\n");
+      msg_error("  -xattempts=<n>        Specify the number <n> of connection retry attempts\n");
       if (pgm->extra_features & HAS_VTARG_READ) {
         msg_error("  -xvtarg               Read target supply voltage\n");
       }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -116,7 +116,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
 
   for (attempt = 0; attempt < max_sync_attempts; attempt++) {
     // Restart Arduino bootloader for every sync attempt
-    if (PDATA(pgm)->autoreset && attempt > 0) {
+    if(str_eq(pgm->type, "Arduino") && PDATA(pgm)->autoreset && attempt > 0) {
       // This code assumes a negative-logic USB to TTL serial adapter
       // Pull the RTS/DTR line low to reset AVR: it is still high from open()/last attempt
       serial_set_dtr_rts(&pgm->fd, 1);
@@ -894,8 +894,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
 }
 
 
-static void stk500_close(PROGRAMMER * pgm)
-{
+static void stk500_close(PROGRAMMER *pgm) {
   // MIB510 close
   if (str_eq(pgmid, "mib510"))
     (void)mib510_isp(pgm, 0);
@@ -1569,7 +1568,7 @@ static void stk500_print_parms(const PROGRAMMER *pgm, FILE *fp) {
   stk500_print_parms1(pgm, "", fp);
 }
 
-static void stk500_setup(PROGRAMMER * pgm) {
+static void stk500_setup(PROGRAMMER *pgm) {
   pgm->cookie = mmt_malloc(sizeof(struct pdata));
   PDATA(pgm)->ext_addr_byte = 0xff;
   PDATA(pgm)->xbeeResetPin = XBEE_DEFAULT_RESET_PIN;
@@ -1578,9 +1577,12 @@ static void stk500_setup(PROGRAMMER * pgm) {
     PDATA(pgm)->xtal = 16000000U;
   else
     PDATA(pgm)->xtal = STK500_XTAL;
+  // The -c arduino programmer has auto-reset enabled be default
+  if (str_eq(pgmid, "arduino"))
+    PDATA(pgm)->autoreset = true;
 }
 
-static void stk500_teardown(PROGRAMMER * pgm) {
+static void stk500_teardown(PROGRAMMER *pgm) {
   mmt_free(pgm->cookie);
   pgm->cookie = NULL;
 }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -116,7 +116,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
 
   for (attempt = 0; attempt < max_sync_attempts; attempt++) {
     // Restart Arduino bootloader for every sync attempt
-    if (str_eq(pgm->type, "Arduino") && attempt > 0) {
+    if (PDATA(pgm)->autoreset && attempt > 0) {
       // This code assumes a negative-logic USB to TTL serial adapter
       // Pull the RTS/DTR line low to reset AVR: it is still high from open()/last attempt
       serial_set_dtr_rts(&pgm->fd, 1);

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -641,14 +641,12 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int attempts;
   int rv = 0;
   bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (sscanf(extended_param, "attempts=%i", &attempts) == 1) {
       PDATA(pgm)->retry_attempts = attempts;

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -60,6 +60,9 @@ struct pdata {
   double fosc_data;
 
   unsigned xtal;                // Set STK500 XTAL frequency
+
+  // Flag to enable/disable autoreset for the arduino programmer
+  bool autoreset;
 };
 
 #define PDATA(pgm) ((struct pdata *)(pgm->cookie))

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1928,12 +1928,11 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
 }
 
 static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rv = 0;
+  bool help = false;
 
-  for(ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for(LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     // SUFFER bits
     // Bit 7 ARDUINO: Adds control of extra LEDs when set to 0
@@ -2037,27 +2036,31 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
     }
 
     if(str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      if(pgm->extra_features & HAS_SUFFER) {
-        msg_error("  -xsuffer              Read SUFFER register value\n");
-        msg_error("  -xsuffer=<arg>        Set SUFFER register value\n");
-      }
-      if(pgm->extra_features & HAS_VTARG_SWITCH) {
-        msg_error("  -xvtarg_switch        Read on-board target voltage switch state\n");
-        msg_error("  -xvtarg_switch=<0..1> Set on-board target voltage switch state\n");
-      }
-      if(pgm->extra_features & HAS_VTARG_ADJ) {
-        msg_error("  -xvtarg               Read on-board target supply voltage\n");
-        msg_error("  -xvtarg=<arg>         Set on-board target supply voltage\n");
-      }
-      if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
-        msg_error("  -xmode=avr|pic        Set programmer to AVR or PIC mode, then exit\n");
-      msg_error  ("  -xhelp                Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter %s\n", extended_param);
-    rv = -1;
+    if(!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    if(pgm->extra_features & HAS_SUFFER) {
+      msg_error("  -xsuffer              Read SUFFER register value\n");
+      msg_error("  -xsuffer=<arg>        Set SUFFER register value\n");
+    }
+    if(pgm->extra_features & HAS_VTARG_SWITCH) {
+      msg_error("  -xvtarg_switch        Read on-board target voltage switch state\n");
+      msg_error("  -xvtarg_switch=<0..1> Set on-board target voltage switch state\n");
+    }
+    if(pgm->extra_features & HAS_VTARG_ADJ) {
+      msg_error("  -xvtarg               Read on-board target supply voltage\n");
+      msg_error("  -xvtarg=<arg>         Set on-board target supply voltage\n");
+    }
+    if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
+      msg_error("  -xmode=avr|pic        Set programmer to AVR or PIC mode, then exit\n");
+    msg_error  ("  -xhelp                Show this help menu and exit\n");
+    return rv;
   }
   return rv;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1905,10 +1905,10 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         }
         else if (str_contains(pgm->type, "STK600")) {
           msg_error("  -x varef          Read channel 0 analog reference voltage\n");
-          msg_error("  -x varef0         Alias for -xvaref\n");
+          msg_error("  -x varef0         Alias for -x varef\n");
           msg_error("  -x varef1         Read channel 1 analog reference voltage\n");
           msg_error("  -x varef=<dbl>    Set channel 0 analog reference voltage to <dbl> V\n");
-          msg_error("  -x varef0=<dbl>   Alias for -xvaref=<dbl>\n");
+          msg_error("  -x varef0=<dbl>   Alias for -x varef=<dbl>\n");
           msg_error("  -x varef1=<dbl>   Set channel 1 analog reference voltage to <dbl> V\n");
         }
       }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1757,7 +1757,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
           PDATA(pgm)->vtarg_data = (double)((int)(vtarg_set_val * 100 + .5)) / 100;
           if (sscanf_success < 1 || vtarg_set_val < 0) {
-            pmsg_error("invalid vtarg value %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
@@ -1810,7 +1810,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         if (PDATA(pgm)->varef_set) {
           PDATA(pgm)->varef_data = (double)((int)(varef_set_val * 100 + .5)) / 100;
           if (sscanf_success < 1 || varef_set_val < 0) {
-            pmsg_error("invalid varef value %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             PDATA(pgm)->varef_set = false;
             rv = -1;
             break;
@@ -1827,7 +1827,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           char fosc_str[16] = {0};
           int sscanf_success = sscanf(extended_param, "fosc=%15[0-9.eE MmKkHhZzof]", fosc_str);
           if (sscanf_success < 1) {
-            pmsg_error("invalid fosc value %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
@@ -1869,7 +1869,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         char xtal_str[16] = {0};
         int sscanf_success = sscanf(extended_param, "xtal=%15[0-9.eE MmKkHhZz]", xtal_str);
         if (sscanf_success < 1) {
-          pmsg_error("invalid xtal value %s\n", extended_param);
+          pmsg_error("invalid value in -x %s\n", extended_param);
           rv = -1;
           break;
         }
@@ -1895,33 +1895,34 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     else if (str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
       if (pgm->extra_features & HAS_VTARG_ADJ) {
-        msg_error("  -xvtarg               Read target supply voltage\n");
-        msg_error("  -xvtarg=<arg>         Set target supply voltage\n");
+        msg_error("  -x vtarg          Read target supply voltage\n");
+        msg_error("  -x vtarg=<dbl>    Set target supply voltage to <dbl> V\n");
       }
       if (pgm->extra_features & HAS_VAREF_ADJ) {
         if (str_contains(pgm->type, "STK500")) {
-          msg_error("  -xvaref               Read analog reference voltage\n");
-          msg_error("  -xvaref=<arg>         Set analog reference voltage\n");
+          msg_error("  -x varef          Read analog reference voltage\n");
+          msg_error("  -x varef=<dbl>    Set analog reference voltage to <dbl> V\n");
         }
         else if (str_contains(pgm->type, "STK600")) {
-          msg_error("  -xvaref               Read channel 0 analog reference voltage\n");
-          msg_error("  -xvaref0              Alias for -xvaref\n");
-          msg_error("  -xvaref1              Read channel 1 analog reference voltage\n");
-          msg_error("  -xvaref=<arg>         Set channel 0 analog reference voltage\n");
-          msg_error("  -xvaref0=<arg>        Alias for -xvaref=<arg>\n");
-          msg_error("  -xvaref1=<arg>        Set channel 1 analog reference voltage\n");
+          msg_error("  -x varef          Read channel 0 analog reference voltage\n");
+          msg_error("  -x varef0         Alias for -xvaref\n");
+          msg_error("  -x varef1         Read channel 1 analog reference voltage\n");
+          msg_error("  -x varef=<dbl>    Set channel 0 analog reference voltage to <dbl> V\n");
+          msg_error("  -x varef0=<dbl>   Alias for -xvaref=<dbl>\n");
+          msg_error("  -x varef1=<dbl>   Set channel 1 analog reference voltage to <dbl> V\n");
         }
       }
       if (pgm->extra_features & HAS_FOSC_ADJ) {
-        msg_error("  -xfosc                Read oscillator clock frequency\n");
-        msg_error("  -xfosc=<arg>[M|k]|off Set oscillator clock frequency\n");
+        msg_error("  -x fosc           Read oscillator clock frequency\n");
+        msg_error("  -x fosc=<n>[unit] Set oscillator clock frequency to <n> Hz (or kHz/MHz)\n");
+        msg_error("  -x fosc=off       Switch the oscillator clock off\n");
       }
-      msg_error("  -xxtal=<arg>[M|k]     Set programmer xtal frequency\n");
-      msg_error("  -xhelp                Show this help menu and exit\n");
+      msg_error("  -x xtal=<n>[unit] Set programmer xtal frequency to <n> Hz (or kHz/MHz)\n");
+      msg_error("  -x help           Show this help menu and exit\n");
       return LIBAVRDUDE_EXIT;;
     }
 
-    pmsg_error("invalid extended parameter %s\n", extended_param);
+    pmsg_error("invalid extended parameter -x %s\n", extended_param);
     rv = -1;
   }
   return rv;
@@ -1945,13 +1946,13 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
         // Set SUFFER value
         if(str_starts(extended_param, "suffer=")) {
           if(sscanf(extended_param, "suffer=%hhi", PDATA(pgm)->suffer_data+1) < 1) {
-            pmsg_error("invalid -xsuffer=<value> %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
           if((PDATA(pgm)->suffer_data[1] & 0x78) != 0x78) {
             PDATA(pgm)->suffer_data[1] |= 0x78;
-            pmsg_info("setting -xsuffer=0x%02x so that reserved bits 3..6 are set\n",
+            pmsg_info("setting -x suffer=0x%02x so that reserved bits 3..6 are set\n",
               PDATA(pgm)->suffer_data[1]);
           }
           PDATA(pgm)->suffer_set = true;
@@ -1962,7 +1963,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
           PDATA(pgm)->suffer_get = true;
           continue;
         }
-        pmsg_error("invalid suffer setting %s. Use -xsuffer or -xsuffer=<arg>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x suffer or -x suffer=<n>\n", extended_param);
         rv = -1;
         break;
       }
@@ -1974,7 +1975,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
         if(str_starts(extended_param, "vtarg_switch=")) {
           int sscanf_success = sscanf(extended_param, "vtarg_switch=%hhi", PDATA(pgm)->vtarg_switch_data+1);
           if(sscanf_success < 1 || PDATA(pgm)->vtarg_switch_data[1] > 1) {
-            pmsg_error("invalid vtarg_switch value %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
@@ -1986,7 +1987,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
           PDATA(pgm)->vtarg_switch_get = true;
           continue;
         }
-        pmsg_error("invalid vtarg_switch setting %s. Use -xvtarg_switch or -xvtarg_switch=<0..1>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x vtarg_switch or -x vtarg_switch=<0..1>\n", extended_param);
         rv = -1;
         break;
       }
@@ -2000,7 +2001,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
           int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
           PDATA(pgm)->vtarg_data = (double)((int)(vtarg_set_val * 100 + .5)) / 100;
           if(sscanf_success < 1 || vtarg_set_val < 0) {
-            pmsg_error("invalid vtarg value %s\n", extended_param);
+            pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
@@ -2012,7 +2013,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
           PDATA(pgm)->vtarg_get = true;
           continue;
         }
-        pmsg_error("invalid vtarg setting %s. Use -xvtarg or -xvtarg=<arg>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x vtarg or -x vtarg=<dbl>\n", extended_param);
         rv = -1;
         break;
       }
@@ -2030,7 +2031,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
         PDATA(pgm)->pk4_snap_mode = PK4_SNAP_MODE_PIC;
         continue;
       }
-      pmsg_error("invalid mode setting %s. Use -xmode=avr or -xmode=pic\n", extended_param);
+      pmsg_error("invalid setting in -x %s; use -x mode=avr or -x mode=pic\n", extended_param);
       rv = -1;
       break;
     }
@@ -2041,25 +2042,25 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
     }
 
     if(!help) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
     if(pgm->extra_features & HAS_SUFFER) {
-      msg_error("  -xsuffer              Read SUFFER register value\n");
-      msg_error("  -xsuffer=<arg>        Set SUFFER register value\n");
+      msg_error("  -x suffer              Read SUFFER register value\n");
+      msg_error("  -x suffer=<n>          Set SUFFER register value to <n>=0x.., 0... or decimal\n");
     }
     if(pgm->extra_features & HAS_VTARG_SWITCH) {
-      msg_error("  -xvtarg_switch        Read on-board target voltage switch state\n");
-      msg_error("  -xvtarg_switch=<0..1> Set on-board target voltage switch state\n");
+      msg_error("  -x vtarg_switch        Read on-board target voltage switch state\n");
+      msg_error("  -x vtarg_switch=<0..1> Set on-board target voltage switch state\n");
     }
     if(pgm->extra_features & HAS_VTARG_ADJ) {
-      msg_error("  -xvtarg               Read on-board target supply voltage\n");
-      msg_error("  -xvtarg=<arg>         Set on-board target supply voltage\n");
+      msg_error("  -x vtarg               Read on-board target supply voltage\n");
+      msg_error("  -x vtarg=<dbl>         Set on-board target supply voltage to <dbl> V\n");
     }
     if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
-      msg_error("  -xmode=avr|pic        Set programmer to AVR or PIC mode, then exit\n");
-    msg_error  ("  -xhelp                Show this help menu and exit\n");
+      msg_error("  -x mode=avr|pic        Set programmer to AVR or PIC mode, then exit\n");
+    msg_error  ("  -x help                Show this help menu and exit\n");
     return rv;
   }
   return rv;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1742,12 +1742,11 @@ static void stk500v2_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rv = 0;
+  bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (str_starts(extended_param, "vtarg")) {
       if (pgm->extra_features & HAS_VTARG_ADJ) {
@@ -1772,7 +1771,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       }
     }
 
-    else if (str_starts(extended_param, "varef")) {
+    if (str_starts(extended_param, "varef")) {
       if (pgm->extra_features & HAS_VAREF_ADJ) {
         int sscanf_success = 0;
         double varef_set_val = -1;
@@ -1820,7 +1819,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       }
     }
 
-    else if (str_starts(extended_param, "fosc")) {
+    if (str_starts(extended_param, "fosc")) {
       if (pgm->extra_features & HAS_FOSC_ADJ) {
         // Set clock generator frequency
         if (str_starts(extended_param, "fosc=")) {
@@ -1863,7 +1862,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       }
     }
 
-    else if (str_starts(extended_param, "xtal")) {
+    if (str_starts(extended_param, "xtal")) {
       // Set clock generator frequency
       if (str_starts(extended_param, "xtal=")) {
         char xtal_str[16] = {0};
@@ -1892,38 +1891,42 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       }
     }
 
-    else if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      if (pgm->extra_features & HAS_VTARG_ADJ) {
-        msg_error("  -x vtarg          Read target supply voltage\n");
-        msg_error("  -x vtarg=<dbl>    Set target supply voltage to <dbl> V\n");
-      }
-      if (pgm->extra_features & HAS_VAREF_ADJ) {
-        if (str_contains(pgm->type, "STK500")) {
-          msg_error("  -x varef          Read analog reference voltage\n");
-          msg_error("  -x varef=<dbl>    Set analog reference voltage to <dbl> V\n");
-        }
-        else if (str_contains(pgm->type, "STK600")) {
-          msg_error("  -x varef          Read channel 0 analog reference voltage\n");
-          msg_error("  -x varef0         Alias for -x varef\n");
-          msg_error("  -x varef1         Read channel 1 analog reference voltage\n");
-          msg_error("  -x varef=<dbl>    Set channel 0 analog reference voltage to <dbl> V\n");
-          msg_error("  -x varef0=<dbl>   Alias for -x varef=<dbl>\n");
-          msg_error("  -x varef1=<dbl>   Set channel 1 analog reference voltage to <dbl> V\n");
-        }
-      }
-      if (pgm->extra_features & HAS_FOSC_ADJ) {
-        msg_error("  -x fosc           Read oscillator clock frequency\n");
-        msg_error("  -x fosc=<n>[unit] Set oscillator clock frequency to <n> Hz (or kHz/MHz)\n");
-        msg_error("  -x fosc=off       Switch the oscillator clock off\n");
-      }
-      msg_error("  -x xtal=<n>[unit] Set programmer xtal frequency to <n> Hz (or kHz/MHz)\n");
-      msg_error("  -x help           Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+    if (str_eq(extended_param, "help")) {
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter -x %s\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    if (pgm->extra_features & HAS_VTARG_ADJ) {
+      msg_error("  -x vtarg          Read target supply voltage\n");
+      msg_error("  -x vtarg=<dbl>    Set target supply voltage to <dbl> V\n");
+    }
+    if (pgm->extra_features & HAS_VAREF_ADJ) {
+      if (str_contains(pgm->type, "STK500")) {
+        msg_error("  -x varef          Read analog reference voltage\n");
+        msg_error("  -x varef=<dbl>    Set analog reference voltage to <dbl> V\n");
+      }
+      else if (str_contains(pgm->type, "STK600")) {
+        msg_error("  -x varef          Read channel 0 analog reference voltage\n");
+        msg_error("  -x varef0         Alias for -x varef\n");
+        msg_error("  -x varef1         Read channel 1 analog reference voltage\n");
+        msg_error("  -x varef=<dbl>    Set channel 0 analog reference voltage to <dbl> V\n");
+        msg_error("  -x varef0=<dbl>   Alias for -x varef=<dbl>\n");
+        msg_error("  -x varef1=<dbl>   Set channel 1 analog reference voltage to <dbl> V\n");
+      }
+    }
+    if (pgm->extra_features & HAS_FOSC_ADJ) {
+      msg_error("  -x fosc           Read oscillator clock frequency\n");
+      msg_error("  -x fosc=<n>[unit] Set oscillator clock frequency to <n> Hz (or kHz/MHz)\n");
+      msg_error("  -x fosc=off       Switch the oscillator clock off\n");
+    }
+    msg_error("  -x xtal=<n>[unit] Set programmer xtal frequency to <n> Hz (or kHz/MHz)\n");
+    msg_error("  -x help           Show this help menu and exit\n");
+    return rv;
   }
   return rv;
 }

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -343,7 +343,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
 
     if (port != NULL && dev_name == NULL)
     {
-        pmsg_error("invalid -P value: '%s'\n", port);
+        pmsg_error("invalid -P value: %s\n", port);
         imsg_error("Use -P usb:bus:device\n");
         return -1;
     }
@@ -561,13 +561,13 @@ static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
 
         if (!help)
         {
-            pmsg_error("invalid extended parameter '%s'\n", extended_param);
+            pmsg_error("invalid extended parameter -x %s\n", extended_param);
             rv =  -1;
         }
         msg_error("%s -c %s extended options:\n", progname, pgmid);
-        msg_error("  -xwait       Wait for the device to be plugged in if not connected\n");
-        msg_error("  -xwait=<arg> Wait <arg> [s] for the device to be plugged in if not connected\n");
-        msg_error("  -xhelp       Show this help menu and exit\n");
+        msg_error("  -x wait     Wait for the device to be plugged in if not connected\n");
+        msg_error("  -x wait=<n> Wait <n> s for the device to be plugged in if not connected\n");
+        msg_error("  -x help     Show this help menu and exit\n");
         return rv;
     }
 

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -530,39 +530,48 @@ static int teensy_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 }
 
 static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
+    int rv = 0;
+    bool help = false;
     pmsg_debug("teensy_parseextparams()\n");
 
     struct pdata *pdata = PDATA(pgm);
-    for (LNODEID node = lfirst(xparams); node != NULL; node = lnext(node))
+    for (LNODEID node = lfirst(xparams); node; node = lnext(node))
     {
-        const char* param = ldata(node);
+        const char* extended_param = ldata(node);
 
-        if (str_eq(param, "wait"))
+        if (str_eq(extended_param, "wait"))
         {
             pdata->wait_until_device_present = true;
             pdata->wait_timout = -1;
+            continue;
         }
-        else if (str_starts(param, "wait="))
+
+        if (str_starts(extended_param, "wait="))
         {
             pdata->wait_until_device_present = true;
-            pdata->wait_timout = atoi(param + 5);
+            pdata->wait_timout = atoi(extended_param + 5);
+            continue;
         }
-        else if (str_eq(param, "help"))
+
+        if (str_eq(extended_param, "help"))
         {
-            msg_error("%s -c %s extended options:\n", progname, pgmid);
-            msg_error("  -xwait       Wait for the device to be plugged in if not connected\n");
-            msg_error("  -xwait=<arg> Wait <arg> [s] for the device to be plugged in if not connected\n");
-            msg_error("  -xhelp       Show this help menu and exit\n");
-            return LIBAVRDUDE_EXIT;;
+            help = true;
+            rv = LIBAVRDUDE_EXIT;
         }
-        else
+
+        if (!help)
         {
-            pmsg_error("invalid extended parameter '%s'\n", param);
-            return -1;
+            pmsg_error("invalid extended parameter '%s'\n", extended_param);
+            rv =  -1;
         }
+        msg_error("%s -c %s extended options:\n", progname, pgmid);
+        msg_error("  -xwait       Wait for the device to be plugged in if not connected\n");
+        msg_error("  -xwait=<arg> Wait <arg> [s] for the device to be plugged in if not connected\n");
+        msg_error("  -xhelp       Show this help menu and exit\n");
+        return rv;
     }
 
-    return 0;
+    return rv;
 }
 
 void teensy_initpgm(PROGRAMMER *pgm) {

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1311,7 +1311,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
   // Manual provision of above bootloader parameters
   if(ur.xbootsize) {
     if(ur.boothigh && ur.xbootsize % ur.uP.pagesize)
-      Return("-xbootsize=%d size not a multiple of flash page size %d",
+      Return("-x bootsize=%d size not a multiple of flash page size %d",
         ur.xbootsize, ur.uP.pagesize);
     if(ur.xbootsize < 64 || ur.xbootsize > urmin(8192, ur.uP.flashsize/4))
       Return("implausible -x bootsize=%d, should be in [64, %d]",
@@ -1342,8 +1342,8 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
 
   if(ur.urprotocol && !(ur.urfeatures & UB_READ_FLASH)) // Bootloader that cannot read flash?
     if(ur.blend <= ur.blstart)
-      Return("please specify -x bootsize=<num> and, if needed, %s-xeepromrw",
-        ur.boothigh? "-xvectornum=<num> or ": "");
+      Return("please specify -x bootsize=<num> and, if needed, %s-x eepromrw",
+        ur.boothigh? "-x vectornum=<num> or ": "");
 
   uint16_t v16 = 0xffff, rjmpwp = ret_opcode;
 
@@ -1822,13 +1822,13 @@ static int parseUrclockID(const PROGRAMMER *pgm) {
     int ad, lg;
 
     if(!(strchr("EF", *idstr) && idstr[1] == '.')) {
-      pmsg_warning("-xid=%s string must start with E. or F.\n", ur.iddesc);
+      pmsg_warning("-x id=%s string must start with E. or F.\n", ur.iddesc);
       mmt_free(idstr);
       return -1;
     }
 
     if(!(idlenp = strchr(idstr+2, '.'))) {
-      pmsg_warning("-xid=%s string must look like [E|F].<addr>.<len>\n", ur.iddesc);
+      pmsg_warning("-x id=%s string must look like [E|F].<addr>.<len>\n", ur.iddesc);
       mmt_free(idstr);
       return -1;
     }

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -586,7 +586,7 @@ static int urclock_flash_readhook(const PROGRAMMER *pgm, const AVRPART *p, const
 
   // Check size of uploded application and protect bootloader from being overwritten
   if((ur.boothigh && size > maxsize) || (!ur.boothigh && firstbeg <= ur.blend))
-    Return("input [0x%04x, 0x%04x] overlaps bootloader [0x%04x, 0x%04x]; consider -xrestore",
+    Return("input [0x%04x, 0x%04x] overlaps b/loader [0x%04x, 0x%04x]; consider -x restore",
       firstbeg, size-1, ur.blstart, ur.blend);
 
   if(size > maxsize)
@@ -595,11 +595,11 @@ static int urclock_flash_readhook(const PROGRAMMER *pgm, const AVRPART *p, const
 
   if(!ur.nometadata) {
     if(size == maxsize)
-      Return("input [0x%04x, 0x%04x] overlaps metadata code byte at 0x%04x, consider -xnometadata",
+      Return("input [0x%04x, 0x%04x] overlaps metadata byte at 0x%04x, consider -x nometadata",
         firstbeg, size-1, ur.pfend);
 
     if(nmdata >= nmeta(0, ur.uP.flashsize) && size > maxsize - nmeta(0, ur.uP.flashsize)) {
-      pmsg_warning("input [0x%04x, 0x%04x] overlaps metadata [0x%04x, 0x%04x], selecting -xnostore\n",
+      pmsg_warning("input [0x%04x, 0x%04x] overlaps metadata [0x%04x, 0x%04x], selecting -x nostore\n",
        firstbeg, size-1, maxsize-nmdata, ur.pfend);
       ur.mcode = 0xff;
       ur.nostore = 1;
@@ -607,7 +607,7 @@ static int urclock_flash_readhook(const PROGRAMMER *pgm, const AVRPART *p, const
     }
 
     if(nmdata >= nmeta(1, ur.uP.flashsize) && size > maxsize - nmeta(1, ur.uP.flashsize)) {
-      pmsg_warning("input [0x%04x, 0x%04x] overlaps metadata [0x%04x, 0x%04x], selecting -xnodate\n",
+      pmsg_warning("input [0x%04x, 0x%04x] overlaps metadata [0x%04x, 0x%04x], selecting -x nodate\n",
         firstbeg, size-1, maxsize-nmdata, ur.pfend);
       ur.mcode = 0;
       ur.nodate = 1;
@@ -615,7 +615,7 @@ static int urclock_flash_readhook(const PROGRAMMER *pgm, const AVRPART *p, const
     }
 
     if(size > maxsize - nmdata) {
-      pmsg_warning("input [0x%04x, 0x%04x] overlaps metadata [0x%04x, 0x%04x], selecting -xnofilename\n",
+      pmsg_warning("input [0x%04x, 0x%04x] overlaps metadata [0x%04x, 0x%04x], selecting -x nofilename\n",
         firstbeg, size-1, maxsize-nmdata, ur.pfend);
       ur.mcode = 1;
       ur.nofilename = 1;
@@ -1314,7 +1314,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
       Return("-xbootsize=%d size not a multiple of flash page size %d",
         ur.xbootsize, ur.uP.pagesize);
     if(ur.xbootsize < 64 || ur.xbootsize > urmin(8192, ur.uP.flashsize/4))
-      Return("implausible -xbootsize=%d, should be in [64, %d]",
+      Return("implausible -x bootsize=%d, should be in [64, %d]",
         ur.xbootsize, urmin(8192, ur.uP.flashsize/4));
     if(ur.boothigh) {
       ur.blstart = flm->size - ur.xbootsize;
@@ -1342,7 +1342,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
 
   if(ur.urprotocol && !(ur.urfeatures & UB_READ_FLASH)) // Bootloader that cannot read flash?
     if(ur.blend <= ur.blstart)
-      Return("please specify -xbootsize=<num> and, if needed, %s-xeepromrw",
+      Return("please specify -x bootsize=<num> and, if needed, %s-xeepromrw",
         ur.boothigh? "-xvectornum=<num> or ": "");
 
   uint16_t v16 = 0xffff, rjmpwp = ret_opcode;
@@ -1377,7 +1377,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
           if(rjmpwp == ret_opcode || (dfromend >= -blsize && dfromend < -6)) { // Due diligence
             if(ur.xbootsize) {
               if(flm->size - blsize != ur.blstart) {
-                pmsg_warning("urboot bootloader size %d explicitly overwritten by -xbootsize=%d\n",
+                pmsg_warning("urboot bootloader size %d explicitly overwritten by -x bootsize=%d\n",
                   blsize, ur.xbootsize);
                 if(!ovsigck && vectnum) {
                   imsg_warning("this can lead to bricking the vector bootloader\n");
@@ -1392,7 +1392,7 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
 
             if(ur.xvectornum != -1) {
               if(ur.vblvectornum != vectnum) {
-                pmsg_warning("urboot vector number %d overwritten by -xvectornum=%d\n",
+                pmsg_warning("urboot vector number %d overwritten by -x vectornum=%d\n",
                   vectnum, ur.xvectornum);
                 imsg_warning("the application might not start correctly\n");
               }
@@ -1499,9 +1499,9 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
     // Still no bootloader start address?
     if(ur.blend <= ur.blstart) {
       if(ur. bloptiversion)
-        Return("bootloader might be optiboot %d.%d? Please use -xbootsize=<num>\n",
+        Return("bootloader might be optiboot %d.%d? Please use -x bootsize=<num>\n",
           ur.bloptiversion>>8, ur.bloptiversion & 255);
-      Return("unknown bootloader ... please specify -xbootsize=<num>\n");
+      Return("unknown bootloader ... please specify -x bootsize=<num>\n");
     }
   } else if(!ur.boothigh) { // @@@ Fixme: guess bootloader size from low flash
   }
@@ -1794,7 +1794,7 @@ static int ur_readEF(const PROGRAMMER *pgm, const AVRPART *p, uint8_t *buf, uint
 
   if(mchr == 'E' && !ur.bleepromrw && !ur.xeepromrw)
     Return("bootloader %s not have EEPROM access%s", ur.blurversion? "does": "might",
-      ur.blurversion? " capability": "; try -xeepromrw if it has");
+      ur.blurversion? " capability": "; try -x eepromrw if it has");
 
   if(len < 1 || len > urmax(ur.uP.pagesize, 256))
     Return("len %d exceeds range [1, %d]", len, urmax(ur.uP.pagesize, 256));
@@ -1816,7 +1816,7 @@ static int ur_readEF(const PROGRAMMER *pgm, const AVRPART *p, uint8_t *buf, uint
 
 
 static int parseUrclockID(const PROGRAMMER *pgm) {
-  if(*ur.iddesc) {              // User override of ID, eg, -xid=F.-4.2 for penultimate flash word
+  if(*ur.iddesc) {              // User override of ID, eg, -x id=F.-4.2 for penultimate flash word
     char *idstr = mmt_strdup(ur.iddesc), *idlenp;
     const char *errstr;
     int ad, lg;
@@ -1835,19 +1835,19 @@ static int parseUrclockID(const PROGRAMMER *pgm) {
     *idlenp++ = 0;
     ad = str_int(idstr+2, STR_INT32, &errstr);
     if(errstr) {
-      pmsg_warning("address %s of -xid=%s: %s\n", idstr+2, ur.iddesc, errstr);
+      pmsg_warning("address %s of -x id=%s: %s\n", idstr+2, ur.iddesc, errstr);
       mmt_free(idstr);
       return -1;
     }
 
     lg = str_int(idlenp, STR_INT32, &errstr);
     if(errstr) {
-      pmsg_warning("length %s of -xid=%s string: %s\n", idlenp, ur.iddesc, errstr);
+      pmsg_warning("length %s of -x id=%s string: %s\n", idlenp, ur.iddesc, errstr);
       mmt_free(idstr);
       return -1;
     }
     if(!lg || lg > 8) {
-      pmsg_warning("length %s of -xid=%s string must be between 1 and 8\n", idlenp, ur.iddesc);
+      pmsg_warning("length %s of -x id=%s string must be between 1 and 8\n", idlenp, ur.iddesc);
       mmt_free(idstr);
       return -1;
     }
@@ -1874,7 +1874,7 @@ static int readUrclockID(const PROGRAMMER *pgm, const AVRPART *p, uint64_t *urcl
 
   *urclockIDp = 0;
 
-  // Sanity for small boards in absence of user -xid=... option
+  // Sanity for small boards in absence of user -x id=... option
   if(!ur.idlen && (addr >= ur.uP.eepromsize || addr+len > ur.uP.eepromsize)) {
     addr = 0;
     if(ur.uP.eepromsize < 8)
@@ -1890,11 +1890,11 @@ static int readUrclockID(const PROGRAMMER *pgm, const AVRPART *p, uint64_t *urcl
       addr += size;
 
     if(addr < 0 || addr >= size)
-      Return("effective address %d of -xids=%s string out of %s range [0, 0x%04x]\n",
+      Return("effective address %d of -x ids=%s string out of %s range [0, 0x%04x]\n",
         addr, ur.iddesc, memstr, size-1);
 
     if(addr+len > size)
-      Return("memory range [0x%04x, 0x%04x] of -xid=%s out of %s range [0, 0x%04x]\n",
+      Return("memory range [0x%04x, 0x%04x] of -x id=%s out of %s range [0, 0x%04x]\n",
         addr, addr+len-1, ur.iddesc, memstr, size-1);
   }
 
@@ -1926,7 +1926,7 @@ static int urclock_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
   if(rv < 0) {
     if(ur.sync_silence < 2)
       pmsg_warning("programmer is not responding%s\n",
-        ur.sync_silence? "; try -xstrict and/or vary -xdelay=100": "");
+        ur.sync_silence? "; try -x strict and/or vary -x delay=100": "");
     return -1;
   }
 
@@ -1982,7 +1982,7 @@ static int urclock_getsync(const PROGRAMMER *pgm) {
      * of step through a missing byte. If AVRDUDE then sends the next request starting with a
      * Cmnd_STK_GET_SYNC command then optiboot v4.4 will bail as ist's not Sync_CRC_EOP. Hence, the
      * strategy here is to send Sync_CRC_EOP/Sync_CRC_EOP for getting a sync. For those bootloaders
-     * that are strict about the protocol, eg, picoboot, the presence of -xstrict implies that
+     * that are strict about the protocol, eg, picoboot, the presence of -x strict implies that
      * comms should use Cmnd_STK_GET_SYNC for getting in sync.
      */
     iob[0] = attempt == 0? autobaud_sync: ur.strict? Cmnd_STK_GET_SYNC: Sync_CRC_EOP;
@@ -2295,7 +2295,7 @@ static int urclock_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
     if(mchr == 'E' && !ur.bleepromrw && !ur.xeepromrw)
       Return("bootloader %s not have paged EEPROM write%s", ur.blurversion? "does": "might",
-        ur.blurversion? " capability": ", try -xeepromrw if it has");
+        ur.blurversion? " capability": ", try -x eepromrw if it has");
 
     n = addr + n_bytes;
 
@@ -2330,7 +2330,7 @@ static int urclock_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
     if(mchr == 'E' && !ur.bleepromrw && !ur.xeepromrw)
       Return("bootloader %s not have paged EEPROM read%s", ur.blurversion? "does": "might",
-        ur.blurversion? " capability": "; try -xeepromrw if it has");
+        ur.blurversion? " capability": "; try -x eepromrw if it has");
 
     n = addr + n_bytes;
     for(; addr < n; addr += chunk) {
@@ -2470,7 +2470,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
     {"id", NULL, sizeof ur.iddesc, ur.iddesc, 1, "Location of Urclock ID, eg, F.12345.6"},
     {"title", NULL, sizeof ur.title, ur.title, 1, "Title stored and shown in lieu of a filename"},
     {"bootsize", &ur.xbootsize, ARG,      "Override/set bootloader size"},
-    {"vectornum", &ur.xvectornum, ARG,    "Treat bootloader as vector b/loader using this vector"},
+    {"vectornum", &ur.xvectornum, ARG,    "Treat bootloader as vector b/loader using vector <n>"},
     {"eepromrw", &ur.xeepromrw, NA,       "Assert bootloader EEPROM read/write capability"},
     {"emulate_ce", &ur.xemulate_ce, NA,   "Emulate chip erase"},
     {"restore", &ur.restore, NA,          "Restore a flash backup and trim the bootloader"},
@@ -2481,7 +2481,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
     {"nostore", &ur.nostore, NA,          "Do not store metadata except a flag saying so"},
     {"nometadata", &ur.nometadata, NA,    "Do not support metadata at all"},
     {"noautoreset", &ur.nometadata, NA,   "Do not reset the board after opening the serial port"},
-    {"delay", &ur.delay, ARG,             "Add delay [ms] after reset, can be negative"},
+    {"delay", &ur.delay, ARG,             "Additional <n> ms delay after reset, can be negative"},
     {"strict", &ur.strict, NA,            "Use strict synchronisation protocol"},
     {"help", &help, NA,                   "Show this help menu and exit"},
   };
@@ -2508,8 +2508,9 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
             const char *errstr;
             int val = str_int(arg, STR_INT32, &errstr);
             if(errstr) {
-             pmsg_error("-x%s: %s\n", extended_param, errstr);
-             return -1;
+              pmsg_error("-x %s: %s\n", extended_param,
+                str_eq(errstr, "no data to convert")? "missing argument": errstr);
+              return -1;
             }
             *options[i].optionp = val;
             pmsg_notice2("%s=%d set\n", options[i].name, (int) val);
@@ -2517,7 +2518,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
           }
         } else if(options[i].nstrbuf > 0) {
           if(plen <= olen || extended_param[olen] != '=') {
-            pmsg_error("missing argument for option %s=...\n", extended_param);
+            pmsg_error("missing argument for -x %s=...\n", extended_param);
             rc = -1;
           } else {
             if(options[i].strbuf) {
@@ -2530,7 +2531,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
       }
     }
     if(i >= sizeof options/sizeof*options) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rc = -1;
     }
   }
@@ -2538,7 +2539,8 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
   if(help || rc < 0) {
     msg_error("%s -c %s extended options:\n", progname, pgmid);
     for(size_t i=0; i<sizeof options/sizeof*options; i++) {
-      msg_error("  -x%s%s%*s%s\n", options[i].name, options[i].assign? "=<arg>": "",
+      msg_error("  -x %s%s%*s%s\n", options[i].name,
+        options[i].assign && options[i].strbuf? "=<str>": options[i].assign? "=<n>  ": "",
         urmax(0, 16-(int) strlen(options[i].name)-(options[i].assign? 6: 0)), "", options[i].help);
     }
     if(rc == 0)

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -296,12 +296,12 @@ static int usbasp_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
     if (str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xsection_config Erase configuration section only with -e (TPI only)\n");
-      msg_error("  -xhelp           Show this help menu and exit\n");
+      msg_error("  -x section_config  Erase configuration section only with -e (TPI only)\n");
+      msg_error("  -x help            Show this help menu and exit\n");
       return LIBAVRDUDE_EXIT;;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter -x %s\n", extended_param);
     rv = -1;
   }
 

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -282,27 +282,31 @@ static void usbasp_teardown(PROGRAMMER *pgm) {
 }
 
 static int usbasp_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rv = 0;
+  bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (str_eq(extended_param, "section_config")) {
       pmsg_notice2("usbasp_parseextparms(): set section_e to 1 (config section)\n");
       PDATA(pgm)->section_e = 1;
       continue;
     }
+
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -x section_config  Erase configuration section only with -e (TPI only)\n");
-      msg_error("  -x help            Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      help = true;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter -x %s\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -x section_config  Erase configuration section only with -e (TPI only)\n");
+    msg_error("  -x help            Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -357,7 +357,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   }
 
   if(NULL != name && NULL == dev_name) {
-    pmsg_error("invalid -P value: '%s'\n", name);
+    pmsg_error("invalid -P value: %s\n", name);
     imsg_error("use -P usb:bus:device\n");
     return -1;
   }

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -108,25 +108,20 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       WIRINGPDATA(pgm)->delay = val;
       continue;
     }
-    else if(str_starts(extended_param, "no_autoreset")) {
-      if(!str_eq(extended_param, "no_autoreset")) {
-        pmsg_error("invalid -xno_autoreset value %s. Use -xno_autoreset\n", extended_param);
-        rv = -1;
-        break;
-      }
+    else if(str_eq(extended_param, "noautoreset")) {
       WIRINGPDATA(pgm)->autoreset = false;
       continue;
     }
     else if (str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xsnooze=<arg> Wait snooze [ms] before protocol sync after port open\n");
-      msg_error("  -xdelay=<arg>  Add delay [ms] after reset, can be negative\n");
-      msg_error("  -xno_autoreset Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
-      msg_error("  -xhelp         Show this help menu and exit\n");
+      msg_error("  -xsnooze=<n>  Wait snooze <n> ms before protocol sync after port open\n");
+      msg_error("  -xdelay=<n>   Add delay [n] ms after reset, can be negative\n");
+      msg_error("  -xnoautoreset Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
+      msg_error("  -xhelp        Show this help menu and exit\n");
       return LIBAVRDUDE_EXIT;;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
+    pmsg_error("invalid extended parameter %s\n", extended_param);
     rv = -1;
   }
 

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -56,7 +56,7 @@
  */
 struct wiringpdata {
   int snoozetime, delay;
-  bool autoreset;
+  bool noautoreset;
 };
 
 
@@ -113,7 +113,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if(str_eq(extended_param, "noautoreset")) {
-      WIRINGPDATA(pgm)->autoreset = false;
+      WIRINGPDATA(pgm)->noautoreset = true;
       continue;
     }
 
@@ -154,7 +154,7 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
     while (timetosnooze--)
       usleep(1000);
     pmsg_notice2("%s(): done snoozing\n", __func__);
-  } else if (WIRINGPDATA(pgm)->autoreset) {
+  } else if (WIRINGPDATA(pgm)->noautoreset == false) {
     // This code assumes a negative-logic USB to TTL serial adapter
     // Set RTS/DTR high to discharge the series-capacitor, if present
     pmsg_notice2("%s(): releasing DTR/RTS\n", __func__);
@@ -199,7 +199,6 @@ void wiring_initpgm(PROGRAMMER *pgm) {
   stk500v2_initpgm(pgm);
 
   strcpy(pgm->type, "Wiring");
-  WIRINGPDATA(&pgm)->autoreset = true; // Auto-reset enabled by default
 
   pgm->open           = wiring_open;
   pgm->close          = wiring_close;

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -83,7 +83,7 @@ static void wiring_teardown(PROGRAMMER *pgm) {
 static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param, *errstr;
-  int rv = 0;
+  int rv = 0, help = 0;
 
   for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
@@ -113,16 +113,20 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
     else if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xsnooze=<n>  Wait snooze <n> ms before protocol sync after port open\n");
-      msg_error("  -xdelay=<n>   Add delay [n] ms after reset, can be negative\n");
-      msg_error("  -xnoautoreset Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
-      msg_error("  -xhelp        Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      help = 1;
+      rv = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter %s\n", extended_param);
-    rv = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter %s\n", extended_param);
+      rv = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xsnooze=<n>  Wait snooze <n> ms before protocol sync after port open\n");
+    msg_error("  -xdelay=<n>   Add delay [n] ms after reset, can be negative\n");
+    msg_error("  -xnoautoreset Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
+    msg_error("  -xhelp        Show this help menu and exit\n");
+    return rv;
   }
 
   return rv;

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -91,17 +91,19 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     if (str_starts(extended_param, "snooze=")) {
       int val = str_int(extended_param+7, STR_INT32, &errstr);
       if(errstr || val < 0) {
-        pmsg_error("-x%s: %s\n", extended_param, errstr? errstr: "snooze time cannot be negative");
+        pmsg_error("-x %s: %s\n", extended_param, errstr? errstr: "snooze time cannot be negative");
         rv = -1;
-        continue;
+        break;
       }
       pmsg_notice2("%s(): snooze time set to %d ms\n", __func__, val);
       WIRINGPDATA(pgm)->snoozetime = val;
       continue;
-    } else if (str_starts(extended_param, "delay=")) {
+    }
+
+    if (str_starts(extended_param, "delay=")) {
       int val = str_int(extended_param+6, STR_INT32, &errstr);
       if(errstr) {
-        pmsg_error("-x%s: %s\n", extended_param, errstr);
+        pmsg_error("-x %s: %s\n", extended_param, errstr);
         rv = -1;
         break;
       }
@@ -109,24 +111,26 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       WIRINGPDATA(pgm)->delay = val;
       continue;
     }
-    else if(str_eq(extended_param, "noautoreset")) {
+
+    if(str_eq(extended_param, "noautoreset")) {
       WIRINGPDATA(pgm)->autoreset = false;
       continue;
     }
-    else if (str_eq(extended_param, "help")) {
+
+    if (str_eq(extended_param, "help")) {
       help = true;
       rv = LIBAVRDUDE_EXIT;
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter %s\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xsnooze=<n>  Wait snooze <n> ms before protocol sync after port open\n");
-    msg_error("  -xdelay=<n>   Add delay [n] ms after reset, can be negative\n");
-    msg_error("  -xnoautoreset Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
-    msg_error("  -xhelp        Show this help menu and exit\n");
+    msg_error("  -x snooze=<n>   Wait snooze <n> ms before protocol sync after port open\n");
+    msg_error("  -x delay=<n>    Add delay [n] ms after reset, can be negative\n");
+    msg_error("  -x noautoreset  Don't toggle RTS/DTR lines on port open to prevent a hardware reset\n");
+    msg_error("  -x help         Show this help menu and exit\n");
     return rv;
   }
 
@@ -175,7 +179,7 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
   stk500v2_drain(pgm, 0);
 
   if (stk500v2_getsync(pgm) < 0) {
-    pmsg_error("stk500v2_getsync() failed; try -xdelay=n with some n in [-80, 100]\n");
+    pmsg_error("stk500v2_getsync() failed; try -x delay=n with some n in [-80, 100]\n");
     return -1;
   }
 

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -81,13 +81,12 @@ static void wiring_teardown(PROGRAMMER *pgm) {
 }
 
 static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param, *errstr;
+  const char *errstr;
   int rv = 0;
   bool help = 0;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (str_starts(extended_param, "snooze=")) {
       int val = str_int(extended_param+7, STR_INT32, &errstr);
@@ -103,7 +102,8 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int val = str_int(extended_param+6, STR_INT32, &errstr);
       if(errstr) {
         pmsg_error("-x%s: %s\n", extended_param, errstr);
-        return -1;
+        rv = -1;
+        break;
       }
       pmsg_notice2("%s(): delay set to %d ms\n", __func__, val);
       WIRINGPDATA(pgm)->delay = val;

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -83,7 +83,8 @@ static void wiring_teardown(PROGRAMMER *pgm) {
 static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
   LNODEID ln;
   const char *extended_param, *errstr;
-  int rv = 0, help = 0;
+  int rv = 0;
+  bool help = 0;
 
   for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
     extended_param = ldata(ln);
@@ -113,7 +114,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       continue;
     }
     else if (str_eq(extended_param, "help")) {
-      help = 1;
+      help = true;
       rv = LIBAVRDUDE_EXIT;
     }
 

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1632,9 +1632,9 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       int resetpin;
       if (sscanf(extended_param, "xbeeresetpin=%i", &resetpin) != 1 ||
           resetpin <= 0 || resetpin > 7) {
-        pmsg_error("invalid xbeeresetpin '%s'\n", extended_param);
+        pmsg_error("invalid value in -x %s\n", extended_param);
         rc = -1;
-        continue;
+        break;
       }
 
       PDATA(pgm)->xbeeResetPin = resetpin;
@@ -1647,12 +1647,12 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if (!help) {
-      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      pmsg_error("invalid extended parameter -x %s\n", extended_param);
       rc = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    msg_error("  -xxbeeresetpin=<1..7> Set XBee pin DIO<1..7> as reset pin\n");
-    msg_error("  -xhelp                Show this help menu and exit\n");
+    msg_error("  -x xbeeresetpin=<1..7> Set XBee pin DIO<1..7> as reset pin\n");
+    msg_error("  -x help                Show this help menu and exit\n");
     return rc;
   }
 

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1622,12 +1622,11 @@ static void xbee_close(PROGRAMMER *pgm)
 }
 
 static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
-  LNODEID ln;
-  const char *extended_param;
   int rc = 0;
+  bool help = false;
 
-  for (ln = lfirst(extparms); ln; ln = lnext(ln)) {
-    extended_param = ldata(ln);
+  for (LNODEID ln = lfirst(extparms); ln; ln = lnext(ln)) {
+    const char *extended_param = ldata(ln);
 
     if (str_starts(extended_param, "xbeeresetpin=")) {
       int resetpin;
@@ -1641,15 +1640,20 @@ static int xbee_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       PDATA(pgm)->xbeeResetPin = resetpin;
       continue;
     }
+
     if (str_eq(extended_param, "help")) {
-      msg_error("%s -c %s extended options:\n", progname, pgmid);
-      msg_error("  -xxbeeresetpin=<1..7> Set XBee pin DIO<1..7> as reset pin\n");
-      msg_error("  -xhelp                Show this help menu and exit\n");
-      return LIBAVRDUDE_EXIT;;
+      help = true;
+      rc = LIBAVRDUDE_EXIT;
     }
 
-    pmsg_error("invalid extended parameter '%s'\n", extended_param);
-    rc = -1;
+    if (!help) {
+      pmsg_error("invalid extended parameter '%s'\n", extended_param);
+      rc = -1;
+    }
+    msg_error("%s -c %s extended options:\n", progname, pgmid);
+    msg_error("  -xxbeeresetpin=<1..7> Set XBee pin DIO<1..7> as reset pin\n");
+    msg_error("  -xhelp                Show this help menu and exit\n");
+    return rc;
   }
 
   return rc;


### PR DESCRIPTION
Adresses #1697.

I've added the `-x autoreset` to the AVR109 programmer so that compatible bootloaders can utilize this feature. I've also added the `-x noautoreset` to the `arduino` and `wiring` programmers.

@stefanrueger I didn't touch the Urclock implementation, since the way it deals with extra parameters is so different than the other. It would be great if you could look into this!

This PR is still a draft, so feedback is welcome.