### PR TITLE
Provide dev option `-c \*/u` that shows udev rules

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1537,6 +1537,8 @@ programmer # avrispmkII
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2104;
 ;
 
 #------------------------------------------------------------
@@ -1714,6 +1716,8 @@ programmer # stk600
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2106;
 ;
 
 #------------------------------------------------------------
@@ -1727,6 +1731,8 @@ programmer # stk600pp
     prog_modes             = PM_HVPP;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2106;
 ;
 
 #------------------------------------------------------------
@@ -1740,6 +1746,8 @@ programmer # stk600hvsp
     prog_modes             = PM_HVSP;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2106;
 ;
 
 #------------------------------------------------------------
@@ -1773,6 +1781,8 @@ programmer # ft245r
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6001;
     reset                  = 4; # D4
     sck                    = 0; # D0
     sdo                    = 2; # D2
@@ -1810,6 +1820,8 @@ programmer # bwmega
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6001;
     reset                  = 7;  # RI
     sck                    = 6;  # DCD
     sdo                    = 3;  # CTS
@@ -1833,6 +1845,8 @@ programmer # arduino-ft232r
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6001;
     reset                  = 7;  # RI  X3(4)
     sck                    = 5;  # DSR X3(2)
     sdo                    = 6;  # DCD X3(3)
@@ -1852,6 +1866,8 @@ programmer # tc2030
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6001;
   #                      FOR TPI devices:
     reset                  = 3;  # CTS = D3 (wire to ~RESET)
     sck                    = 2;  # RTS = D2 (wire to SCK)
@@ -1876,6 +1892,8 @@ programmer # uncompatino
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6001;
     reset                  = 7; # ri
     sck                    = 5; # dsr
     sdo                    = 6; # dcd
@@ -1908,6 +1926,8 @@ programmer # ttl232r
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     connection_type        = usb;
+    usbvid                 = 0x0403;
+    usbpid                 = 0x6001;
     reset                  = 0; # txd
     sck                    = 1; # rxd
     sdo                    = 3; # cts
@@ -2280,6 +2300,8 @@ programmer # jtagmkII
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 19200;    # default is 19200
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2103;
 ;
 
 #------------------------------------------------------------
@@ -2315,6 +2337,8 @@ programmer # jtag2isp
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2103;
 ;
 
 #------------------------------------------------------------
@@ -2331,6 +2355,8 @@ programmer # jtag2dw
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2103;
 ;
 
 #------------------------------------------------------------
@@ -2347,6 +2373,8 @@ programmer # jtagmkII_avr32
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2103;
 ;
 
 #------------------------------------------------------------
@@ -2363,6 +2391,8 @@ programmer # jtag2pdi
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2103;
 ;
 
 #------------------------------------------------------------
@@ -2381,6 +2411,8 @@ programmer # dragon_jtag
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2107;
 ;
 
 #------------------------------------------------------------
@@ -2397,6 +2429,8 @@ programmer # dragon_isp
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2107;
 ;
 
 #------------------------------------------------------------
@@ -2413,6 +2447,8 @@ programmer # dragon_pp
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2107;
 ;
 
 #------------------------------------------------------------
@@ -2429,6 +2465,8 @@ programmer # dragon_hvsp
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2107;
 ;
 
 #------------------------------------------------------------
@@ -2445,6 +2483,8 @@ programmer # dragon_dw
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2107;
 ;
 
 #------------------------------------------------------------
@@ -2461,6 +2501,8 @@ programmer # dragon_pdi
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
     baudrate               = 115200;
+    usbvid                 = 0x03eb;
+    usbpid                 = 0x2107;
 ;
 
 #------------------------------------------------------------
@@ -2488,6 +2530,7 @@ programmer # jtag3
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
 ;
 
@@ -2502,6 +2545,7 @@ programmer # jtag3pdi
     prog_modes             = PM_PDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
 ;
 
@@ -2516,6 +2560,7 @@ programmer # jtag3updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
     hvupdi_support         = 1;
 ;
@@ -2531,6 +2576,7 @@ programmer # jtag3dw
     prog_modes             = PM_debugWIRE;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
 ;
 
@@ -2545,6 +2591,7 @@ programmer # jtag3isp
     prog_modes             = PM_ISP;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
 ;
 
@@ -2570,6 +2617,7 @@ programmer # xplainedpro
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2111;
 ;
 
@@ -2584,6 +2632,7 @@ programmer # xplainedpro_pdi
     prog_modes             = PM_PDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2111;
     hvupdi_support         = 1;
 ;
@@ -2599,6 +2648,7 @@ programmer # xplainedpro_updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2111;
     hvupdi_support         = 1;
 ;
@@ -2631,6 +2681,7 @@ programmer # xplainedmini
     prog_modes             = PM_ISP;
     extra_features         = HAS_SUFFER | HAS_VTARG_SWITCH;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2145;
 ;
 
@@ -2650,6 +2701,7 @@ programmer # xplainedmini_dw
     prog_modes             = PM_debugWIRE;
     extra_features         = HAS_SUFFER | HAS_VTARG_SWITCH;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2145;
 ;
 
@@ -2667,6 +2719,7 @@ programmer # xplainedmini_updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_SUFFER | HAS_VTARG_SWITCH;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2145;
     hvupdi_support         = 1;
 ;
@@ -2681,6 +2734,7 @@ programmer # xplainedmini_tpi
     type                   = "jtagice3_tpi";
     prog_modes             = PM_TPI;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2145;
 ;
 
@@ -2709,6 +2763,7 @@ programmer # atmelice
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2141;
 ;
 
@@ -2723,6 +2778,7 @@ programmer # atmelice_pdi
     prog_modes             = PM_PDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2141;
 ;
 
@@ -2737,6 +2793,7 @@ programmer # atmelice_updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2141;
     hvupdi_support         = 1;
 ;
@@ -2752,6 +2809,7 @@ programmer # atmelice_dw
     prog_modes             = PM_debugWIRE;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2141;
 ;
 
@@ -2766,6 +2824,7 @@ programmer # atmelice_isp
     prog_modes             = PM_ISP;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2141;
 ;
 
@@ -2780,6 +2839,7 @@ programmer # atmelice_tpi
     prog_modes             = PM_TPI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2141;
 ;
 
@@ -2813,6 +2873,7 @@ programmer # powerdebugger
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2144;
 ;
 
@@ -2827,6 +2888,7 @@ programmer # powerdebugger_pdi
     prog_modes             = PM_PDI;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2144;
 ;
 
@@ -2841,6 +2903,7 @@ programmer # powerdebugger_updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2144;
     hvupdi_support         = 0, 1;
 ;
@@ -2856,6 +2919,7 @@ programmer # powerdebugger_dw
     prog_modes             = PM_debugWIRE;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2144;
 ;
 
@@ -2870,6 +2934,7 @@ programmer # powerdebugger_isp
     prog_modes             = PM_ISP;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2144;
 ;
 
@@ -2884,6 +2949,7 @@ programmer # powerdebugger_tpi
     prog_modes             = PM_TPI;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2144;
 ;
 
@@ -2930,6 +2996,7 @@ programmer # pickit4
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
 
@@ -2944,6 +3011,7 @@ programmer # pickit4_updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
     hvupdi_support         = 0, 1, 2;
 ;
@@ -2959,6 +3027,7 @@ programmer # pickit4_pdi
     prog_modes             = PM_PDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
 
@@ -2976,6 +3045,7 @@ programmer # pickit4_isp
     prog_modes             = PM_ISP;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
 
@@ -2990,6 +3060,7 @@ programmer # pickit4_tpi
     prog_modes             = PM_TPI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
 ;
 
@@ -3036,6 +3107,7 @@ programmer # snap
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2180, 0x217f, 0x2181;
 ;
 
@@ -3054,6 +3126,7 @@ programmer # snap_updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2180, 0x217f, 0x2181;
     hvupdi_support         = 1;
 ;
@@ -3069,6 +3142,7 @@ programmer # snap_pdi
     prog_modes             = PM_PDI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2180, 0x217f, 0x2181;
 ;
 
@@ -3086,6 +3160,7 @@ programmer # snap_isp
     prog_modes             = PM_ISP;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2180, 0x217f, 0x2181;
 ;
 
@@ -3100,6 +3175,7 @@ programmer # snap_tpi
     prog_modes             = PM_TPI;
     extra_features         = HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2180, 0x217f, 0x2181;
 ;
 
@@ -3121,6 +3197,7 @@ programmer # pkobn_updi
     prog_modes             = PM_UPDI;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
     usbpid                 = 0x2175;
     hvupdi_support         = 1;
 ;
@@ -3163,6 +3240,8 @@ programmer # pickit2
     type                   = "pickit2";
     prog_modes             = PM_ISP;
     connection_type        = usb;
+    usbvid                 = 0x04d8;
+    usbpid                 = 0x0033;
 ;
 
 #------------------------------------------------------------
@@ -3180,6 +3259,7 @@ programmer # flip1
     type                   = "flip1";
     prog_modes             = PM_SPM;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
 ;
 
 #------------------------------------------------------------
@@ -3196,6 +3276,7 @@ programmer # flip2
     type                   = "flip2";
     prog_modes             = PM_SPM;
     connection_type        = usb;
