### PR TITLE
Fix addresses for jtag3_pdi boot and apptable

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1459,7 +1459,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   mmt_free(PDATA(pgm)->eeprom_pagecache);
   PDATA(pgm)->flash_pagecache = mmt_malloc(PDATA(pgm)->flash_pagesize);
   PDATA(pgm)->eeprom_pagecache = mmt_malloc(PDATA(pgm)->eeprom_pagesize);
-  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = (unsigned long) -1L;
+  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = ~0UL;
 
   return 0;
 }
@@ -1920,10 +1920,10 @@ static int jtag3_page_erase(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   if (mem_is_in_flash(m)) {
     cmd[3] = is_updi(p) || jtag3_mtype(pgm, p, m, addr) == MTYPE_FLASH?
       XMEGA_ERASE_APP_PAGE: XMEGA_ERASE_BOOT_PAGE;
-    PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->flash_pageaddr = ~0UL;
   } else if (mem_is_eeprom(m)) {
     cmd[3] = XMEGA_ERASE_EEPROM_PAGE;
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
   } else if (mem_is_userrow(m)) {
     cmd[3] = XMEGA_ERASE_USERSIG;
   } else if (mem_is_bootrow(m)) {
@@ -1971,7 +1971,7 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   cmd[1] = CMD3_WRITE_MEMORY;
   cmd[2] = 0;
   if (mem_is_flash(m)) {
-    PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->flash_pageaddr = ~0UL;
     cmd[3] = jtag3_mtype(pgm, p, m, addr);
     if (p->prog_modes & PM_PDI)
       /* dynamically decide between flash/boot mtype */
@@ -1993,7 +1993,7 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
       return n_bytes;
     }
     cmd[3] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM_XMEGA: MTYPE_EEPROM_PAGE;
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
   } else if (mem_is_userrow(m) || mem_is_bootrow(m)) {
     cmd[3] = MTYPE_USERSIG;
   } else if (mem_is_boot(m)) {
@@ -2278,7 +2278,7 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
    *
    * Page cache validation is based on "{flash,eeprom}_pageaddr"
    * (holding the base address of the most recent cache fill
-   * operation).  This variable is set to (unsigned long)-1L when the
+   * operation).  This variable is set to ~0UL when the
    * cache needs to be invalidated.
    */
   if (pagesize && paddr == *paddr_ptr) {
@@ -2347,7 +2347,7 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   if (mem_is_flash(mem)) {
      cache_ptr = PDATA(pgm)->flash_pagecache;
      pagesize = PDATA(pgm)->flash_pagesize;
-     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+     PDATA(pgm)->flash_pageaddr = ~0UL;
      if (pgm->flag & PGM_FL_IS_DW)
        unsupp = 1;
   } else if (mem_is_eeprom(mem)) {
@@ -2357,7 +2357,7 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
       cache_ptr = PDATA(pgm)->eeprom_pagecache;
       pagesize = PDATA(pgm)->eeprom_pagesize;
     }
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[3] = MTYPE_FUSE_BITS;
     if(!(p->prog_modes & PM_UPDI) && mem_is_a_fuse(mem))

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -504,7 +504,7 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   mmt_free(PDATA(pgm)->eeprom_pagecache);
   PDATA(pgm)->flash_pagecache = mmt_malloc(PDATA(pgm)->flash_pagesize);
   PDATA(pgm)->eeprom_pagecache = mmt_malloc(PDATA(pgm)->eeprom_pagesize);
-  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = (unsigned long) -1L;
+  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = ~0UL;
 
   if (jtagmkI_reset(pgm) < 0)
     return -1;
@@ -627,12 +627,12 @@ static int jtagmkI_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   cmd[0] = CMD_WRITE_MEM;
   if (mem_is_flash(m)) {
     cmd[1] = MTYPE_FLASH_PAGE;
-    PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->flash_pageaddr = ~0UL;
     page_size = PDATA(pgm)->flash_pagesize;
     is_flash = 1;
   } else if (mem_is_eeprom(m)) {
     cmd[1] = MTYPE_EEPROM_PAGE;
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
     page_size = PDATA(pgm)->eeprom_pagesize;
   }
   datacmd[0] = CMD_DATA;
@@ -856,7 +856,7 @@ static int jtagmkI_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
    *
    * Page cache validation is based on "{flash,eeprom}_pageaddr"
    * (holding the base address of the most recent cache fill
-   * operation).  This variable is set to (unsigned long)-1L when the
+   * operation).  This variable is set to ~0UL when the
    * cache needs to be invalidated.
    */
   if (pagesize && paddr == *paddr_ptr) {
@@ -928,12 +928,12 @@ static int jtagmkI_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   if (mem_is_flash(mem)) {
     cmd[1] = MTYPE_SPM;
     need_progmode = 0;
-    PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->flash_pageaddr = ~0UL;
   } else if (mem_is_eeprom(mem)) {
     cmd[1] = MTYPE_EEPROM;
     need_progmode = 0;
     need_dummy_read = 1;
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[1] = MTYPE_FUSE_BITS;
     need_dummy_read = 1;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1276,7 +1276,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   mmt_free(PDATA(pgm)->eeprom_pagecache);
   PDATA(pgm)->flash_pagecache = mmt_malloc(PDATA(pgm)->flash_pagesize);
   PDATA(pgm)->eeprom_pagecache = mmt_malloc(PDATA(pgm)->eeprom_pagesize);
-  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = (unsigned long) -1L;
+  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = ~0UL;
 
   if (PDATA(pgm)->fwver >= 0x700 && (p->prog_modes & (PM_PDI | PM_UPDI))) {
     /*
@@ -1897,7 +1897,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   cmd = mmt_malloc(page_size + 10);
   cmd[0] = CMND_WRITE_MEMORY;
   if (mem_is_flash(m)) {
-    PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->flash_pageaddr = ~0UL;
     cmd[1] = jtagmkII_mtype(pgm, p, addr);
     if (p->prog_modes & (PM_PDI | PM_UPDI)) // Dynamically decide between flash/boot mtype
       dynamic_mtype = 1;
@@ -1918,7 +1918,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
       return n_bytes;
     }
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM_XMEGA: MTYPE_EEPROM_PAGE;
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
   } else if (mem_is_userrow(m) || mem_is_bootrow(m)) {
     cmd[1] = MTYPE_USERSIG;
   } else if (mem_is_boot(m)) {
@@ -2227,7 +2227,7 @@ static int jtagmkII_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
    *
    * Page cache validation is based on "{flash,eeprom}_pageaddr"
    * (holding the base address of the most recent cache fill
-   * operation).  This variable is set to (unsigned long)-1L when the
+   * operation).  This variable is set to ~0UL when the
    * cache needs to be invalidated.
    */
   if (pagesize && paddr == *paddr_ptr) {
@@ -2309,14 +2309,14 @@ static int jtagmkII_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
      writesize = 2;
      if(str_eq(p->family_id, "megaAVR") || str_eq(p->family_id, "tinyAVR")) // AVRs with UPDI except AVR-Dx/Ex
        need_progmode = 0;
-     PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+     PDATA(pgm)->flash_pageaddr = ~0UL;
      if (pgm->flag & PGM_FL_IS_DW)
        unsupp = 1;
   } else if (mem_is_eeprom(mem)) {
     cmd[1] = p->prog_modes & (PM_PDI | PM_UPDI)? MTYPE_EEPROM_XMEGA: MTYPE_EEPROM;
     if(str_eq(p->family_id, "megaAVR") || str_eq(p->family_id, "tinyAVR")) // AVRs with UPDI except AVR-Dx/Ex
       need_progmode = 0;
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
   } else if (mem_is_a_fuse(mem) || mem_is_fuses(mem)) {
     cmd[1] = MTYPE_FUSE_BITS;
     if((p->prog_modes & PM_Classic) && mem_is_a_fuse(mem))
@@ -2978,7 +2978,7 @@ static int jtagmkII_initialize32(const PROGRAMMER *pgm, const AVRPART *p) {
   mmt_free(PDATA(pgm)->eeprom_pagecache);
   PDATA(pgm)->flash_pagecache = mmt_malloc(PDATA(pgm)->flash_pagesize);
   PDATA(pgm)->eeprom_pagecache = mmt_malloc(PDATA(pgm)->eeprom_pagesize);
-  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = (unsigned long) -1L;
+  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = ~0UL;
 
   for(j=0; j<2; ++j) {
     buf[0] = CMND_GET_IR;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -248,6 +248,7 @@ typedef struct opcode {
 #define is_avr32jtag(x) (!!((x)->prog_modes & PM_AVR32JTAG))
 #define is_awire(x)     (!!((x)->prog_modes & PM_aWire))
 #define is_classic(x)   (!!((x)->prog_modes & PM_Classic))
+#define is_avr32(x)     (!!((x)->prog_modes & (PM_AVR32JTAG | PM_aWire)))
 
 // Set of overlapping programming modes of programmer and part
 #define joint_pm(pgm, p) ((pgm)->prog_modes & (p)->prog_modes)

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1315,7 +1315,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   mmt_free(PDATA(pgm)->eeprom_pagecache);
   PDATA(pgm)->flash_pagecache = mmt_malloc(PDATA(pgm)->flash_pagesize);
   PDATA(pgm)->eeprom_pagecache = mmt_malloc(PDATA(pgm)->eeprom_pagesize);
-  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = ~0UL;
 
   if (p->flags & AVRPART_IS_AT90S1200) {
     /*
@@ -1456,7 +1456,7 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   mmt_free(PDATA(pgm)->eeprom_pagecache);
   PDATA(pgm)->flash_pagecache = mmt_malloc(PDATA(pgm)->flash_pagesize);
   PDATA(pgm)->eeprom_pagecache = mmt_malloc(PDATA(pgm)->eeprom_pagesize);
-  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = (unsigned long) -1L;
+  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = ~0UL;
 
   return pgm->program_enable(pgm, p);
 }
@@ -1620,7 +1620,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
   mmt_free(PDATA(pgm)->eeprom_pagecache);
   PDATA(pgm)->flash_pagecache = mmt_malloc(PDATA(pgm)->flash_pagesize);
   PDATA(pgm)->eeprom_pagecache = mmt_malloc(PDATA(pgm)->eeprom_pagesize);
-  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = (unsigned long) -1L;
+  PDATA(pgm)->flash_pageaddr = PDATA(pgm)->eeprom_pageaddr = ~0UL;
 
   return pgm->program_enable(pgm, p);
 }
@@ -2330,7 +2330,7 @@ static int stk500hv_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVR
    *
    * Page cache validation is based on "{flash,eeprom}_pageaddr"
    * (holding the base address of the most recent cache fill
-   * operation).  This variable is set to (unsigned long)-1L when the
+   * operation).  This variable is set to ~0UL when the
    * cache needs to be invalidated.
    */
   if (pagesize && paddr == *paddr_ptr) {
@@ -2608,7 +2608,7 @@ static int stk500hv_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AV
 
   if (pagesize) {
     /* Invalidate the page cache. */
-    *paddr_ptr = (unsigned long)-1L;
+    *paddr_ptr = ~0UL;
   }
 
   return 0;
@@ -2889,7 +2889,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
   // determine which command is to be used
   if (mem_is_flash(m)) {
     addrshift = 1;
-    PDATA(pgm)->flash_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->flash_pageaddr = ~0UL;
     commandbuf[0] = mode == PPMODE? CMD_PROGRAM_FLASH_PP: CMD_PROGRAM_FLASH_HVSP;
     /*
      * If bit 31 is set, this indicates that the following read/write
@@ -2901,7 +2901,7 @@ static int stk500hv_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
       use_ext_addr = (1U << 31);
     }
   } else if (mem_is_eeprom(m)) {
-    PDATA(pgm)->eeprom_pageaddr = (unsigned long)-1L;
+    PDATA(pgm)->eeprom_pageaddr = ~0UL;
     commandbuf[0] = mode == PPMODE? CMD_PROGRAM_EEPROM_PP: CMD_PROGRAM_EEPROM_HVSP;
   }
   /*


### PR DESCRIPTION
Might fix a bug discovered [here](https://github.com/avrdudes/avrdude/discussions/1654#discussioncomment-10319331).

@MCUdude The `jtag3.c` code looks like it would never have worked on `apptable` and `boot` memories what with `jtag3_mtype()` not even considering the memory just the address and `jtag3_memaddr()` making no distinction between a `flash` and an `apptable`/`boot` memory.