### PR TITLE
Add missing documentation from #1844

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -502,18 +502,18 @@ case before programming the cell.
 .Xc
 Pass
 .Ar exitspec
-to the chosen programmer. The interpretation of the exitspec arguments
+to the chosen programmer. The interpretation of the exitspec parameter
 depends on the programmer itself. See below for a list of programmers
-accepting extended parameters or issue
+accepting exitspec parameter options or issue
 .Nm
--E help ... to see the extended options of the chosen programmer.
+-E help ... to see the options of the chosen programmer.
 .It Fl F
 Normally,
 .Nm
 tries to verify that the device signature read from the part is
 reasonable before continuing.  Since it can happen from time to time
 that a device has a broken (erased or overwritten) device signature
-but is otherwise operating normally, this options is provided to
+but is otherwise operating normally, this option is provided to
 override the check.
 Also, for programmers like the Atmel STK500 and STK600 which can
 adjust parameters local to the programming tool (independent of an
@@ -557,7 +557,7 @@ No-write: disables writing data to the MCU whilst processing -U
 .Nm avrdude
 ). The terminal mode continues to write to the device.
 .It Fl O
-Perform a RC oscillator run-time calibration according to Atmel
+Perform an RC oscillator run-time calibration according to Atmel
 application note AVR053.
 This is only supported on the STK500v2, AVRISP mkII, and JTAG ICE mkII
 hardware.
@@ -2173,11 +2173,11 @@ This option allows to choose these additional CSes (1, 2, ...) for programming t
 Show help menu and exit.
 .El
 .El
-.Ss Programmers accepting exitspec arguments
+.Ss Programmers accepting exitspec parameter
 Currently, only the flip2, linuxspi and old school parallel port programmers
-such as stk200 and dapa support exitspec arguments. These lets the user
+such as stk200 and dapa support exitspec parameter. These lets the user
 decide in which state the programmer pins after ended programming session.
-Multiple exitspec arguments can be separated with commas.
+Multiple exitspec options can be separated with commas.
 .Bl -tag -offset indent -width indent
 .It Ar flip2
 .It Ar linuxspi

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -500,65 +500,13 @@ case before programming the cell.
 .It Xo Fl E Ar exitspec Ns
 .Op \&, Ns Ar exitspec
 .Xc
-By default,
-.Nm
-leaves the parallel port in the same state at exit as it has been
-found at startup.  This option modifies the state of the
-.Ql /RESET
-and
-.Ql Vcc
-lines the parallel port is left at, according to the
+Pass
 .Ar exitspec
-arguments provided, as follows:
-.Bl -tag -width noreset
-.It Ar reset
-The
-.Ql /RESET
-signal will be left activated at program exit, that is it will be held
-.Em low ,
-in order to keep the MCU in reset state afterwards.  Note in particular
-that the programming algorithm for the AT90S1200 device mandates that
-the
-.Ql /RESET
-signal is active
-.Em before
-powering up the MCU, so in case an external power supply is used for this
-MCU type, a previous invocation of
+to the chosen programmer. The interpretation of the exitspec arguments
+depends on the programmer itself. See below for a list of programmers
+accepting extended parameters or issue
 .Nm
-with this option specified is one of the possible ways to guarantee this
-condition.
-.Em reset
-is supported by the linuxspi and flip2 programmer options, as well as all
-parallel port based programmers.
-.It Ar noreset
-The
-.Ql /RESET
-line will be deactivated at program exit, thus allowing the MCU target
-program to run while the programming hardware remains connected.
-.Em noreset
-is supported by the linuxspi and flip2 programmer options, as well as all
-parallel port based programmers.
-.It Ar vcc
-This option will leave those parallel port pins active
-.Pq \&i. \&e. Em high
-that can be used to supply
-.Ql Vcc
-power to the MCU.
-.It Ar novcc
-This option will pull the
-.Ql Vcc
-pins of the parallel port down at program exit.
-.It Ar d_high
-This option will leave the 8 data pins on the parallel port active.
-.Pq \&i. \&e. Em high
-.It Ar d_low
-This option will leave the 8 data pins on the parallel port inactive.
-.Pq \&i. \&e. Em low
-.El
-.Pp
-Multiple
-.Ar exitspec
-arguments can be separated with commas.
+-E help ... to see the extended options of the chosen programmer.
 .It Fl F
 Normally,
 .Nm
