### PR TITLE
Some bugfixes for the tools/test-avrdude script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install
         run: sudo make -C _ambuild install
       - name: Dryrun_test
-        run: printf "\n\n" | ./tools/test-avrdude -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
+        run: printf "\n\n" | ./tools/test-avrdude -e _ambuild/avrdude -c '-C _ambuild/avrdude.conf' -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: distcheck
         run: make -C _ambuild -j$(nproc) distcheck
 

--- a/tools/test-avrdude
+++ b/tools/test-avrdude
@@ -149,13 +149,9 @@ fi
 
 arraylength=${#pgm_and_target[@]}
 
-echo -n "Testing executable type for '$avrdude_bin'..."
-if type "$avrdude_bin" >/dev/null 2>&1; then
-    echo -n " "
-    type "$avrdude_bin"
-else
-    echo
+if ! type "$avrdude_bin" >/dev/null 2>&1; then
     echo "$progname: cannot execute $avrdude_bin"
+    type "$avrdude_bin"
     exit 1
 fi
 
@@ -167,13 +163,12 @@ tmpfile=$(mktemp "$tmp/$progname.tmp.XXXXXX")
 resfile=$(mktemp "$tmp/$progname.res.XXXXXX")
 trap "rm -f $status $logfile $outfile $tmpfile $resfile" EXIT
 
-echo -n "Testing $avrdude_bin version..."
-$avrdude_bin -v 2>&1 | grep '[vV]ersion' | sed 's/^.* [Vv]ersion //' | head -n1 > "$outfile"
+echo -n "Testing $(type -p "$avrdude_bin")"
+$avrdude_bin -v 2>&1 | grep '[vV]ersion' | sed 's/^.* [Vv]ersion//' | head -n1 > "$outfile"
 if test -s "$outfile"; then
-    echo -n " "
     cat "$outfile"
 else
-    echo " error"
+    echo ": error obtaining version from '$avrdude_bin -v'"
     $avrdude_bin -v
     exit 1
 fi

--- a/tools/test-avrdude
+++ b/tools/test-avrdude
@@ -149,8 +149,6 @@ fi
 
 arraylength=${#pgm_and_target[@]}
 type "$avrdude_bin" >/dev/null 2>&1 || { echo "$progname: cannot execute $avrdude_bin"; exit 1; }
-echo -n "Testing $avrdude_bin "
-$avrdude_bin -v 2>&1 | grep '[vV]ersion' | sed 's/^.* [Vv]ersion/version/' | head -n1
 
 [[ -d $tmp && -w $tmp ]] || tmp=/tmp # Fall back to /tmp if tmp directory unusable
 status=$(mktemp "$tmp/$progname.status.XXXXXX")
@@ -159,6 +157,17 @@ outfile=$(mktemp "$tmp/$progname.out.XXXXXX")
 tmpfile=$(mktemp "$tmp/$progname.tmp.XXXXXX")
 resfile=$(mktemp "$tmp/$progname.res.XXXXXX")
 trap "rm -f $status $logfile $outfile $tmpfile $resfile" EXIT
+
+echo -n "Testing $avrdude_bin version..."
+$avrdude_bin -v 2>&1 | grep '[vV]ersion' | sed 's/^.* [Vv]ersion //' | head -n1 > "$outfile"
+if test -s "$outfile"; then
+    echo -n " "
+    cat "$outfile"
+else
+    echo " error"
+    $avrdude_bin -v
+    exit 1
+fi
 
 devnull=$tmpfile                # Cannot use /dev/null as file in Windows avrdude
 

--- a/tools/test-avrdude
+++ b/tools/test-avrdude
@@ -149,8 +149,8 @@ fi
 
 arraylength=${#pgm_and_target[@]}
 type "$avrdude_bin" >/dev/null 2>&1 || { echo "$progname: cannot execute $avrdude_bin"; exit 1; }
-echo -n "Testing $avrdude_bin"
-$avrdude_bin -v 2>&1 | grep Version | cut -f2- -d: | sed s/Version/version/
+echo -n "Testing $avrdude_bin "
+$avrdude_bin -v 2>&1 | grep '[vV]ersion' | sed 's/^.* [Vv]ersion/version/' | head -n1
 
 [[ -d $tmp && -w $tmp ]] || tmp=/tmp # Fall back to /tmp if tmp directory unusable
 status=$(mktemp "$tmp/$progname.status.XXXXXX")

--- a/tools/test-avrdude
+++ b/tools/test-avrdude
@@ -148,7 +148,16 @@ if [[ ${#pgm_and_target[@]} -eq 0 ]]; then
 fi
 
 arraylength=${#pgm_and_target[@]}
-type "$avrdude_bin" >/dev/null 2>&1 || { echo "$progname: cannot execute $avrdude_bin"; exit 1; }
+
+echo -n "Testing executable type for '$avrdude_bin'..."
+if type "$avrdude_bin" >/dev/null 2>&1; then
+    echo -n " "
+    type "$avrdude_bin"
+else
+    echo
+    echo "$progname: cannot execute $avrdude_bin"
+    exit 1
+fi
 
 [[ -d $tmp && -w $tmp ]] || tmp=/tmp # Fall back to /tmp if tmp directory unusable
 status=$(mktemp "$tmp/$progname.status.XXXXXX")

--- a/tools/test-avrdude
+++ b/tools/test-avrdude
@@ -268,9 +268,9 @@ for (( p=0; p<$arraylength; p++ )); do
     avrdude=($avrdude_bin -l $logfile $avrdude_conf -qq ${pgm_and_target[$p]})
 
     # Get flash and EEPROM size in bytes and make sure the numbers are in dec form
-    flash_size=$(${avrdude[@]} -cdryrun -T 'part -m' 2>/dev/null | grep flash | awk '{print $2}')
+    flash_size=$($avrdude_bin $avrdude_conf -c dryrun -p $part -T 'part -m' 2>/dev/null | grep flash | awk '{print $2}')
     bench_flwr_size=$((flash_size/6)) # Approximate(!) size of file holes_rjmp_loops_${flash_size}B.hex
-    ee_size=$(${avrdude[@]} -cdryrun -T 'part -m' 2>/dev/null | grep eeprom | awk '{print $2}')
+    ee_size=$($avrdude_bin $avrdude_conf -c dryrun -p $part -T 'part -m' 2>/dev/null | grep eeprom | awk '{print $2}')
     bench_eewr_size=$((ee_size/6)) # Approximate(!) size of file holes_pack_my_box_${ee_size}B.hex
 
     if [[ -z "$flash_size" ]]; then

--- a/tools/test-avrdude
+++ b/tools/test-avrdude
@@ -320,9 +320,19 @@ for (( p=0; p<$arraylength; p++ )); do
       result [ $? == 0 ]
 
       # Test binary, octal, decimal, hexadecimal and R number lists for I/O
-      declare -A numsys=([b]=binary [o]=octal [d]=decimal [h]=hexadecimal [R]=R)
+      numsys() {
+	  # this function replaces constant associative array, as
+	  # macos bash does not support associative arrays.
+	  case "$1" in
+	      b) echo "binary" ;;
+	      o) echo "octal" ;;
+	      d) echo "decimal" ;;
+	      h) echo "hexadecimal" ;;
+	      R) echo "R" ;;
+	  esac
+      }
       for fmt in b o d h R; do
-        specify="flash writing ${numsys[$fmt]} numbers"
+        specify="flash writing $(numsys "$fmt") numbers"
         command=(${avrdude[@]}
           -U $tfiles/urboot_m2560_1s_x16m0_115k2_uart0_rxe0_txe1_led+b7_pr_ee_ce.hex
           -T '"write flash 0x3fd00 0xc0cac01a 0xcafe \"secret Coca Cola recipe\""'
@@ -331,7 +341,7 @@ for (( p=0; p<$arraylength; p++ )); do
         execute "${command[@]}"
         result [ $? == 0 ]
 
-        specify="flash reading and verifying ${numsys[$fmt]} numbers"
+        specify="flash reading and verifying $(numsys "$fmt") numbers"
         command=(${avrdude[@]}
           -U flash:w:$tmpfile:$fmt
           -U flash:r:$resfile:r)


### PR DESCRIPTION
While working on https://github.com/avrdudes/avrdude/pull/1888, I have found and fixed a few issues with `tools/test-avrdude`:

  * Since commit cf0822bb71086bf633c3166b21beb3201ad202dd, the `avrdude -v` version line looks different, and therefore the `test-avrdude` code which deals with the version does not work any more. Impact: The output looks like
    ```
    Testing avrdudePrepare "-cdryrun -pm2560" and press 'enter' or 'space' to continue. Press any other key to skip
    Cannot detect flash; check that "-cdryrun -pm2560" are valid avrdude options; skipping this test
    ```
    instead of
    ```
    Testing avrdude version 1.2.3
    Prepare "-cdryrun -pm2560" and press 'enter' or 'space' to continue. Press any other key to skip
    Cannot detect flash; check that "-cdryrun -pm2560" are valid avrdude options; skipping this test
    ```

    The fix is easy and just make grep look for both "version" and "Version".

  * If `avrdude -v` does not run, the remaining tests in `tools/test-avrdude` will not run either, so aborting with a useful error message showing the complete output of `avrdude -v` makes sense.

  * As it is not clear yet which `avrdude` executable `tools/test-avrdude` is actually running, it makes sense to... well not so sure about that any more. But having the complete output of `type $avrdude_bin` has certainly been helpful when trying to run the wrong `avrdude` executable, and that is what that commit does.

  * `tools/test-avrdude` uses bash associative arrays. Associative arrays are a feature introduced with bash 4.0, so the bash version shipped with MacOS (3.x) does not support associative arrays. I have replaced the associative array with a shell function.

@stefanrueger Not sure whether you want to merge any of this before 8.0. I would suggest at least cherrypicking https://github.com/avrdudes/avrdude/commit/29133dc9d43d0f46022b9e9df5b6d6cffb709eef.