### PR TITLE
Fix missing stdlib.h include for free()

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -20,6 +20,7 @@
 #define avrdude_h
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #define SYSTEM_CONF_FILE "avrdude.conf"
 


### PR DESCRIPTION
Building avrdude with current clang+mingw-w64 for arm64 on Windows leads to the following error:
serbb_win32.c:294:3: error: call to undeclared library function 'free' with type 'void (void *)'

Explicitely import stdlib.h for free() in avrdude.h where mmt_free() is defind to free() to fix this.

Fixes #1940