### PR TITLE
Suggest compatible command when SNAP/PICKit4 in PIC mode is detected

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1724,8 +1724,14 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
             }
             imsg_error("run %s again to continue the session\n\n", progname);
           } else {
-            pmsg_error("to switch into AVR mode try\n");
-            imsg_error("$ %s -c %s%s -P %s -x mode=avr\n", progname, pgmid, partdesc? strcat(" -p ", partdesc): "", port);
+
+            const char *partsdesc_flag = partdesc? " -p ": "";
+            const char *partsdesc_str = partdesc? partdesc: "";
+            const char *pgm_suffix = strchr(pgmid, '_')? strchr(pgmid, '_'): "";
+            imsg_error("to switch into AVR mode try\n");
+            imsg_error("$ %s -c %s%s%s -P %s -x mode=avr\n\n", progname, pgmid, partsdesc_flag, partsdesc_str, port);
+            imsg_error("or use PIC mode by using the pickit5%s programmer option:\n", pgm_suffix);
+            imsg_error("$ %s -c pickit5%s%s%s -P %s\n", progname, pgm_suffix, partsdesc_flag, partsdesc_str, port);
           }
           serial_close(&pgm->fd);
           return LIBAVRDUDE_EXIT;;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1725,7 +1725,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
             imsg_error("run %s again to continue the session\n\n", progname);
           } else {
             pmsg_error("to switch into AVR mode try\n");
-            imsg_error("$ %s -c %s -p %s -P %s -x mode=avr\n", progname, pgmid, partdesc, port);
+            imsg_error("$ %s -c %s%s -P %s -x mode=avr\n", progname, pgmid, partdesc? strcat(" -p ", partdesc): "", port);
           }
           serial_close(&pgm->fd);
           return LIBAVRDUDE_EXIT;;

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -663,7 +663,6 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
     cx->usb_access_error = 0;
 
     pmsg_error("MPLAB SNAP in AVR mode detected\n");
-
     imsg_error("to switch into PIC mode try\n");
     imsg_error("$ %s -c snap%s %s-P %s -x mode=pic\n", progname, pgm_suffix, part_option, port);
     imsg_error("or use the programmer in AVR mode with the following command:\n");
@@ -672,11 +671,6 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
     serial_close(&pgm->fd);
     return LIBAVRDUDE_EXIT;
   }
-  pinfo.usbinfo.flags = PINFO_FL_SILENT;
-  pgm->fd.usb.max_xfer = USBDEV_MAX_XFER_3;
-  pgm->fd.usb.rep = USBDEV_BULK_EP_READ_3;
-  pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_3;
-  pgm->fd.usb.eep = USBDEV_EVT_EP_READ_3;
   pinfo.usbinfo.pid = USB_DEVICE_PICKIT4_AVR_MODE;
   rv = serial_open(port, pinfo, &pgm->fd);  // Try PICkit4 PID
 
@@ -685,7 +679,6 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
     cx->usb_access_error = 0;
 
     pmsg_error("PICkit 4 in AVR mode detected\n");
-
     imsg_error("to switch into PIC mode try\n");
     imsg_error("$ %s -c pickit4%s %s-P %s -x mode=pic\n", progname, pgm_suffix, part_option, port);
     imsg_error("or use the programmer in AVR mode with the following command:\n");

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -627,7 +627,79 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
       my.pgm_type = PGM_TYPE_SNAP;
   }
 
