### PR TITLE
Abort bigendian builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@
 #     cmake -B build
 #     cmake --build build
 
+# Some useful tool versions to know about:
+#     cmake 3.14.0  2019-03-14  Current minimum requirement
+#     cmake 3.20.0  2021-03-23  Adds CMAKE_C_BYTE_ORDER
+
 cmake_minimum_required(VERSION 3.14)
 project(avrdude VERSION 8.0 LANGUAGES C)
 
@@ -50,6 +54,21 @@ include(GNUInstallDirs)
 
 set(CONFIG_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}")
 set(AVRDUDE_FULL_VERSION ${CMAKE_PROJECT_VERSION})
+
+
+# =====================================================================
+# Abort the build for non-little endian targets
+#
+# Our minimum cmake requirement is 3.14, so we cannot use
+# CMAKE_C_BYTE_ORDER (cmake >= 3.20) to detect the byte order.
+# =====================================================================
+
+include (TestBigEndian)
+test_big_endian(AVRDUDE_TARGET_IS_BIG_ENDIAN)
+if(AVRDUDE_TARGET_IS_BIG_ENDIAN)
+  message(FATAL_ERROR "avrdude only supports building for little endian targets at this time")
+endif()
+
 
 # =====================================
 # Get Git commit info

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -24,6 +24,7 @@ dnl
 dnl 2019-03-14 cmake    3.13
 dnl
 dnl 2006-10-23 autoconf 2.60    used to be avrdude's requirement
+dnl 2012-04-24 autoconf 2.62    AC_C_BIGENDIAN
 dnl 2012-04-24 autoconf 2.69
 dnl 2021-01-28 autoconf 2.71
 dnl
@@ -168,6 +169,22 @@ fi
 
 dnl Makefile.am:77: compiling `config_gram.c' with per-target flags requires `AM_PROG_CC_C_O' in `configure.ac'
 AM_PROG_CC_C_O
+
+
+ad_target_is_little_endian=false
+AC_C_BIGENDIAN([dnl
+], [dnl
+  dnl Target is Little Endian, which avrdude actually supports.
+  ad_target_is_little_endian=:
+], [dnl
+], [dnl
+])
+
+AS_IF([$ad_target_is_little_endian], [dnl
+], [dnl
+  AC_MSG_ERROR([avrdude only supports building for little endian targets at this time])
+])
+
 
 # Checks for libraries.
 # For MinGW.


### PR DESCRIPTION
This tries to kind of fix https://github.com/avrdudes/avrdude/issues/1917 by aborting builds for non-littleendian targets.
