### PR TITLE
Fix ATxmega fuses memory sizes

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -15768,7 +15768,7 @@ part # .xmega-cd
     #  - fuses[6] only used in XMEGA-E parts
     #
     memory "fuses"
-        size               = 7;
+        size               = 6;
         offset             = 0x8f0020;
     ;
 
@@ -15877,6 +15877,10 @@ part parent ".xmega-cd" # .xmega-e
 
     memory "boot"
         page_size          = 128;
+    ;
+
+    memory "fuses"
+        size               = 7;
     ;
 
     memory "fuse2"


### PR DESCRIPTION
Fixes the following observation in this [comment](https://github.com/avrdudes/avrdude/discussions/1878#discussioncomment-10960355):

>  the fuse size seems to be set to 7 when it should be 6
 
@askn37 Please could you review?