@@ -828,7 +776,6 @@ of that by erasing pages before programming them unless -e (chip erase) or
 -D (do not erase before writing) was requested. It should be noted that in
 absence of the -e chip erase option any ATxmega or UPDI flash pages not
 affected by the programming will retain their previous content.
-
 .Pp
 Classic devices may have the following memories in addition to eeprom, flash, signature and lock:
 .Bl -tag -width "  calibration" -compact
@@ -1854,6 +1801,13 @@ original STK500. Used by avrdude for the correct calculation of fosc and sck.
 .It Ar help
 Show help menu and exit.
 .El
+.It Ar AVR109
+.Bl -tag -offset indent -width indent
+.It Ar autoreset
+Toggle RTS/DTR lines on port open to issue a hardware reset.
+.It Ar help
+Show help menu and exit.
+.El
 .It Ar AVR910
 .Bl -tag -offset indent -width indent
 .It Ar devcode=VALUE
@@ -1886,6 +1840,8 @@ Show help menu and exit.
 .It Ar attemps[=<1..99>]
 Specify how many connection retry attemps to perform before exiting.
 Defaults to 10 if not specified.
+.It Ar noautoreset
+Don't toggle RTS/DTR lines on port open to prevent a hardware reset.
 .It Ar help
 Show help menu and exit.
 .El
@@ -1984,6 +1940,8 @@ title) and no date either.
 On writing to flash do not store metadata except the metadata code byte
 0xff saying there are no metadata.  In particular, no data store frame is
 programmed.
+.It Ar noautoreset
+Don't toggle RTS/DTR lines on port open to prevent a hardware reset.
 .It Ar nometadata
 Do not support any metadata. The full flash besides the bootloader is
 available for the application. If the application is smaller than the
@@ -2131,6 +2089,8 @@ Add a <n> milliseconds delay after resetting the part through toggling the
 DTR/RTS lines. This can be useful if a board takes a particularly long
 time to exit from external reset. <n> can be negative, in which case the
 default 100 ms delay after issuing reset will be shortened accordingly.
+.It Ar noautoreset
+Don't toggle RTS/DTR lines on port open to prevent a hardware reset.
 .It Ar help
 Show help menu and exit.
 .El
@@ -2212,6 +2172,59 @@ This option allows to choose these additional CSes (1, 2, ...) for programming t
 .It Ar help
 Show help menu and exit.
 .El
+.El
+.Ss Programmers accepting exitspec arguments
+Currently, only the flip2, linuxspi and old school parallel port programmers
+such as stk200 and dapa support exitspec arguments. These lets the user
+decide in which state the programmer pins after ended programming session.
+Multiple exitspec arguments can be separated with commas.
+.Bl -tag -offset indent -width indent
+.It Ar flip2
+.It Ar linuxspi
+.It Parallel port programmers
+.Bl -tag -offset indent -width indent
+.It Ar help
+Show help menu and exit.
+.It Ar reset
+The
+.Ql /RESET
+signal will be left activated at program exit, that is it will be held
+.Em low ,
+in order to keep the MCU in reset state afterwards.  Note in particular
+that the programming algorithm for the AT90S1200 device mandates that
+the
+.Ql /RESET
+signal is active
+.Em before
+powering up the MCU, so in case an external power supply is used for this
+MCU type, a previous invocation of
+.Nm
+with this option specified is one of the possible ways to guarantee this
+condition.
+.It Ar noreset
+The
+.Ql /RESET
+line will be deactivated at program exit, thus allowing the MCU target
+program to run while the programming hardware remains connected.
+.El
+.It Parallel port programmers
+.Bl -tag -offset indent -width indent
+.It Ar vcc
+This option will leave those parallel port pins active
+.Pq \&i. \&e. Em high
+that can be used to supply
+.Ql Vcc
+power to the MCU.
+.It Ar novcc
+This option will pull the
+.Ql Vcc
+pins of the parallel port down at program exit.
+.It Ar d_high
+This option will leave the 8 data pins on the parallel port active.
+.Pq \&i. \&e. Em high
+.It Ar d_low
+This option will leave the 8 data pins on the parallel port inactive.
+.Pq \&i. \&e. Em low
 .El
 .Sh FILES
 .Bl -tag -offset indent -width /dev/ppi0XXX

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1332,6 +1332,17 @@ original STK500. Used by avrdude for the correct calculation of fosc and sck.
 Show help menu and exit.
 @end table
 