-  return rv;
+  // No PICkit4 / SNAP (PIC mode) nor PICkit5 found, look for programmer in AVR mode
+  if(rv >= 0)  // if a programmer in PIC mode found, we're done
+    return rv;
+
+  // otherwise, try to see if there is a SNAP or PK4 in AVR mode
+  pinfo.usbinfo.vid = USB_VENDOR_ATMEL;
+  pinfo.usbinfo.pid = USB_DEVICE_SNAP_AVR_MODE;
+
+  pgm->fd.usb.max_xfer = USBDEV_MAX_XFER_3;
+  pgm->fd.usb.rep = USBDEV_BULK_EP_READ_3;
+  pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_3;
+  pgm->fd.usb.eep = USBDEV_EVT_EP_READ_3;
+
+  const char *pgm_suffix = strchr(pgmid, '_')? strchr(pgmid, '_'): "";
+  char part_option[32] = {};  // 32 should be enough
+
+  if(partdesc)
+    snprintf(part_option, 31, "-p %s ", partdesc);
+  else
+    strcpy(part_option, "");
+
+// Use LIBHIDAPI to connect to SNAP/PICkit4 if present.
+// For some reason, chances are smaller to get
+// permission denied errors when using LIBHIDAPI
+#if defined(HAVE_LIBHIDAPI)
+  serdev = &usbhid_serdev;
+  pgm->fd.usb.eep = 0;
+#endif
+
+  rv = serial_open(port, pinfo, &pgm->fd);  // Try SNAP PID
+
+  if(rv >= 0) {
+    msg_error("\n");
+    cx->usb_access_error = 0;
+
+    pmsg_error("MPLAB SNAP in AVR mode detected\n");
+
+    imsg_error("to switch into PIC mode try\n");
+    imsg_error("$ %s -c snap%s %s-P %s -x mode=pic\n", progname, pgm_suffix, part_option, port);
+    imsg_error("or use the programmer in AVR mode with the following command:\n");
+    imsg_error("$ %s -c snap%s %s-P %s\n", progname, pgm_suffix, part_option, port);
+
+    serial_close(&pgm->fd);
+    return LIBAVRDUDE_EXIT;
+  }
+  pinfo.usbinfo.flags = PINFO_FL_SILENT;
+  pgm->fd.usb.max_xfer = USBDEV_MAX_XFER_3;
+  pgm->fd.usb.rep = USBDEV_BULK_EP_READ_3;
+  pgm->fd.usb.wep = USBDEV_BULK_EP_WRITE_3;
+  pgm->fd.usb.eep = USBDEV_EVT_EP_READ_3;
+  pinfo.usbinfo.pid = USB_DEVICE_PICKIT4_AVR_MODE;
+  rv = serial_open(port, pinfo, &pgm->fd);  // Try PICkit4 PID
+
+  if(rv >= 0) {
+    msg_error("\n");
+    cx->usb_access_error = 0;
+
+    pmsg_error("PICkit 4 in AVR mode detected\n");
+
+    imsg_error("to switch into PIC mode try\n");
+    imsg_error("$ %s -c pickit4%s %s-P %s -x mode=pic\n", progname, pgm_suffix, part_option, port);
+    imsg_error("or use the programmer in AVR mode with the following command:\n");
+    imsg_error("$ %s -c pickit4%s %s-P %s\n", progname, pgm_suffix, part_option, port);
+
+    serial_close(&pgm->fd);
+    return LIBAVRDUDE_EXIT;
+  }
+
+  pmsg_error("no device found matching VID 0x%04x and PID list: 0x%04x, 0x%04x, 0x%04x\n", USB_VENDOR_MICROCHIP,
+              USB_DEVICE_PICKIT5, USB_DEVICE_PICKIT4_PIC_MODE, USB_DEVICE_SNAP_PIC_MODE);
+  imsg_error("nor VID 0x%04x with PID list: 0x%04x, 0x%04x\n", USB_VENDOR_ATMEL, USB_DEVICE_PICKIT4_AVR_MODE, USB_DEVICE_SNAP_AVR_MODE);
+
+  return LIBAVRDUDE_EXIT;
 }
 
 static void pickit5_close(PROGRAMMER *pgm) {

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -641,12 +641,10 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
   pgm->fd.usb.eep = USBDEV_EVT_EP_READ_3;
 
   const char *pgm_suffix = strchr(pgmid, '_')? strchr(pgmid, '_'): "";
-  char part_option[32] = {};  // 32 should be enough
+  char part_option[128] = {0};
 
   if(partdesc)
-    snprintf(part_option, 31, "-p %s ", partdesc);
-  else
-    strcpy(part_option, "");
+    snprintf(part_option, sizeof(part_option), "-p %s ", partdesc);
 
 // Use LIBHIDAPI to connect to SNAP/PICkit4 if present.
 // For some reason, chances are smaller to get


### PR DESCRIPTION
With this PR Avrdude suggests either switching the SNAP/PICkit4 to AVR mode (`-xmode=avr)`, or providing an alternative command where the appropriate `pickit5` programmer option is selected. And now it wont print `-p (null)` if no `-p` option is specified.

```
$ avrdude -c pickit4_isp

avrdude error: PICkit 4 in PIC mode detected
        to switch into AVR mode try
        $ avrdude -c pickit4_isp -P usb -x mode=avr
        or use PIC mode by using the pickit5_isp programmer option:
        $ avrdude -c pickit5_isp -P usb
```

This has only been implemented for SNAP/PICkit4 in PIC mode. Similar functionality should be implemented for the `pickit5` programmer option if a SNAP/PICkit4 in AVR mode is detected. @MX682X probably has thoughts on how something like this could be implemented. Ideally something like this:

```
$ avrdude -c pickit5_isp

avrdude error: PICkit 4 in AVR mode detected
        to switch into AVR mode try
        $ avrdude -c pickit4_isp -P usb -x mode=pic
        or use AVR mode by using the pickit4_isp programmer option:
        $ avrdude -c pickit4_isp -P usb
```
