### PR TITLE
Fix GitHub upload artifact

### DIFF
--- a/.github/workflows/arduino_packing.yml
+++ b/.github/workflows/arduino_packing.yml
@@ -85,7 +85,7 @@ jobs:
         tar -czv ${{ env.PROJECT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF##*/}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
         name: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/arduino_packing.yml
+++ b/.github/workflows/arduino_packing.yml
@@ -88,5 +88,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
-        name: ${{ env.ARTIFACT_NAME }}
+        name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}
         path: ${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}_*

--- a/.github/workflows/arduino_packing_release.yml
+++ b/.github/workflows/arduino_packing_release.yml
@@ -77,7 +77,7 @@ jobs:
         tar -czv ${{ env.PROJECT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF##*/}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         if-no-files-found: error
         name: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         run: printf "\n\n" | ./tools/test-avrdude -v -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-linux-x86_64
           path: |
@@ -138,7 +138,7 @@ jobs:
             !**/*.d
             !**/*.o
       - name: Archive executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: avrdude-linux-x86_64
           path: |
@@ -200,7 +200,7 @@ jobs:
         run: build/src/avrdude -?
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-linux-${{matrix.processor}}
           path: |
@@ -208,7 +208,7 @@ jobs:
             !**/*.d
             !**/*.o
       - name: Archive executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: avrdude-linux-${{matrix.processor}}
           path: |
@@ -259,7 +259,7 @@ jobs:
         run: printf "\n\n" | ./tools/test-avrdude -v -e build/src/avrdude -c '-C build/src/avrdude.conf' -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-macos-x86_64
           path: |
@@ -267,7 +267,7 @@ jobs:
             !**/*.d
             !**/*.o
       - name: Archive executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: avrdude-macos-x86_64
           path: |
@@ -368,7 +368,7 @@ jobs:
           Write-Host "`n`n" -NoNewline | bash tools/test-avrdude -v -t "$tmp_slash" -e build/src/${{env.BUILD_TYPE}}/avrdude.exe -c "-C build/src/avrdude.conf" -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-msvc-${{matrix.arch}}
           path: |
@@ -380,7 +380,7 @@ jobs:
           mv build/src/${{env.BUILD_TYPE}}/avrdude.exe build/src
           mv build/src/${{env.BUILD_TYPE}}/avrdude.pdb build/src
       - name: Archive executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: avrdude-msvc-${{matrix.arch}}
           path: |
@@ -436,13 +436,13 @@ jobs:
       #   run: printf "\n\n" | ./tools/test-avrdude -v -e build/src/avrdude.exe -c "-C build/src/avrdude.conf" -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-mingw-${{matrix.env}}
           path: |
             build/
       - name: Archive executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: avrdude-mingw-${{matrix.env}}
           path: |


### PR DESCRIPTION
This changes the upload-artifact calls to use v4.

With v4, there must be no name duplication anymore, so arduino_packaging needs to distinguish between OS + architecture.

Fixes issue #1944 