### PR TITLE
Add long options like --part

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -377,7 +377,7 @@ to trigger programming mode for certain boards like Arduino Leonardo,
 Arduino Micro/Pro Micro and the Arduino Nano Every. Longer waits, and
 therefore multiple -r options, are sometimes needed for slower, less
 powerful hosts.
-.It Fl B \-bitclock
+.It Fl B \-bitclock Ar bitclock
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.
 Alternatively, the value might be suffixed with "Hz", "kHz" or

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -25,33 +25,32 @@
 .Nd driver program for ``simple'' Atmel AVR MCU programmer
 .Sh SYNOPSIS
 .Nm
-.Fl p Ar partno
-.Op Fl b Ar baudrate
-.Op Fl r
-.Op Fl B Ar bitclock
-.Op Fl c Ar programmer-id
-.Op Fl C Ar config-file
-.Op Fl N
+.Op Fl p, \-part Ar partno
+.Op Fl b, \-baud Ar baudrate
+.Op Fl B, \-bitclock Ar bitclock
+.Op Fl c, \-programmer Ar programmer-id
+.Op Fl C, \-config Ar config-file
+.Op Fl N, \-noconfig
 .Op Fl A
-.Op Fl D
-.Op Fl e
+.Op Fl D, \-noerase
+.Op Fl e, \-erase
 .Oo Fl E Ar exitspec Ns
 .Op \&, Ns Ar exitspec
 .Oc
 .Op Fl F
 .Op Fl i Ar delay
-.Op Fl l Ar logfile
-.Op Fl n
-.Op Fl O
-.Op Fl P Ar port
-.Op Fl r
-.Op Fl q
+.Op Fl l, \-logfile Ar logfile
+.Op Fl n, \-test
+.Op Fl O, \-osccal 
+.Op Fl P, \-port Ar port
+.Op Fl r, \-reconnect
+.Op Fl q, \-quell
 .Op Fl T Ar cmd
-.Op Fl t
-.Op Fl U Ar memory:op:filename:filefmt
-.Op Fl v
+.Op Fl t, \-terminal
+.Op Fl U, \-memory Ar memory:op:filename:filefmt
+.Op Fl v, \-verbose
 .Op Fl x Ar extended_param
-.Op Fl V
+.Op Fl V, \-noverify
 .Sh DESCRIPTION
 .Nm Avrdude
 is a program for downloading and uploading on-chip memories of Atmel AVR
@@ -326,7 +325,7 @@ In order to control all the different operation modi, a number of options
 need to be specified to
 .Nm avrdude .
 .Bl -tag -offset indent -width indent
-.It Fl p Ar partno
+.It Fl p \-part Ar partno
 This option specifies the MCU connected to the programmer. The MCU
 descriptions are read from the config file. To see a list of currently
 supported MCUs use ? as partno, which will print the part ids and official
@@ -351,19 +350,18 @@ programmers talking the STK500v2 protocol.
 .It "AT90S2343"
 The AT90S2323 and ATtiny22 use the same algorithm.
 .It "ATmega2560, ATmega2561"
-Flash addressing above 128 KB is not supported by all
-programming hardware.  Known to work are jtag2, stk500v2,
-and bit-bang programmers.
+Flash addressing above 128 KB may not be supported by all
+programming hardware.
 .It "ATtiny11"
 The ATtiny11 can only be
 programmed in high-voltage serial mode.
 .El
-.It Fl p Ar wildcard/flags
+.It Fl p \-part Ar wildcard/flags
 Run developer options for MCUs that are matched by wildcard. Whilst
 their main use is for developers some flags can be of utility for users, e.g.,
 avrdude -p m328p/S outputs AVRDUDE's understanding of ATmega328P MCU properties;
 for more information run avrdude -p x/h.
-.It Fl b Ar baudrate
+.It Fl b \-baud Ar baudrate
 Override the RS-232 connection baud rate specified in the respective
 programmer's entry of the configuration file or defined by the default_baudrate
 entry in your user configuration file
@@ -371,7 +369,7 @@ entry in your user configuration file
 or
 .Pa ${HOME}/.avrduderc
 if no baudrate was defined for this programmer.
-.It Fl r
+.It Fl r \-reconnect
 Opens the serial port at 1200 baud and immediately closes it, waits 400 ms
 for each -r on the command line and then establishes communication with
 the programmer. This is commonly known as a "1200bps touch", and is used
@@ -379,7 +377,7 @@ to trigger programming mode for certain boards like Arduino Leonardo,
 Arduino Micro/Pro Micro and the Arduino Nano Every. Longer waits, and
 therefore multiple -r options, are sometimes needed for slower, less
 powerful hosts.
-.It Fl B Ar bitclock
+.It Fl B \-bitclock
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.
 Alternatively, the value might be suffixed with "Hz", "kHz" or
@@ -404,7 +402,7 @@ will continue to use it until a different value is provided. This applies to
 "3rd gen"programmers (JTAGICE3, Atmel ICE, Power Debugger). "4th gen"
 programmers (PICkit 4, MPLAB SNAP) will store the last user-specified bitclock
 until the programmer is disconnected from the computer.
