### PR TITLE
doc: Stop building and installing .ps and .dvi

### DIFF
--- a/src/avrdude.spec.in
+++ b/src/avrdude.spec.in
@@ -86,7 +86,6 @@ fi
 %doc %{_infodir}/*info*
 %doc doc/avrdude-html/*.html
 %doc doc/TODO
-%doc doc/avrdude.ps
 %doc doc/avrdude.pdf
 %endif
 

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -111,36 +111,12 @@ add_custom_command(
     )
 
 add_custom_command(
-    OUTPUT avrdude.dvi
-    COMMAND ${MAKEINFO_EXECUTABLE}
-        --dvi
-        --Xopt=--quiet
-        --Xopt=--build-dir=dvi
-        -o avrdude.dvi
-        ${TEXINFOS}
-    DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS}
-    VERBATIM
-    )
-
-add_custom_command(
     OUTPUT avrdude.pdf
     COMMAND ${MAKEINFO_EXECUTABLE}
         --pdf
         --Xopt=--quiet
         --Xopt=--build-dir=pdf
         -o avrdude.pdf
-        ${TEXINFOS}
-    DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS}
-    VERBATIM
-    )
-
-add_custom_command(
-    OUTPUT avrdude.ps
-    COMMAND ${MAKEINFO_EXECUTABLE}
-        --ps
-        --Xopt=--quiet
-        --Xopt=--build-dir=ps
-        -o avrdude.ps
         ${TEXINFOS}
     DEPENDS ${TEXINFOS} ${GENERATED_TEXINFOS}
     VERBATIM
@@ -163,9 +139,7 @@ add_custom_command(
 # =====================================
 
 add_custom_target(info ALL DEPENDS avrdude.info)
-add_custom_target(dvi ALL DEPENDS avrdude.dvi)
 add_custom_target(pdf ALL DEPENDS avrdude.pdf)
-add_custom_target(ps ALL DEPENDS avrdude.ps)
 add_custom_target(html ALL DEPENDS avrdude-html/avrdude.html)
 
 # =====================================
@@ -173,7 +147,5 @@ add_custom_target(html ALL DEPENDS avrdude-html/avrdude.html)
 # =====================================
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.info" DESTINATION ${CMAKE_INSTALL_INFODIR})
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.dvi" DESTINATION ${CMAKE_INSTALL_DOCDIR})
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.pdf" DESTINATION ${CMAKE_INSTALL_DOCDIR})
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/avrdude.ps" DESTINATION ${CMAKE_INSTALL_DOCDIR})
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/avrdude-html" DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/src/doc/Makefile.am
+++ b/src/doc/Makefile.am
@@ -31,7 +31,7 @@ info_TEXINFOS = avrdude.texi
 EXTRA_DIST = \
 	parts_comments.txt
 
-all-local: info html ps pdf
+all-local: info html pdf
 
 html: avrdude-html/avrdude.html
 
@@ -76,9 +76,8 @@ clean-local:
 
 install-data-local: install-docs
 
-install-docs: html ps pdf
+install-docs: html pdf
 	$(mkinstalldirs) $(DOC_INST_DIR)
-	$(INSTALL_DATA) avrdude.ps $(DOC_INST_DIR)/avrdude.ps
 	$(INSTALL_DATA) avrdude.pdf $(DOC_INST_DIR)/avrdude.pdf
 	$(mkinstalldirs) $(DOC_INST_DIR)/avrdude-html
 	@list=`echo avrdude-html/*.html`; \


### PR DESCRIPTION
Building info, pdf, and HTML is enough.

ps and dvi are not needed any more.