### PR TITLE
Remove obsolete SVN $Id$ tags from source files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,3 @@
-$Id$
-
 Approximate change log for AVRDUDE by version.
 
 (For detailed changes, see the version control system logs.)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,10 +26,6 @@
 #
 # make V=1
 
-#
-# $Id$
-#
-
 EXTRA_DIST   = \
 	avrdude.1 \
 	avrdude.spec \

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Arduino programmer
  *

--- a/src/arduino.h
+++ b/src/arduino.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef arduino_h__
 #define arduino_h__
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdio.h>

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Atmel Low Cost Serial programmers which adher to the
  * protocol described in application note avr910.

--- a/src/avr910.h
+++ b/src/avr910.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef avr910_h
 #define avr910_h
 

--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdio.h>

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -17,8 +17,6 @@
 .\" along with this program. If not, see <http://www.gnu.org/licenses/>.
 .\"
 .\"
-.\" $Id$
-.\"
 .Dd January 15, 2023
 .Os
 .Dt AVRDUDE 1

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1,6 +1,4 @@
-# $Id$ -*- text -*-
-#
-# AVRDUDE Configuration File
+# AVRDUDE Configuration File                               -*- text -*-
 #
 
 avrdude_conf_version = "@AVRDUDE_FULL_VERSION@";

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* $Id$ */
-
 #ifndef avrdude_h
 #define avrdude_h
 

--- a/src/avrdude.spec.in
+++ b/src/avrdude.spec.in
@@ -1,7 +1,5 @@
 ## -*- mode: rpm-spec; -*-
 ##
-## $Id$
-##
 ## @configure_input@
 ##
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -17,7 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
 /*
  * Interface to the MPSSE Engine of FTDI Chips using libftdi.
  */

--- a/src/avrftdi.h
+++ b/src/avrftdi.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef avrftdi_h
 #define avrftdi_h
 

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -19,8 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
- /* $Id$ */
 
 #include <ac_cfg.h>
 

--- a/src/bitbang.h
+++ b/src/bitbang.h
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id$ */
 
 #ifndef bitbang_h
 #define bitbang_h

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -33,8 +33,6 @@
  * Tested with BusPirate PTH, firmware version 2.1 programming ATmega328P
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdio.h>

--- a/src/buspirate.h
+++ b/src/buspirate.h
@@ -19,8 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef buspirate_h
 #define buspirate_h
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for the serial programming mode of the Atmel butterfly
  * evaluation board. This board features a bootloader which uses a protocol

--- a/src/butterfly.h
+++ b/src/butterfly.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef butterfly_h
 #define butterfly_h
 

--- a/src/config.c
+++ b/src/config.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <errno.h>

