### PR TITLE
Make usbproduct available to programmers

### DIFF
--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -889,6 +889,7 @@ struct serial_device {
   int (*set_dtr_rts)(const union filedescriptor *fd, int is_on);
 
   const char *usbsn;
+  const char *usbproduct;
   int flags;
 #define SERDEV_FL_NONE         0x0000 /* no flags */
 #define SERDEV_FL_CANSETSPEED  0x0001 /* device can change speed */

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2156,9 +2156,13 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
-  // Make USB serial number available to programmer
-  if (serdev && serdev->usbsn)
-    pgm->usbsn = serdev->usbsn;
+  // Make USB serial number and USB product name available to programmer
+  if (serdev) {
+    if (serdev->usbsn)
+      pgm->usbsn = serdev->usbsn;
+    if (serdev->usbproduct)
+      pgm->usbproduct = serdev->usbproduct;
+  }
 
   // Drain any extraneous input, synchronise and drain again
   if(stk500v2_drain(pgm, 0) < 0 || stk500v2_getsync(pgm) < 0 || stk500v2_drain(pgm, 0) < 0)

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -147,6 +147,19 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
     }
   }
 
+  // Store USB product string to prod_str
+  wchar_t prodstr[256];
+  if (hid_get_product_string(dev, prodstr, sizeof(prodstr)/sizeof(*prodstr)) == 0) {
+    size_t n = wcstombs(NULL, prodstr, 0) + 1;
+    if (n) {
+      char *cn = mmt_malloc(n);
+      if (wcstombs(cn, prodstr, n) != (size_t) -1)
+        if(serdev)
+          serdev->usbproduct = cache_string(cn);
+      mmt_free(cn);
+    }
+  }
+
   fd->usb.handle = dev;
 
   /*

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -128,6 +128,8 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
 		      pmsg_warning("reading product name, %s\n", usb_strerror());
 		      strcpy(product, "[unnamed product]");
 		    }
+		  if(serdev)
+		    serdev->usbproduct = cache_string(product);
 
 		  /* We need to write to endpoint 2 to switch the PICkit4 and SNAP
 		   * from PIC to AVR mode


### PR DESCRIPTION
I messed up PR #1879, so I'm trying again.

I figured it would be nice to have the actual USB string available so we could print it using `pgm->display`. Especially now that PR #1863 supports multiple different programmers using `-c pickit5`.

@stefanrueger I know we generally shouldn't touch the existing code formatting, ~~but the usb_libusb.c formatting was _completely broken_, to a point where no text editor tabs/spaces setting could make the code acceptable. Indents were everywhere, and things were just a mess. I took the liberty to re-format the file as a separate commit.~~

I haven't done anything with the formatting yet, but I'm itching to do so! I can't believe how it could end up this bad. Intents are all over the place regardless of text editor settings. 