### PR TITLE
Update usbpids in avrdude.conf

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16055,7 +16055,6 @@ part parent ".xmega-cd" # x16d4
     n_interrupts           = 91;
     boot_section_size      = 4096;
     signature              = 0x1e 0x94 0x42;
-    usbpid                 = 0x2fe3;
 
     memory "eeprom"
         size               = 1024;
@@ -16109,7 +16108,6 @@ part parent ".xmega-ab" # x16a4
     n_interrupts           = 94;
     boot_section_size      = 4096;
     signature              = 0x1e 0x94 0x41;
-    usbpid                 = 0x2fe3;
 
     memory "eeprom"
         size               = 1024;
@@ -16265,7 +16263,6 @@ part parent ".xmega-cd" # x32d4
     n_interrupts           = 91;
     boot_section_size      = 4096;
     signature              = 0x1e 0x95 0x42;
-    usbpid                 = 0x2fe4;
 
     memory "eeprom"
         size               = 1024;
@@ -16319,7 +16316,6 @@ part parent ".xmega-ab" # x32a4
     n_interrupts           = 94;
     boot_section_size      = 4096;
     signature              = 0x1e 0x95 0x41;
-    usbpid                 = 0x2fe4;
 
     memory "eeprom"
         size               = 1024;
@@ -16456,7 +16452,6 @@ part parent ".xmega-cd" # x32d3
     n_interrupts           = 114;
     boot_section_size      = 4096;
     signature              = 0x1e 0x95 0x4a;
-    usbpid                 = 0x2fe4;
 
     memory "eeprom"
         size               = 1024;
@@ -16540,7 +16535,6 @@ part parent ".xmega-cd" # x64d3
     n_interrupts           = 114;
     boot_section_size      = 4096;
     signature              = 0x1e 0x96 0x4a;
-    usbpid                 = 0x2fe5;
 
     memory "prodsig"
         size               = 52;
@@ -16573,7 +16567,6 @@ part parent ".xmega-cd" # x64d4
     n_interrupts           = 91;
     boot_section_size      = 4096;
     signature              = 0x1e 0x96 0x47;
-    usbpid                 = 0x2fe5;
 
     memory "prodsig"
         page_size          = 64;
@@ -16604,7 +16597,6 @@ part parent ".xmega-ab" # x64a1
     n_interrupts           = 125;
     boot_section_size      = 4096;
     signature              = 0x1e 0x96 0x4e;
-    usbpid                 = 0x2fe5;
 
     memory "fuse2"
         bitmask            = 0x43;
@@ -16667,7 +16659,6 @@ part parent ".xmega-ab" # x64a3
     n_interrupts           = 122;
     boot_section_size      = 4096;
     signature              = 0x1e 0x96 0x42;
-    usbpid                 = 0x2fe5;
 
     memory "fuse2"
         bitmask            = 0x43;
@@ -16718,7 +16709,6 @@ part parent ".xmega-ab" # x64a4
     n_interrupts           = 125;
     boot_section_size      = 4096;
     signature              = 0x1e 0x96 0x46;
-    usbpid                 = 0x2fe5;
 
     memory "fuse0"
         initval            = -1;
@@ -16892,7 +16882,6 @@ part parent ".xmega-cd" # x128d3
     n_interrupts           = 114;
     boot_section_size      = 8192;
     signature              = 0x1e 0x97 0x48;
-    usbpid                 = 0x2fd7;
 
     memory "flash"
         size               = 0x22000;
@@ -16952,7 +16941,6 @@ part parent ".xmega-cd" # x128d4
     n_interrupts           = 91;
     boot_section_size      = 8192;
     signature              = 0x1e 0x97 0x47;
-    usbpid                 = 0x2fd7;
 
     memory "flash"
         size               = 0x22000;
@@ -17009,7 +16997,6 @@ part parent ".xmega-ab" # x128a1
     n_interrupts           = 125;
     boot_section_size      = 8192;
     signature              = 0x1e 0x97 0x4c;
-    usbpid                 = 0x2fd7;
 
     memory "flash"
         size               = 0x22000;
@@ -17138,7 +17125,6 @@ part parent ".xmega-ab" # x128a3
     n_interrupts           = 122;
     boot_section_size      = 8192;
     signature              = 0x1e 0x97 0x42;
