### PR TITLE
Add checks for zombie sourcecode problems

### DIFF
--- a/.github/workflows/check-sourcecode.yml
+++ b/.github/workflows/check-sourcecode.yml
@@ -1,0 +1,24 @@
+name: "Check Sourcecode"
+
+on:
+  push:
+    branches-ignore:
+      - 'onlinedocs'
+  pull_request:
+    branches-ignore:
+      - 'onlinedocs'
+
+jobs:
+
+  check-sourcecode:
+    name: "Check Sourcecode"
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      # - name: Install prerequisites
+
+      - name: "Check the sourcecode"
+        run: ./tools/check-sourcecode

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -20,7 +20,7 @@
 
 %{
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -25,7 +25,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 #include "avrdude.h"
 #include "libavrdude.h"
 #include "config.h"

--- a/src/libavrdude.i
+++ b/src/libavrdude.i
@@ -35,7 +35,7 @@ The following global variables are available in `ad.cvar`:
 %module (docstring=DOCSTRING) swig_avrdude
 %feature("autodoc", "1");
 %{
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 #include "libavrdude.h"
 
 // global variables referenced by library

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -22,7 +22,7 @@
  *
  */
 
-#include "ac_cfg.h"
+#include <ac_cfg.h>
 
 #include "avrdude.h"
 #include "libavrdude.h"

--- a/tools/check-sourcecode
+++ b/tools/check-sourcecode
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# check-sourcecode -- check the avrdude source code for zombie mistakes
+# Copyright (C) 2024 Hans Ulrich Niedermann <hun@n-dimensional.de>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+
+set -e
+
+prog="$(basename "$0")"
+cd "$(dirname "$0")"
+cd ..
+test -s README.md
+test -s COPYING
+test -s build.sh
+test -d .git/refs/heads
+
+
+declare -a checks=()
+fail=0
+succ=0
+
+
+checks+=(check_ac_cfg)
+check_ac_cfg() {
+    if git grep -E '#include\s+"ac_cfg\.h"'
+    then
+	echo "Error: Found #include \"ac_cfg.h\" with double quotes \"\". Should be <>."
+	echo "       See https://github.com/avrdudes/avrdude/issues/1706 for details."
+	return 1
+    fi
+}
+
+
+for check in "${checks[@]}"
+do
+    if "$check"; then
+	succ=$(( "$succ" + 1 ))
+	status="SUCC"
+    else
+	fail=$(( "$fail" + 1 ))
+	status="FAIL"
+    fi
+    echo "$status $check"
+done
+total=$(( "$succ" + "$fail" ))
+
+
+echo "$prog: Summary: $fail checks failed, $succ checks succeeded. $total checks in total."
+if [[ "$fail" -gt 0 ]]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
This adds checks for zombie sourcecode problems, i.e. problems we have tried to eliminate but which might be or have been resurrected.

The example check is for the problematic

    #include "ac_cfg.h"

with double quotes instead of <> which were identified as a problem in https://github.com/avrdudes/avrdude/issues/1706 and then fixed.