### PR TITLE
Fix ATmega1284/P readsize

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -10856,7 +10856,6 @@ part parent "m164p" # m1284
         size               = 0x20000;
         page_size          = 256;
         num_pages          = 512;
-        readsize           = 128;
         read_lo            = "0010.0000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
         read_hi            = "0010.1000--aaaa.aaaa--aaaa.aaaa--oooo.oooo";
         loadpage_lo        = "0100.0000--00xx.xxxx--xaaa.aaaa--iiii.iiii";


### PR DESCRIPTION
Might fix weird jtagice3 [jtag behaviour](https://github.com/avrdudes/avrdude/discussions/1654#discussioncomment-10318020)

Seeing that the firmware of the programmers is working and that m1281 can be programmed and m1284p cannot, I looked at the differences of their definitions:
```
avrdude -p m1281/S >/tmp/1
avrdude -p m1284p/S >/tmp/4
diff /tmp/[14]
```

The readsize and blocksize entries look suspect, as they are smaller than page size with the m1284p (but not with the m1281).

Turns out blocksize is *only* used for TPI parts (and that in `jtag3.c`), but `readsize` is used in `jtag3.c` for classic non-tpi parts. Also turns out there are only two parts where readsize is smaller than page size: m1284 and m1284p. 

This PR makes their readsizes 256. Might work?