-    usbpid                 = 0x2fd7;
 
     memory "flash"
         size               = 0x22000;
@@ -17843,7 +17829,6 @@ part parent ".xmega-cd" # x256d3
     n_interrupts           = 114;
     boot_section_size      = 8192;
     signature              = 0x1e 0x98 0x44;
-    usbpid                 = 0x2fda;
 
     memory "eeprom"
         size               = 4096;
@@ -17901,7 +17886,6 @@ part parent ".xmega-ab" # x256a1
     n_interrupts           = 127;
     boot_section_size      = 8192;
     signature              = 0x1e 0x98 0x46;
-    usbpid                 = 0x2fda;
 
     memory "eeprom"
         size               = 4096;
@@ -17991,7 +17975,6 @@ part parent ".xmega-ab" # x256a3
     n_interrupts           = 122;
     boot_section_size      = 8192;
     signature              = 0x1e 0x98 0x42;
-    usbpid                 = 0x2fda;
 
     memory "eeprom"
         size               = 4096;
@@ -18109,7 +18092,6 @@ part parent ".xmega-ab" # x256a3b
     n_interrupts           = 122;
     boot_section_size      = 8192;
     signature              = 0x1e 0x98 0x43;
-    usbpid                 = 0x2fda;
 
     memory "eeprom"
         size               = 4096;
@@ -18285,7 +18267,6 @@ part parent ".xmega-cd" # x384d3
     n_interrupts           = 114;
     boot_section_size      = 8192;
     signature              = 0x1e 0x98 0x47;
-    usbpid                 = 0x2fdb;
 
     memory "eeprom"
         size               = 4096;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -14599,7 +14599,7 @@ part parent ".classic" # m16u4
     pagel                  = 0xd7;
     bs2                    = 0xa0;
     signature              = 0x1e 0x94 0x88;
-    usbpid                 = 0x2ff4;
+    usbpid                 = 0x2ff3;
     reset                  = io;
     timeout                = 200;
     stabdelay              = 100;
@@ -14720,6 +14720,7 @@ part parent "m16u4" # m32u4
         "ATmega32U4RC-MUR: QFN44,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 65;
     signature              = 0x1e 0x95 0x87;
+    usbpid                 = 0x2ff4;
 
     memory "eeprom"
         size               = 1024;
@@ -16001,7 +16002,7 @@ part parent ".xmega-cd" # x16c4
     n_interrupts           = 127;
     boot_section_size      = 4096;
     signature              = 0x1e 0x94 0x43;
-    usbpid                 = 0x2fe3;
+    usbpid                 = 0x2fd8;
 
     memory "eeprom"
         size               = 1024;
@@ -16210,7 +16211,7 @@ part parent ".xmega-cd" # x32c4
     n_interrupts           = 127;
     boot_section_size      = 4096;
     signature              = 0x1e 0x95 0x44;
-    usbpid                 = 0x2fe4;
+    usbpid                 = 0x2fd9;
 
     memory "eeprom"
         size               = 1024;
@@ -16371,7 +16372,7 @@ part parent ".xmega-ab" # x64a4u
     n_interrupts           = 127;
     boot_section_size      = 4096;
     signature              = 0x1e 0x96 0x46;
-    usbpid                 = 0x2fe5;
+    usbpid                 = 0x2fdd;
 
     memory "prodsig"
         size               = 64;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -16372,7 +16372,7 @@ part parent ".xmega-ab" # x64a4u
     n_interrupts           = 127;
     boot_section_size      = 4096;
     signature              = 0x1e 0x96 0x46;
-    usbpid                 = 0x2fdd;
+    usbpid                 = 0x2fe5;
 
     memory "prodsig"
         size               = 64;


### PR DESCRIPTION
Fixes #1915 as far as `avrdude.conf` is concerned. The list in https://github.com/dfu-programmer/dfu-programmer/blob/master/src/arguments.c (thanks @askn37) was used to reliably (and semi-automatically) update avrdude.conf.

@askn37 Would you like to review? `avrdude -p '*/st' | grep usbpid` should show AVRDUDE's current understanding of `usbpid` assignments.