+    usbvid                 = 0x03eb;
 ;
 
 #------------------------------------------------------------

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1586,9 +1586,9 @@ void dev_output_pgm_defs(char *pgmidcp) {
   }
 
   if(udev && ui) {
-    dev_info("# 1. Put Linux udev rules into /etc/udev/rules.d/55-avrdude.rules (or similar)\n");
-    dev_info("# 2. sudo udevadm control --reload-rules && sudo udevadm trigger (or similar)\n");
-    dev_info("# 3. Unplug the device and plug it in again\n");
+    dev_info("# 1. Put Linux udev rules into, eg, /etc/udev/rules.d/55-avrdude.rules\n");
+    dev_info("# 2. Unplug the device and plug it in again\n");
+    dev_info("# 3. Enjoy user access to the USB programmer\n");
     qsort(udr, ui, sizeof *udr, udev_cmp);
     char *prev_head = mmt_strdup("<none>");
     for(Dev_udev *u = udr; u-udr < ui; u++) {

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1381,8 +1381,9 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
   for(int i=0; i<N_PINS; i++) {
     const char *str = pins_to_str(pgm->pin+i);
     const char *bstr = base? pins_to_str(base->pin+i): NULL;
-    if(!base || !str_eq(bstr, str))
-      _pgmout_fmt(avr_pin_lcname(i), "%s", str);
+    const char *pinname = avr_pin_lcname(i);
+    if((!base || !str_eq(bstr, str)) && !str_eq(pinname, "<unknown>"))
+      _pgmout_fmt(pinname, "%s", str);
   }
 
   pgmstr = dev_hvupdi_support_liststr(pgm);
@@ -1413,9 +1414,54 @@ static void dev_pgm_strct(const PROGRAMMER *pgm, bool tsv, const PROGRAMMER *bas
 }
 
 
-// -c <wildcard>/[dASsrtiBUPTIJWHQ]
+typedef struct {
+  int vid, pid, ishid;
+  const char *ids;
+} Dev_udev;
+
+
+static Dev_udev *add_udev(Dev_udev *ud, int *uip, int vid, int pid, int ishid, const char *ids) {
+  for(int i = 0; i < *uip; i++)  // Already entered?
+    if(ud[i].vid == vid && ud[i].pid == pid && ud[i].ishid == ishid && ud[i].ids == ids)
+      return ud;
+  if(*uip % 128 == 0)
+    ud = (Dev_udev *) mmt_realloc(ud, sizeof*ud*(*uip+128));
+
+  ud[*uip].vid = vid;
+  ud[*uip].pid = pid;
+  ud[*uip].ishid = ishid;
+  ud[*uip].ids = ids;
+  (*uip)++;
+
+  return ud;
+}
+
+static int udev_cmp_wout_ids(const Dev_udev *p1, const Dev_udev *p2) {
+  int diff;
+  if((diff = p1->vid - p2->vid))
+    return diff;
+  if((diff = p1->pid - p2->pid))
+    return diff;
+  return p1->ishid - p2->ishid;
+}
+
+static int udev_cmp(const void *v1, const void *v2) {
+  const Dev_udev *p1 = v1, *p2 = v2;
+  int diff;
+
+  if((diff = udev_cmp_wout_ids(p1, p2)))
+    return diff;
+  return strcmp(p1->ids, p2->ids);
+}
+
+#include "flip1.h"
+#include "flip2.h"
+#include "jtag3.h"
+#include "stk500v2.h"
+
+// -c <wildcard>/[duASsrtiBUPTIJWHQ]
 void dev_output_pgm_defs(char *pgmidcp) {
-  bool descs, astrc, strct, cmpst, raw, tsv, injct;
+  bool descs, astrc, strct, cmpst, raw, tsv, injct, udev;
   char *flags;
   int nprinted;
   PROGRAMMER *nullpgm = pgm_new();
@@ -1426,7 +1472,7 @@ void dev_output_pgm_defs(char *pgmidcp) {
   if(!flags && str_eq(pgmidcp, "*")) // Treat -c * as if it was -c */s
     flags = "s";
 
-  if(!*flags || !strchr("dASsrtiBUPTIJWHQ", *flags)) {
+  if(!*flags || !strchr("duASsrtiBUPTIJWHQ", *flags)) {
     dev_info("Error: flags for developer option -c <wildcard>/<flags> not recognised\n");
     dev_info(
       "Wildcard examples (these need protecting in the shell through quoting):\n"
@@ -1436,6 +1482,7 @@ void dev_output_pgm_defs(char *pgmidcp) {
       "  jtag?pdi matches jtag2pdi and jtag3pdi\n"
       "Flags (one or more of the characters below):\n"
       "         d  description of core programmer features\n"
+      "         u  show udev entry for programmer\n"
       "         A  show entries of avrdude.conf programmers with all values\n"
       "         S  show entries of avrdude.conf programmers with necessary values\n"
       "         s  show short entries of avrdude.conf programmers using parent\n"
@@ -1465,8 +1512,12 @@ void dev_output_pgm_defs(char *pgmidcp) {
   raw   = !!strchr(flags, 'r');
   tsv   = !!strchr(flags, 't');
   injct = !!strchr(flags, 'i');
+  udev  = !!strchr(flags, 'u');
 
   nprinted = dev_nprinted;
+
+  int ui = 0;
+  Dev_udev *udr = NULL;
 
   LNODEID ln1, ln2;
   for(ln1=lfirst(programmers); ln1; ln1=lnext(ln1)) {
@@ -1480,6 +1531,7 @@ void dev_output_pgm_defs(char *pgmidcp) {
     }
     if(!matched)
       continue;
+
     if(!prog_modes_in_flags(pgm->prog_modes, flags))
       continue;
 
@@ -1508,7 +1560,60 @@ void dev_output_pgm_defs(char *pgmidcp) {
         );
       }
 
+    if(udev && pgm->usbpid && (pgm->conntype == CONNTYPE_USB || is_serialadapter(pgm))) {
+      void (* pi)(PROGRAMMER *) = pgm->initpgm;
+      const char *ids = cache_string(str_ccpgmids(pgm->id));
+      int usbvid = pgm->usbvid, ishid =
+        pi == jtag3_initpgm || pi == jtag3_pdi_initpgm || pi == jtag3_updi_initpgm ||
+        pi == jtag3_dw_initpgm || pi == stk500v2_jtag3_initpgm || pi == jtag3_tpi_initpgm;
+
+      if(!lfirst(pgm->usbpid)) {
+        if(pi == flip1_initpgm || pi == flip2_initpgm) { // Bootloaders, add possible part pids
+          for(LNODEID lp = lfirst(part_list); lp; lp = lnext(lp)) {
+            AVRPART *pt = ldata(lp);
+            if(pt->usbpid)
+              udr = add_udev(udr, &ui, usbvid, pt->usbpid, 0, ids);
+          }
+        }
+      }
+
+      for(LNODEID pidn=lfirst(pgm->usbpid); pidn; pidn=lnext(pidn))
+        udr = add_udev(udr, &ui, usbvid, *(int *) ldata(pidn), ishid, ids);
+    }
+
     if(raw)
       dev_pgm_raw(pgm);
+  }
+
+  if(udev && ui) {
+    dev_info("# 1. Put Linux udev rules into /etc/udev/rules.d/80-avrdude.rules (or similar)\n");
+    dev_info("# 2. sudo udevadm control --reload-rules && sudo udevadm trigger (or similar)\n");
+    dev_info("# 3. Unplug the device and plug it in again\n");
+    qsort(udr, ui, sizeof *udr, udev_cmp);
+    char *prev_head = mmt_strdup("<none>");
+    for(Dev_udev *u = udr; u-udr < ui; u++) {
+      char head[1024] = {0}, *h = head;
+      strncpy(h, u->ids, sizeof head - 1), h += strlen(h);
+      for(Dev_udev *v = u+1; v-udr < ui; v++) {
+        if(udev_cmp_wout_ids(u, v))
+          break;
+        if((int) (strlen(v->ids) + 3 + h-head) <= (int) sizeof head) {
+          strcpy(h, ", "), h += 2;
+          strcpy(h, v->ids), h += strlen(v->ids);
+        }
+        u = v;
+      }
+      if(!str_eq(prev_head, head)) {
+        dev_info("\n# %s\n", head);
+        mmt_free(prev_head);
+        prev_head = mmt_strdup(head);
+      }
+      dev_info("SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"%04x\", ATTRS{idProduct}==\"%04x\", "
+        "GROUP=\"plugdev\", MODE=\"0660\", TAG+=\"uaccess\"\n", u->vid, u->pid);
+      if(u->ishid)
+        dev_info("KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", ATTRS{idVendor}==\"%04x\", "
+        "ATTRS{idProduct}==\"%04x\", GROUP=\"plugdev\", MODE=\"0660\", TAG+=\"uaccess\"\n", u->vid, u->pid);
+    }
+    mmt_free(prev_head);
   }
 }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1586,7 +1586,7 @@ void dev_output_pgm_defs(char *pgmidcp) {
   }
 
   if(udev && ui) {
-    dev_info("# 1. Put Linux udev rules into /etc/udev/rules.d/80-avrdude.rules (or similar)\n");
+    dev_info("# 1. Put Linux udev rules into /etc/udev/rules.d/55-avrdude.rules (or similar)\n");
     dev_info("# 2. sudo udevadm control --reload-rules && sudo udevadm trigger (or similar)\n");
     dev_info("# 3. Unplug the device and plug it in again\n");
     qsort(udr, ui, sizeof *udr, udev_cmp);
@@ -1609,10 +1609,10 @@ void dev_output_pgm_defs(char *pgmidcp) {
         prev_head = mmt_strdup(head);
       }
       dev_info("SUBSYSTEM==\"usb\", ATTRS{idVendor}==\"%04x\", ATTRS{idProduct}==\"%04x\", "
-        "GROUP=\"plugdev\", MODE=\"0660\", TAG+=\"uaccess\"\n", u->vid, u->pid);
+        "MODE=\"0660\", TAG+=\"uaccess\"\n", u->vid, u->pid);
       if(u->ishid)
         dev_info("KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", ATTRS{idVendor}==\"%04x\", "
-        "ATTRS{idProduct}==\"%04x\", GROUP=\"plugdev\", MODE=\"0660\", TAG+=\"uaccess\"\n", u->vid, u->pid);
+          "ATTRS{idProduct}==\"%04x\", MODE=\"0660\", TAG+=\"uaccess\"\n", u->vid, u->pid);
     }
     mmt_free(prev_head);
   }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1586,9 +1586,20 @@ void dev_output_pgm_defs(char *pgmidcp) {
   }
 
   if(udev && ui) {
-    dev_info("# 1. Put Linux udev rules into, eg, /etc/udev/rules.d/55-avrdude.rules\n");
-    dev_info("# 2. Unplug the device and plug it in again\n");
-    dev_info("# 3. Enjoy user access to the USB programmer\n");
+    int all = str_eq(pgmidcp, "*");
+    const char *var = all? "": str_asciiname((char *) str_ccprintf("-%s", pgmidcp));
+    dev_info("1. Examine the suggested udev rule%s below; to install run:\n\n", str_plural(ui + udr[0].ishid));
+    dev_info("%s -c \"%s/u\" | tail -n +%d | sudo tee /etc/udev/rules.d/55-%s%s.rules\n",
+      progname, pgmidcp, all? 9: 11, progname, var);
+    dev_info("sudo chmod 0644 /etc/udev/rules.d/55-%s%s.rules\n\n", progname, var);
+    dev_info("2. Unplug any AVRDUDE USB programmers and plug them in again\n");
+    dev_info("3. Enjoy user access to the USB programmer(s)\n\n");
+    if(!all)
+      dev_info("Note: To install all udev rules known to AVRDUDE follow: %s -c \"*/u\" | more\n\n",
+        progname);
+    dev_info("# Generated from avrdude -c \"%s/u\"\n", pgmidcp);
+    if(ui > 3)
+      dev_info("\nACTION!=\"add|change\", GOTO=\"avrdude_end\"\n");
     qsort(udr, ui, sizeof *udr, udev_cmp);
     char *prev_head = mmt_strdup("<none>");
     for(Dev_udev *u = udr; u-udr < ui; u++) {
@@ -1615,5 +1626,7 @@ void dev_output_pgm_defs(char *pgmidcp) {
           "ATTRS{idProduct}==\"%04x\", MODE=\"0660\", TAG+=\"uaccess\"\n", u->vid, u->pid);
     }
     mmt_free(prev_head);
+    if(ui > 3)
+      dev_info("\nLABEL=\"avrdude_end\"\n");
   }
 }

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -413,6 +413,7 @@ char * get_usb_string(usb_dev_handle * dev_handle, int index) {
   result = usb_get_string_simple(dev_handle, index, buffer, sizeof(buffer)-1);
 
   if (result < 0) {
+    cx->usb_access_error = 1;
     pmsg_error("unable to read USB device string %d: %s\n", index, usb_strerror());
     return NULL;
   }

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -539,6 +539,7 @@ usbtiny's properties; for more information run @code{avrdude -c x/h}.
 
 @item -C @var{config-file}
 @cindex Option @code{-C} @var{config-file}
+@cindex Configuration files
 Use the specified config file for configuration data.  This file
 contains all programmer and part definitions that AVRDUDE knows about.
 If not specified, AVRDUDE looks for the configuration file in the following
@@ -4297,6 +4298,7 @@ Other combinations should not show after exit.
 @node Unix Installation, Unix Configuration Files, Unix, Unix
 @subsection Unix Installation
 @cindex Unix installation
+@cindex Installation
 
 @noindent
 To build and install from the source tarball on Unix like systems:
@@ -4335,6 +4337,7 @@ $ make install
 @node FreeBSD Installation, Linux Installation, Unix Installation, Unix Installation
 @subsubsection FreeBSD Installation
 @cindex FreeBSD installation
+@cindex Installation
 
 @noindent
 AVRDUDE is installed via the FreeBSD Ports Tree as follows:
@@ -4363,6 +4366,7 @@ obtained.
 @node Linux Installation,  , FreeBSD Installation, Unix Installation
 @subsubsection Linux Installation
 @cindex Linux installation
+@cindex Installation
 
 @noindent
 On rpm based Linux systems (such as RedHat, SUSE, Mandrake, etc.), you
@@ -4383,6 +4387,7 @@ to system. The above example is specific to RedHat.
 @node Unix Configuration Files, Unix Port Names, Unix Installation, Unix
 @subsection Unix Configuration Files
 @cindex Unix configuration files
+@cindex Configuration files
 
 @noindent
 When AVRDUDE is built using the default @option{--prefix} configure
@@ -4403,6 +4408,7 @@ augment the system default configuration file.
 @node FreeBSD Configuration Files, Linux Configuration Files, Unix Configuration Files, Unix Configuration Files
 @subsubsection FreeBSD Configuration Files
 @cindex FreeBSD configuration files
+@cindex Configuration files
 
 @noindent
 When AVRDUDE is installed using the FreeBSD ports system, the system
@@ -4414,6 +4420,7 @@ configuration file is always @code{/usr/local/etc/avrdude.conf}.
 @node Linux Configuration Files,  , FreeBSD Configuration Files, Unix Configuration Files
 @subsubsection Linux Configuration Files
 @cindex Linux configuration files
+@cindex Configuration files
 
 @noindent
 When AVRDUDE is installed using from an rpm package, the system
@@ -4465,7 +4472,7 @@ access.
 @node Unix USB Permissions, Unix Port Names, Unix Documentation, Unix
 @subsection Unix USB Permissions
 @cindex Unix USB permissions
-@cindex udev rules
+@cindex USB permissions
 
 In most cases the kernel driver initializes a plug-and-play device to be
 owned by user @code{root} and group @code{root} with only r/w permission
@@ -4486,7 +4493,8 @@ Both are typically used to identify the device that needs new permissions.
 @c
 @node FreeBSD USB Permissions, Linux USB Permissions, Unix USB Permissions, Unix USB Permissions
 @subsubsection FreeBSD USB Permissions
-@cindex FreeBSD configuration files
+@cindex FreeBSD USB permissions
+@cindex USB permissions
 
 In FreeBSD a so-called @code{devd} config files in
 @code{/usr/local/etc/devd} serve to modify permissions of plugged-in USB
@@ -4518,7 +4526,8 @@ member of who wish to have access to the programmer.
 @c
 @node Linux USB Permissions,  , FreeBSD USB Permissions, Unix USB Permissions
 @subsubsection Linux USB Permissions
-@cindex Linux configuration files
+@cindex Linux USB permissions
+@cindex USB permissions
 
 Linux has a special userspace @code{/dev} device manager called udev that
 deals with, amongst other things, plug-and-play USB devices. It is
@@ -4597,6 +4606,7 @@ SUBSYSTEM=="usb", ATTRS@{idVendor@}=="0403", ATTRS@{idProduct@}=="cff8", \
 @end cartouche
 @end smallexample
 
+@cindex USB permissions
 @noindent Again, each rule must be written as one line: breaking up rules
 into two lines was only done to fit AVRDUDE's output to the boxed display.
 USB devices in HID mode require a second rule dealing with the

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -4468,18 +4468,24 @@ access.
 @cindex udev rules
 
 Linux has a special userspace @code{/dev} device manager called udev that
-deals with, amongst other things, plug-and-play USB devices. So called
-udev rules describe who has the right to access these devices. They
-typically reside in a file with the name pattern
-@var{nn}@code{-}@var{descriptive-name}@code{.rules} in typically the
-directory @code{/etc/udev/rules.d}. Here, @var{nn} is a two-digit number
-that determines the lexical order in which the udev rule files are
-processed. Rules processed later can overwrite earlier rules. One frequent
-way of assigning an ordinary user access to a plugged in USB AVR
-programmer is to identify the programmer by a two-byte hexadecimal vendor
-ID and a two-byte hexadecimal product id in the @code{.rules} file. Here
-is an example for the popular AVRISP mkII programmer (product ID 0x2104)
-by Atmel (vendor ID 0x0eb)
+deals with, amongst other things, plug-and-play USB devices. In most cases
+the kernel driver initializes a plug-and-play device to be owned by user
+@code{root} and group @code{root} with only r/w permission for the user
+@code{root} rendering the device inaccessible to regular users. Whilst
+users can run AVRDUDE sessions as root this is definitely @emph{not} good
+practice.
+
+It is recommended to specify so-called udev rules to define access
+permissions for these devices instead. These rules typically reside in a
+file with the name @var{nn}@code{-}@var{descriptive-name}@code{.rules} in
+the directory @code{/etc/udev/rules.d}. Here, @var{nn} is a two-digit
+number that determines the lexical order in which the udev rule files are
+processed. Rules processed later can overwrite earlier rules.
+
+USB AVR programmers are normally identified by a two-byte hexadecimal
+vendor ID and a two-byte hexadecimal product id. Here a typical udev rule
+for allowing an ordinary user access to the plugged-in AVRISP mkII
+programmer (product ID 0x2104) by Atmel (vendor ID 0x0eb):
 
 @smallexample
 @cartouche
@@ -4490,26 +4496,27 @@ SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2104", \
 @end cartouche
 @end smallexample
 
-When used in anger, udev rules must appear on one line. Above example was
-broken into two lines so it fits into the example box.
+This furnishes the corresponding device node with @code{0660} access
+permissions: this means r/w for the user @code{root} and any user
+belonging to the group of the device, which the device driver might assign
+to a different group than the default @code{root}. The key of the rule is
+the attached @code{TAG} named @code{uaccess}, which makes udev apply a
+dynamic user access control list to the device node, which makes the
+device usable for logged-in users. When used in anger, udev rules must
+appear on one line; above example was broken into two lines so it fits
+into the example box.
 
-This creates a device with @code{0660} access permissions (r/w for the
-user and any user belonging to the group of the device). The attached TAG
-named uaccess makes udev apply a dynamic user ACL to the device node,
-which coordinates with the system login daemon to make the device also
-usable to logged-in users.
-
-AVRDUDE's developer option @code{-c }@var{programmer}@code{/u} shows above
-suggested udev rule for the named programmer. Wildcards are allowed:
+AVRDUDE's developer option @code{-c }@var{programmer}@code{/u} will show
+above suggested udev rule for the named programmer. Wildcards are allowed:
 
 @smallexample
 @cartouche
 
 $ avrdude -c jtag\*/u
 
-# 1. Put Linux udev rules into /etc/udev/rules.d/80-avrdude.rules (or similar)
-# 2. sudo udevadm control --reload-rules && sudo udevadm trigger (or similar)
-# 3. Unplug the device and plug it in again
+# 1. Put Linux udev rules into, eg, /etc/udev/rules.d/55-avrdude.rules
+# 2. Unplug the device and plug it in again
+# 3. Enjoy user access to the USB programmer
 
 # jtag2dw, jtag2fast, jtag2, jtag2isp, jtag2pdi, jtag2slow, jtagmkII, jtag2avr32
 SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2103", \
@@ -4533,12 +4540,11 @@ SUBSYSTEM=="usb", ATTRS@{idVendor@}=="0403", ATTRS@{idProduct@}=="cff8", \
 @end cartouche
 @end smallexample
 
-Again, each rule must be written as one line (and AVRDUDE outputs them
-correctly): breaking them up as above into two lines with the continuation
-character @code{\} was only done to fit the output to the boxed display.
+Again, each rule must be written as one line: breaking up rules into two
+lines was only done to fit AVRDUDE's output to the boxed display.
 
 USB devices in HID mode require a second rule dealing with the
-@code{hidraw} subsystem.
+@code{hidraw} subsystem as seen above.
 
 @c
 @c Node

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -137,7 +137,7 @@ entire memory of the chip from the contents of a file, while interactive mode
 is useful for exploring memory contents, modifying individual bytes of
 eeprom, programming fuse/lock bits, etc.
 
-@cindex Programmers Supported
+@cindex Programmers supported
 
 AVRDUDE supports the following basic programmer types: Atmel's STK500,
 Atmel's AVRISP and AVRISP mkII devices,
@@ -361,7 +361,7 @@ below for Teensy specific options.
 @c
 @node History,  , Introduction, Introduction
 @section History and Credits
-@cindex History and Credits
+@cindex History and credits
 
 AVRDUDE was written by Brian S. Dean under the name of AVRPROG to run on
 the FreeBSD Operating System.  Brian renamed the software to be called
@@ -392,7 +392,7 @@ Roth.
 @c
 @node Command Line Options, Terminal Mode Operation, Introduction, Top
 @chapter Command Line Options
-@cindex Command Line Options
+@cindex Command line options
 
 @menu
 * Option Descriptions::
@@ -407,7 +407,7 @@ Roth.
 @node Option Descriptions, Programmers Accepting Exitspec Parameter, Programmers Accepting Extended Parameters, Command Line Options
 @cindex Options (command-line)
 @section Option Descriptions
-@cindex Option Descriptions
+@cindex Option descriptions
 
 @noindent
 AVRDUDE is a command line tool, used as follows:
@@ -442,7 +442,7 @@ there can be deviations from this list, particularly if programming is
 directly via a bootloader. Currently, the following MCU types are
 understood:
 
-@cindex Device Support
+@cindex Device support
 
 @multitable @columnfractions .15 .45
 @include parts.texi
@@ -522,7 +522,7 @@ combination. In reality there can be deviations from this list,
 particularly if programming is directly via a bootloader. Currently, the
 following programmer ids are understood and supported:
 
-@cindex Programmer Support
+@cindex Programmer support
 
 @multitable @columnfractions .3 .68
 @include programmers.texi
@@ -1136,13 +1136,13 @@ see the extended options of the chosen programmer.
 @c Node
 @c
 @node Programmers Accepting Exitspec Parameter, Programmers Accepting Extended Parameters, Option Descriptions, Command Line Options
-@section Programmers Accepting Exitspec Parameter
-@cindex Programmers Accepting Exitspec parameter
+@section Programmers Accepting Exitspec Parameters
+@cindex Programmers accepting exitspec parameters
 @table @code
 
 @cindex Option @code{-x} flip2
 @cindex Option @code{-x} linuxspi
-@cindex Option @code{-x} Parallel port programmers
+@cindex Option @code{-x} parallel port programmers
 @item flip2
 @itemx linuxspi
 @itemx Parallel port programmers
@@ -1174,7 +1174,7 @@ start the application if @samp{noreset} is used, and this is the default
 behaviour for this bootloader.
 @end table
 
-@cindex Option @code{-x} Parallel port programmers
+@cindex Option @code{-x} parallel port programmers
 @item Parallel port programmers
 
 Parallel port based programmers have a few more options.
@@ -1205,7 +1205,7 @@ This option will leave the 8 data pins on the parallel port inactive
 @c
 @node Programmers Accepting Extended Parameters, Example Command Line Invocations, Programmers Accepting Exitspec Parameter, Command Line Options
 @section Programmers Accepting Extended Parameters
-@cindex Programmers Accepting Extended Parameters
+@cindex Programmers accepting extended parameters
 @table @code
 
 @cindex Option @code{-x} dryboot
@@ -1819,7 +1819,7 @@ Show help menu and exit.
 @c
 @node Example Command Line Invocations,  , Programmers Accepting Extended Parameters, Command Line Options
 @section Example Command Line Invocations
-@cindex Example Command Line Invocations
+@cindex Example Command line invocations
 
 AVRDUDE error messages, warnings and progress reports are generally
 written to stderr which can, in bash, be turned off by @code{2>/dev/null}
@@ -2307,7 +2307,7 @@ avrdude done.  Thank you.
 @c
 @node Terminal Mode Operation, Configuration Files, Command Line Options, Top
 @chapter Terminal Mode Operation
-@cindex Terminal Mode Operation
+@cindex Terminal mode operation
 
 AVRDUDE has an interactive mode called @var{terminal mode} that is
 enabled by the @option{-t} option.  This mode allows one to enter
@@ -2325,7 +2325,7 @@ commands can be recalled and edited.
 
 @node Terminal Mode Commands, Terminal Mode Examples, Terminal Mode Operation, Terminal Mode Operation
 @section Terminal Mode Commands
-@cindex Terminal Mode Commands
+@cindex Terminal mode commands
 
 In this mode, AVRDUDE only initializes communication with the MCU, and then
 awaits user commands on standard input.  Commands and parameters may be
@@ -3420,7 +3420,7 @@ avrdude done.  Thank you.
 @c Node
 @c
 @node Configuration Files, Programmer Specific Information, Terminal Mode Operation, Top
-@cindex Configuration Files
+@cindex Configuration files
 @cindex @code{avrdude.conf}
 @chapter Configuration Files
 
@@ -3462,7 +3462,7 @@ the executable.
 @c
 @node AVRDUDE Defaults, Programmer Definitions, Configuration Files, Configuration Files
 @section AVRDUDE Defaults
-@cindex AVRDUDE Defaults
+@cindex AVRDUDE defaults
 
 @table @code
 
@@ -3519,7 +3519,7 @@ configuration file with @var{yes}.
 @node Programmer Definitions, Serial Adapter Definitions, AVRDUDE Defaults, Configuration Files
 @cindex @code{programmer}
 @section Programmer Definitions
-@cindex Programmer Definitions
+@cindex Programmer definitions
 
 @noindent
 The format of the programmer definition is as follows:
@@ -3642,7 +3642,7 @@ The following programmer types are currently implemented:
 @node Serial Adapter Definitions, Part Definitions, Programmer Definitions, Configuration Files
 @cindex @code{serialadapter}
 @section Serial Adapter Definitions
-@cindex Serial Adapter Definitions
+@cindex Serial adapter definitions
 
 @noindent
 The format of a serial adapter definition is as follows:
@@ -3688,7 +3688,7 @@ utilised as a serialadapter.
 @node Part Definitions, Other Notes, Serial Adapter Definitions, Configuration Files
 @cindex @code{part}
 @section Part Definitions
-@cindex Part Definitions
+@cindex Part definitions
 
 @smallexample
 part
@@ -3830,7 +3830,7 @@ arithemtic and bitwise operators.
 @c
 @node Parent Part, Instruction Format, Part Definitions, Part Definitions
 @subsection Parent Part
-@cindex Parent Part
+@cindex Parent part
 
 @noindent
 Parts can also inherit parameters from previously defined parts using
@@ -3862,7 +3862,7 @@ Example format for part inheritance:
 @c
 @node Instruction Format,  , Parent Part, Part Definitions
 @subsection Instruction Format
-@cindex Instruction Format
+@cindex Instruction format
 
 @noindent
 Instruction formats are specified as a comma separated list of string
@@ -3939,7 +3939,7 @@ Examples:
 @c
 @node Other Notes,  , Part Definitions, Configuration Files
 @section Other Notes
-@cindex Other Notes
+@cindex Other notes
 
 
 @itemize @bullet
@@ -3995,8 +3995,8 @@ Reading fuse and lock bits is fully supported.
 @c Node
 @c
 @node Programmer Specific Information, Platform Dependent Information, Configuration Files, Top
-@chapter Programmer Specific Information
-@cindex Programmer Specific Information
+@chapter Programmer-Specific Information
+@cindex Programmer-specific information
 
 @menu
 * Atmel STK600::
@@ -4108,7 +4108,7 @@ least 4.5 V in order to work.  This can be done using
 @c
 @node DFU Bootloader Using FLIP Version 1, SerialUPDI Programmer , Atmel STK600, Programmer Specific Information
 @section DFU Bootloader Using FLIP Version 1
-@cindex DFU Bootloader Using FLIP Version 1
+@cindex DFU Bootloader using FLIP version 1
 
 Bootloaders using the FLIP protocol version 1 experience some very
 specific behaviour.
@@ -4138,7 +4138,7 @@ versions of the bootloader.
 @node SerialUPDI Programmer, Programmer LED Management, DFU Bootloader Using FLIP Version 1, Programmer Specific Information
 @cindex SerialUPDI
 @section SerialUPDI Programmer
-@cindex SerialUPDI Programmer
+@cindex SerialUPDI programmer
 
 SerialUPDI programmer can be used for programming UPDI-only devices
 using very simple serial connection.
@@ -4231,7 +4231,8 @@ analysis of UPDI protocol quirks easier.
 @c
 @node Programmer LED Management, , SerialUPDI Programmer, Programmer Specific Information
 @section Programmer LED Management
-@cindex Programmer LED Management
+@cindex Programmer LED management
+@cindex LED management
 
 Some hardware programmers have LEDs, and the firmware controls them fully
 without AVRDUDE having a way to influence their LED states. Other
@@ -4286,6 +4287,7 @@ Other combinations should not show after exit.
 * Unix Installation::           
 * Unix Configuration Files::    
 * Unix Port Names::             
+* Linux Udev Rules::
 * Unix Documentation::          
 @end menu
 
@@ -4294,7 +4296,7 @@ Other combinations should not show after exit.
 @c
 @node Unix Installation, Unix Configuration Files, Unix, Unix
 @subsection Unix Installation
-@cindex Unix Installation
+@cindex Unix installation
 
 @noindent
 To build and install from the source tarball on Unix like systems:
@@ -4332,7 +4334,7 @@ $ make install
 @c
 @node FreeBSD Installation, Linux Installation, Unix Installation, Unix Installation
 @subsubsection FreeBSD Installation
-@cindex FreeBSD Installation
+@cindex FreeBSD installation
 
 @noindent
 AVRDUDE is installed via the FreeBSD Ports Tree as follows:
@@ -4360,7 +4362,7 @@ obtained.
 @c
 @node Linux Installation,  , FreeBSD Installation, Unix Installation
 @subsubsection Linux Installation
-@cindex Linux Installation
+@cindex Linux installation
 
 @noindent
 On rpm based Linux systems (such as RedHat, SUSE, Mandrake, etc.), you
@@ -4380,7 +4382,7 @@ to system. The above example is specific to RedHat.
 @c
 @node Unix Configuration Files, Unix Port Names, Unix Installation, Unix
 @subsection Unix Configuration Files
-@cindex Unix Configuration Files
+@cindex Unix configuration files
 
 @noindent
 When AVRDUDE is build using the default @option{--prefix} configure
@@ -4400,7 +4402,7 @@ augment the system default configuration file.
 @c
 @node FreeBSD Configuration Files, Linux Configuration Files, Unix Configuration Files, Unix Configuration Files
 @subsubsection FreeBSD Configuration Files
-@cindex FreeBSD Configuration Files
+@cindex FreeBSD configuration files
 
 @noindent
 When AVRDUDE is installed using the FreeBSD ports system, the system
@@ -4411,7 +4413,7 @@ configuration file is always @code{/usr/local/etc/avrdude.conf}.
 @c
 @node Linux Configuration Files,  , FreeBSD Configuration Files, Unix Configuration Files
 @subsubsection Linux Configuration Files
-@cindex Linux Configuration Files
+@cindex Linux configuration files
 
 @noindent
 When AVRDUDE is installed using from an rpm package, the system
@@ -4420,9 +4422,9 @@ configuration file will be always be @code{/etc/avrdude.conf}.
 @c
 @c Node
 @c
-@node Unix Port Names, Unix Documentation, Unix Configuration Files, Unix
+@node Unix Port Names, Linux Udev Rules, Unix Configuration Files, Unix
 @subsection Unix Port Names
-@cindex Unix Port Names
+@cindex Unix port names
 
 @noindent
 The parallel and serial port device file names are system specific.
@@ -4460,9 +4462,90 @@ access.
 @c
 @c Node
 @c
+@node Linux Udev Rules, Unix Port Names, Unix Documentation, Unix
+@subsection Linux Udev Rules
+@cindex Linux udev rules
+@cindex udev rules
+
+Linux has a special userspace @code{/dev} device manager called udev that
+deals with, amongst other things, plug-and-play USB devices. So called
+udev rules describe who has the right to access these devices. They
+typically reside in a file with the name pattern
+@var{nn}@code{-}@var{descriptive-name}@code{.rules} in typically the
+directory @code{/etc/udev/rules.d}. Here, @var{nn} is a two-digit number
+that determines the lexical order in which the udev rule files are
+processed. Rules processed later can overwrite earlier rules. One frequent
+way of assigning an ordinary user access to a plugged in USB AVR
+programmer is to identify the programmer by a two-byte hexadecimal vendor
+ID and a two-byte hexadecimal product id in the @code{.rules} file. Here
+is an example for the popular AVRISP mkII programmer (product ID 0x2104)
+by Atmel (vendor ID 0x0eb)
+
+@smallexample
+@cartouche
+
+SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2104", \
+  MODE="0660", TAG+="uaccess"
+
+@end cartouche
+@end smallexample
+
+When used in anger, udev rules must appear on one line. Above example was
+broken into two lines so it fits into the example box.
+
+This creates a device with @code{0660} access permissions (r/w for the
+user and any user belonging to the group of the device). The attached TAG
+named uaccess makes udev apply a dynamic user ACL to the device node,
+which coordinates with the system login daemon to make the device also
+usable to logged-in users.
+
+AVRDUDE's developer option @code{-c }@var{programmer}@code{/u} shows above
+suggested udev rule for the named programmer. Wildcards are allowed:
+
+@smallexample
+@cartouche
+
+$ avrdude -c jtag\*/u
+
+# 1. Put Linux udev rules into /etc/udev/rules.d/80-avrdude.rules (or similar)
+# 2. sudo udevadm control --reload-rules && sudo udevadm trigger (or similar)
+# 3. Unplug the device and plug it in again
+
+# jtag2dw, jtag2fast, jtag2, jtag2isp, jtag2pdi, jtag2slow, jtagmkII, jtag2avr32
+SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2103", \
+  MODE="0660", TAG+="uaccess"
+
+# jtag3, jtag3dw, jtag3isp, jtag3pdi, jtag3updi
+SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2110", \
+  MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS@{idVendor@}=="03eb", \
+  ATTRS@{idProduct@}=="2110", MODE="0660", TAG+="uaccess"
+
+SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2140", \
+  MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS@{idVendor@}=="03eb", \
+  ATTRS@{idProduct@}=="2140", MODE="0660", TAG+="uaccess"
+
+# jtagkey
+SUBSYSTEM=="usb", ATTRS@{idVendor@}=="0403", ATTRS@{idProduct@}=="cff8", \
+  MODE="0660", TAG+="uaccess"
+
+@end cartouche
+@end smallexample
+
+Again, each rule must be written as one line (and AVRDUDE outputs them
+correctly): breaking them up as above into two lines with the continuation
+character @code{\} was only done to fit the output to the boxed display.
+
+USB devices in HID mode require a second rule dealing with the
+@code{hidraw} subsystem.
+
+@c
+@c Node
+@c
 @node Unix Documentation,  , Unix Port Names, Unix
 @subsection Unix Documentation
-@cindex Unix Documentation
+@cindex Unix documentation
 
 @noindent
 AVRDUDE installs a manual page as well as info, HTML and PDF
@@ -4533,7 +4616,7 @@ compiler version that still supports MinGW builds, or use MinGW
 @c
 @node Windows Configuration Files, Windows Port Names, Windows Installation, Windows
 @subsection Windows Configuration Files
-@cindex Windows Configuration Files
+@cindex Windows configuration files
 
 @menu
 * Configuration file names::    
@@ -4545,7 +4628,7 @@ compiler version that still supports MinGW builds, or use MinGW
 @c
 @node Configuration file names, Windows Configuration File Location, Windows Configuration Files, Windows Configuration Files
 @subsubsection Windows Configuration File Names
-@cindex Windows Configuration File Names
+@cindex Windows configuration file names
 
 @noindent
 AVRDUDE on Windows looks for a system configuration file name of
@@ -4557,7 +4640,7 @@ AVRDUDE on Windows looks for a system configuration file name of
 @c
 @node Windows Configuration File Location,  , Configuration file names, Windows Configuration Files
 @subsubsection Windows Configuration File Location
-@cindex Windows Configuration File Location
+@cindex Windows configuration file location
  
 @noindent
 AVRDUDE on Windows has a different way of searching for the system and
@@ -4598,7 +4681,7 @@ The directories that are listed in the PATH environment variable.
 @c
 @node Windows Port Names, Windows Configuration Files, Windows
 @subsection Windows Port Names
-@cindex Windows Port Names
+@cindex Windows port names
 
 @menu
 * Serial Ports::                
@@ -4610,7 +4693,7 @@ The directories that are listed in the PATH environment variable.
 @c
 @node Serial Ports, Parallel Ports, Windows Port Names, Windows Port Names
 @subsubsection Windows Serial Ports
-@cindex Windows Serial Ports
+@cindex Windows serial ports
  
 @noindent
 When you select a serial port (i.e. when using an STK500) use the
@@ -4621,7 +4704,7 @@ Windows serial port device names such as: com1, com2, etc.
 @c
 @node Parallel Ports,  , Serial Ports, Windows Port Names
 @subsubsection Windows Parallel Ports
-@cindex Windows Parallel Ports
+@cindex Windows parallel ports
 
 @noindent
 AVRDUDE will accept 3 Windows parallel port names: lpt1, lpt2, or

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -4480,7 +4480,9 @@ permissions for these devices instead. These rules typically reside in a
 file with the name @var{nn}@code{-}@var{descriptive-name}@code{.rules} in
 the directory @code{/etc/udev/rules.d}. Here, @var{nn} is a two-digit
 number that determines the lexical order in which the udev rule files are
-processed. Rules processed later can overwrite earlier rules.
+processed. Rules processed later can overwrite earlier rules, but it not
+recommended to put user-generated rules higher than 60, as some of the
+actions they require are processed by higher-level system rules.
 
 USB AVR programmers are normally identified by a two-byte hexadecimal
 vendor ID and a two-byte hexadecimal product id. Here a typical udev rule
@@ -4500,11 +4502,11 @@ This furnishes the corresponding device node with @code{0660} access
 permissions: this means r/w for the user @code{root} and any user
 belonging to the group of the device, which the device driver might assign
 to a different group than the default @code{root}. The key of the rule is
-the attached @code{TAG} named @code{uaccess}, which makes udev apply a
-dynamic user access control list to the device node, which makes the
-device usable for logged-in users. When used in anger, udev rules must
-appear on one line; above example was broken into two lines so it fits
-into the example box.
+the attached @code{TAG} named @code{uaccess}, which has the effect that
+the login daemon applies a dynamic user access control list to the device
+node making the device usable for the currently logged-in user. When used
+in anger, udev rules must appear on one line; above example was broken
+into two lines so it fits into the example box.
 
 AVRDUDE's developer option @code{-c }@var{programmer}@code{/u} will show
 above suggested udev rule for the named programmer. Wildcards are allowed:

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -4287,7 +4287,7 @@ Other combinations should not show after exit.
 * Unix Installation::           
 * Unix Configuration Files::    
 * Unix Port Names::             
-* Linux Udev Rules::
+* Unix USB Permissions::
 * Unix Documentation::          
 @end menu
 
@@ -4385,7 +4385,7 @@ to system. The above example is specific to RedHat.
 @cindex Unix configuration files
 
 @noindent
-When AVRDUDE is build using the default @option{--prefix} configure
+When AVRDUDE is built using the default @option{--prefix} configure
 option, the default configuration file for a Unix system is located at
 @code{/usr/local/etc/avrdude.conf}.  This can be overridden by using the
 @option{-C} command line option.  Additionally, the user's home directory
@@ -4422,7 +4422,7 @@ configuration file will be always be @code{/etc/avrdude.conf}.
 @c
 @c Node
 @c
-@node Unix Port Names, Linux Udev Rules, Unix Configuration Files, Unix
+@node Unix Port Names, Unix USB Permissions, Unix Configuration Files, Unix
 @subsection Unix Port Names
 @cindex Unix port names
 
@@ -4462,32 +4462,78 @@ access.
 @c
 @c Node
 @c
-@node Linux Udev Rules, Unix Port Names, Unix Documentation, Unix
-@subsection Linux Udev Rules
-@cindex Linux udev rules
+@node Unix USB Permissions, Unix Port Names, Unix Documentation, Unix
+@subsection Unix USB Permissions
+@cindex Unix USB permissions
 @cindex udev rules
 
+In most cases the kernel driver initializes a plug-and-play device to be
+owned by user @code{root} and group @code{root} with only r/w permission
+for the user @code{root} rendering the device inaccessible to regular
+users. Whilst users can run AVRDUDE sessions as root this is definitely
+@emph{not good practice}. Giving USB plug-and-play devices the correct
+permissions is much better. USB AVR programmers are normally identified by
+a two-byte hexadecimal vendor ID and a two-byte hexadecimal product id.
+Both are typically used to identify the device that needs new permissions.
+
+@menu
+* FreeBSD USB Permissions::
+* Linux USB Permissions::
+@end menu
+
+@c
+@c Node
+@c
+@node FreeBSD USB Permissions, Linux USB Permissions, Unix USB Permissions, Unix USB Permissions
+@subsubsection FreeBSD USB Permissions
+@cindex FreeBSD configuration files
+
+In FreeBSD a so-called @code{devd} config files in
+@code{/usr/local/etc/devd} serve to modify permissions of plugged-in USB
+devices. Here is an example how Atmel's JTAGICE3 programmer (product ID
+0x2110 or 0x2140) by Atmel (vendor ID 0x0eb) can be given appropriate
+permissions using a file @code{jtagice3.conf}:
+
+@smallexample
+@cartouche
+
+notify 100 @{
+  match "system" "USB";
+  match "subsystem" "DEVICE";
+  match "type" "ATTACH";
+  match "vendor" "0x03eb";
+  match "product" "(0x2110|0x2140)";
+  action "chmod 660 /dev/$cdev";
+  action "chgrp yourgroup /dev/$cdev";
+@};
+
+@end cartouche
+@end smallexample
+
+@noindent @code{yourgroup} would be a group that the user(s) should be
+member of who wish to have access to the programmer.
+
+@c
+@c Node
+@c
+@node Linux USB Permissions,  , FreeBSD USB Permissions, Unix USB Permissions
+@subsubsection Linux USB Permissions
+@cindex Linux configuration files
+
 Linux has a special userspace @code{/dev} device manager called udev that
-deals with, amongst other things, plug-and-play USB devices. In most cases
-the kernel driver initializes a plug-and-play device to be owned by user
-@code{root} and group @code{root} with only r/w permission for the user
-@code{root} rendering the device inaccessible to regular users. Whilst
-users can run AVRDUDE sessions as root this is definitely @emph{not} good
-practice.
+deals with, amongst other things, plug-and-play USB devices. It is
+recommended to specify so-called udev rules to define access permissions
+for these devices instead. These rules typically reside in a file with the
+name @var{nn}@code{-}@var{descriptive-name}@code{.rules} in the directory
+@code{/etc/udev/rules.d}. Here, @var{nn} is a two-digit number that
+determines the lexical order in which the udev rule files are processed.
+Rules processed later can overwrite earlier rules, but it not recommended
+to put user-generated rules higher than 60, as some of the actions they
+require are processed by higher-level system rules.
 
-It is recommended to specify so-called udev rules to define access
-permissions for these devices instead. These rules typically reside in a
-file with the name @var{nn}@code{-}@var{descriptive-name}@code{.rules} in
-the directory @code{/etc/udev/rules.d}. Here, @var{nn} is a two-digit
-number that determines the lexical order in which the udev rule files are
-processed. Rules processed later can overwrite earlier rules, but it not
-recommended to put user-generated rules higher than 60, as some of the
-actions they require are processed by higher-level system rules.
-
-USB AVR programmers are normally identified by a two-byte hexadecimal
-vendor ID and a two-byte hexadecimal product id. Here a typical udev rule
-for allowing an ordinary user access to the plugged-in AVRISP mkII
-programmer (product ID 0x2104) by Atmel (vendor ID 0x0eb):
+Here a typical udev rule for allowing an ordinary user access to the
+plugged-in AVRISP mkII programmer (product ID 0x2104) by Atmel (vendor ID
+0x0eb):
 
 @smallexample
 @cartouche
@@ -4498,8 +4544,8 @@ SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2104", \
 @end cartouche
 @end smallexample
 
-This furnishes the corresponding device node with @code{0660} access
-permissions: this means r/w for the user @code{root} and any user
+@noindent This furnishes the corresponding device node with @code{0660}
+access permissions: this means r/w for the user @code{root} and any user
 belonging to the group of the device, which the device driver might assign
 to a different group than the default @code{root}. The key of the rule is
 the attached @code{TAG} named @code{uaccess}, which has the effect that
@@ -4516,9 +4562,19 @@ above suggested udev rule for the named programmer. Wildcards are allowed:
 
 $ avrdude -c jtag\*/u
 
-# 1. Put Linux udev rules into, eg, /etc/udev/rules.d/55-avrdude.rules
-# 2. Unplug the device and plug it in again
-# 3. Enjoy user access to the USB programmer
+1. Examine the suggested udev rules below; to install run:
+
+avrdude -c "jtag*/u" | tail -n +11 | sudo tee /etc/udev/rules.d/55-avrdude-jtagX.rules
+sudo chmod 0644 /etc/udev/rules.d/55-avrdude-jtagX.rules
+
+2. Unplug any AVRDUDE USB programmers and plug them in again
+3. Enjoy user access to the USB programmer(s)
+
+Note: To install all udev rules known to AVRDUDE follow: avrdude -c "*/u" | more
+
+# Generated from avrdude -c "jtag*/u"
+
+ACTION!="add|change", GOTO="avrdude_end"
 
 # jtag2dw, jtag2fast, jtag2, jtag2isp, jtag2pdi, jtag2slow, jtagmkII, jtag2avr32
 SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2103", \
@@ -4529,7 +4585,6 @@ SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2110", \
   MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS@{idVendor@}=="03eb", \
   ATTRS@{idProduct@}=="2110", MODE="0660", TAG+="uaccess"
-
 SUBSYSTEM=="usb", ATTRS@{idVendor@}=="03eb", ATTRS@{idProduct@}=="2140", \
   MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS@{idVendor@}=="03eb", \
@@ -4542,9 +4597,8 @@ SUBSYSTEM=="usb", ATTRS@{idVendor@}=="0403", ATTRS@{idProduct@}=="cff8", \
 @end cartouche
 @end smallexample
 
-Again, each rule must be written as one line: breaking up rules into two
-lines was only done to fit AVRDUDE's output to the boxed display.
-
+@noindent Again, each rule must be written as one line: breaking up rules
+into two lines was only done to fit AVRDUDE's output to the boxed display.
 USB devices in HID mode require a second rule dealing with the
 @code{hidraw} subsystem as seen above.
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -706,6 +706,7 @@ static int jtag3_edbg_recv_frame(const PROGRAMMER *pgm, unsigned char **msg) {
       // Documentation says:
       // "FragmentInfo 0x00 indicates that no response data is
       // available, and the rest of the packet is ignored."
+      cx->usb_access_error = 1; // Also end up here on wrong USB permissions
       pmsg_notice("%s(): no response available\n", __func__);
       mmt_free(*msg);
       mmt_free(request);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1672,6 +1672,7 @@ char *str_lc(char *s);
 char *str_uc(char *s);
 char *str_lcfirst(char *s);
 char *str_ucfirst(char *s);
+char *str_asciiname(char *s);
 char *str_utoa(unsigned n, char *buf, int base);
 char *str_endnumber(const char *str);
 const char *str_plural(int x);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1696,6 +1696,7 @@ int str_levenshtein(const char *str1, const char *str2, int swap, int subst, int
 size_t str_weighted_damerau_levenshtein(const char *str1, const char *str2);
 int str_mcunames_signature(const unsigned char *sigs, int pm, char *p, size_t n);
 const char *str_ccmcunames_signature(const unsigned char *sigs, int pm);
+const char *str_ccpgmids(LISTID pgm_id);
 
 int led_set(const PROGRAMMER *pgm, int led);
 int led_clr(const PROGRAMMER *pgm, int led);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1839,6 +1839,9 @@ typedef struct {
 
   // Variable connecting lexer.l and config_gram.y
   int lex_kw_is_programmer;     // Was the K_PROGRAMMER keyword "programmer"?
+
+  // Global variable indicating usb access problems
+  int usb_access_error;
 } libavrdude_context;
 
 extern libavrdude_context *cx;

--- a/src/main.c
+++ b/src/main.c
@@ -1123,7 +1123,7 @@ int main(int argc, char * argv [])
     pgmid = cache_string(default_programmer);
 
   // Developer options to print parts and/or programmer entries of avrdude.conf
-  int dev_opt_c = dev_opt(pgmid);    // -c <wildcard>/[dASsrtiBUPTIJWHQ]
+  int dev_opt_c = dev_opt(pgmid);    // -c <wildcard>/[duASsrtiBUPTIJWHQ]
   int dev_opt_p = dev_opt(partdesc); // -p <wildcard>/[cdoASsrw*tiBUPTIJWHQ]
 
   if(dev_opt_c || dev_opt_p) {  // See -c/h and or -p/h

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#if !defined(WIN32)
+#include <dirent.h>
+#endif
 
 #include "avrdude.h"
 #include "libavrdude.h"
@@ -1805,6 +1808,22 @@ main_exit:
     pgm->powerdown(pgm);
     pgm->disable(pgm);
     pgm->close(pgm);
+  }
+
+  if(cx->usb_access_error) {
+    pmsg_info(
+      "\nUSB access errors detected; this could have many reasons; if it is\n"
+      "USB permission problems, avrdude is likely to work when run as root\n"
+      "but this is not good practice; instead you might want to\n");
+#if 0 && !defined(WIN32)
+    DIR *dir;
+    if((dir = opendir("/etc/udev/rules.d"))) { // Linux udev land
+      closedir(dir);
+      imsg_info("run the command below to show udev rules recitifying USB access\n"
+        "$ %s -c %s/u\n", progname, pgmid);
+    } else
+#endif
+    imsg_info("check out USB port permissions on your OS and set them correctly\n");
   }
 
   msg_info("\n");

--- a/src/main.c
+++ b/src/main.c
@@ -130,16 +130,17 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
               fprintf(fp, " %s", mt);
             bols[bi].bol = 0;
           }
-          if(verbose >= MSG_NOTICE2 && (msgmode & MSG2_FUNCTION))
-            fprintf(fp, " %s()", func);
-          if(verbose >= MSG_DEBUG && (msgmode & MSG2_FILELINE)) {
-            const char *pr = strrchr(file, '/'); // Only print basename
+          if(verbose >= MSG_NOTICE2) {
+            const char *bfname = strrchr(file, '/'); // Only print basename
 #if defined (WIN32)
-            if(!pr)
-              pr =  strrchr(file, '\\');
+            if(!bfname)
+              bfname =  strrchr(file, '\\');
 #endif
-            pr = pr? pr+1: file;
-            fprintf(fp, " [%s:%d]", pr, lno);
+            bfname = bfname? bfname+1: file;
+            if(msgmode & MSG2_FUNCTION)
+              fprintf(fp, " %s()", func);
+            if(msgmode & MSG2_FILELINE)
+              fprintf(fp, " %s %d", bfname, lno);
           }
           fprintf(fp, ": ");
         } else if(msgmode & MSG2_INDENT1) {

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -121,6 +121,8 @@ static int micronucleus_check_connection(struct pdata *pdata) {
             0, 0,
             (char*)buffer, sizeof(buffer),
             MICRONUCLEUS_DEFAULT_TIMEOUT);
+	if(result < 0)
+		cx->usb_access_error = 1;
         return result == sizeof(buffer) ? 0 : -1;
     }
     else
@@ -133,6 +135,8 @@ static int micronucleus_check_connection(struct pdata *pdata) {
             0, 0,
             (char*)buffer, sizeof(buffer),
             MICRONUCLEUS_DEFAULT_TIMEOUT);
+	if(result < 0)
+		cx->usb_access_error = 1;
         return result == sizeof(buffer) ? 0 : -1;
     }
 }

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1109,15 +1109,15 @@ static int usb_open_device(PROGRAMMER *pgm, struct usb_dev_handle **device, int 
 
                     if ((errorCode = usb_set_configuration(handle, 1)) < 0)
                     {
-                        pmsg_ext_error("cannot set configuration, error code %d, %s\n"
-                          "you may need to run avrdude as root or set up correct usb port permissions",
+                        cx->usb_access_error = 1;
+                        pmsg_ext_error("cannot set configuration, error code %d, %s\n",
                           errorCode, usb_strerror());
                     }
 
                     if ((errorCode = usb_claim_interface(handle, 0)) < 0)
                     {
-                        pmsg_ext_error("cannot claim interface, error code %d, %s\n"
-                           "You may need to run avrdude as root or set up correct usb port permissions.",
+                        cx->usb_access_error = 1;
+                        pmsg_ext_error("cannot claim interface, error code %d, %s\n",
                            errorCode, usb_strerror());
                     }
 

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1422,3 +1422,18 @@ const char *str_ccmcunames_signature(const unsigned char *sigs, int pm) {
 
   return str_ccprintf("%s", names);
 }
+
+// Returns a comma-separated list of pgm->id names
+const char *str_ccpgmids(LISTID pgm_id) {
+  char ids[1024], *idp = ids;
+
+  for(LNODEID idn=lfirst(pgm_id); idn; idn=lnext(idn)) {
+    char *id = ldata(idn);
+    if((idp - ids) + 3 + strlen(id) <= sizeof ids) {
+      if(idp > ids)
+        strcpy(idp, ", "), idp += 2;
+      strcpy(idp, id), idp += strlen(id);
+    }
+  }
+  return str_ccprintf("%s", ids);
+}

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -412,6 +412,35 @@ char *str_ucfirst(char *s) {
   return s;
 }
 
+// Convert to ASCII name leaving only letters, numbers, underscore, period and dash
+char *str_asciiname(char *s) {
+  for(char *t = s; *t; t++)
+    switch(*t) {
+    case '?':  *t = 'Q'; break;
+    case '*':  *t = 'X'; break;
+    case '|':  *t = 'I'; break;
+    case '{':  *t = 'l'; break;
+    case '}':  *t = 'j'; break;
+    case '[':  *t = 'L'; break;
+    case ']':  *t = 'J'; break;
+    case '(':  *t = 'L'; break;
+    case ')':  *t = 'J'; break;
+    case '<':  *t = 'l'; break;
+    case '>':  *t = 'j'; break;
+    case '&':  *t = '+'; break;
+    case '!':  *t = 'I'; break;
+    case '"':  *t = 'q'; break;
+    case '\'': *t = 'q'; break;
+    case '`':  *t = 'q'; break;
+    case '.': case '-': break;
+    default:
+      if(!isascii(*t & 0xff) || !isalnum(*t & 0xff))
+        *t = '_';
+    }
+
+  return s;
+}
+
 
 // Convert unsigned to ASCII string; caller needs to allocate enough space for buf
 char *str_utoa(unsigned n, char *buf, int base) {

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -450,15 +450,17 @@ static int usbOpenDevice(const PROGRAMMER *pgm, libusb_device_handle **device, i
 	    /* we need to open the device in order to query strings */
             r = libusb_open(dev, &handle);
             if (!handle) {
-                 errorCode = USB_ERROR_ACCESS;
-                 pmsg_warning("cannot open USB device: %s\n", errstr(pgm, r));
-                 continue;
+                cx->usb_access_error = 1;
+                errorCode = USB_ERROR_ACCESS;
+                pmsg_warning("cannot open USB device: %s\n", errstr(pgm, r));
+                continue;
             }
             errorCode = 0;
             /* now check whether the names match: */
             /* if vendorName not given ignore it (any vendor matches) */
 	    r = libusb_get_string_descriptor_ascii(handle, descriptor.iManufacturer & 0xff, (unsigned char*)string, sizeof(string));
             if (r < 0) {
+                cx->usb_access_error = 1;
                 if ((vendorName != NULL) && (vendorName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
                     pmsg_warning("cannot query manufacturer for device: %s\n", errstr(pgm, r));
@@ -471,6 +473,7 @@ static int usbOpenDevice(const PROGRAMMER *pgm, libusb_device_handle **device, i
             /* if productName not given ignore it (any product matches) */
 	    r = libusb_get_string_descriptor_ascii(handle, descriptor.iProduct & 0xff, (unsigned char*)string, sizeof(string));
             if (r < 0) {
+                cx->usb_access_error = 1;
                 if ((productName != NULL) && (productName[0] != 0)) {
                     errorCode = USB_ERROR_IO;
                     pmsg_warning("cannot query product for device: %s\n", errstr(pgm, r));
@@ -529,6 +532,7 @@ static int usbOpenDevice(const PROGRAMMER *pgm, usb_dev_handle **device, int ven
 		/* we need to open the device in order to query strings */
                 handle = usb_open(dev);
                 if(!handle){
+                    cx->usb_access_error = 1;
                     errorCode = USB_ERROR_ACCESS;
                     pmsg_warning("cannot open USB device: %s\n", usb_strerror());
                     continue;
@@ -539,9 +543,10 @@ static int usbOpenDevice(const PROGRAMMER *pgm, usb_dev_handle **device, int ven
                 len = usb_get_string_simple(handle, dev->descriptor.iManufacturer,
 					    string, sizeof(string));
                 if(len < 0){
+                    cx->usb_access_error = 1;
                     if ((vendorName != NULL) && (vendorName[0] != 0)) {
-                    errorCode = USB_ERROR_IO;
-                    pmsg_warning("cannot query manufacturer for device: %s\n", usb_strerror());
+                        errorCode = USB_ERROR_IO;
+                        pmsg_warning("cannot query manufacturer for device: %s\n", usb_strerror());
 		    }
                 } else {
                     pmsg_notice2("seen device from vendor >%s<\n", string);
@@ -552,6 +557,7 @@ static int usbOpenDevice(const PROGRAMMER *pgm, usb_dev_handle **device, int ven
                 len = usb_get_string_simple(handle, dev->descriptor.iProduct,
 					    string, sizeof(string));
                 if(len < 0){
+                    cx->usb_access_error = 1;
                     if ((productName != NULL) && (productName[0] != 0)) {
                         errorCode = USB_ERROR_IO;
                         pmsg_warning("cannot query product for device: %s\n", usb_strerror());

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -86,9 +86,9 @@ static void usbtiny_teardown(PROGRAMMER *pgm) {
 }
 
 // Wrapper for simple usb_control_msg messages
-static int usb_control (const PROGRAMMER *pgm,
-			unsigned int requestid, unsigned int val, unsigned int index )
-{
+static int usb_control(const PROGRAMMER *pgm,
+  unsigned int requestid, unsigned int val, unsigned int index, int silent) {
+
   int nbytes;
   nbytes = usb_control_msg( PDATA(pgm)->usb_handle,
 			    USB_ENDPOINT_IN | USB_TYPE_VENDOR | USB_RECIP_DEVICE,
@@ -97,8 +97,10 @@ static int usb_control (const PROGRAMMER *pgm,
 			    NULL, 0,              // no data buffer in control message
 			    USB_TIMEOUT );        // default timeout
   if(nbytes < 0){
-    msg_error("\n");
-    pmsg_error("%s\n", usb_strerror());
+    if(!silent) {
+      msg_error("\n");
+      pmsg_error("%s\n", usb_strerror());
+    }
     return -1;
   }
 
@@ -408,7 +410,7 @@ static int usbtiny_set_sck_period (const PROGRAMMER *pgm, double v) {
 
   // send the command to the usbtiny device.
   // MEME: for at90's fix resetstate?
-  if (usb_control(pgm, USBTINY_POWERUP, PDATA(pgm)->sck_period, RESET_LOW) < 0)
+  if (usb_control(pgm, USBTINY_POWERUP, PDATA(pgm)->sck_period, RESET_LOW, 0) < 0)
     return -1;
 
   // with the new speed, we'll have to update how much data we send per usb transfer
@@ -430,7 +432,7 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
     PDATA(pgm)->sck_period = SCK_DEFAULT;
     pmsg_notice("using SCK period of %d usec\n", PDATA(pgm)->sck_period );
     if (usb_control(pgm,  USBTINY_POWERUP,
-		    PDATA(pgm)->sck_period, RESET_LOW ) < 0)
+		    PDATA(pgm)->sck_period, RESET_LOW, 0) < 0)
       return -1;
     usbtiny_set_chunk_size(pgm, PDATA(pgm)->sck_period);
   }
@@ -471,10 +473,8 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
     if (pgm->program_enable(pgm, p) >= 0)
       break;
     // no response, RESET and try again
-    if (usb_control(pgm, USBTINY_POWERUP,
-		    PDATA(pgm)->sck_period, RESET_HIGH) < 0 ||
-	usb_control(pgm, USBTINY_POWERUP,
-		    PDATA(pgm)->sck_period, RESET_LOW) < 0)
+    if(usb_control(pgm, USBTINY_POWERUP, PDATA(pgm)->sck_period, RESET_HIGH, 0) < 0 ||
+       usb_control(pgm, USBTINY_POWERUP, PDATA(pgm)->sck_period, RESET_LOW, 0) < 0)
       return -1;
     usleep(50000);
   }
@@ -486,10 +486,8 @@ static int usbtiny_initialize (const PROGRAMMER *pgm, const AVRPART *p ) {
 static int usbtiny_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
   /* USBtiny is not a bit bang device, but it can set RESET */
   if(pinfunc == PIN_AVR_RESET) {
-    if (usb_control(pgm, USBTINY_POWERUP,
-                    PDATA(pgm)->sck_period, value ? RESET_HIGH : RESET_LOW) < 0) {
+    if(usb_control(pgm, USBTINY_POWERUP, PDATA(pgm)->sck_period, value? RESET_HIGH: RESET_LOW, 0) < 0)
       return -1;
-    }
     usleep(50000);
     return 0;
   }
@@ -498,10 +496,9 @@ static int usbtiny_setpin(const PROGRAMMER *pgm, int pinfunc, int value) {
 
 /* Tell the USBtiny to release the output pins, etc */
 static void usbtiny_powerdown(const PROGRAMMER *pgm) {
-  if (!PDATA(pgm)->usb_handle) {
+  if (!PDATA(pgm)->usb_handle)
     return;                 // wasn't connected in the first place
-  }
-  usb_control(pgm, USBTINY_POWERDOWN, 0, 0);      // Send USB control command to device
+  usb_control(pgm, USBTINY_POWERDOWN, 0, 0, 1);
 }
 
 /* Send a 4-byte SPI command to the USBtinyISP for execution
@@ -718,7 +715,7 @@ static int usbtiny_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     unsigned int poll_value = (m->readback[1] << 8) | m->readback[0];
     if(!poll_value)
       poll_value = 0xffff;
-    if (usb_control(pgm, USBTINY_POLL_BYTES, poll_value, 0 ) < 0)
+    if(usb_control(pgm, USBTINY_POLL_BYTES, poll_value, 0, 0) < 0)
       return -1;
     delay = m->max_write_delay;
   }

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -97,6 +97,7 @@ static int usb_control(const PROGRAMMER *pgm,
 			    NULL, 0,              // no data buffer in control message
 			    USB_TIMEOUT );        // default timeout
   if(nbytes < 0){
+    cx->usb_access_error = 1;
     if(!silent) {
       msg_error("\n");
       pmsg_error("%s\n", usb_strerror());


### PR DESCRIPTION
Closes #1860 

Wildcards for the programmer name are allowed:
```
 avrdude -c \jtag*/u
# 1. Put Linux udev rules into /etc/udev/rules.d/55-avrdude.rules (or similar)
# 2. sudo udevadm control --reload-rules && sudo udevadm trigger (or similar)
# 3. Unplug the device and plug it in again

# jtag2dw, jtag2fast, jtag2, jtag2isp, jtag2pdi, jtag2slow, jtagmkII, jtagmkII_avr32, jtag2avr32
SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2103", MODE="0660", TAG+="uaccess"

# jtag3, jtag3dw, jtag3isp, jtag3pdi, jtag3updi
SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2110", MODE="0660", TAG+="uaccess"
KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2110", MODE="0660", TAG+="uaccess"
SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2140", MODE="0660", TAG+="uaccess"
KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2140", MODE="0660", TAG+="uaccess"

# jtagkey
SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="cff8", MODE="0660", TAG+="uaccess"
```