+@cindex Option @code{-x} AVR109
+@item AVR109
+
+The AVR109 programmer type accepts the following extended parameter:
+@table @code
+@item @samp{autoreset}
+Toggle RTS/DTR lines on port open to issue a hardware reset.
+@item @samp{help}
+Show help menu and exit.
+@end table
+
 @cindex Option @code{-x} AVR910
 @item AVR910
 
@@ -1360,8 +1371,11 @@ Show help menu and exit.
 
 The Arduino programmer type accepts the following extended parameter:
 @table @code
-@item @samp{attempts=VALUE}
-Overide the default number of connection retry attempt by using @var{VALUE}.
+@item @samp{attempts[=<1..99>]}
+Specify how many connection retry attempts to perform before exiting.
+Defaults to 10 if not specified.
+@item @samp{noautoreset}
+Do not toggle RTS/DTR lines on port open to prevent a hardware reset.
 @item @samp{help}
 Show help menu and exit.
 @end table
@@ -1478,6 +1492,8 @@ available, so that a such prepared flash can always be queried with
 @code{avrdude -x showall}. In contrast to this, it cannot be guaranteed
 that a @code{-x showall} query on flash prepared with @code{-x nometadata}
 yields useful results.
+@item @samp{noautoreset}
+Do not toggle RTS/DTR lines on port open to prevent a hardware reset.
 @item @samp{delay=<n>}
 Add a <n> ms delay after reset. This can be useful if a board takes a
 particularly long time to exit from external reset. <n> can be negative,

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -396,6 +396,7 @@ Roth.
 
 @menu
 * Option Descriptions::
+* Programmers Accepting Exitspec Parameter::
 * Programmers Accepting Extended Parameters::
 * Example Command Line Invocations::
 @end menu
@@ -403,7 +404,7 @@ Roth.
 @c
 @c Node
 @c
-@node Option Descriptions, Programmers Accepting Extended Parameters, Command Line Options, Command Line Options
+@node Option Descriptions, Programmers Accepting Exitspec Parameter, Programmers Accepting Extended Parameters, Command Line Options
 @cindex Options (command-line)
 @section Option Descriptions
 @cindex Option Descriptions
@@ -606,50 +607,12 @@ programming the cell.
 
 @item -E @var{exitspec}[,@dots{}]
 @cindex Option @code{-E} @var{exitspec}[,@dots{}]
-By default, AVRDUDE leaves the parallel port in the same state at exit
-as it has been found at startup.  This option modifies the state of the
-`/RESET' and `Vcc' lines the parallel port is left at, according to
-the exitspec arguments provided, as follows:
+Pass @var{exitspec} to the programmer. The interpretation of the exitspec
+parameter depends on the programmer itself. See below for a list of
+programmers accepting exitspec parameter options or issue
+@code{avrdude -E help ...} to see the  options for the programmer.
 
