### PR TITLE
Add more hard-coded usbvid/pid to udev rules

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1743,6 +1743,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
         }
         if(pic_mode >= 0) {
           msg_error("\n");
+          cx->usb_access_error = 0;
           pmsg_error("%s in %s mode detected\n",
             pgmstr, pinfo.usbinfo.pid == bl_pid? "bootloader": "PIC");
           if(mode_switch == PK4_SNAP_MODE_AVR) {
@@ -1757,7 +1758,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
             imsg_error("run %s again to continue the session\n\n", progname);
           } else {
             pmsg_error("to switch into AVR mode try\n");
-            imsg_error("$ %s -c%s -p%s -P%s -x mode=avr\n", progname, pgmid, partdesc, port);
+            imsg_error("$ %s -c %s -p %s -P %s -x mode=avr\n", progname, pgmid, partdesc, port);
           }
           serial_close(&pgm->fd);
           return LIBAVRDUDE_EXIT;;

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -626,6 +626,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
       /* check if device with old VID/PID is available */
       if(usbOpenDevice(pgm, &PDATA(pgm)->usbhandle, USBASP_OLD_VID, "www.fischl.de",
                         USBASP_OLD_PID, "USBasp", port) == 0) {
+        cx->usb_access_error = 0;
         /* found USBasp with old IDs */
         pmsg_error("found USB device USBasp with old VID/PID; please update firmware of USBasp\n");
 	return 0;


### PR DESCRIPTION
Looking at the source code, it turns out there are a few hardcoded usbvid/usbpid pairs that are not in avrdude.conf.

They are treated as update in this PR. Should be safe to merge