### PR TITLE
Writing BOOTROW for Curiosity Nano

### DIFF
--- a/src/avrcache.c
+++ b/src/avrcache.c
@@ -439,7 +439,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       }
     }
 
-    if(!mem_is_user_type(mems[i].mem)) // Only force CE if unable to write to flash/EEPROM
+    if(!mem_is_usersig(mems[i].mem)) // CE does not erase usersig
       chiperase = 1;
   }
 
@@ -461,7 +461,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       AVR_Cache *cp = mems[i].cp;
       if(!mem)
         continue;
-      if(mem_is_user_type(mem)) // CE does not affect bootrow/userrow
+      if(mem_is_usersig(mem)) // CE does not affect usersig/userrow
         continue;
 
       for(int pgno = 0, n = 0; n < cp->size; pgno++, n += cp->page_size)
@@ -477,7 +477,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
         AVR_Cache *cp = mems[i].cp;
         if(!mem)
           continue;
-        if(mem_is_user_type(mem)) // CE does not affect bootrow/userrow
+        if(mem_is_usersig(mem)) // CE does not affect usersig/userrow
           continue;
 
         for(int ird = 0, pgno = 0, n = 0; n < cp->size; pgno++, n += cp->page_size) {
@@ -506,7 +506,7 @@ int avr_flush_cache(const PROGRAMMER *pgm, const AVRPART *p) {
       AVR_Cache *cp = mems[i].cp;
       if(!mem)
         continue;
-      if(mem_is_user_type(mem)) // CE does not affect bootrow/userrow
+      if(mem_is_usersig(mem))   // CE does not affect usersig/userrow
         continue;
 
       if(mems[i].isflash) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -25,7 +25,7 @@
  * Scope
  *
  * Code in this file serves the following programmers
- * $ avrdude -c*/At | grep type..jtagice3 | cut -f2
+ * $ avrdude -c "*"/At | grep type..jtagice3 | cut -f2
  *
  * These are
  *  - jtag3, jtag3pdi, jtag3updi, jtag3dw, jtag3isp

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -19,42 +19,44 @@
  */
 
 /*
- * avrdude interface for Atmel JTAGICE3 programmer
- */
-
-/******
- * NOTE
- * 
- * This "jtag3.c" file contains the following open issues, challenges, and limitations.
- * Please see the respective links for more information.
- * Further information and contributions are welcome to improve the completeness of the release.
- */
-
-/********
- * ISSUES
+ * Avrdude interface for Atmel JTAGICE3 programmer
  *
- * * ATMELICE3 is only recognized correctly in USB High-Speed mode.
- *   This also relates to the hidapi and libusb backends.
- *   - https://github.com/avrdudes/avrdude/issues/1221
- */
-
-/*************
- * LIMITATIONS
+ *
+ * Scope
+ *
+ * Code in this file serves the following programmers
+ * $ avrdude -c*/At | grep type..jtagice3 | cut -f2
+ *
+ * These are
+ *  - jtag3, jtag3pdi, jtag3updi, jtag3dw, jtag3isp
+ *  - xplainedpro, xplainedpro_pdi, xplainedpro_updi
+ *  - xplainedmini, xplainedmini_dw, xplainedmini_updi, xplainedmini_tpi
+ *  - atmelice, atmelice_pdi, atmelice_updi, atmelice_dw, atmelice_isp, atmelice_tpi
+ *  - powerdebugger, powerdebugger_pdi, powerdebugger_updi, powerdebugger_dw, powerdebugger_isp, powerdebugger_tpi
+ *  - pickit4, pickit4_updi, pickit4_pdi, pickit4_isp, pickit4_tpi
+ *  - snap, snap_updi, snap_pdi, snap_isp, snap_tpi
+ *  - pkobn_updi
+ *
+ *
+ * Issues
+ *
+ *  - ATMELICE3 is only recognised correctly in USB High-Speed mode this
+ *    also relates to the hidapi and libusb backends, see
+ *    https://github.com/avrdudes/avrdude/issues/1221
+ *
+ *
+ * Limitations
  * 
- * * jtag3_page_erase() does not work in the BOOTROW section of the AVR-DU series.
- *   Can only be written correctly once unless "Chip-Erase" command is performed.
- *   Confirmed: "Curiosity Nano AVR32DU32" ICE-FW(nEDBG) <= 1.31 (rel 39) - Page-Erase fail
- *   - "Curiosity Nano AVR16EB32" and PICKit4 have not been tested yet.
- *   - https://github.com/avrdudes/avrdude/issues/1868
- */
-
-/**********
- * UNSOLVED
+ *  - jtag3_page_erase() does not work in the bootrow section of the
+ *    AVR-DU series, ie, can only be written correctly once unless the
+ *    chip-erase command is performed. Confirmed: bootrow page-erase fails
+ *    for Curiosity Nano AVR32DU32 ICE-FW(nEDBG) <= 1.31 (rel 39)
+ *
+ *  - Trace output -vvvv is not complete and would benefit from enhancing
  * 
- * * `-vvvv` debug output is missing a lot and would like to be enhanced.
- * 
- * * Not sure how to allow "High-Voltage Programming" on TPI parts.
- *   Procedures to change the behavior of the "Target-RESET pin" are unknown or not implemented.
+ *  - High-Voltage Programming on TPI parts not implemented
+ *
+ *  - Procedures to change the behaviour of the "Target-RESET pin" are unknown or not implemented
  */
 
 #include <ac_cfg.h>
@@ -1919,12 +1921,9 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   } else if (mem_is_userrow(m)) {
     cmd[3] = XMEGA_ERASE_USERSIG;
   } else if (mem_is_bootrow(m)) {
-    cmd[3] = XMEGA_ERASE_USERSIG;
-    // TENTATIVE: For AVR-DU and AVR-EB series
-    // Currently, AVR-DU BOOTROW cannot be erased with CMD3_ERASE_MEMORY.
-    // It can only be initialized with chip erase.
-    // Quoting ATDF: <memory-segment name="BOOTROW", ... type="user_signatures"/>
-    // Therefore, this parameter is provisional. It may be fixed in the future.
+    // Currently, AVR-DU BOOTROW cannot be erased with CMD3_ERASE_MEMORY
+    // Note ATDF: <memory-segment name="BOOTROW", ... type="user_signatures"/>
+    cmd[3] = XMEGA_ERASE_USERSIG; // Tentative for AVR-DU and AVR-EB series
   } else {
     cmd[3] = XMEGA_ERASE_APP_PAGE;
   }


### PR DESCRIPTION
https://github.com/avrdudes/avrdude/issues/1868

This suggestion is valid for the following products. It may also be valid for PICKit4 + AVR-DU/EB series configurations.
This does not affect program drivers that do not use "jtag3.c".

- Curiosity Nano AVR16EB32
- Curiosity Nano AVR64DU32

Before the PR, BOOTROW can only be read, rewriting fails, and pages cannot be erased.

After PR, BOOTROW can be rewritten with the following exceptions:

- For AVR-DU series, bits can only be changed from 1 to 0. Page erase still does not work, meaning it can only be successfully written once after chip erase. This issue may not occur for AVR-EB series. Other chips do not have BOOTROW, so it is not relevant.
- On AVR-DU series, erasing BOOTROW only succeeds with chip erase, not if the protection bits in FUSE_SYSCFG0 are enabled.

Any open issues regarding "jtag3.c" are summarized at the top of the file.