### PR TITLE
Refine programmer/part/memory compatibility for ALL expansion

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -504,7 +504,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
       if (rc != LIBAVRDUDE_SUCCESS) {
         pmsg_error("unable to read byte at address 0x%04lx\n", i);
         if (rc == LIBAVRDUDE_GENERAL_FAILURE) {
-          pmsg_error("read operation not supported for memory %s\n", mem->desc);
+          // pmsg_error("read operation not supported for memory %s\n", mem->desc);
           report_progress(1, -1, NULL);
           led_set(pgm, LED_ERR);
           led_clr(pgm, LED_PGM);

--- a/src/avr.c
+++ b/src/avr.c
@@ -1384,14 +1384,14 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
         // Mismatch is only in unused bits
         if ((buf1[i] | bitmask) != 0xff) {
           // Programmer returned unused bits as 0, must be the part/programmer
-          pmsg_warning("ignoring mismatch in unused bits of %s\n", a->desc);
-          imsg_warning("(device 0x%02x != input 0x%02x); to prevent this warning fix\n", buf1[i], buf2[i]);
-          imsg_warning("the part or programmer definition in the config file\n");
+          pmsg_debug("ignoring mismatch in unused bits of %s\n", a->desc);
+          imsg_debug("(device 0x%02x != input 0x%02x); to prevent this warning fix\n", buf1[i], buf2[i]);
+          imsg_debug("the part or programmer definition in the config file\n");
         } else {
           // Programmer returned unused bits as 1, must be the user
-          pmsg_warning("ignoring mismatch in unused bits of %s\n", a->desc);
-          imsg_warning("(device 0x%02x != input 0x%02x); to prevent this warning set\n", buf1[i], buf2[i]);
-          imsg_warning("unused bits to 1 when writing (double check with datasheet)\n");
+          pmsg_debug("ignoring mismatch in unused bits of %s\n", a->desc);
+          imsg_debug("(device 0x%02x != input 0x%02x); to prevent this warning set\n", buf1[i], buf2[i]);
+          imsg_debug("unused bits to 1 when writing (double check with datasheet)\n");
         }
       }
     }

--- a/src/avr.c
+++ b/src/avr.c
@@ -1599,6 +1599,12 @@ Memtable avr_mem_order[100] = {
   {"sib",         MEM_SIB | MEM_READONLY},
 };
 