-@table @code
-@item reset
-The `/RESET' signal will be left activated at program exit, that is it
-will be held low, in order to keep the MCU in reset state afterwards.
-Note in particular that the programming algorithm for the AT90S1200
-device mandates that the `/RESET' signal is active before powering up
-the MCU, so in case an external power supply is used for this MCU type,
-a previous invocation of AVRDUDE with this option specified is one of
-the possible ways to guarantee this condition. @code{reset} is supported
-by the @code{linuxspi} and @code{flip2} programmer options, as well as
-all parallel port based programmers.
-
-@item noreset
-The `/RESET' line will be deactivated at program exit, thus allowing the
-MCU target program to run while the programming hardware remains
-connected. @code{noreset} is supported by the @code{linuxspi} and
-@code{flip2} programmer options, as well as all parallel port based
-programmers.
-
-@item vcc
-This option will leave those parallel port pins active (i. e. high) that
-can be used to supply `Vcc' power to the MCU.
-
-@item novcc
-This option will pull the `Vcc' pins of the parallel port down at
-program exit.
-
-@item d_high
-This option will leave the 8 data pins on the parallel port active
-(i. e. high).
-
-@item d_low
-This option will leave the 8 data pins on the parallel port inactive
-(i. e. low).
-
-@end table
-
-Multiple @var{exitspec} arguments can be separated with commas.
-
+Multiple @var{exitspec} options can be separated with commas.
 
 @item -F
 @cindex Option @code{-F}
@@ -1152,10 +1115,77 @@ see the extended options of the chosen programmer.
 @c
 @c Node
 @c
-@node Programmers Accepting Extended Parameters, Example Command Line Invocations, Option Descriptions, Command Line Options
+@node Programmers Accepting Exitspec Parameter, Programmers Accepting Extended Parameters, Option Descriptions, Command Line Options
+@section Programmers Accepting Exitspec Parameter
+@cindex Programmers Accepting Exitspec parameter
+@table @code
+
+@cindex Option @code{-x} flip2
+@cindex Option @code{-x} linuxspi
+@cindex Option @code{-x} Parallel port programmers
+@item flip2
+@itemx linuxspi
+@itemx Parallel port programmers
+
+Currently, only the @code{flip2}, @code{linuxspi} and old school parallel port programmers
+such as @code{stk200} and @code{dapa} support exitspec parameter options. These lets the user
+decide in which state the programmer pins after ended programming session.
+Multiple exitspec options can be separated with commas.
+
+@table @code
+@item @samp{help}
+Show help menu and exit.
+
+@item @samp{reset}
+The `/RESET' signal will be left activated at program exit, that is it
+will be held low, in order to keep the MCU in reset state afterwards.
+Note in particular that the programming algorithm for the AT90S1200
+device mandates that the `/RESET' signal is active before powering up
+the MCU, so in case an external power supply is used for this MCU type,
+a previous invocation of AVRDUDE with this option specified is one of
+the possible ways to guarantee this condition. @code{flip2} will not
+exit bootloader mode at program exit if @samp{reset} is used.
+
+@item @samp{noreset}
+The `/RESET' line will be deactivated at program exit, thus allowing the
+MCU target program to run while the programming hardware remains
+connected. @code{flip2} will exit bootloader mode at program exit and
+start the application if @samp{noreset} is used, and this is the default
+behaviour for this bootloader.
+@end table
+
+@cindex Option @code{-x} Parallel port programmers
+@item Parallel port programmers
+
+Parallel port based programmers have a few more options.
+
+@table @code
+@item @samp{vcc}
+This option will leave those parallel port pins active (i. e. high) that
+can be used to supply `Vcc' power to the MCU.
+
+@item @samp{novcc}
+This option will pull the `Vcc' pins of the parallel port down at
+program exit.
+
+@item @samp{d_high}
+This option will leave the 8 data pins on the parallel port active
+(i. e. high).
+
+@item @samp{d_low}
+This option will leave the 8 data pins on the parallel port inactive
+(i. e. low).
+@end table
+
+@end table
+
+@page
+@c
+@c Node
+@c
+@node Programmers Accepting Extended Parameters, Example Command Line Invocations, Programmers Accepting Exitspec Parameter, Command Line Options
 @section Programmers Accepting Extended Parameters
 @cindex Programmers Accepting Extended Parameters
-@cindex Option @code{-x} AVR Dragon
 @table @code
 
 @cindex Option @code{-x} dryboot


### PR DESCRIPTION
Just a small documentation update.

@stefanrueger do you want me to create a dedicated section in the Texinfo document (Under [2. Command line options](https://avrdudes.github.io/avrdude/7.3/avrdude_3.html#Command-Line-Options)) where I list the -E exitspec arguments along with supported programmers, similar to what we have done with the -x extended parameters?