-.It Fl c Ar programmer-id
+.It Fl c \-programmer Ar programmer-id
 Use the programmer specified by the argument.  Programmers and their pin
 configurations are read from the config file (see the
 .Fl C
@@ -426,12 +424,12 @@ If -c ? is specified with a specific part, see
 to be able to handle this part, together with the programming interface(s) that can be
 used in that combination. In reality there can be deviations from this list,
 particularly if programming is directly via a bootloader.
-.It Fl c Ar wildcard/flags
+.It Fl c \-programmer Ar wildcard/flags
 Run developer options for programmers that are matched by wildcard. Whilst
 their main use is for developers some flags can be of utility for users, e.g.,
 avrdude -c usbtiny/S shows AVRDUDE's understanding of usbtiny's properties;
 for more information run avrdude -c x/h.
-.It Fl C Ar config-file
+.It Fl C \-config Ar config-file
 Use the specified config file to load configuration data.  This file
 contains all programmer and part definitions that
 .Nm avrdude
@@ -449,7 +447,7 @@ files. This can be used to add entries to the configuration
 without patching your system wide configuration file. It can be used
 several times, the files are read in same order as given on the command
 line.
-.It Fl N
+.It Fl N \-noconfig
 Do not load the personal configuration file that is usually located at
 ~/.config/avrdude/avrdude.rc, ~/.avrduderc or in the same directory as the
 avrdude executable
@@ -467,9 +465,9 @@ Arduino bootloaders exhibit this behaviour; for this reason
 is engaged by default when specifying
 . Fl c
 arduino.
-.It Fl D
+.It Fl D \-noerase
 Disable auto-erase for flash. When the
-.Fl U
+.Fl U \-memory
 option for writing to any flash memory is specified,
 .Nm
 will perform a chip erase before starting any of the programming
@@ -482,7 +480,7 @@ operation will retain its previous contents. Setting
 .Fl D
 implies
 .Fl A.
-.It Fl e
+.It Fl e \-erase
 Causes a chip erase to be executed. This will reset the contents of the
 flash ROM and EEPROM to the value
 .Ql 0xff ,
@@ -572,7 +570,7 @@ is running.
 On Win32 operating systems, a preconfigured number of cycles per
 microsecond is assumed that might be off a bit for very fast or very
 slow machines.
-.It Fl l Ar logfile
+.It Fl l \-logfile Ar logfile
 Use
 .Ar logfile
 rather than
@@ -582,18 +580,18 @@ Note that initial diagnostic messages (during option parsing) are still
 written to
 .Va stderr
 anyway.
-.It Fl n
+.It Fl n \-test
 No-write: disables writing data to the MCU whilst processing -U
 (useful for debugging
 .Nm avrdude
 ). The terminal mode continues to write to the device.
-.It Fl O
+.It Fl O \-osccal
 Perform an RC oscillator run-time calibration according to Atmel
 application note AVR053.
 This is only supported on the STK500v2, AVRISP mkII, and JTAG ICE mkII
 hardware.
 Note that the result will be stored in the EEPROM cell at address 0.
-.It Fl P Ar port
+.It Fl P \-port Ar port
 Use
 .Ar port
 to identify the connection through which the programmer is attached. This
@@ -718,7 +716,7 @@ for a STK500.
 .Pp
 Note: The ability to handle IPv6 hostnames and addresses is limited to
 Posix systems (by now).
-.It Fl q
+.It Fl q \-quell
 Disable (or quell) output of the progress bar while reading or writing
 to the device.  Specify it more often for even quieter operations.
 .It Fl s, u
@@ -733,13 +731,13 @@ of terminal commands the argument
 .Ar cmd
 will most likely need to be set in quotes, see your OS shell manual for
 details. See below for a detailed description of all terminal commands.
-.It Fl t
+.It Fl t \-terminal
 Tells
 .Nm
 to run an interactive terminal when it is its turn in relation to
 other -t interactive terminals, -T terminal commands and -U memory
 operations.
-.It Xo Fl U Ar memory Ns
+.It Xo Fl U \-memory Ar memory Ns
 .Ar \&: Ns Ar op Ns
 .Ar \&: Ns Ar filename Ns
 .Op \&: Ns Ar format
@@ -928,12 +926,12 @@ This will only work if
 does not have a pair of colons in it that sandwich a single character
 as otherwise the first part might be interpreted as memory, and the single
 character as memory operation.
-.It Fl v
+.It Fl v \-verbose
 Enable verbose output.
 More
 .Fl v
 options increase verbosity level.
-.It Fl V
+.It Fl V \-noverify
 Disable automatic verify check when writing data to the AVR with -U.
 .It Fl x Ar extended_param
 Pass
@@ -2125,6 +2123,7 @@ This option will leave the 8 data pins on the parallel port active.
 This option will leave the 8 data pins on the parallel port inactive.
 .Pq \&i. \&e. Em low
 .El
+.El
 .Sh FILES
 .Bl -tag -offset indent -width /dev/ppi0XXX
 .It Pa /dev/ppi0
@@ -2191,7 +2190,9 @@ normal ISP communication.
 .Pp
 The AVR microcontroller product description can be found at
 .Pp
-.Dl "https://www.microchip.com/en-us/products/microcontrollers-and-microprocessors/8-bit-mcus/avr-mcus"
+.nf
+https://www.microchip.com/en-us/products/microcontrollers-and-microprocessors/8-bit-mcus/avr-mcus
+.fi
 .\" .Sh HISTORY
 .Sh AUTHORS
 .Nm Avrdude

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -25,7 +25,7 @@
 .Nd driver program for ``simple'' Atmel AVR MCU programmer
 .Sh SYNOPSIS
 .Nm
-.Op Fl p, \-part Ar partno
+.Op Fl p, \-part Ar partname
 .Op Fl b, \-baud Ar baudrate
 .Op Fl B, \-bitclock Ar bitclock
 .Op Fl c, \-programmer Ar programmer-id
@@ -325,10 +325,10 @@ In order to control all the different operation modi, a number of options
 need to be specified to
 .Nm avrdude .
 .Bl -tag -offset indent -width indent
-.It Fl p \-part Ar partno
+.It Fl p \-part Ar partname
 This option specifies the MCU connected to the programmer. The MCU
 descriptions are read from the config file. To see a list of currently
-supported MCUs use ? as partno, which will print the part ids and official
+supported MCUs use ? as partname, which will print the part ids and official
 part names. In connection with -v, this will also print a list of variant
 part names followed by an optional colon, the package code and some
 absolute maximum ratings. The part id, their official part name, any of

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -40,7 +40,7 @@
 .Op Fl F
 .Op Fl i Ar delay
 .Op Fl l, \-logfile Ar logfile
-.Op Fl n, \-test
+.Op Fl n, \-test-memory
 .Op Fl O, \-osccal 
 .Op Fl P, \-port Ar port
 .Op Fl r, \-reconnect
@@ -50,7 +50,7 @@
 .Op Fl U, \-memory Ar memory:op:filename:filefmt
 .Op Fl v, \-verbose
 .Op Fl x Ar extended_param
-.Op Fl V, \-noverify
+.Op Fl V, \-noverify-memory
 .Sh DESCRIPTION
 .Nm Avrdude
 is a program for downloading and uploading on-chip memories of Atmel AVR
@@ -580,7 +580,7 @@ Note that initial diagnostic messages (during option parsing) are still
 written to
 .Va stderr
 anyway.
-.It Fl n \-test
+.It Fl n \-test-memory
 No-write: disables writing data to the MCU whilst processing -U
 (useful for debugging
 .Nm avrdude
@@ -931,7 +931,7 @@ Enable verbose output.
 More
 .Fl v
 options increase verbosity level.
-.It Fl V \-noverify
+.It Fl V \-noverify-memory
 Disable automatic verify check when writing data to the AVR with -U.
 .It Fl x Ar extended_param
 Pass

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -509,8 +509,9 @@ following options are recognized:
 
 @table @code
 @item -p @var{partno}
-@cindex Option @code{-p} @var{partno}
-@cindex @code{-p} @var{partno}
+@item --part @var{partno}
+@cindex Option @code{-p ,--part} @var{partno}
+@cindex @code{-p, --part} @var{partno}
 
 This option tells AVRDUDE what part (MCU) is connected to the programmer.
 The @var{partno} parameter is the part's id listed in the configuration
@@ -533,16 +534,18 @@ directly via a bootloader. See @ref{List of Parts} for a full and detailed
 listing of supported parts.
 
 @item -p @var{wildcard/flags}
-@cindex Option @code{-p} @var{wildcard/flags}
-@cindex @code{-p} @var{wildcard/flags}
+@item --part @var{wildcard/flags}
+@cindex Option @code{-p, --part} @var{wildcard/flags}
+@cindex @code{-p, --part} @var{wildcard/flags}
 Run developer options for MCUs that are matched by @var{wildcard}. Whilst
 their main use is for developers some @var{flags} can be of utility for
 users, e.g.,  @code{avrdude -p m328p/S} outputs AVRDUDE's understanding of
 ATmega328P MCU properties; for more information run @code{avrdude -p x/h}.
 
 @item -b @var{baudrate}
-@cindex Option @code{-b} @var{baudrate}
-@cindex @code{-b} @var{baudrate}
+@item --baud @var{baudrate}
+@cindex Option @code{-b, --baud} @var{baudrate}
+@cindex @code{-b, baud} @var{baudrate}
 Override the RS-232 connection baud rate specified in the respective
 programmer's @code{baudrate} entry of the configuration file
 or defined by the @code{default_baudrate} entry in your
@@ -550,8 +553,9 @@ or defined by the @code{default_baudrate} entry in your
 file if no @code{baudrate} entry was provided for this programmer.
 
 @item -B @var{bitclock}
-@cindex Option @code{-B} @var{bitclock}
-@cindex @code{-B} @var{bitclock}
+@item --bitclock @var{bitclock}
+@cindex Option @code{-B, --bitclock} @var{bitclock}
+@cindex @code{-B, --bitclock} @var{bitclock}
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.
 Alternatively, the value might be suffixed with Hz, kHz or
@@ -577,8 +581,9 @@ the last user-specified bitclock until the programmer is disconnected from
 the computer.
 
 @item -c @var{programmer-id}
-@cindex Option @code{-c} @var{programmer-id}
-@cindex @code{-c} @var{programmer-id}
+@item --programmer @var{programmer-id}
+@cindex Option @code{-c, --programmer} @var{programmer-id}
+@cindex @code{-c, --programmer} @var{programmer-id}
 
 Specify the programmer to be used.  AVRDUDE knows about quite a few
 programmers. The @var{programmer-id} parameter is the programmer's id
@@ -596,16 +601,18 @@ bootloader. See @ref{List of Programmers} for a full and detailed listing
 of known programmers.
 
 @item -c @var{wildcard/flags}
-@cindex Option @code{-c} @var{wildcard/flags}
-@cindex @code{-c} @var{wildcard/flags}
+@item --programmer @var{wildcard/flags}
+@cindex Option @code{-c, --programmer} @var{wildcard/flags}
+@cindex @code{-c, --programmer} @var{wildcard/flags}
 Run developer options for programmers that are matched by @var{wildcard}.
 Whilst their main use is for developers some @var{flags} can be of utility
 for users, e.g., @code{avrdude -c usbtiny/S} shows AVRDUDE's understanding of
 usbtiny's properties; for more information run @code{avrdude -c x/h}.
 
 @item -C @var{config-file}
-@cindex Option @code{-C} @var{config-file}
-@cindex @code{-C} @var{config-file}
+@item --config @var{config-file}
+@cindex Option @code{-C, --config} @var{config-file}
+@cindex @code{-C, --config} @var{config-file}
 @cindex Configuration files
 Use the specified config file for configuration data.  This file
 contains all programmer and part definitions that AVRDUDE knows about.
@@ -634,8 +641,9 @@ several times, the files are read in same order as given on the command
 line.
 
 @item -N
-@cindex Option @code{-N}
-@cindex @code{-N}
+@item --noconfig
+@cindex Option @code{-N, --noconfig}
+@cindex @code{-N, --noconfig}
 Do not load the personal configuration file that is usually located at
 @code{~/.config/avrdude/avrdude.rc}, @code{~/.avrduderc} or in the same
 directory as the avrdude executable.
@@ -654,8 +662,9 @@ The popular Arduino bootloader exhibits this behaviour; for this reason
 @code{-A} is engaged by default when specifying @code{-c} arduino.
 
 @item -D
-@cindex Option @code{-D}
-@cindex @code{-D}
+@item --noerase
+@cindex Option @code{-D, --noerase}
+@cindex @code{-D, --noerase}
 @cindex @code{flash}
 Disable auto-erase for flash. When the @code{-U} option for writing to any
 flash memory is specified, avrdude will perform a chip erase before
@@ -668,8 +677,9 @@ page not affected by the current operation will retain its previous
 contents. Setting @code{-D} implies @code{-A}.
 
 @item -e
-@cindex Option @code{-e}
-@cindex @code{-e}
+@item --erase
+@cindex Option @code{-e, --erase}
+@cindex @code{-e, --erase}
 @cindex @code{flash}
 @cindex @code{eeprom}
 Causes a chip erase to be executed. This will reset the contents of the
@@ -746,22 +756,25 @@ microsecond is assumed that might be off a bit for very fast or very
 slow machines.
 
 @item -l @var{logfile}
-@cindex Option @code{-l} @var{logfile}
-@cindex @code{-l} @var{logfile}
+@item --logfile @var{logfile}
+@cindex Option @code{-l, --logfile} @var{logfile}
+@cindex @code{-l, --logfile} @var{logfile}
 Use @var{logfile} rather than @var{stderr} for diagnostics output.
 Note that initial diagnostic messages (during option parsing) are still
 written to @var{stderr} anyway.
 
 @item -n
-@cindex Option @code{-n}
-@cindex @code{-n}
+@item --test
+@cindex Option @code{-n, --test}
+@cindex @code{-n, --test}
 No-write: disables writing data to the MCU whilst processing @code{-U}
 (useful for debugging AVRDUDE). The terminal mode continues to write to
 the device.
 
 @item -O
-@cindex Option @code{-O}
-@cindex @code{-O}
+@item --osccal
+@cindex Option @code{-O, --osccal}
+@cindex @code{-O, --osccal}
 @cindex @code{calibration}
 Perform a RC oscillator run-time calibration according to Atmel
 application note AVR053.
@@ -771,8 +784,9 @@ hardware.
 Note that the result will be stored in the EEPROM cell at address 0.
 
 @item -P @var{port}
-@cindex Option @code{-P} @var{port}
-@cindex @code{-P} @var{port}
+@item --port @var{port}
+@cindex Option @code{-P, --port} @var{port}
+@cindex @code{-P, --port} @var{port}
 
 Use @var{port} to identify the connection through which the programmer is
 attached. This can be a parallel, serial, spi or linuxgpio connection. The
@@ -858,8 +872,9 @@ Note: The ability to handle IPv6 hostnames and addresses is limited to
 Posix systems (by now).
 
 @item -r
-@cindex Option @code{-r}
-@cindex @code{-r}
+@item --reconnect
+@cindex Option @code{-r, --reconnect}
+@cindex @code{-r, --reconnect}
 Opens the serial port at 1200 baud and immediately closes it, waits 400 ms
 for each @code{-r} on the command line and then establishes communication
 with the programmer. This is commonly known as a "1200bps touch", and is
@@ -869,8 +884,9 @@ therefore multiple @code{-r} options, are sometimes needed for slower, less
 powerful hosts.
 
 @item -q
-@cindex Option @code{-q}
-@cindex @code{-q}
+@item --quell
+@cindex Option @code{-q, --quell}
+@cindex @code{-q, --quell}
 Disable (or quell) output of the progress bar while reading or writing
 to the device.  Specify it a second time for even quieter operation.
 
@@ -891,15 +907,17 @@ OS shell manual for details. See below for a detailed description of all
 terminal commands.
 
 @item -t
-@cindex Option @code{-t}
-@cindex @code{-t}
+@item --terminal
+@cindex Option @code{-t, --terminal}
+@cindex @code{-t, --terminal}
 Tells AVRDUDE to run an interactive terminal when it is its turn in
 relation to other @code{-t} interactive terminals, @code{-T}
 terminal commands and @code{-U} memory operations.
 
 @item -U @var{memory}:@var{op}:@var{filename}[:@var{format}]
-@cindex Option @code{-U} @var{memory}:@var{op}:@var{filename}[:@var{format}]
-@cindex @code{-U} @var{memory}:@var{op}:@var{filename}[:@var{format}]
+@item --memory @var{memory}:@var{op}:@var{filename}[:@var{format}]
+@cindex Option @code{-U, --memory} @var{memory}:@var{op}:@var{filename}[:@var{format}]
+@cindex @code{-U, --memory} @var{memory}:@var{op}:@var{filename}[:@var{format}]
 
 Perform a memory operation when it is its turn in relation to other
 @code{-t} interactive terminals, @code{-T} terminal commands and @code{-U}
@@ -1075,14 +1093,16 @@ that sandwich a single character as otherwise the first part might be
 interpreted as memory, and the single character as memory operation.
 
 @item -v
-@cindex Option @code{-v}
-@cindex @code{-v}
+@item --verbose
+@cindex Option @code{-v, --verbose}
+@cindex @code{-v, --verbose}
 Enable verbose output.
 More @code{-v} options increase verbosity level.
 
 @item -V
-@cindex Option @code{-V}
-@cindex @code{-V}
+@item --noverify
+@cindex Option @code{-V, --noverify}
+@cindex @code{-V, --noverify}
 Disable automatic verify check when writing data to the AVR with @code{-U}.
 
 @item -x @var{extended_param}
@@ -2094,12 +2114,6 @@ verbosity level:
 @smallexample
 @cartouche
 $ avrdude -c jtag2 -p m128 -P usb:xxx -v
-
-Avrdude version 7.3-20240815 (e230d889)
-Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS
-
-System wide configuration file is /usr/local/etc/avrdude.conf
-User configuration file is /home/srueger/.avrduderc
 
 Using port            : usb:xxx
 Using programmer      : jtag2fast

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -764,9 +764,9 @@ Note that initial diagnostic messages (during option parsing) are still
 written to @var{stderr} anyway.
 
 @item -n
-@item --test
-@cindex Option @code{-n, --test}
-@cindex @code{-n, --test}
+@item --test-memory
+@cindex Option @code{-n, --test-memory}
+@cindex @code{-n, --test-memory}
 No-write: disables writing data to the MCU whilst processing @code{-U}
 (useful for debugging AVRDUDE). The terminal mode continues to write to
 the device.
@@ -1100,9 +1100,9 @@ Enable verbose output.
 More @code{-v} options increase verbosity level.
 
 @item -V
-@item --noverify
-@cindex Option @code{-V, --noverify}
-@cindex @code{-V, --noverify}
+@item --noverify-memory
+@cindex Option @code{-V, --noverify-memory}
+@cindex @code{-V, --noverify-memory}
 Disable automatic verify check when writing data to the AVR with @code{-U}.
 
 @item -x @var{extended_param}

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -510,9 +510,10 @@ following options are recognized:
 @table @code
 @item -p @var{partname}
 @item --part @var{partname}
-@cindex Option @code{-p ,--part} @var{partname}
-@cindex @code{-p, --part} @var{partname}
-
+@cindex Option @code{-p} @var{partname}
+@cindex Option @code{--part} @var{partname}
+@cindex @code{-p} @var{partname}
+@cindex @code{--part} @var{partname}
 This option tells AVRDUDE what part (MCU) is connected to the programmer.
 The @var{partname} parameter is the part's id listed in the configuration
 file. To see a list of currently supported MCUs use @code{?} as partname,
@@ -535,8 +536,10 @@ listing of supported parts.
 
 @item -p @var{wildcard/flags}
 @item --part @var{wildcard/flags}
-@cindex Option @code{-p, --part} @var{wildcard/flags}
-@cindex @code{-p, --part} @var{wildcard/flags}
+@cindex Option @code{-p} @var{wildcard/flags}
+@cindex Option @code{--part} @var{wildcard/flags}
+@cindex @code{-p} @var{wildcard/flags}
+@cindex @code{--part} @var{wildcard/flags}
 Run developer options for MCUs that are matched by @var{wildcard}. Whilst
 their main use is for developers some @var{flags} can be of utility for
 users, e.g.,  @code{avrdude -p m328p/S} outputs AVRDUDE's understanding of
@@ -544,8 +547,10 @@ ATmega328P MCU properties; for more information run @code{avrdude -p x/h}.
 
 @item -b @var{baudrate}
 @item --baud @var{baudrate}
-@cindex Option @code{-b, --baud} @var{baudrate}
-@cindex @code{-b, baud} @var{baudrate}
+@cindex Option @code{-b} @var{baudrate}
+@cindex Option @code{--baud} @var{baudrate}
+@cindex @code{-b} @var{baudrate}
+@cindex @code{--baud} @var{baudrate}
 Override the RS-232 connection baud rate specified in the respective
 programmer's @code{baudrate} entry of the configuration file
 or defined by the @code{default_baudrate} entry in your
@@ -554,8 +559,10 @@ file if no @code{baudrate} entry was provided for this programmer.
 
 @item -B @var{bitclock}
 @item --bitclock @var{bitclock}
-@cindex Option @code{-B, --bitclock} @var{bitclock}
-@cindex @code{-B, --bitclock} @var{bitclock}
+@cindex Option @code{-B} @var{bitclock}
+@cindex Option @code{--bitclock} @var{bitclock}
+@cindex @code{-B} @var{bitclock}
+@cindex @code{--bitclock} @var{bitclock}
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.
 Alternatively, the value might be suffixed with Hz, kHz or
@@ -582,9 +589,10 @@ the computer.
 
 @item -c @var{programmer-id}
 @item --programmer @var{programmer-id}
-@cindex Option @code{-c, --programmer} @var{programmer-id}
-@cindex @code{-c, --programmer} @var{programmer-id}
-
+@cindex Option @code{-c} @var{programmer-id}
+@cindex Option @code{--programmer} @var{programmer-id}
+@cindex @code{-c} @var{programmer-id}
+@cindex @code{--programmer} @var{programmer-id}
 Specify the programmer to be used.  AVRDUDE knows about quite a few
 programmers. The @var{programmer-id} parameter is the programmer's id
 listed in the configuration file.  Specify @code{-c ?} to list all
@@ -602,8 +610,10 @@ of known programmers.
 
 @item -c @var{wildcard/flags}
 @item --programmer @var{wildcard/flags}
-@cindex Option @code{-c, --programmer} @var{wildcard/flags}
-@cindex @code{-c, --programmer} @var{wildcard/flags}
+@cindex Option @code{-c} @var{wildcard/flags}
+@cindex Option @code{--programmer} @var{wildcard/flags}
+@cindex @code{-c} @var{wildcard/flags}
+@cindex @code{--programmer} @var{wildcard/flags}
 Run developer options for programmers that are matched by @var{wildcard}.
 Whilst their main use is for developers some @var{flags} can be of utility
 for users, e.g., @code{avrdude -c usbtiny/S} shows AVRDUDE's understanding of
@@ -611,8 +621,10 @@ usbtiny's properties; for more information run @code{avrdude -c x/h}.
 
 @item -C @var{config-file}
 @item --config @var{config-file}
-@cindex Option @code{-C, --config} @var{config-file}
-@cindex @code{-C, --config} @var{config-file}
+@cindex Option @code{-c} @var{config-file}
+@cindex Option @code{--config} @var{config-file}
+@cindex @code{-C} @var{config-file}
+@cindex @code{--config} @var{config-file}
 @cindex Configuration files
 Use the specified config file for configuration data.  This file
 contains all programmer and part definitions that AVRDUDE knows about.
@@ -642,8 +654,10 @@ line.
 
 @item -N
 @item --noconfig
-@cindex Option @code{-N, --noconfig}
-@cindex @code{-N, --noconfig}
+@cindex Option @code{-N}
+@cindex Option @code{--noconfig}
+@cindex @code{-N}
+@cindex @code{--noconfig}
 Do not load the personal configuration file that is usually located at
 @code{~/.config/avrdude/avrdude.rc}, @code{~/.avrduderc} or in the same
 directory as the avrdude executable.
@@ -663,8 +677,10 @@ The popular Arduino bootloader exhibits this behaviour; for this reason
 
 @item -D
 @item --noerase
-@cindex Option @code{-D, --noerase}
-@cindex @code{-D, --noerase}
+@cindex Option @code{-D}
+@cindex Option @code{--noerase}
+@cindex @code{-D}
+@cindex @code{--noerase}
 @cindex @code{flash}
 Disable auto-erase for flash. When the @code{-U} option for writing to any
 flash memory is specified, avrdude will perform a chip erase before
@@ -678,8 +694,10 @@ contents. Setting @code{-D} implies @code{-A}.
 
 @item -e
 @item --erase
-@cindex Option @code{-e, --erase}
-@cindex @code{-e, --erase}
+@cindex Option @code{-e}
+@cindex Option @code{--erase}
+@cindex @code{-e}
+@cindex @code{--erase}
 @cindex @code{flash}
 @cindex @code{eeprom}
 Causes a chip erase to be executed. This will reset the contents of the
@@ -757,24 +775,30 @@ slow machines.
 
 @item -l @var{logfile}
 @item --logfile @var{logfile}
-@cindex Option @code{-l, --logfile} @var{logfile}
-@cindex @code{-l, --logfile} @var{logfile}
+@cindex Option @code{-l} @var{logfile}
+@cindex Option @code{--logfile} @var{logfile}
+@cindex @code{-l} @var{logfile}
+@cindex @code{--logfile} @var{logfile}
 Use @var{logfile} rather than @var{stderr} for diagnostics output.
 Note that initial diagnostic messages (during option parsing) are still
 written to @var{stderr} anyway.
 
 @item -n
 @item --test-memory
-@cindex Option @code{-n, --test-memory}
-@cindex @code{-n, --test-memory}
+@cindex Option @code{-n}
+@cindex Option @code{--test-memory}
+@cindex @code{-n}
+@cindex @code{--test-memory}
 No-write: disables writing data to the MCU whilst processing @code{-U}
 (useful for debugging AVRDUDE). The terminal mode continues to write to
 the device.
 
 @item -O
 @item --osccal
-@cindex Option @code{-O, --osccal}
-@cindex @code{-O, --osccal}
+@cindex Option @code{-O}
+@cindex Option @code{--osccal}
+@cindex @code{-O}
+@cindex @code{--osccal}
 @cindex @code{calibration}
 Perform a RC oscillator run-time calibration according to Atmel
 application note AVR053.
@@ -785,9 +809,10 @@ Note that the result will be stored in the EEPROM cell at address 0.
 
 @item -P @var{port}
 @item --port @var{port}
-@cindex Option @code{-P, --port} @var{port}
-@cindex @code{-P, --port} @var{port}
-
+@cindex Option @code{-P} @var{port}
+@cindex Option @code{--port} @var{port}
+@cindex @code{-P} @var{port}
+@cindex @code{--port} @var{port}
 Use @var{port} to identify the connection through which the programmer is
 attached. This can be a parallel, serial, spi or linuxgpio connection. The
 programmer normally specifies the connection type; in absence of a @code{-P}
@@ -873,8 +898,10 @@ Posix systems (by now).
 
 @item -r
 @item --reconnect
-@cindex Option @code{-r, --reconnect}
-@cindex @code{-r, --reconnect}
+@cindex Option @code{-r}
+@cindex Option @code{--reconnect}
+@cindex @code{-r}
+@cindex @code{--reconnect}
 Opens the serial port at 1200 baud and immediately closes it, waits 400 ms
 for each @code{-r} on the command line and then establishes communication
 with the programmer. This is commonly known as a "1200bps touch", and is
@@ -885,8 +912,10 @@ powerful hosts.
 
 @item -q
 @item --quell
-@cindex Option @code{-q, --quell}
-@cindex @code{-q, --quell}
+@cindex Option @code{-q}
+@cindex Option @code{--quell}
+@cindex @code{-q}
+@cindex @code{--quell}
 Disable (or quell) output of the progress bar while reading or writing
 to the device.  Specify it a second time for even quieter operation.
 
@@ -908,16 +937,20 @@ terminal commands.
 
 @item -t
 @item --terminal
-@cindex Option @code{-t, --terminal}
-@cindex @code{-t, --terminal}
+@cindex Option @code{-t}
+@cindex Option @code{--terminal}
+@cindex @code{-t}
+@cindex @code{--terminal}
 Tells AVRDUDE to run an interactive terminal when it is its turn in
 relation to other @code{-t} interactive terminals, @code{-T}
 terminal commands and @code{-U} memory operations.
 
 @item -U @var{memory}:@var{op}:@var{filename}[:@var{format}]
 @item --memory @var{memory}:@var{op}:@var{filename}[:@var{format}]
-@cindex Option @code{-U, --memory} @var{memory}:@var{op}:@var{filename}[:@var{format}]
-@cindex @code{-U, --memory} @var{memory}:@var{op}:@var{filename}[:@var{format}]
+@cindex Option @code{-U} @var{memory}:@var{op}:@var{filename}[:@var{format}]
+@cindex Option @code{--memory} @var{memory}:@var{op}:@var{filename}[:@var{format}]
+@cindex @code{-U} @var{memory}:@var{op}:@var{filename}[:@var{format}]
+@cindex @code{--memory} @var{memory}:@var{op}:@var{filename}[:@var{format}]
 
 Perform a memory operation when it is its turn in relation to other
 @code{-t} interactive terminals, @code{-T} terminal commands and @code{-U}
@@ -1094,15 +1127,19 @@ interpreted as memory, and the single character as memory operation.
 
 @item -v
 @item --verbose
-@cindex Option @code{-v, --verbose}
-@cindex @code{-v, --verbose}
+@cindex Option @code{-v}
+@cindex Option @code{--verbose}
+@cindex @code{-v}
+@cindex @code{--verbose}
 Enable verbose output.
 More @code{-v} options increase verbosity level.
 
 @item -V
 @item --noverify-memory
-@cindex Option @code{-V, --noverify-memory}
-@cindex @code{-V, --noverify-memory}
+@cindex Option @code{-V}
+@cindex Option @code{--noverify-memory}
+@cindex @code{-V}
+@cindex @code{--noverify-memory}
 Disable automatic verify check when writing data to the AVR with @code{-U}.
 
 @item -x @var{extended_param}

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -500,7 +500,7 @@ Roth.
 AVRDUDE is a command line tool, used as follows:
 
 @smallexample
-avrdude -p partno @var{options} @dots{}
+avrdude -p partname @var{options} @dots{}
 @end smallexample
 
 @noindent
@@ -508,14 +508,14 @@ Command line options are used to control AVRDUDE's behaviour.  The
 following options are recognized:
 
 @table @code
-@item -p @var{partno}
-@item --part @var{partno}
-@cindex Option @code{-p ,--part} @var{partno}
-@cindex @code{-p, --part} @var{partno}
+@item -p @var{partname}
+@item --part @var{partname}
+@cindex Option @code{-p ,--part} @var{partname}
+@cindex @code{-p, --part} @var{partname}
 
 This option tells AVRDUDE what part (MCU) is connected to the programmer.
-The @var{partno} parameter is the part's id listed in the configuration
-file. To see a list of currently supported MCUs use @code{?} as partno,
+The @var{partname} parameter is the part's id listed in the configuration
+file. To see a list of currently supported MCUs use @code{?} as partname,
 which will, for each part, print its id; its official part name;
 alternative names, if any; and the list of available programming
 interfaces. In connection with @code{-v}, this will also print a table of

--- a/src/main.c
+++ b/src/main.c
@@ -238,14 +238,17 @@ static void usage(void) {
 
   msg_error("Usage: %s [options]\n"
     "Options:\n"
-    "  -p <partno>               Specify AVR device; -p ? lists all known parts\n"
-    "  -p <wildcard>/<flags>     Run developer options for matched AVR devices,\n"
+    "  -p, --part <partno>       Specify AVR device; -p ? lists all known parts\n"
+    "  -p, --part <wildcard>/<flags>\n"
+    "                            Run developer options for matched AVR devices,\n"
     "                            e.g., -p ATmega328P/s or /S for part definition\n"
     "  -b, --baud <baudrate>     Override RS-232 baud rate\n"
     "  -B, --bitclock <bitclock> Specify bit clock period (us)\n"
-    "  -C <config-file>          Specify location of configuration file\n"
-    "  -C +<config-file>         Specify additional config file, can be repeated\n"
-    "  -N                        Do not load %s%s\n"
+    "  -C, --config <config-file>\n"
+    "                            Specify location of configuration file\n"
+    "  -C, --config +<config-file>\n"
+    "                            Specify additional config file, can be repeated\n"
+    "  -N, --noconfig            Do not load %s%s\n"
     "  -c, --programmer <programmer>\n"
     "                            Specify programmer; -c ? and -c ?type list all\n"
     "  -c, --programmer <wildcard>/<flags>\n"
@@ -259,8 +262,8 @@ static void usage(void) {
     "                            400 ms for each -r; needed for some USB boards\n"
     "  -F                        Override invalid signature or initial checks\n"
     "  -e, --erase               Perform a chip erase at the beginning\n"
-    "  -O                        Perform RC oscillator calibration (see AVR053)\n"
-    "  -t, --terminal, --tty     Run an interactive terminal when it is its turn\n"
+    "  -O, --osccal              Perform RC oscillator calibration (see AVR053)\n"
+    "  -t, --terminal,            Run an interactive terminal when it is its turn\n"
     "  -T <terminal cmd line>    Run terminal line when it is its turn\n"
     "  -U, --memory <memstr>:r|w|v:<filename>[:format]\n"
     "                            Carry out memory operation when it is its turn\n"
@@ -270,7 +273,7 @@ static void usage(void) {
     "  -E <exitsp>[,<exitsp>]    List programmer exit specifications\n"
     "  -x <extended_param>       Pass <extended_param> to programmer, see -x help\n"
     "  -v, --verbose             Verbose output; -v -v for more\n"
-    "  -q                        Quell progress output; -q -q for less\n"
+    "  -q, --quiet               Quell progress output; -q -q for less\n"
     "  -l, --logfile logfile     Use logfile rather than stderr for diagnostics\n"
     "  -?, --help                Display this usage\n"
     "\navrdude version %s, https://github.com/avrdudes/avrdude\n",
@@ -828,13 +831,12 @@ int main(int argc, char *argv[]) {
     {"logfile",    required_argument, NULL, 'l'},
     {"test",       no_argument,       NULL, 'n'},
     {"noconfig",   no_argument,       NULL, 'N'},
+    {"osccal",     no_argument,       NULL, 'O'},
     {"part",       required_argument, NULL, 'p'},
-    {"chip",       required_argument, NULL, 'p'},
     {"port",       required_argument, NULL, 'P'},
     {"quiet",      no_argument,       NULL, 'q'},
     {"reconnect",  no_argument,       NULL, 'r'},
     {"terminal",   no_argument,       NULL, 't'},
-    {"tty",        no_argument,       NULL, 't'},
     {"memory",     required_argument, NULL, 'U'},
     {"verbose",    no_argument,       NULL, 'v'},
     {"noverify",   no_argument,       NULL, 'V'},

--- a/src/main.c
+++ b/src/main.c
@@ -273,7 +273,7 @@ static void usage(void) {
     "  -E <exitsp>[,<exitsp>]    List programmer exit specifications\n"
     "  -x <extended_param>       Pass <extended_param> to programmer, see -x help\n"
     "  -v, --verbose             Verbose output; -v -v for more\n"
-    "  -q, --quiet               Quell progress output; -q -q for less\n"
+    "  -q, --quell               Quell progress output; -q -q for less\n"
     "  -l, --logfile logfile     Use logfile rather than stderr for diagnostics\n"
     "  -?, --help                Display this usage\n"
     "\navrdude version %s, https://github.com/avrdudes/avrdude\n",
@@ -834,7 +834,7 @@ int main(int argc, char *argv[]) {
     {"osccal",     no_argument,       NULL, 'O'},
     {"part",       required_argument, NULL, 'p'},
     {"port",       required_argument, NULL, 'P'},
-    {"quiet",      no_argument,       NULL, 'q'},
+    {"quell",      no_argument,       NULL, 'q'},
     {"reconnect",  no_argument,       NULL, 'r'},
     {"terminal",   no_argument,       NULL, 't'},
     {"memory",     required_argument, NULL, 'U'},

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <getopt.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -237,39 +238,41 @@ static void usage(void) {
 
   msg_error("Usage: %s [options]\n"
     "Options:\n"
-    "  -p <partno>            Specify AVR device; -p ? lists all known parts\n"
-    "  -p <wildcard>/<flags>  Run developer options for matched AVR devices,\n"
-    "                         e.g., -p ATmega328P/s or /S for part definition\n"
-    "  -b <baudrate>          Override RS-232 baud rate\n"
-    "  -B <bitclock>          Specify bit clock period (us)\n"
-    "  -C <config-file>       Specify location of configuration file\n"
-    "  -C +<config-file>      Specify additional config file, can be repeated\n"
-    "  -N                     Do not load %s%s\n"
-    "  -c <programmer>        Specify programmer; -c ? and -c ?type list all\n"
-    "  -c <wildcard>/<flags>  Run developer options for matched programmers,\n"
-    "                         e.g., -c 'ur*'/s for programmer info/definition\n"
-    "  -A                     Disable trailing-0xff removal for file/AVR read\n"
-    "  -D                     Disable auto-erase for flash memory; implies -A\n"
-    "  -i <delay>             ISP Clock Delay [in microseconds]\n"
-    "  -P <port>              Connection; -P ?s or -P ?sa lists serial ones\n"
-    "  -r                     Reconnect to -P port after \"touching\" it; wait\n"
-    "                         400 ms for each -r; needed for some USB boards\n"
-    "  -F                     Override invalid signature or initial checks\n"
-    "  -e                     Perform a chip erase at the beginning\n"
-    "  -O                     Perform RC oscillator calibration (see AVR053)\n"
-    "  -t                     Run an interactive terminal when it is its turn\n"
-    "  -T <terminal cmd line> Run terminal line when it is its turn\n"
-    "  -U <memstr>:r|w|v:<filename>[:format]\n"
-    "                         Carry out memory operation when it is its turn\n"
-    "                         Multiple -t, -T and -U options can be specified\n"
-    "  -n                     Do not write to the device whilst processing -U\n"
-    "  -V                     Do not automatically verify during -U\n"
-    "  -E <exitsp>[,<exitsp>] List programmer exit specifications\n"
-    "  -x <extended_param>    Pass <extended_param> to programmer, see -x help\n"
-    "  -v                     Verbose output; -v -v for more\n"
-    "  -q                     Quell progress output; -q -q for less\n"
-    "  -l logfile             Use logfile rather than stderr for diagnostics\n"
-    "  -?                     Display this usage\n"
+    "  -p <partno>               Specify AVR device; -p ? lists all known parts\n"
+    "  -p <wildcard>/<flags>     Run developer options for matched AVR devices,\n"
+    "                            e.g., -p ATmega328P/s or /S for part definition\n"
+    "  -b, --baud <baudrate>     Override RS-232 baud rate\n"
+    "  -B, --bitclock <bitclock> Specify bit clock period (us)\n"
+    "  -C <config-file>          Specify location of configuration file\n"
+    "  -C +<config-file>         Specify additional config file, can be repeated\n"
+    "  -N                        Do not load %s%s\n"
+    "  -c, --programmer <programmer>\n"
+    "                            Specify programmer; -c ? and -c ?type list all\n"
+    "  -c, --programmer <wildcard>/<flags>\n"
+    "                            Run developer options for matched programmers,\n"
+    "                            e.g., -c 'ur*'/s for programmer info/definition\n"
+    "  -A                        Disable trailing-0xff removal for file/AVR read\n"
+    "  -D, --noerase             Disable auto-erase for flash memory; implies -A\n"
+    "  -i <delay>                ISP Clock Delay [in microseconds]\n"
+    "  -P, --port <port>         Connection; -P ?s or -P ?sa lists serial ones\n"
+    "  -r, --reconnect           Reconnect to -P port after \"touching\" it; wait\n"
+    "                            400 ms for each -r; needed for some USB boards\n"
+    "  -F                        Override invalid signature or initial checks\n"
+    "  -e, --erase               Perform a chip erase at the beginning\n"
+    "  -O                        Perform RC oscillator calibration (see AVR053)\n"
+    "  -t, --terminal, --tty     Run an interactive terminal when it is its turn\n"
+    "  -T <terminal cmd line>    Run terminal line when it is its turn\n"
+    "  -U, --memory <memstr>:r|w|v:<filename>[:format]\n"
+    "                            Carry out memory operation when it is its turn\n"
+    "                            Multiple -t, -T and -U options can be specified\n"
+    "  -n, --test                Do not write to the device whilst processing -U\n"
+    "  -V, --noverify            Do not automatically verify during -U\n"
+    "  -E <exitsp>[,<exitsp>]    List programmer exit specifications\n"
+    "  -x <extended_param>       Pass <extended_param> to programmer, see -x help\n"
+    "  -v, --verbose             Verbose output; -v -v for more\n"
+    "  -q                        Quell progress output; -q -q for less\n"
+    "  -l, --logfile logfile     Use logfile rather than stderr for diagnostics\n"
+    "  -?, --help                Display this usage\n"
     "\navrdude version %s, https://github.com/avrdudes/avrdude\n",
     progname, strlen(cfg) < 24? "config file ": "", cfg, AVRDUDE_FULL_VERSION);
 
@@ -814,7 +817,32 @@ int main(int argc, char *argv[]) {
 #endif
 
   // Process command line arguments
-  while((ch = getopt(argc, argv, "?Ab:B:c:C:DeE:Fi:l:nNp:OP:qrtT:U:vVx:")) != -1) {
+  struct option longopts[] = {
+    {"help",       no_argument,       NULL, '?'},
+    {"baud",       required_argument, NULL, 'b'},
+    {"bitclock",   required_argument, NULL, 'B'},
+    {"programmer", required_argument, NULL, 'c'},
+    {"config",     required_argument, NULL, 'C'},
+    {"noerase",    no_argument,       NULL, 'D'},
+    {"erase",      no_argument,       NULL, 'e'},
+    {"logfile",    required_argument, NULL, 'l'},
+    {"test",       no_argument,       NULL, 'n'},
+    {"noconfig",   no_argument,       NULL, 'N'},
+    {"part",       required_argument, NULL, 'p'},
+    {"chip",       required_argument, NULL, 'p'},
+    {"port",       required_argument, NULL, 'P'},
+    {"quiet",      no_argument,       NULL, 'q'},
+    {"reconnect",  no_argument,       NULL, 'r'},
+    {"terminal",   no_argument,       NULL, 't'},
+    {"tty",        no_argument,       NULL, 't'},
+    {"memory",     required_argument, NULL, 'U'},
+    {"verbose",    no_argument,       NULL, 'v'},
+    {"noverify",   no_argument,       NULL, 'V'},
+    {NULL,         0,                 NULL, 0}
+  };
+  while((ch = getopt_long(argc, argv,
+			  "?Ab:B:c:C:DeE:Fi:l:nNp:OP:qrtT:U:vVx:",
+			  longopts, NULL)) != -1) {
     switch(ch) {
     case 'b':                  // Override default programmer baud rate
       baudrate = str_int(optarg, STR_INT32, &errstr);

--- a/src/main.c
+++ b/src/main.c
@@ -268,8 +268,8 @@ static void usage(void) {
     "  -U, --memory <memstr>:r|w|v:<filename>[:format]\n"
     "                            Carry out memory operation when it is its turn\n"
     "                            Multiple -t, -T and -U options can be specified\n"
-    "  -n, --test                Do not write to the device whilst processing -U\n"
-    "  -V, --noverify            Do not automatically verify during -U\n"
+    "  -n, --test-memory         Do not write to the device whilst processing -U\n"
+    "  -V, --noverify-memory     Do not automatically verify during -U\n"
     "  -E <exitsp>[,<exitsp>]    List programmer exit specifications\n"
     "  -x <extended_param>       Pass <extended_param> to programmer, see -x help\n"
     "  -v, --verbose             Verbose output; -v -v for more\n"
@@ -829,7 +829,7 @@ int main(int argc, char *argv[]) {
     {"noerase",    no_argument,       NULL, 'D'},
     {"erase",      no_argument,       NULL, 'e'},
     {"logfile",    required_argument, NULL, 'l'},
-    {"test",       no_argument,       NULL, 'n'},
+    {"test-memory",no_argument,       NULL, 'n'},
     {"noconfig",   no_argument,       NULL, 'N'},
     {"osccal",     no_argument,       NULL, 'O'},
     {"part",       required_argument, NULL, 'p'},
@@ -839,7 +839,7 @@ int main(int argc, char *argv[]) {
     {"terminal",   no_argument,       NULL, 't'},
     {"memory",     required_argument, NULL, 'U'},
     {"verbose",    no_argument,       NULL, 'v'},
-    {"noverify",   no_argument,       NULL, 'V'},
+    {"noverify-memory",no_argument,   NULL, 'V'},
     {NULL,         0,                 NULL, 0}
   };
   while((ch = getopt_long(argc, argv,


### PR DESCRIPTION
Switch from getopt(3) to getopt_long(3) and add a few long options as aliases to existing short options, e.g. "--help" and "--part" being aliases for "-?" and "-p", respectively.

The getopt_long(3) function is available on GNU, BSD, and the existing msvc/getopt.[ch] already implements getopt_long() on Windows. This should cover all systems avrdude supports.

- [X] Use `getopt_long(3)` instead of `getopt(3)`
- [X] Add long options from @westfw https://github.com/avrdudes/avrdude/issues/1922#issuecomment-2337274055
- [X] Adapt the avrdude usage message shown by "-?" or "--help" to show the new long options.
- [x] Refine, review and finalize the set of new long options
- [x] Adapt the man page to reflect the long options
- [x] Adapt the texi manual to reflect the long options

Closes: #1922