### PR TITLE
Fix byte writes to TPI lockbits for jpag3.c

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -3038,10 +3038,12 @@ static int jtag3_write_byte_tpi(const PROGRAMMER *pgm, const AVRPART *p, const A
     return -1;
   }
 
-  status = jtag3_erase_tpi(pgm, p, mem, addr);
-  if (status < 0) {
-    pmsg_error("error in communication, received status 0x%02x\n", status);
-    return -1;
+  if (mem_is_a_fuse(mem) || mem_is_flash(mem)) {
+    status = jtag3_erase_tpi(pgm, p, mem, addr);
+    if (status < 0) {
+      pmsg_error("error in communication, received status 0x%02x\n", status);
+      return -1;
+    }
   }
 
   paddr = mem->offset + addr;


### PR DESCRIPTION
Fixes #1858 

As the change is vvv simple there is no need for testing, but if you want to (and have the gear) it would be
```
$ avrdude -c xplainedmini -p t104 -U ALL:r:xplainedmini-t104-bak.hex -U ALL:w:xplainedmini-t104-bak.hex
```
for testing the issue and testing against regressions.