+// Whether a memory is an exception that shouldn't be there for this particular i/face
+int avr_mem_exclude(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
+  return // Classic part usersig memories cannot be read/written using ISP
+    mem_is_usersig(mem) && (p->prog_modes&PM_Classic) && (pgm->prog_modes&p->prog_modes&PM_ISP);
+}
+
 int avr_get_mem_type(const char *str) {
   for(size_t i=0; i < sizeof avr_mem_order/sizeof *avr_mem_order; i++) {
     if(avr_mem_order[i].str && str_eq(avr_mem_order[i].str, str))

--- a/src/avr.c
+++ b/src/avr.c
@@ -428,7 +428,7 @@ int avr_read_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, con
 
   // HW programmers need a page size > 1, bootloader typ only offer paged r/w
   if ((pgm->paged_load && mem->page_size > 1 && mem->size % mem->page_size == 0) ||
-     ((pgm->prog_modes & PM_SPM) && avr_has_paged_access(pgm, mem))) {
+     ((pgm->prog_modes & PM_SPM) && avr_has_paged_access(pgm, p, mem))) {
     /*
      * the programmer supports a paged mode read
      */
@@ -1054,7 +1054,7 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
 
   // HW programmers need a page size > 1, bootloader typ only offer paged r/w
   if ((pgm->paged_load && m->page_size > 1 && m->size % m->page_size == 0) ||
-     ((pgm->prog_modes & PM_SPM) && avr_has_paged_access(pgm, m))) {
+     ((pgm->prog_modes & PM_SPM) && avr_has_paged_access(pgm, p, m))) {
     /*
      * the programmer supports a paged mode write
      */

--- a/src/avr.c
+++ b/src/avr.c
@@ -873,8 +873,8 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
         rc = pgm->initialize(pgm, p);
         if (rc < 0) {
           pmsg_error("initialization failed (rc = %d):\n", rc);
-          imsg_error("cannot re-initialize device after programming the %s bits; you\n", mem->desc);
-          imsg_error("must manually power-down the device and restart %s to continue\n", progname);
+          imsg_error("cannot re-initialize device after programming the %s bits;\n", mem->desc);
+          imsg_error("manually power-down the device and restart %s to continue\n", progname);
           rc = -3;
           goto rcerror;
         }

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -4033,12 +4033,20 @@ part parent "t11" # t12
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
+    memory "prodsig"
+        read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
+    ;
+
     memory "signature"
         read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sernum"
+        read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
     ;
 ;
 
@@ -4119,12 +4127,20 @@ part parent "t11" # t15
         write              = "1010.1100--1111.1ii1--xxxx.xxxx--xxxx.xxxx";
     ;
 
+    memory "prodsig"
+        read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
+    ;
+
     memory "signature"
         read               = "0011.0000--xxxx.xxxx--0000.00aa--oooo.oooo";
     ;
 
     memory "calibration"
         read               = "0011.1000--xxxx.xxxx--0000.0000--oooo.oooo";
+    ;
+
+    memory "sernum"
+        read               = "0 0 1 1 a0 0 0 0  0 0 0 0 0 0 0 0  0 0 0 0 a4 a3 a2 a1  o o o o o o o o";
     ;
 ;
 

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -256,9 +256,9 @@ static int tagfile_readline(char *line, int lineno, const char * const *isrnames
 // Allocate, copy, append a suffix (H, L, 0...8 or nothing), cleanup name and return
 static char *regname(const char *pre, const char *reg, int suf) {
   char *ret =
-    suf <= -1? str_sprintf("%s%s", pre, reg):
-    suf == 'h' || suf == 'l'? str_sprintf("%s%s%c", pre, reg, suf):
-    str_sprintf("%s%s%d", pre, reg, suf);
+    suf <= -1? mmt_sprintf("%s%s", pre, reg):
+    suf == 'h' || suf == 'l'? mmt_sprintf("%s%s%c", pre, reg, suf):
+    mmt_sprintf("%s%s%d", pre, reg, suf);
 
   return cleanup(ret);
 }
@@ -556,10 +556,10 @@ static int process_string(const char *buf, int buflen, int pos, int offset) {
     str[i-pos] = 0;
     out = cfg_escape(str);
     mmt_free(str);
-    code = str_sprintf(".ascii  %s", out);
+    code = mmt_sprintf(".ascii  %s", out);
   } else {                      // Nul terminated string
     out = cfg_escape(buf + pos);
-    code = str_sprintf(".asciz  %s", out);
+    code = mmt_sprintf(".asciz  %s", out);
     i++;
   }
 

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -155,7 +155,7 @@ static int dryrun_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   if(!(dmem = avr_locate_mem(dry.dp, m->desc)))
     Return("cannot locate %s %s memory for paged write", dry.dp->desc, m->desc);
 
-  if(!avr_has_paged_access(pgm, dmem) || addr >= (unsigned) dmem->size)
+  if(!avr_has_paged_access(pgm, dry.dp, dmem) || addr >= (unsigned) dmem->size)
     Return("%s does not support paged access", dmem->desc);
   addr &= ~(dmem->page_size-1);
   if(addr + dmem->page_size > (unsigned) dmem->size)

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -535,6 +535,8 @@ typedef struct avrmem_alias {
   AVRMEM *aliased_mem;
 } AVRMEM_ALIAS;
 
+typedef struct programmer PROGRAMMER; // Forward declaration
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -572,7 +574,7 @@ AVRMEM * avr_locate_mem_by_type(const AVRPART *p, Memtype type);
 unsigned int avr_data_offset(const AVRPART *p);
 AVRMEM_ALIAS * avr_locate_memalias(const AVRPART *p, const char *desc);
 AVRMEM_ALIAS * avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig);
-void avr_mem_display(FILE *f, const AVRPART *p, const char *prefix);
+void avr_mem_display(FILE *f, const PROGRAMMER *pgm, const AVRPART *p, const char *prefix);
 
 /* Functions for AVRPART structures */
 AVRPART * avr_new_part(void);
@@ -585,7 +587,7 @@ AVRPART * locate_part_by_signature_pm(const LISTID parts, unsigned char *sig, in
 int avr_sig_compatible(const unsigned char *sig1, const unsigned char *sig2);
 
 char *avr_prog_modes(int pm), *str_prog_modes(int pm), *dev_prog_modes(int pm);
-void avr_display(FILE *f, const AVRPART *p, const char *prefix, int verbose);
+void avr_display(FILE *f, const PROGRAMMER *pgm, const AVRPART *p, const char *prefix, int verbose);
 int avr_variants_display(FILE *f, const AVRPART *p, const char *prefix);
 
 typedef void (*walk_avrparts_cb)(const char *name, const char *desc,
@@ -709,8 +711,6 @@ void pin_set_value(struct pindef * const pindef, const int pin, const bool inver
  * @param[out] pindef pin definition to clear
  */
 void pin_clear_all(struct pindef * const pindef);
-
-typedef struct programmer PROGRAMMER; // Forward declaration
 
 /**
  * Convert for given programmer new pin definitions to old pin definitions.
@@ -1170,7 +1170,7 @@ void report_progress(int completed, int total, const char *hdr);
 
 void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen);
 
-int avr_has_paged_access(const PROGRAMMER *pgm, const AVRMEM *m);
+int avr_has_paged_access(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);
 
 int avr_read_page_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, int addr, unsigned char *buf);
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1320,7 +1320,7 @@ int update_is_readable(const char *fn);
 
 int update_dryrun(const AVRPART *p, UPDATE *upd);
 
-AVRMEM **memory_list(const char *mstr, const AVRPART *p, int *np, int *rwvsoftp, int *dry);
+AVRMEM **memory_list(const char *mstr, const PROGRAMMER *pgm, const AVRPART *p, int *np, int *rwvsoftp, int *dry);
 int memlist_contains_flash(const char *mstr, const AVRPART *p);
 
 #ifdef __cplusplus

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1144,6 +1144,8 @@ int avr_get_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int *cycles);
 
 int avr_put_cycle_count(const PROGRAMMER *pgm, const AVRPART *p, int cycles);
 
+int avr_mem_exclude(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem);
+
 int avr_get_mem_type(const char *str);
 
 int avr_mem_is_flash_type(const AVRMEM *mem);

--- a/src/main.c
+++ b/src/main.c
@@ -1677,8 +1677,8 @@ skipopen:
         msg_info("\n");
         pmsg_error("invalid device signature\n");
         if (!ovsigck) {
-          pmsg_error("expected signature for %s is%s; double\n", p->desc, str_cchex(p->signature, 3, 1));
-          imsg_error("check connections and try again, or use -F to carry on regardless\n");
+          pmsg_error("expected signature for %s is%s\n", p->desc, str_cchex(p->signature, 3, 1));
+          imsg_error("  - double check connections and try again, or use -F to carry on regardless\n");
           exitrc = 1;
           goto main_exit;
         }
@@ -1690,8 +1690,8 @@ skipopen:
         if (ovsigck) {
           pmsg_warning("expected signature for %s is%s\n", p->desc, str_cchex(p->signature, 3, 1));
         } else {
-          pmsg_error("expected signature for %s is%s; double\n", p->desc, str_cchex(p->signature, 3, 1));
-          imsg_error("check chip or use -F to carry on regardless\n");
+          pmsg_error("expected signature for %s is%s\n", p->desc, str_cchex(p->signature, 3, 1));
+          imsg_error("  - double check chip or use -F to carry on regardless\n");
           exitrc = 1;
           goto main_exit;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -1515,7 +1515,7 @@ skipopen:
   }
 
   if (verbose > 0 && quell_progress < 2) {
-    avr_display(stderr, p, progbuf, verbose);
+    avr_display(stderr, pgm, p, progbuf, verbose);
     msg_notice2("\n");
     programmer_display(pgm, progbuf);
   }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2820,7 +2820,7 @@ static int stk500v2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
 
   // the read command is common to both methods
   if (rop == NULL) {
-    pmsg_error("read instruction not defined for part %s\n", p->desc);
+    pmsg_error("read instruction not defined for memory %s of part %s\n", m->desc, p->desc);
     return -1;
   }
   memset(cmds, 0, sizeof cmds);
@@ -3025,7 +3025,7 @@ static int stk500v2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   // the read command is common to both methods
   if (rop == NULL) {
-    pmsg_error("read instruction not defined for part %s\n", p->desc);
+    pmsg_error("read instruction not defined for memory %s of part %s\n", m->desc, p->desc);
     return -1;
   }
   memset(cmds, 0, sizeof cmds);

--- a/src/update.c
+++ b/src/update.c
@@ -269,15 +269,9 @@ static void ioerror(const char *iotype, const UPDATE *upd) {
   msg_ext_error("\n");
 }
 
-// Whether a memory is an exception that shouldn't be included
-static int exclude(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
-  return // Classic part usersig memories cannot be read/written using ISP
-    mem_is_usersig(mem) && (p->prog_modes&PM_Classic) && (pgm->prog_modes&p->prog_modes&PM_ISP);
-}
-
 // Whether a memory should be returned for ALL: exclude IO/SRAM
 static int is_interesting_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
-  return !mem_is_io(mem) && !mem_is_sram(mem) && !(pgm && exclude(pgm, p, mem));
+  return !mem_is_io(mem) && !mem_is_sram(mem) && !(pgm && avr_mem_exclude(pgm, p, mem));
 }
 
 // Whether a memory should be backup-ed: exclude sub-memories

--- a/src/update.c
+++ b/src/update.c
@@ -277,7 +277,7 @@ static int exclude(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
 
 // Whether a memory should be returned for ALL: exclude IO/SRAM
 static int is_interesting_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
-  return !(mem_is_io(mem) || mem_is_sram(mem));
+  return !mem_is_io(mem) && !mem_is_sram(mem) && !(pgm && exclude(pgm, p, mem));
 }
 
 // Whether a memory should be backup-ed: exclude sub-memories
@@ -285,7 +285,7 @@ static int is_backup_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *
   return mem_is_in_flash(mem)? mem_is_flash(mem):
     mem_is_in_sigrow(mem)? mem_is_sigrow(mem):
     mem_is_in_fuses(mem)? mem_is_fuses(mem) || !avr_locate_fuses(p):
-    is_interesting_mem(pgm, p, mem) && !(pgm && exclude(pgm, p, mem));
+    is_interesting_mem(pgm, p, mem);
 }
 
 // Add (not == 0) or subtract (not == 1) a memory from list


### PR DESCRIPTION
avrdude.conf lists programming modes and memories for each part but is not capable of expressing that some memories are *only* available in certain programming modes. This PR hard-codes known exceptions for the purpose of expanding `ALL` to a suitable list of memories.

For example, usersig of classic parts (think m256rfr2) cannot be read or written via ISP. Testing (or good memories) will smoke out a few more. This technique can also be used for now to encode exceptions for new memories (eg, BOOTROW) for old programmers that didn't foresee these. 

Depending on how many incompatibilities we discover, whether we can fix them, it might later turn out that we do sth else, eg, better modelling in avrdude.conf. This is just to get things right for now.

This PR also fixes sernum/prodsig access for `t15` discovered [here](https://github.com/avrdudes/avrdude/discussions/1654#discussioncomment-10246445) and `t12` (same problem)