--- a/src/config.h
+++ b/src/config.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /* These are the internal definitions needed for config parsing */
 
 #ifndef config_h

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -18,7 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
 %{
 
 #include "ac_cfg.h"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -16,10 +16,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-#
-# $Id$
-#
-
 # Process this file with autoreconf to produce a configure script.
 
 dnl A few tool releases with release dates for orientation which tool

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * Code to program an Atmel AVR device through one of the supported
  * programmers.

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdio.h>

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef dfu_h
 #define dfu_h
 

--- a/src/doc/Makefile.am
+++ b/src/doc/Makefile.am
@@ -16,10 +16,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-#
-# $Id$
-#
-
 GENERATED_TEXINFOS = \
 	$(builddir)/programmers.texi \
 	$(builddir)/parts.texi \

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1,8 +1,6 @@
 %% -*-texinfo-*-
 \input texinfo
 
-@c $Id$
-
 @setfilename avrdude.info
 @settitle AVRDUDE
 @finalout

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * The dryrun programmer emulates a physical programmer by allocating a copy of the part and
  * pretending all operations work well.

--- a/src/dryrun.h
+++ b/src/dryrun.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef dryrun_h__
 #define dryrun_h__
 

--- a/src/dryrun_private.h
+++ b/src/dryrun_private.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef dryrun_private_h__
 #define dryrun_private_h__
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <limits.h>

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -19,8 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdint.h>

--- a/src/flip1.h
+++ b/src/flip1.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef flip1_h
 #define flip1_h
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdint.h>

--- a/src/flip2.h
+++ b/src/flip2.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef flip2_h
 #define flip2_h
 

--- a/src/freebsd_ppi.h
+++ b/src/freebsd_ppi.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef freebsd_ppi_h
 #define freebsd_ppi_h
 

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -19,8 +19,6 @@
  */
 
 
-/* $Id$ */
-
 /* ft245r -- FT245R/FT232R Synchronous BitBangMode Programmer
   default pin assign
                FT232R / FT245R

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Atmel JTAGICE3 programmer
  */

--- a/src/jtag3.h
+++ b/src/jtag3.h
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef jtag3_h
 #define jtag3_h
 

--- a/src/jtag3_private.h
+++ b/src/jtag3_private.h
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 
 /*
  * JTAGICE3 definitions

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Atmel JTAG ICE (mkI) programmer
  */

--- a/src/jtagmkI.h
+++ b/src/jtagmkI.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef jtagmkI_h
 #define jtagmkI_h
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -21,8 +21,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Atmel JTAG ICE mkII programmer
  *

--- a/src/jtagmkII.h
+++ b/src/jtagmkII.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef jtagmkII_h
 #define jtagmkII_h
 

--- a/src/jtagmkII_private.h
+++ b/src/jtagmkII_private.h
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 
 /*
  * JTAG ICE mkII definitions

--- a/src/jtagmkI_private.h
+++ b/src/jtagmkI_private.h
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 
 /*
  * JTAG ICE mkI definitions

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 %{
 #include <math.h>
 #include <string.h>

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef libavrdude_h
 #define libavrdude_h
 

--- a/src/linux_ppdev.h
+++ b/src/linux_ppdev.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef linux_ppdev_h
 #define linux_ppdev_h
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* $Id$ */
-
 
 
 /*----------------------------------------------------------------------

--- a/src/main.c
+++ b/src/main.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * Code to program an Atmel AVR device through one of the supported
  * programmers.

--- a/src/par.c
+++ b/src/par.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdio.h>

--- a/src/par.h
+++ b/src/par.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef par_h
 #define par_h
 

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <stdio.h>

--- a/src/ppi.c
+++ b/src/ppi.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 
 #if !defined(WIN32)
 

--- a/src/ppi.h
+++ b/src/ppi.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef ppi_h
 #define ppi_h
 

--- a/src/ppiwin.c
+++ b/src/ppiwin.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
 This is the parallel port interface for Windows built using Cygwin.
 

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * Serial Interface emulation for USB programmer "AVR-Doper" in HID mode.
  */

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * Posix serial interface for avrdude.
  */

--- a/src/serbb.h
+++ b/src/serbb.h
@@ -16,7 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id$ */
 
 #ifndef serbb_h
 #define serbb_h

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id$ */
 
 /*
  * Posix serial bitbanging interface for avrdude.

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id$ */
 
 /*
  * Win32 serial bitbanging interface for avrdude.

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Interface to the SerialUPDI programmer.
  *

--- a/src/serialupdi.h
+++ b/src/serialupdi.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/solaris_ecpp.h
+++ b/src/solaris_ecpp.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef solaris_ecpp_h
 #define solaris_ecpp_h
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Atmel STK500 programmer
  *

--- a/src/stk500.h
+++ b/src/stk500.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef stk500_h
 #define stk500_h
 

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Atmel STK500 programmer
  *

--- a/src/stk500generic.h
+++ b/src/stk500generic.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef stk500generic_h__
 #define stk500generic_h__
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -19,7 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
 /* Based on Id: stk500.c,v 1.46 2004/12/22 01:52:45 bdean Exp */
 
 /*

--- a/src/stk500v2.h
+++ b/src/stk500v2.h
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef stk500v2_h
 #define stk500v2_h
 

--- a/src/term.c
+++ b/src/term.c
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <ac_cfg.h>
 
 #include <ctype.h>

--- a/src/tpi.h
+++ b/src/tpi.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef tpi_h
 #define tpi_h
 

--- a/src/update.c
+++ b/src/update.c
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/src/updi_constants.h
+++ b/src/updi_constants.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_link.h
+++ b/src/updi_link.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm.c
+++ b/src/updi_nvm.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm.h
+++ b/src/updi_nvm.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v0.c
+++ b/src/updi_nvm_v0.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v0.h
+++ b/src/updi_nvm_v0.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v2.c
+++ b/src/updi_nvm_v2.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v2.h
+++ b/src/updi_nvm_v2.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v3.c
+++ b/src/updi_nvm_v3.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v3.h
+++ b/src/updi_nvm_v3.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v4.c
+++ b/src/updi_nvm_v4.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v4.h
+++ b/src/updi_nvm_v4.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v5.c
+++ b/src/updi_nvm_v5.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_nvm_v5.h
+++ b/src/updi_nvm_v5.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_readwrite.c
+++ b/src/updi_readwrite.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_readwrite.h
+++ b/src/updi_readwrite.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_state.c
+++ b/src/updi_state.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/updi_state.h
+++ b/src/updi_state.h
@@ -17,8 +17,6 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/* $Id$ */
-
 /*
  * Based on pymcuprog
  * See https://github.com/microchip-pic-avr-tools/pymcuprog

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * The Urclock programmer
  *

--- a/src/urclock.h
+++ b/src/urclock.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef urclock_h__
 #define urclock_h__
 

--- a/src/urclock_hash.h
+++ b/src/urclock_hash.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef urclock_hash_h__
 #define urclock_hash_h__
 

--- a/src/urclock_private.h
+++ b/src/urclock_private.h
@@ -16,7 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
 
 #ifndef urclock_private_h
 #define urclock_private_h

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * USB interface via libhidapi for avrdude.
  */

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * USB interface via libusb for avrdude.
  */

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -17,8 +17,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * Interface to the USBasp programmer.
  *

--- a/src/usbasp.h
+++ b/src/usbasp.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef usbasp_h
 #define usbasp_h
 

--- a/src/usbdevs.h
+++ b/src/usbdevs.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * defines for the USB interface
  */

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for Wiring bootloaders
  *

--- a/src/wiring.h
+++ b/src/wiring.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef wiring_h__
 #define wiring_h__
 

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 /*
  * avrdude interface for AVR devices Over-The-Air programmable via an
  * XBee Series 2 device.

--- a/src/xbee.h
+++ b/src/xbee.h
@@ -16,8 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* $Id$ */
-
 #ifndef xbee_h__
 #define xbee_h__
 

--- a/tools/get-dw-params.xsl
+++ b/tools/get-dw-params.xsl
@@ -15,8 +15,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- * $Id$
 -->
 <!--
  * Extract the debugWire parameters

--- a/tools/get-hv-params.xsl
+++ b/tools/get-hv-params.xsl
@@ -15,8 +15,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- * $Id$
 -->
 <!--
  * Extract high-voltage (parallel and serial) programming parameters

--- a/tools/get-stk600-cards.xsl
+++ b/tools/get-stk600-cards.xsl
@@ -15,8 +15,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- * $Id$
 -->
 <!--
     * Extract STK600 routing and socket card information out of

--- a/tools/get-stk600-devices.xsl
+++ b/tools/get-stk600-devices.xsl
@@ -15,8 +15,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- * $Id$
 -->
 <!--
     * Extract STK600 device support out of


### PR DESCRIPTION
Remove SVN `$Id$` tags from source files which have been made obsolete by moving to git and serve no purpose any more.

This mostly removes the matches printed by the command

    git grep -E '\$[A-Za-z]+\$'

The remaining exceptions are some binary files (PDF and font files), and jquery js files with both `$Id$` and `$Date$` tags.