### PR TITLE
CI: Ensure only supported configure options are used (--enable-option-checking=fatal)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,10 +218,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Original PATH and build tools
+        run: |
+          echo "PATH=$PATH"
+          for b in bison flex pkg-config; do type "$b"; done
       - name: Install prerequisites
         run: >-
-          # brew update
-
           brew install
           cmake
           flex
@@ -233,12 +235,18 @@ jobs:
           libftdi
           readline
           libserialport
-          pkg-config
+      - name: Configure environment to use brew kegs for flex and bison
+        run: |
+          echo "PATH=/opt/homebrew/opt/flex/bin:/opt/homebrew/opt/bison/bin:$PATH" >> $GITHUB_ENV
+      - name: post-brew PATH and build tools
+        run: |
+          echo "PATH=$PATH"
+          for b in bison flex pkg-config; do type "$b"; done
       - name: Configure
         run: >-
           cmake
-          -D CMAKE_C_FLAGS=-I/opt/homebrew/include
-          -D CMAKE_EXE_LINKER_FLAGS=-L/opt/homebrew/Cellar
+          -D CMAKE_C_FLAGS="-I/opt/homebrew/include -I/opt/homebrew/opt/flex/include"
+          -D CMAKE_EXE_LINKER_FLAGS="-L/opt/homebrew/Cellar -L/opt/homebew/opt/flex/lib"
           -D DEBUG_CMAKE=1
           -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
           -B build
@@ -269,10 +277,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Original PATH and build tools
+        run: |
+          echo "PATH=$PATH"
+          for b in bison flex pkg-config; do type "$b"; done
       - name: Install prerequisites
         run: >-
-          # brew update
-
           brew install
           automake
           autoconf
@@ -286,15 +296,21 @@ jobs:
           libftdi
           readline
           libserialport
-          pkg-config
+      - name: Configure environment to use brew kegs for flex and bison
+        run: |
+          echo "PATH=/opt/homebrew/opt/flex/bin:/opt/homebrew/opt/bison/bin:$PATH" >> $GITHUB_ENV
+      - name: post-brew PATH and build tools
+        run: |
+          echo "PATH=$PATH"
+          for b in bison flex pkg-config; do type "$b"; done
       - name: Configure
         run: >-
           ./src/bootstrap
 
           mkdir _ambuild && cd _ambuild
 
-          CFLAGS="-I/opt/homebrew/include"
-          LDFLAGS="-L/opt/homebrew/lib"
+          CFLAGS="-I/opt/homebrew/include -I/opt/homebrew/opt/flex/include"
+          LDFLAGS="-L/opt/homebrew/lib    -L/opt/homebrew/opt/bison/lib"
           ../src/configure
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,8 +293,10 @@ jobs:
 
           mkdir _ambuild && cd _ambuild
 
-          CFLAGS="-I/opt/homebrew/include" LDFLAGS="-L/opt/homebrew/lib" ../src/configure
-          
+          CFLAGS="-I/opt/homebrew/include"
+          LDFLAGS="-L/opt/homebrew/lib"
+          ../src/configure
+
       - name: Build
         run: make -C _ambuild -j$(nproc)
       - name: "avrdude -? (not installed)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
           mkdir _ambuild && cd _ambuild
 
           ../src/configure
+          --enable-option-checking=fatal
           --enable-doc
           --enable-parport
           --enable-linuxgpio
@@ -312,6 +313,7 @@ jobs:
           CFLAGS="-I/opt/homebrew/include -I/opt/homebrew/opt/flex/include"
           LDFLAGS="-L/opt/homebrew/lib    -L/opt/homebrew/opt/bison/lib"
           ../src/configure
+          --enable-option-checking=fatal
 
       - name: Build
         run: make -C _ambuild -j$(nproc)


### PR DESCRIPTION
This ensures that only supported `configure` options are used in the CI builds, by adding `--enable-option-checking=fatal` to the `configure` command line (since Autoconf 2.62 from 2008 or something).

To make this work at all, this PR first fixes the issue of the MacOS "brew install" command suddenly failing while installing `pkg-config`.