### PR TITLE
Remove known limitations comment from serprog.c

### DIFF
--- a/src/serprog.c
+++ b/src/serprog.c
@@ -20,9 +20,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * Known limitations:
- *  - performance is suboptimal
- *  - connecting over TCP/IP to programmers is not implemented yet
  */
 
 #include "ac_cfg.h"


### PR DESCRIPTION
This PR removes obsolete comments from the serprog.c file header.

Connecting over tcp is already possible by specifying net:<host>:<port> as a port.
Performance is already good and further improvements would require custom AVR read/write logic to batch operations which seems not worth the maintenance effort for now.