### PR TITLE
Update build.yml to re-enable Windows on ARM64 MSVC build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,7 +285,7 @@ jobs:
         include:
           - { arch: x86, platform: Win32 }
           - { arch: x64, platform: x64 }
-          # - { arch: arm64, platform: ARM64 }
+          - { arch: arm64, platform: ARM64 }
     steps:
       - uses: actions/checkout@v3
       - name: Install prerequisites


### PR DESCRIPTION
Previously there is an issue that CMake will pick up the wrong Python installation for the Windows ARM64 build. The issue is now gone. So we can re-enable Windows on ARM64 MSVC build.