### PR TITLE
Add AVR64DAnnS, AVR32DAnnS and AVR32SDnn

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -20734,7 +20734,7 @@ part parent ".avr8x_tiny" # t3227
 # ATmega808
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny" # m808
+part parent ".avr8x_mega" # m808
     desc                   = "ATmega808";
     id                     = "m808";
     variants               =
@@ -20769,12 +20769,13 @@ part parent ".avr8x_tiny" # m808
         readsize           = 256;
     ;
 
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "userrow"
+        size               = 32;
+        page_size          = 32;
     ;
 
     memory "sram"
@@ -20787,7 +20788,7 @@ part parent ".avr8x_tiny" # m808
 # ATmega809
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny" # m809
+part parent ".avr8x_mega" # m809
     desc                   = "ATmega809";
     id                     = "m809";
     variants               =
@@ -20818,12 +20819,13 @@ part parent ".avr8x_tiny" # m809
         readsize           = 256;
     ;
 
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "userrow"
+        size               = 32;
+        page_size          = 32;
     ;
 
     memory "sram"
@@ -20836,7 +20838,7 @@ part parent ".avr8x_tiny" # m809
 # ATmega1608
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny" # m1608
+part parent ".avr8x_mega" # m1608
     desc                   = "ATmega1608";
     id                     = "m1608";
     variants               =
@@ -20871,12 +20873,13 @@ part parent ".avr8x_tiny" # m1608
         readsize           = 256;
     ;
 
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "userrow"
+        size               = 32;
+        page_size          = 32;
     ;
 
     memory "sram"
@@ -20889,7 +20892,7 @@ part parent ".avr8x_tiny" # m1608
 # ATmega1609
 #------------------------------------------------------------
 
-part parent ".avr8x_tiny" # m1609
+part parent ".avr8x_mega" # m1609
     desc                   = "ATmega1609";
     id                     = "m1609";
     variants               =
@@ -20920,12 +20923,13 @@ part parent ".avr8x_tiny" # m1609
         readsize           = 256;
     ;
 
-    memory "fuse5"
-        bitmask            = 0xc9;
-    ;
-
     memory "lock"
         initval            = 0xc5;
+    ;
+
+    memory "userrow"
+        size               = 32;
+        page_size          = 32;
     ;
 
     memory "sram"

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -21148,12 +21148,12 @@ part parent ".avr8x_mega" # m4809
 ;
 
 #------------------------------------------------------------
-# AVR-Dx family common values
+# AVR-DA/DB family common values
 #------------------------------------------------------------
 
-part # .avrdx
-    desc                   = "AVR-Dx family common values";
-    id                     = ".avrdx";
+part # .avr-da-db
+    desc                   = "AVR-DA/DB family common values";
+    id                     = ".avr-da-db";
     family_id              = "AVR    ";
     prog_modes             = PM_SPM | PM_UPDI;
     n_boot_sections        = 1;
@@ -21320,7 +21320,7 @@ part # .avrdx
 # AVR32DA28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32da28
+part parent ".avr-da-db" # 32da28
     desc                   = "AVR32DA28";
     id                     = "32da28";
     variants               =
@@ -21372,7 +21372,7 @@ part parent ".avrdx" # 32da28
 # AVR32DA32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32da32
+part parent ".avr-da-db" # 32da32
     desc                   = "AVR32DA32";
     id                     = "32da32";
     variants               =
@@ -21422,7 +21422,7 @@ part parent ".avrdx" # 32da32
 # AVR32DA48
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32da48
+part parent ".avr-da-db" # 32da48
     desc                   = "AVR32DA48";
     id                     = "32da48";
     variants               =
@@ -21472,7 +21472,7 @@ part parent ".avrdx" # 32da48
 # AVR64DA28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64da28
+part parent ".avr-da-db" # 64da28
     desc                   = "AVR64DA28";
     id                     = "64da28";
     variants               =
@@ -21524,7 +21524,7 @@ part parent ".avrdx" # 64da28
 # AVR64DA32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64da32
+part parent ".avr-da-db" # 64da32
     desc                   = "AVR64DA32";
     id                     = "64da32";
     variants               =
@@ -21574,7 +21574,7 @@ part parent ".avrdx" # 64da32
 # AVR64DA48
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64da48
+part parent ".avr-da-db" # 64da48
     desc                   = "AVR64DA48";
     id                     = "64da48";
     variants               =
@@ -21624,7 +21624,7 @@ part parent ".avrdx" # 64da48
 # AVR64DA64
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64da64
+part parent ".avr-da-db" # 64da64
     desc                   = "AVR64DA64";
     id                     = "64da64";
     variants               =
@@ -21674,7 +21674,7 @@ part parent ".avrdx" # 64da64
 # AVR128DA28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128da28
+part parent ".avr-da-db" # 128da28
     desc                   = "AVR128DA28";
     id                     = "128da28";
     variants               =
@@ -21726,7 +21726,7 @@ part parent ".avrdx" # 128da28
 # AVR128DA32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128da32
+part parent ".avr-da-db" # 128da32
     desc                   = "AVR128DA32";
     id                     = "128da32";
     variants               =
@@ -21776,7 +21776,7 @@ part parent ".avrdx" # 128da32
 # AVR128DA48
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128da48
+part parent ".avr-da-db" # 128da48
     desc                   = "AVR128DA48";
     id                     = "128da48";
     variants               =
@@ -21826,7 +21826,7 @@ part parent ".avrdx" # 128da48
 # AVR128DA64
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128da64
+part parent ".avr-da-db" # 128da64
     desc                   = "AVR128DA64";
     id                     = "128da64";
     variants               =
@@ -22151,7 +22151,7 @@ part parent "128da64" # 128da64s
 # AVR32DB28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32db28
+part parent ".avr-da-db" # 32db28
     desc                   = "AVR32DB28";
     id                     = "32db28";
     variants               =
@@ -22197,7 +22197,7 @@ part parent ".avrdx" # 32db28
 # AVR32DB32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32db32
+part parent ".avr-da-db" # 32db32
     desc                   = "AVR32DB32";
     id                     = "32db32";
     variants               =
@@ -22241,7 +22241,7 @@ part parent ".avrdx" # 32db32
 # AVR32DB48
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32db48
+part parent ".avr-da-db" # 32db48
     desc                   = "AVR32DB48";
     id                     = "32db48";
     variants               =
@@ -22285,7 +22285,7 @@ part parent ".avrdx" # 32db48
 # AVR64DB28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64db28
+part parent ".avr-da-db" # 64db28
     desc                   = "AVR64DB28";
     id                     = "64db28";
     variants               =
@@ -22331,7 +22331,7 @@ part parent ".avrdx" # 64db28
 # AVR64DB32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64db32
+part parent ".avr-da-db" # 64db32
     desc                   = "AVR64DB32";
     id                     = "64db32";
     variants               =
@@ -22375,7 +22375,7 @@ part parent ".avrdx" # 64db32
 # AVR64DB48
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64db48
+part parent ".avr-da-db" # 64db48
     desc                   = "AVR64DB48";
     id                     = "64db48";
     variants               =
@@ -22419,7 +22419,7 @@ part parent ".avrdx" # 64db48
 # AVR64DB64
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64db64
+part parent ".avr-da-db" # 64db64
     desc                   = "AVR64DB64";
     id                     = "64db64";
     variants               =
@@ -22463,7 +22463,7 @@ part parent ".avrdx" # 64db64
 # AVR128DB28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128db28
+part parent ".avr-da-db" # 128db28
     desc                   = "AVR128DB28";
     id                     = "128db28";
     variants               =
@@ -22509,7 +22509,7 @@ part parent ".avrdx" # 128db28
 # AVR128DB32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128db32
+part parent ".avr-da-db" # 128db32
     desc                   = "AVR128DB32";
     id                     = "128db32";
     variants               =
@@ -22553,7 +22553,7 @@ part parent ".avrdx" # 128db32
 # AVR128DB48
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128db48
+part parent ".avr-da-db" # 128db48
     desc                   = "AVR128DB48";
     id                     = "128db48";
     variants               =
@@ -22597,7 +22597,7 @@ part parent ".avrdx" # 128db48
 # AVR128DB64
 #------------------------------------------------------------
 
-part parent ".avrdx" # 128db64
+part parent ".avr-da-db" # 128db64
     desc                   = "AVR128DB64";
     id                     = "128db64";
     variants               =
@@ -22638,19 +22638,21 @@ part parent ".avrdx" # 128db64
 ;
 
 #------------------------------------------------------------
-# AVR16DD14
+# AVR-DD/DU family common values
 #------------------------------------------------------------
 
-part parent ".avrdx" # 16dd14
-    desc                   = "AVR16DD14";
-    id                     = "16dd14";
-    variants               =
-        "AVR16DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD14-SOIC: DIP14,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
-    mcuid                  = 329;
-    n_interrupts           = 36;
+part # .avr-dd-du
+    desc                   = "AVR-DD/DU family common values";
+    id                     = ".avr-dd-du";
+    family_id              = "AVR    ";
+    prog_modes             = PM_SPM | PM_UPDI;
+    n_boot_sections        = 1;
+    boot_section_size      = 512;
     hvupdi_variant         = 2;
-    signature              = 0x1e 0x94 0x34;
+    nvm_base               = 0x1000;
+    ocd_base               = 0x0f80;
+    syscfg_base            = 0x0f00;
+    factory_fcpu           = 4000000;
 
     memory "eeprom"
         size               = 256;
@@ -22658,20 +22660,177 @@ part parent ".avrdx" # 16dd14
         readsize           = 256;
     ;
 
+    memory "fuses"
+        size               = 16;
+        offset             = 0x1050;
+        readsize           = 1;
+    ;
+
+    memory "fuse0"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1050;
+        readsize           = 1;
+    ;
+
+    memory "wdtcfg"
+        alias "fuse0";
+    ;
+
+    memory "fuse1"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1051;
+        readsize           = 1;
+    ;
+
+    memory "bodcfg"
+        alias "fuse1";
+    ;
+
+    memory "fuse2"
+        size               = 1;
+        initval            = 0x00;
+        bitmask            = 0x07;
+        offset             = 0x1052;
+        readsize           = 1;
+    ;
+
+    memory "osccfg"
+        alias "fuse2";
+    ;
+
+    memory "fuse5"
+        size               = 1;
+        initval            = 0xd0;
+        bitmask            = 0xf9;
+        offset             = 0x1055;
+        readsize           = 1;
+    ;
+
+    memory "syscfg0"
+        alias "fuse5";
+    ;
+
+    memory "fuse6"
+        size               = 1;
+        initval            = 0x08;
+        bitmask            = 0x1f;
+        offset             = 0x1056;
+        readsize           = 1;
+    ;
+
+    memory "syscfg1"
+        alias "fuse6";
+    ;
+
+    memory "fuse7"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1057;
+        readsize           = 1;
+    ;
+
+    memory "codesize"
+        alias "fuse7";
+    ;
+
+    memory "append"
+        alias "fuse7";
+    ;
+
+    memory "fuse8"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1058;
+        readsize           = 1;
+    ;
+
+    memory "bootsize"
+        alias "fuse8";
+    ;
+
+    memory "bootend"
+        alias "fuse8";
+    ;
+
+    memory "lock"
+        size               = 4;
+        initval            = 0x5cc5c55c;
+        offset             = 0x1040;
+        readsize           = 4;
+    ;
+
+    memory "prodsig"
+        size               = 128;
+        page_size          = 128;
+        offset             = 0x1100;
+        readsize           = 128;
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
+    ;
+
+    memory "signature"
+        size               = 3;
+        offset             = 0x1100;
+        readsize           = 3;
+    ;
+
+    memory "tempsense"
+        size               = 4;
+        offset             = 0x1104;
+        readsize           = 1;
+    ;
+
+    memory "sernum"
+        size               = 16;
+        offset             = 0x1110;
+        readsize           = 1;
+    ;
+
+    memory "userrow"
+        size               = 32;
+        page_size          = 32;
+        offset             = 0x1080;
+        readsize           = 32;
+    ;
+
+    memory "usersig"
+        alias "userrow";
+    ;
+
+    memory "io"
+        size               = 4160;
+        readsize           = 1;
+    ;
+
+    memory "sib"
+        size               = 32;
+        readsize           = 1;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR16DD14
+#------------------------------------------------------------
+
+part parent ".avr-dd-du" # 16dd14
+    desc                   = "AVR16DD14";
+    id                     = "16dd14";
+    variants               =
+        "AVR16DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD14-SOIC: DIP14,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 329;
+    n_interrupts           = 36;
+    signature              = 0x1e 0x94 0x34;
+
     memory "flash"
         size               = 0x4000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22684,7 +22843,7 @@ part parent ".avrdx" # 16dd14
 # AVR16DD20
 #------------------------------------------------------------
 
-part parent ".avrdx" # 16dd20
+part parent ".avr-dd-du" # 16dd20
     desc                   = "AVR16DD20";
     id                     = "16dd20";
     variants               =
@@ -22694,29 +22853,13 @@ part parent ".avrdx" # 16dd20
         "AVR16DD20-VQFN:  QFP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 330;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x94 0x33;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x4000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22729,7 +22872,7 @@ part parent ".avrdx" # 16dd20
 # AVR16DD28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 16dd28
+part parent ".avr-dd-du" # 16dd28
     desc                   = "AVR16DD28";
     id                     = "16dd28";
     variants               =
@@ -22741,29 +22884,13 @@ part parent ".avrdx" # 16dd28
         "AVR16DD28-VQFN:            QFP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 331;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x94 0x32;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x4000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22776,7 +22903,7 @@ part parent ".avrdx" # 16dd28
 # AVR16DD32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 16dd32
+part parent ".avr-dd-du" # 16dd32
     desc                   = "AVR16DD32";
     id                     = "16dd32";
     variants               =
@@ -22785,29 +22912,13 @@ part parent ".avrdx" # 16dd32
         "AVR16DD32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 333;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x94 0x31;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x4000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22820,7 +22931,7 @@ part parent ".avrdx" # 16dd32
 # AVR32DD14
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32dd14
+part parent ".avr-dd-du" # 32dd14
     desc                   = "AVR32DD14";
     id                     = "32dd14";
     variants               =
@@ -22828,29 +22939,13 @@ part parent ".avrdx" # 32dd14
         "AVR32DD14-SOIC: DIP14,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 336;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x95 0x3b;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x8000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22863,7 +22958,7 @@ part parent ".avrdx" # 32dd14
 # AVR32DD20
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32dd20
+part parent ".avr-dd-du" # 32dd20
     desc                   = "AVR32DD20";
     id                     = "32dd20";
     variants               =
@@ -22873,29 +22968,13 @@ part parent ".avrdx" # 32dd20
         "AVR32DD20-VQFN:  QFP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 337;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x95 0x3a;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x8000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22908,7 +22987,7 @@ part parent ".avrdx" # 32dd20
 # AVR32DD28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32dd28
+part parent ".avr-dd-du" # 32dd28
     desc                   = "AVR32DD28";
     id                     = "32dd28";
     variants               =
@@ -22920,29 +22999,13 @@ part parent ".avrdx" # 32dd28
         "AVR32DD28-VQFN:            QFP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 340;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x95 0x39;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x8000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22955,7 +23018,7 @@ part parent ".avrdx" # 32dd28
 # AVR32DD32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 32dd32
+part parent ".avr-dd-du" # 32dd32
     desc                   = "AVR32DD32";
     id                     = "32dd32";
     variants               =
@@ -22964,29 +23027,13 @@ part parent ".avrdx" # 32dd32
         "AVR32DD32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 344;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x95 0x38;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x8000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -22999,7 +23046,7 @@ part parent ".avrdx" # 32dd32
 # AVR64DD14
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64dd14
+part parent ".avr-dd-du" # 64dd14
     desc                   = "AVR64DD14";
     id                     = "64dd14";
     variants               =
@@ -23007,29 +23054,13 @@ part parent ".avrdx" # 64dd14
         "AVR64DD14-SOIC: DIP14,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 349;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x96 0x1d;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x10000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -23042,7 +23073,7 @@ part parent ".avrdx" # 64dd14
 # AVR64DD20
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64dd20
+part parent ".avr-dd-du" # 64dd20
     desc                   = "AVR64DD20";
     id                     = "64dd20";
     variants               =
@@ -23050,29 +23081,13 @@ part parent ".avrdx" # 64dd20
         "AVR64DD20-SOIC: DIP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 350;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x96 0x1c;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x10000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -23085,7 +23100,7 @@ part parent ".avrdx" # 64dd20
 # AVR64DD28
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64dd28
+part parent ".avr-dd-du" # 64dd28
     desc                   = "AVR64DD28";
     id                     = "64dd28";
     variants               =
@@ -23097,29 +23112,13 @@ part parent ".avrdx" # 64dd28
         "AVR64DD28-VQFN:            QFP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 353;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x96 0x1b;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x10000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -23132,7 +23131,7 @@ part parent ".avrdx" # 64dd28
 # AVR64DD32
 #------------------------------------------------------------
 
-part parent ".avrdx" # 64dd32
+part parent ".avr-dd-du" # 64dd32
     desc                   = "AVR64DD32";
     id                     = "64dd32";
     variants               =
@@ -23141,29 +23140,13 @@ part parent ".avrdx" # 64dd32
         "AVR64DD32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 357;
     n_interrupts           = 36;
-    hvupdi_variant         = 2;
     signature              = 0x1e 0x96 0x1a;
-
-    memory "eeprom"
-        size               = 256;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
 
     memory "flash"
         size               = 0x10000;
         page_size          = 512;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "fuse5"
-        initval            = 0xd0;
-        bitmask            = 0xf9;
-    ;
-
-    memory "lock"
-        initval            = 0x5cc5c55c;
     ;
 
     memory "sram"
@@ -23176,7 +23159,7 @@ part parent ".avrdx" # 64dd32
 # AVR64DU28
 #------------------------------------------------------------
 
-part parent "64dd28" # 64du28
+part parent ".avr-dd-du" # 64du28
     desc                   = "AVR64DU28";
     id                     = "64du28";
     variants               =
@@ -23185,6 +23168,13 @@ part parent "64dd28" # 64du28
     mcuid                  = 384;
     n_interrupts           = 34;
     signature              = 0x1e 0x96 0x22;
+
+    memory "flash"
+        size               = 0x10000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
+    ;
 
     memory "fuse5"
         bitmask            = 0xfb;
@@ -23233,6 +23223,11 @@ part parent "64dd28" # 64du28
         size               = 512;
         page_size          = 512;
         offset             = 0x1200;
+    ;
+
+    memory "sram"
+        size               = 8192;
+        offset             = 0x6000;
     ;
 ;
 
@@ -23379,32 +23374,168 @@ part parent "32du14" # 32du32
 # AVR-Ex family common values
 #------------------------------------------------------------
 
-part parent ".avrdx" # .avrex
+part # .avr-ex
     desc                   = "AVR-Ex family common values";
-    id                     = ".avrex";
+    id                     = ".avr-ex";
+    family_id              = "AVR    ";
+    prog_modes             = PM_SPM | PM_UPDI;
+    n_boot_sections        = 1;
     boot_section_size      = 256;
     # Shared UPDI pin, HV on _RESET
     hvupdi_variant         = 2;
+    nvm_base               = 0x1000;
+    ocd_base               = 0x0f80;
+    syscfg_base            = 0x0f00;
     factory_fcpu           = 20000000;
 
+    memory "fuses"
+        size               = 16;
+        offset             = 0x1050;
+        readsize           = 1;
+    ;
+
+    memory "fuse0"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1050;
+        readsize           = 1;
+    ;
+
+    memory "wdtcfg"
+        alias "fuse0";
+    ;
+
+    memory "fuse1"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1051;
+        readsize           = 1;
+    ;
+
+    memory "bodcfg"
+        alias "fuse1";
+    ;
+
     memory "fuse2"
+        size               = 1;
+        initval            = 0x00;
         bitmask            = 0x08;
+        offset             = 0x1052;
+        readsize           = 1;
+    ;
+
+    memory "osccfg"
+        alias "fuse2";
     ;
 
     memory "fuse5"
+        size               = 1;
         initval            = 0xd0;
         bitmask            = 0xf9;
+        offset             = 0x1055;
+        readsize           = 1;
+    ;
+
+    memory "syscfg0"
+        alias "fuse5";
     ;
 
     memory "fuse6"
+        size               = 1;
         initval            = 0x07;
         bitmask            = 0x07;
+        offset             = 0x1056;
+        readsize           = 1;
+    ;
+
+    memory "syscfg1"
+        alias "fuse6";
+    ;
+
+    memory "fuse7"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1057;
+        readsize           = 1;
+    ;
+
+    memory "codesize"
+        alias "fuse7";
+    ;
+
+    memory "append"
+        alias "fuse7";
+    ;
+
+    memory "fuse8"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1058;
+        readsize           = 1;
+    ;
+
+    memory "bootsize"
+        alias "fuse8";
+    ;
+
+    memory "bootend"
+        alias "fuse8";
+    ;
+
+    memory "lock"
+        size               = 4;
+        offset             = 0x1040;
+        readsize           = 4;
+    ;
+
+    memory "prodsig"
+        size               = 128;
+        page_size          = 128;
+        offset             = 0x1100;
+        readsize           = 128;
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
+    ;
+
+    memory "signature"
+        size               = 3;
+        offset             = 0x1100;
+        readsize           = 3;
+    ;
+
+    memory "tempsense"
+        size               = 4;
+        offset             = 0x1104;
+        readsize           = 1;
+    ;
+
+    memory "sernum"
+        size               = 16;
+        offset             = 0x1110;
+        readsize           = 1;
     ;
 
     memory "userrow"
         size               = 64;
         page_size          = 64;
+        offset             = 0x1080;
         readsize           = 64;
+    ;
+
+    memory "usersig"
+        alias "userrow";
+    ;
+
+    memory "io"
+        size               = 4160;
+        readsize           = 1;
+    ;
+
+    memory "sib"
+        size               = 32;
+        readsize           = 1;
     ;
 ;
 
@@ -23412,7 +23543,7 @@ part parent ".avrdx" # .avrex
 # AVR8EA28
 #------------------------------------------------------------
 
-part parent ".avrex" # 8ea28
+part parent ".avr-ex" # 8ea28
     desc                   = "AVR8EA28";
     id                     = "8ea28";
     mcuid                  = 327;
@@ -23468,7 +23599,7 @@ part parent ".avrex" # 8ea28
 # AVR8EA32
 #------------------------------------------------------------
 
-part parent ".avrex" # 8ea32
+part parent ".avr-ex" # 8ea32
     desc                   = "AVR8EA32";
     id                     = "8ea32";
     mcuid                  = 328;
@@ -23524,7 +23655,7 @@ part parent ".avrex" # 8ea32
 # AVR16EA28
 #------------------------------------------------------------
 
-part parent ".avrex" # 16ea28
+part parent ".avr-ex" # 16ea28
     desc                   = "AVR16EA28";
     id                     = "16ea28";
     variants               =
@@ -23562,7 +23693,7 @@ part parent ".avrex" # 16ea28
 # AVR16EA32
 #------------------------------------------------------------
 
-part parent ".avrex" # 16ea32
+part parent ".avr-ex" # 16ea32
     desc                   = "AVR16EA32";
     id                     = "16ea32";
     variants               =
@@ -23599,7 +23730,7 @@ part parent ".avrex" # 16ea32
 # AVR16EA48
 #------------------------------------------------------------
 
-part parent ".avrex" # 16ea48
+part parent ".avr-ex" # 16ea48
     desc                   = "AVR16EA48";
     id                     = "16ea48";
     variants               =
@@ -23636,7 +23767,7 @@ part parent ".avrex" # 16ea48
 # AVR32EA28
 #------------------------------------------------------------
 
-part parent ".avrex" # 32ea28
+part parent ".avr-ex" # 32ea28
     desc                   = "AVR32EA28";
     id                     = "32ea28";
     variants               =
@@ -23674,7 +23805,7 @@ part parent ".avrex" # 32ea28
 # AVR32EA32
 #------------------------------------------------------------
 
-part parent ".avrex" # 32ea32
+part parent ".avr-ex" # 32ea32
     desc                   = "AVR32EA32";
     id                     = "32ea32";
     variants               =
@@ -23711,7 +23842,7 @@ part parent ".avrex" # 32ea32
 # AVR32EA48
 #------------------------------------------------------------
 
-part parent ".avrex" # 32ea48
+part parent ".avr-ex" # 32ea48
     desc                   = "AVR32EA48";
     id                     = "32ea48";
     variants               =
@@ -23748,7 +23879,7 @@ part parent ".avrex" # 32ea48
 # AVR64EA28
 #------------------------------------------------------------
 
-part parent ".avrex" # 64ea28
+part parent ".avr-ex" # 64ea28
     desc                   = "AVR64EA28";
     id                     = "64ea28";
     variants               =
@@ -23788,7 +23919,7 @@ part parent ".avrex" # 64ea28
 # AVR64EA32
 #------------------------------------------------------------
 
-part parent ".avrex" # 64ea32
+part parent ".avr-ex" # 64ea32
     desc                   = "AVR64EA32";
     id                     = "64ea32";
     variants               =
@@ -23827,7 +23958,7 @@ part parent ".avrex" # 64ea32
 # AVR64EA48
 #------------------------------------------------------------
 
-part parent ".avrex" # 64ea48
+part parent ".avr-ex" # 64ea48
     desc                   = "AVR64EA48";
     id                     = "64ea48";
     variants               =
@@ -23866,7 +23997,7 @@ part parent ".avrex" # 64ea48
 # AVR16EB14
 #------------------------------------------------------------
 
-part parent ".avrex" # 16eb14
+part parent ".avr-ex" # 16eb14
     desc                   = "AVR16EB14";
     id                     = "16eb14";
     variants               =
@@ -24072,9 +24203,9 @@ part parent "16eb32" # 32eb32
 # AVR-Sx family common values
 #------------------------------------------------------------
 
-part # .avrsx
+part # .avr-sx
     desc                   = "AVR-Sx family common values";
-    id                     = ".avrsx";
+    id                     = ".avr-sx";
     family_id              = "AVR    ";
     prog_modes             = PM_SPM | PM_UPDI;
     n_boot_sections        = 1;
@@ -24266,7 +24397,7 @@ part # .avrsx
 # AVR32SD20
 #------------------------------------------------------------
 
-part parent ".avrsx" # 32sd20s
+part parent ".avr-sx" # 32sd20s
     desc                   = "AVR32SD20";
     id                     = "32sd20s";
     variants               =
@@ -24280,7 +24411,7 @@ part parent ".avrsx" # 32sd20s
 # AVR32SD28
 #------------------------------------------------------------
 
-part parent ".avrsx" # 32sd28s
+part parent ".avr-sx" # 32sd28s
     desc                   = "AVR32SD28";
     id                     = "32sd28s";
     variants               =
@@ -24295,7 +24426,7 @@ part parent ".avrsx" # 32sd28s
 # AVR32SD32
 #------------------------------------------------------------
 
-part parent ".avrsx" # 32sd32s
+part parent ".avr-sx" # 32sd32s
     desc                   = "AVR32SD32";
     id                     = "32sd32s";
     variants               =

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -21873,6 +21873,106 @@ part parent ".avrdx" # 128da64
 ;
 
 #------------------------------------------------------------
+# AVR64DA28S
+#------------------------------------------------------------
+
+part parent "64da28" # 64da28s
+    desc                   = "AVR64DA28S";
+    id                     = "64da28s";
+    variants               =
+        "AVR64DA28S-SPDIP: DIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 408;
+    signature              = 0x1e 0x96 0x2e;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64DA32S
+#------------------------------------------------------------
+
+part parent "64da32" # 64da32s
+    desc                   = "AVR64DA32S";
+    id                     = "64da32s";
+    variants               =
+        "AVR64DA32S-VQFN/TQFP: QFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 409;
+    signature              = 0x1e 0x96 0x2d;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64DA48S
+#------------------------------------------------------------
+
+part parent "64da48" # 64da48s
+    desc                   = "AVR64DA48S";
+    id                     = "64da48s";
+    variants               =
+        "AVR64DA48S-VQFN/TQFP: QFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 410;
+    signature              = 0x1e 0x96 0x2c;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+;
+
+#------------------------------------------------------------
+# AVR64DA64S
+#------------------------------------------------------------
+
+part parent "64da64" # 64da64s
+    desc                   = "AVR64DA64S";
+    id                     = "64da64s";
+    variants               =
+        "AVR64DA64S-VQFN/TQFP: QFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 411;
+    signature              = 0x1e 0x96 0x2b;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+;
+
+#------------------------------------------------------------
 # AVR128DA28S
 #------------------------------------------------------------
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24067,3 +24067,240 @@ part parent "16eb32" # 32eb32
         offset             = 0x7400;
     ;
 ;
+
+#------------------------------------------------------------
+# AVR-Sx family common values
+#------------------------------------------------------------
+
+part # .avrsx
+    desc                   = "AVR-Sx family common values";
+    id                     = ".avrsx";
+    family_id              = "AVR    ";
+    prog_modes             = PM_SPM | PM_UPDI;
+    n_boot_sections        = 1;
+    boot_section_size      = 512;
+    hvupdi_variant         = 2;
+    nvm_base               = 0x1000;
+    ocd_base               = 0x0f80;
+    syscfg_base            = 0x0f00;
+    factory_fcpu           = 4000000;
+
+    memory "eeprom"
+        size               = 256;
+        offset             = 0x1400;
+        readsize           = 256;
+    ;
+
+    memory "flash"
+        size               = 0x8000;
+        page_size          = 512;
+        offset             = 0x800000;
+        readsize           = 256;
+    ;
+
+    memory "fuses"
+        size               = 16;
+        offset             = 0x1050;
+        readsize           = 1;
+    ;
+
+    memory "fuse0"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1050;
+        readsize           = 1;
+    ;
+
+    memory "wdtcfg"
+        alias "fuse0";
+    ;
+
+    memory "fuse1"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1051;
+        readsize           = 1;
+    ;
+
+    memory "bodcfg"
+        alias "fuse1";
+    ;
+
+    memory "fuse5"
+        size               = 1;
+        initval            = 0x00;
+        bitmask            = 0xc3;
+        offset             = 0x1055;
+        readsize           = 1;
+    ;
+
+    memory "syscfg0"
+        alias "fuse5";
+    ;
+
+    memory "fuse6"
+        size               = 1;
+        initval            = 0x48;
+        bitmask            = 0xdf;
+        offset             = 0x1056;
+        readsize           = 1;
+    ;
+
+    memory "syscfg1"
+        alias "fuse6";
+    ;
+
+    memory "fuse7"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1057;
+        readsize           = 1;
+    ;
+
+    memory "codesize"
+        alias "fuse7";
+    ;
+
+    memory "append"
+        alias "fuse7";
+    ;
+
+    memory "fuse8"
+        size               = 1;
+        initval            = 0x00;
+        offset             = 0x1058;
+        readsize           = 1;
+    ;
+
+    memory "bootsize"
+        alias "fuse8";
+    ;
+
+    memory "bootend"
+        alias "fuse8";
+    ;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+
+    memory "lock"
+        size               = 4;
+        initval            = 0x5cc5c55c;
+        offset             = 0x1040;
+        readsize           = 4;
+    ;
+
+    memory "prodsig"
+        size               = 128;
+        page_size          = 128;
+        offset             = 0x1080;
+        readsize           = 128;
+    ;
+
+    memory "sigrow"
+        alias "prodsig";
+    ;
+
+    memory "signature"
+        size               = 3;
+        offset             = 0x1080;
+        readsize           = 3;
+    ;
+
+    memory "tempsense"
+        size               = 4;
+        offset             = 0x1084;
+        readsize           = 1;
+    ;
+
+    memory "sernum"
+        size               = 16;
+        offset             = 0x1090;
+        readsize           = 1;
+    ;
+
+    memory "bootrow"
+        size               = 256;
+        page_size          = 64;
+        offset             = 0x1100;
+        readsize           = 256;
+    ;
+
+    memory "userrow"
+        size               = 512;
+        page_size          = 512;
+        offset             = 0x1200;
+        readsize           = 32;
+    ;
+
+    memory "usersig"
+        alias "userrow";
+    ;
+
+    memory "io"
+        size               = 4160;
+        readsize           = 1;
+    ;
+
+    memory "sram"
+        size               = 4096;
+        offset             = 0x7000;
+    ;
+
+    memory "sib"
+        size               = 32;
+        readsize           = 1;
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32SD20
+#------------------------------------------------------------
+
+part parent ".avrsx" # 32sd20s
+    desc                   = "AVR32SD20";
+    id                     = "32sd20s";
+    variants               =
+        "AVR32SD20-SSOP: DIP20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 402;
+    n_interrupts           = 50;
+    signature              = 0x1e 0x95 0x54;
+;
+
+#------------------------------------------------------------
+# AVR32SD28
+#------------------------------------------------------------
+
+part parent ".avrsx" # 32sd28s
+    desc                   = "AVR32SD28";
+    id                     = "32sd28s";
+    variants               =
+        "AVR32SD28-SSOP/SPDIP: DIP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32SD28-VQFN:       QFP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 403;
+    n_interrupts           = 54;
+    signature              = 0x1e 0x95 0x53;
+;
+
+#------------------------------------------------------------
+# AVR32SD32
+#------------------------------------------------------------
+
+part parent ".avrsx" # 32sd32s
+    desc                   = "AVR32SD32";
+    id                     = "32sd32s";
+    variants               =
+        "AVR32SD32-VQFN/TQFP: QFP32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 404;
+    n_interrupts           = 56;
+    signature              = 0x1e 0x95 0x52;
+;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24214,7 +24214,7 @@ part # .avr-sx
     prog_modes             = PM_SPM | PM_UPDI;
     n_boot_sections        = 1;
     boot_section_size      = 512;
-    hvupdi_variant         = 2;
+    hvupdi_variant         = 3;
     nvm_base               = 0x1000;
     ocd_base               = 0x0f80;
     syscfg_base            = 0x0f00;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -21873,6 +21873,81 @@ part parent ".avrdx" # 128da64
 ;
 
 #------------------------------------------------------------
+# AVR32DA28S
+#------------------------------------------------------------
+
+part parent "32da28" # 32da28s
+    desc                   = "AVR32DA28S";
+    id                     = "32da28s";
+    variants               =
+        "AVR32DA28S-SPDIP: DIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 405;
+    signature              = 0x1e 0x95 0x72;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32DA32S
+#------------------------------------------------------------
+
+part parent "32da32" # 32da32s
+    desc                   = "AVR32DA32S";
+    id                     = "32da32s";
+    variants               =
+        "AVR32DA32S-VQFN/TQFP: QFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 406;
+    signature              = 0x1e 0x95 0x71;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+;
+
+#------------------------------------------------------------
+# AVR32DA48S
+#------------------------------------------------------------
+
+part parent "32da48" # 32da48s
+    desc                   = "AVR32DA48S";
+    id                     = "32da48s";
+    variants               =
+        "AVR32DA48S-VQFN/TQFP: QFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+    mcuid                  = 407;
+    signature              = 0x1e 0x95 0x70;
+
+    memory "fusea"
+        size               = 2;
+        initval            = 0x03;
+        bitmask            = 0xfff3;
+        offset             = 0x105a;
+        readsize           = 1;
+    ;
+
+    memory "pdicfg"
+        alias "fusea";
+    ;
+;
+
+#------------------------------------------------------------
 # AVR64DA28S
 #------------------------------------------------------------
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -4070,7 +4070,6 @@ part parent ".classic" # t11
     desc                   = "ATtiny11";
     id                     = "t11";
     variants               =
-        "ATtiny11:      N/A,   Fmax=N/A,   T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
         "ATtiny11-6PC:  DIP8,  Fmax=6 MHz, T=[0 C,   70 C], Vcc=[4 V,   5.5 V]",
         "ATtiny11-6PI:  DIP8,  Fmax=6 MHz, T=[-40 C, 85 C], Vcc=[4 V,   5.5 V]",
         "ATtiny11-6PU:  DIP8,  Fmax=6 MHz, T=[-40 C, 85 C], Vcc=[4 V,   5.5 V]",
@@ -4165,12 +4164,24 @@ part parent "t11" # t12
     desc                   = "ATtiny12";
     id                     = "t12";
     variants               =
-        "ATtiny12:       N/A,   Fmax=8 MHz,   T=[N/A,   85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny12:       N/A,   Fmax=8 MHz,   T=[N/A,   85 C], Vcc=[N/A,     N/A]",
+        "ATtiny12-8PC:   PDIP8, Fmax=8 MHz,   T=[0,     70 C], Vcc=[4.0 V, 5.5 V]",
+        "ATtiny12-8PI:   PDIP8, Fmax=8 MHz,   T=[-40 C, 80 C], Vcc=[4.0 V, 5.5 V]",
         "ATtiny12-8PU:   PDIP8, Fmax=8 MHz,   T=[-40 C, 85 C], Vcc=[4 V,   5.5 V]",
+        "ATtiny12-8SC:   SOIC8, Fmax=8 MHz,   T=[0,     70 C], Vcc=[4.0 V, 5.5 V]",
+        "ATtiny12-8SI:   SOIC8, Fmax=8 MHz,   T=[-40 C, 85 C], Vcc=[4.0 V, 5.5 V]",
         "ATtiny12-8SU:   SOIC8, Fmax=8 MHz,   T=[-40 C, 85 C], Vcc=[4 V,   5.5 V]",
+        "ATtiny12L-4PC:  PDIP8, Fmax=4 MHz,   T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny12L-4PI:  PDIP8, Fmax=4 MHz,   T=[-40 C, 80 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny12L-4PU:  PDIP8, Fmax=4 MHz,   T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny12L-4SC:  SOIC8, Fmax=4 MHz,   T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny12L-4SI:  SOIC8, Fmax=4 MHz,   T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny12L-4SU:  SOIC8, Fmax=4 MHz,   T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny12L-4SUR: SOIC8, Fmax=4 MHz,   T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny12V-1PC:  PDIP8, Fmax=1.2 MHz, T=[0,     70 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny12V-1PI:  PDIP8, Fmax=1.2 MHz, T=[-40 C, 80 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny12V-1SC:  SOIC8, Fmax=1.2 MHz, T=[0,     70 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny12V-1SI:  SOIC8, Fmax=1.2 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny12V-1SU:  SOIC8, Fmax=1.2 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny12V-1SUR: SOIC8, Fmax=1.2 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     prog_modes             = PM_ISP | PM_HVSP;
@@ -4256,7 +4267,6 @@ part parent "t11" # t15
     desc                   = "ATtiny15";
     id                     = "t15";
     variants               =
-        "ATtiny15:      N/A,   Fmax=N/A,     T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
         "ATtiny15L-1PC: DIP8,  Fmax=1.6 MHz, T=[0 C,   70 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny15L-1PI: DIP8,  Fmax=1.6 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny15L-1PU: DIP8,  Fmax=1.6 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
@@ -4941,14 +4951,14 @@ part parent ".classic" # t2313
     desc                   = "ATtiny2313";
     id                     = "t2313";
     variants               =
-        "ATtiny2313:        N/A,    Fmax=20 MHz, T=[N/A,   85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny2313:        N/A,    Fmax=20 MHz, T=[N/A,   85 C], Vcc=[N/A,     N/A]",
         "ATtiny2313-20MU:   MLF20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny2313-20MUR:  MLF20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny2313-20PU:   PDIP20, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny2313-20SU:   SOIC20, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny2313-20SUR:  SOIC20, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny2313V-10MU:  MLF20,  Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny2313V-10MUR: WQFN20, Fmax=10 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny2313V-10MUR: WQFN20, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny2313V-10PU:  PDIP20, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny2313V-10SU:  SOIC20, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny2313V-10SUR: SOIC20, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
@@ -5094,7 +5104,6 @@ part parent "t2313" # t2313a
     desc                   = "ATtiny2313A";
     id                     = "t2313a";
     variants               =
-        "ATtiny2313A:      N/A,    Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATtiny2313A-MMH:  VQFN20, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny2313A-MMHR: VQFN20, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny2313A-MU:   QFN20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
@@ -5119,7 +5128,6 @@ part parent "t2313" # t4313
     desc                   = "ATtiny4313";
     id                     = "t4313";
     variants               =
-        "ATtiny4313:      N/A,    Fmax=N/A,    T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
         "ATtiny4313-MMH:  VQFN20, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny4313-MMHR: VQFN20, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny4313-MU:   MLF20,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
@@ -5166,9 +5174,9 @@ part parent ".classic" # t24
     desc                   = "ATtiny24";
     id                     = "t24";
     variants               =
-        "ATtiny24:         N/A,     Fmax=20 MHz, T=[N/A,   85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny24:         N/A,     Fmax=20 MHz, T=[N/A,   85 C], Vcc=[N/A,     N/A]",
         "ATtiny24-20MU:    QFN20,   Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny24-20MUR:   WQFN20,  Fmax=20 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny24-20MUR:   WQFN20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny24-20PU:    PDIP14,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny24-20SSU:   SOIC14N, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny24-20SSUR:  SOIC14N, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
@@ -5340,17 +5348,21 @@ part parent "t24" # t44
     desc                   = "ATtiny44";
     id                     = "t44";
     variants               =
-        "ATtiny44:         N/A,     Fmax=20 MHz, T=[N/A,   85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny44-20MU:    QFN20,   Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny44-20MUR:   WQFN20,  Fmax=20 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny44-20PU:    PDIP14,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny44-20SSU:   SOIC14N, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny44-20SSUR:  SOIC14N, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny44V-10MU:   MLF20,   Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny44V-10MUR:  WQFN20,  Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny44V-10PU:   PDIP14,  Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny44V-10SSU:  SOIC14N, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny44V-10SSUR: SOIC14N, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
+        "ATtiny44:         N/A,     Fmax=20 MHz, T=[N/A,    85 C], Vcc=[N/A,     N/A]",
+        "ATtiny44-15MZ:    WQFN20,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44-15SSZ:   SOIC14,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44-20MU:    QFN20,   Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny44-20MUR:   WQFN20,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny44-20PU:    PDIP14,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny44-20SSU:   SOIC14N, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny44-20SSUR:  SOIC14N, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny44V-10MU:   MLF20,   Fmax=10 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44V-10MUR:  WQFN20,  Fmax=10 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44V-10PU:   PDIP14,  Fmax=10 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44V-10SSU:  SOIC14N, Fmax=10 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44V-10SSUR: SOIC14N, Fmax=10 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44V-15MT:   WQFN20,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny44V-15SST:  SOIC14,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 20;
     signature              = 0x1e 0x92 0x07;
 
@@ -5412,7 +5424,7 @@ part parent "t24" # t84
     desc                   = "ATtiny84";
     id                     = "t84";
     variants               =
-        "ATtiny84:         N/A,     Fmax=20 MHz, T=[N/A,   85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny84:         N/A,     Fmax=20 MHz, T=[N/A,   85 C], Vcc=[N/A,     N/A]",
         "ATtiny84-15MZ:    MLF20,   Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny84-20MU:    MLF20,   Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny84-20MUR:   WQFN20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
@@ -5653,9 +5665,9 @@ part parent ".classic" # t26
     desc                   = "ATtiny26";
     id                     = "t26";
     variants               =
-        "ATtiny26:       N/A,    Fmax=16 MHz, T=[N/A,   85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny26:       N/A,    Fmax=16 MHz, T=[N/A,   85 C], Vcc=[N/A,     N/A]",
         "ATtiny26-16MU:  MLF32,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
-        "ATtiny26-16MUR: VQFN32, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[4.5 V, 5.5 V]",
+        "ATtiny26-16MUR: VQFN32, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATtiny26-16PU:  PDIP20, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATtiny26-16SU:  SOIC20, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATtiny26-16SUR: SOIC20, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
@@ -5917,12 +5929,12 @@ part parent "t261" # t261a
     desc                   = "ATtiny261A";
     id                     = "t261a";
     variants               =
-        "ATtiny261A:     N/A,     Fmax=N/A,    T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-MF:  MLF32,   Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-MFR: MLF32,   Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-MN:  MLF32,   Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-MNR: VQFN32,  Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-MU:  QFN32,   Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny261A-MUR: MLF32,   Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-PU:  PDIP20,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-SU:  SOIC20,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny261A-SUR: SOIC20,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
@@ -5987,8 +5999,8 @@ part parent "t461" # t461a
     desc                   = "ATtiny461A";
     id                     = "t461a";
     variants               =
-        "ATtiny461A:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATtiny461A-MU:  QFN32,   Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny461A-MUR: VQFN32,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny461A-PU:  PDIP20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny461A-SU:  SOIC20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny461A-SUR: SOIC20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
@@ -6054,7 +6066,6 @@ part parent "t861" # t861a
     desc                   = "ATtiny861A";
     id                     = "t861a";
     variants               =
-        "ATtiny861A:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATtiny861A-MU:  QFN32,   Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny861A-MUR: VQFN32,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny861A-PU:  PDIP20,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
@@ -6334,9 +6345,8 @@ part parent ".classic" # t43u
     desc                   = "ATtiny43U";
     id                     = "t43u";
     variants               =
-        "ATtiny43U:     N/A,    Fmax=N/A,   T=[N/A,    N/A], Vcc=[0.7 V, 5.5 V]",
         "ATtiny43U-MU:  QFN20,  Fmax=8 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny43U-MUR: WQFN20, Fmax=8 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny43U-MUR: WQFN20, Fmax=8 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny43U-SU:  SOIC20, Fmax=8 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny43U-SUR: SOIC20, Fmax=8 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_debugWIRE;
@@ -6471,11 +6481,12 @@ part parent ".classic" # t828
     desc                   = "ATtiny828";
     id                     = "t828";
     variants               =
-        "ATtiny828:     N/A,    Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.62 V, 5.5 V]",
-        "ATtiny828-AU:  TQFP32, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.7 V,  5.5 V]",
-        "ATtiny828-AUR: TQFP32, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.7 V,  5.5 V]",
-        "ATtiny828-MU:  QFN32,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.7 V,  5.5 V]",
-        "ATtiny828-MUR: VQFN32, Fmax=N/A,    T=[N/A,    N/A], Vcc=[N/A,      N/A]";
+        "ATtiny828-AU:   TQFP32, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.7 V,  5.5 V]",
+        "ATtiny828-AUR:  TQFP32, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.7 V,  5.5 V]",
+        "ATtiny828-MU:   QFN32,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.7 V,  5.5 V]",
+        "ATtiny828-MUR:  VQFN32, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.62 V, 5.5 V]",
+        "ATtiny828R-AU:  TQFP32, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.62 V, 5.5 V]",
+        "ATtiny828R-AUR: TQFP32, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.62 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_debugWIRE;
     mcuid                  = 35;
     archnum                = 25;
@@ -6617,13 +6628,15 @@ part parent ".classic" # t87
     desc                   = "ATtiny87";
     id                     = "t87";
     variants               =
-        "ATtiny87:     N/A,     Fmax=N/A,    T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny87-MU:  VQFN32,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny87-MUR: VQFN32,  Fmax=16 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny87-SU:  SOIC20,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny87-SUR: SOIC20,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny87-XU:  TSSOP20, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny87-XUR: TSSOP20, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "ATtiny87-A15MD-VAO: VQFN32,  Fmax=16 MHz, T=[-40 C, 150 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-A15SZ:     SOIC20,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-A15XD:     TSSOP20, Fmax=16 MHz, T=[-40 C, 150 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-MU:        VQFN32,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-MUR:       VQFN32,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-SU:        SOIC20,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-SUR:       SOIC20,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-XU:        TSSOP20, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny87-XUR:       TSSOP20, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_debugWIRE;
     mcuid                  = 27;
     archnum                = 25;
@@ -6751,7 +6764,6 @@ part parent "t87" # t167
     desc                   = "ATtiny167";
     id                     = "t167";
     variants               =
-        "ATtiny167:       N/A,     Fmax=N/A,    T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
         "ATtiny167-A15XD: TSSOP20, Fmax=16 MHz, T=[-40 C, 150 C], Vcc=[2.7 V, 5.5 V]",
         "ATtiny167-MMU:   WQFN20,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
         "ATtiny167-MMUR:  WQFN20,  Fmax=N/A,    T=[N/A,     N/A], Vcc=[N/A,     N/A]",
@@ -6780,13 +6792,16 @@ part parent ".classic" # t1634
     desc                   = "ATtiny1634";
     id                     = "t1634";
     variants               =
-        "ATtiny1634:     N/A,    Fmax=N/A,    T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny1634-MN:  WQFN20, Fmax=12 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny1634-MNR: WQFN20, Fmax=12 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny1634-MU:  QFN20,  Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny1634-MUR: QFN20,  Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny1634-SU:  SOIC20, Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATtiny1634-SUR: SOIC20, Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "ATtiny1634-MN:   WQFN20, Fmax=12 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634-MNR:  WQFN20, Fmax=12 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634-MU:   QFN20,  Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634-MUR:  QFN20,  Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634-SU:   SOIC20, Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634-SUR:  SOIC20, Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634R-MU:  QFN20,  Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634R-MUR: QFN20,  Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634R-SU:  SOIC20, Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATtiny1634R-SUR: SOIC20, Fmax=12 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_debugWIRE;
     mcuid                  = 40;
     archnum                = 35;
@@ -7129,8 +7144,10 @@ part parent ".classic" # pwm81
     id                     = "pwm81";
     variants               =
         "AT90PWM81:        N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM81-16ME:   QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM81-16MF:   QFN32,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM81-16MN:   QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM81-16SE:   SOIC20, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM81-16SF:   SOIC20, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM81-16SN:   SOIC20, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM81EP-16MN: QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
@@ -7259,9 +7276,10 @@ part parent "pwm81" # pwm161
     desc                   = "AT90PWM161";
     id                     = "pwm161";
     variants               =
-        "AT90PWM161:       N/A,    Fmax=N/A,    T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM161-16MF:  QFN32,  Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM161-16MN:  QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM161-16MNR: QFN32,  Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM161-16SF:  SOIC20, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM161-16SN:  SOIC20, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM161-16SNR: SOIC20, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 177;
@@ -7552,6 +7570,7 @@ part parent "pwm2" # pwm2b
     id                     = "pwm2b";
     variants               =
         "AT90PWM2B:       N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM2B-16SE:  SOIC32, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM2B-16SU:  SOIC24, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM2B-16SUR: SOIC24, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 168;
@@ -7581,9 +7600,10 @@ part parent "pwm1" # pwm3
     desc                   = "AT90PWM3";
     id                     = "pwm3";
     variants               =
-        "AT90PWM3:       N/A,   Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
-        "AT90PWM3-16MQ:  QFN32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
-        "AT90PWM3-16MQT: QFN32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
+        "AT90PWM3:       N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3-16MQ:  QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3-16MQT: QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3-16SQ:  SOIC32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 169;
     stk500_devcode         = 0x65;
     pagel                  = 0xd8;
@@ -7629,9 +7649,13 @@ part parent "pwm3" # pwm3b
     desc                   = "AT90PWM3B";
     id                     = "pwm3b";
     variants               =
-        "AT90PWM3B:       N/A,   Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
-        "AT90PWM3B-16MU:  QFN32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
-        "AT90PWM3B-16MUR: QFN32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
+        "AT90PWM3-16ME:   QFN32,  Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3-16MU:   QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3-16SE:   SOIC32, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3-16SU:   SOIC32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3B:       N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3B-16MU:  QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM3B-16MUR: QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 170;
     signature              = 0x1e 0x93 0x83;
 ;
@@ -7645,7 +7669,7 @@ part parent ".classic" # pwm216
     desc                   = "AT90PWM216";
     id                     = "pwm216";
     variants               =
-        "AT90PWM216:       N/A,    Fmax=N/A,    T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM216-16SE:  SOIC24, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM216-16SU:  SOIC24, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "AT90PWM216-16SUR: SOIC24, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_debugWIRE;
@@ -7776,9 +7800,12 @@ part parent "pwm216" # pwm316
     desc                   = "AT90PWM316";
     id                     = "pwm316";
     variants               =
-        "AT90PWM316:       N/A,   Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
-        "AT90PWM316-16MU:  QFN32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
-        "AT90PWM316-16MUR: QFN32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
+        "AT90PWM316:       N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM316-16ME:  QFN32,  Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM316-16MU:  QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM316-16MUR: QFN32,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM316-16SE:  SOIC32, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
+        "AT90PWM316-16SU:  SOIC32, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 180;
 ;
 
@@ -8022,7 +8049,8 @@ part parent ".classic" # usb82
     desc                   = "AT90USB82";
     id                     = "usb82";
     variants               =
-        "AT90USB82:       QFN32, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "90USB82-16MU:    QFN32, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "AT90USB82:       QFN32, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "AT90USB82-16MU:  QFN32, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "AT90USB82-16MUR: QFN32, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_debugWIRE;
@@ -8152,6 +8180,8 @@ part parent "usb82" # usb162
     desc                   = "AT90USB162";
     id                     = "usb162";
     variants               =
+        "90USB162-16AU:    TQFP32, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "90USB162-16MU:    QFN32,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "AT90USB162:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
         "AT90USB162-16AU:  TQFP32, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "AT90USB162-16AUR: TQFP32, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
@@ -9143,7 +9173,7 @@ part parent ".classic" # m162
     desc                   = "ATmega162";
     id                     = "m162";
     variants               =
-        "ATmega162:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega162:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega162-16AC:  TQFP44,  Fmax=16 MHz, T=[0 C,   70 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega162-16AI:  TQFP44,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega162-16AJ:  TQFP44,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
@@ -9412,20 +9442,36 @@ part parent ".classic" # m8515
     desc                   = "ATmega8515";
     id                     = "m8515";
     variants               =
-        "ATmega8515:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
+        "ATmega8515-16AC:  TQFP44, Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515-16AI:  TQFP44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8515-16AU:  TQFP44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8515-16AUR: TQFP44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515-16JC:  PLCC44, Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515-16JI:  PLCC44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8515-16JU:  PLCC44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8515-16JUR: PLCC44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515-16MC:  QFN44,  Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515-16MI:  QFN44,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8515-16MU:  QFN44,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8515-16MUR: VQFN44, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515-16PC:  PDIP40, Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515-16PI:  PDIP40, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8515-16PU:  PDIP40, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8515L-8AC:  TQFP44, Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515L-8AI:  TQFP44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8515L-8AU:  TQFP44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8515L-8AUR: TQFP44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515L-8JC:  PLCC44, Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515L-8JI:  PLCC44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8515L-8JU:  PLCC44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8515L-8JUR: PLCC44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515L-8MC:  QFN44,  Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515L-8MI:  QFN44,  Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8515L-8MU:  MLF44,  Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8515L-8MUR: VQFN44, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515L-8PC:  PDIP40, Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8515L-8PI:  PDIP40, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8515L-8PU:  PDIP40, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP;
     mcuid                  = 160;
@@ -9539,20 +9585,36 @@ part parent ".classic" # m8535
     desc                   = "ATmega8535";
     id                     = "m8535";
     variants               =
-        "ATmega8535:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
+        "ATmega8535-16AC:  TQFP44, Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535-16AI:  TQFP44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8535-16AU:  TQFP44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8535-16AUR: TQFP44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535-16JC:  PLCC44, Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535-16JI:  PLCC44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8535-16JU:  PLCC44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8535-16JUR: PLCC44, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535-16MC:  QFN44,  Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535-16MI:  QFN44,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8535-16MU:  MLF44,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8535-16MUR: VQFN44, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535-16PC:  PDIP40, Fmax=16 MHz, T=[0,     70 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535-16PI:  PDIP40, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
         "ATmega8535-16PU:  PDIP40, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
+        "ATmega8535L-8AC:  TQFP44, Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535L-8AI:  TQFP44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8535L-8AU:  TQFP44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8535L-8AUR: TQFP44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535L-8JC:  PLCC44, Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535L-8JI:  PLCC44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8535L-8JU:  PLCC44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8535L-8JUR: PLCC44, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535L-8MC:  QFN44,  Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535L-8MI:  QFN44,  Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8535L-8MU:  MLF44,  Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8535L-8MUR: MLF44,  Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535L-8PC:  PDIP40, Fmax=8 MHz,  T=[0,     70 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega8535L-8PI:  PDIP40, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega8535L-8PU:  PDIP40, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP;
     mcuid                  = 161;
@@ -11023,14 +11085,13 @@ part parent ".classic" # m128rfa1
     desc                   = "ATmega128RFA1";
     id                     = "m128rfa1";
     variants               =
-        "ATmega128RFA1:           N/A,     Fmax=N/A, T=[N/A,     N/A], Vcc=[1.8 V, 3.6 V]",
-        "ATmega128RFA1-ZF:        VFQFN64, Fmax=N/A, T=[-40 C, 125 C], Vcc=[1.8 V, 3.6 V]",
-        "ATmega128RFA1-ZFR:       VFQFN64, Fmax=N/A, T=[-40 C, 125 C], Vcc=[1.8 V, 3.6 V]",
-        "ATmega128RFA1-ZU:        VFQFN64, Fmax=N/A, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
-        "ATmega128RFA1-ZU00:      VFQFN64, Fmax=N/A, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
-        "ATmega128RFA1-ZUR:       VFQFN64, Fmax=N/A, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
-        "ATmega128RFA1-ZUR-SL514: VFQFN64, Fmax=N/A, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
-        "ATmega128RFA1-ZUR00:     VFQFN64, Fmax=N/A, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]";
+        "ATmega128RFA1-ZF:        VFQFN64, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 3.6 V]",
+        "ATmega128RFA1-ZFR:       VFQFN64, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 3.6 V]",
+        "ATmega128RFA1-ZU:        VFQFN64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
+        "ATmega128RFA1-ZU00:      VFQFN64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
+        "ATmega128RFA1-ZUR:       VFQFN64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
+        "ATmega128RFA1-ZUR-SL514: VFQFN64, Fmax=N/A,    T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]",
+        "ATmega128RFA1-ZUR00:     VFQFN64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 3.6 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 87;
     archnum                = 51;
@@ -11742,7 +11803,7 @@ part parent "m165" # m165p
     desc                   = "ATmega165P";
     id                     = "m165p";
     variants               =
-        "ATmega165P:       N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165P:       N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[N/A,     N/A]",
         "ATmega165P-16AN:  TQFP64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega165P-16ANR: TQFP64, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[2.7 V, 5.5 V]",
         "ATmega165P-16AU:  TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
@@ -11773,11 +11834,16 @@ part parent "m165" # m165a
     desc                   = "ATmega165A";
     id                     = "m165a";
     variants               =
-        "ATmega165A:     N/A,    Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165A-AU:  TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165A-AUR: TQFP64, Fmax=N/A,    T=[N/A,    N/A], Vcc=[N/A,     N/A]",
-        "ATmega165A-MU:  MLF64,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165A-MUR: TQFP64, Fmax=N/A,    T=[N/A,    N/A], Vcc=[N/A,     N/A]";
+        "ATmega165A-AN:   TQFP64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-ANR:  TQFP64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-AU:   TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-AUR:  TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-MCH:  QFN64,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-MCHR: QFN64,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-MN:   QFN64,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-MNR:  QFN64,  Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-MU:   MLF64,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165A-MUR:  TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 96;
     signature              = 0x1e 0x94 0x10;
 
@@ -11795,12 +11861,17 @@ part parent "m165" # m165pa
     desc                   = "ATmega165PA";
     id                     = "m165pa";
     variants               =
-        "ATmega165PA:     N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165PA-AU:  TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165PA-AUR: TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165PA-MN:  TQFP64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165PA-MNR: VQFN64, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega165PA-MUR: VQFN64, Fmax=16 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega165PA:      N/A,    Fmax=16 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-AN:   TQFP64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-ANR:  TQFP64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-AU:   TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-AUR:  TQFP64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-MCH:  QFN64,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-MCHR: QFN64,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-MN:   TQFP64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-MNR:  VQFN64, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-MU:   QFN64,  Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega165PA-MUR:  VQFN64, Fmax=16 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 98;
 
     memory "eeprom"
@@ -11817,15 +11888,15 @@ part parent "m165" # m325
     desc                   = "ATmega325";
     id                     = "m325";
     variants               =
-        "ATmega325:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega325-16AU:  TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega325-16AUR: TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega325-16MU:  QFN64,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega325-16MUR: VQFN64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega325V-8AU:  TQFP64, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325V-8AUR: TQFP64, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325V-8AUR: TQFP64, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATmega325V-8MU:  MLF64,  Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325V-8MUR: VQFN64, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega325V-8MUR: VQFN64, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 114;
     boot_section_size      = 512;
 #   stk500_devcode         = 0x??; # No STK500v1 support?
@@ -11887,7 +11958,7 @@ part parent "m325" # m325p
     desc                   = "ATmega325P";
     id                     = "m325p";
     variants               =
-        "ATmega325P:        N/A,    Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325P:        N/A,    Fmax=20 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega325P-20AU:   TQFP64, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega325P-20AUR:  TQFP64, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega325P-20MU:   MLF64,  Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
@@ -11907,15 +11978,22 @@ part parent "m325" # m325a
     desc                   = "ATmega325A";
     id                     = "m325a";
     variants               =
-        "ATmega325A:     N/A,    Fmax=N/A,    T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-AN:  TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-ANR: TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-AU:  TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-AUR: TQFP64, Fmax=20 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-MN:  VQFN64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-MNR: VQFN64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-MU:  QFN64,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325A-MUR: VQFN64, Fmax=20 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3250A-AN:  TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-ANR: TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-AU:  TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-AUR: TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-MN:  QFN64,  Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-MNR: QFN64,  Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-MU:  QFN64,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-MUR: QFN64,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-AN:   TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-ANR:  TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-AU:   TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-AUR:  TQFP64, Fmax=20 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-MN:   VQFN64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-MNR:  VQFN64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-MU:   QFN64,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325A-MUR:  VQFN64, Fmax=20 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 115;
 ;
 
@@ -11927,11 +12005,19 @@ part parent "m325" # m325pa
     desc                   = "ATmega325PA";
     id                     = "m325pa";
     variants               =
-        "ATmega325PA:     N/A,    Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325PA-AU:  TQFP64, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325PA-AUR: TQFP64, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325PA-MU:  VQFN64, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega325PA-MUR: VQFN64, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3250PA-AN:  TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-ANR: TQFP64, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-AU:  TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-AUR: TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-MN:  QFN64,  Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-MNR: QFN64,  Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-MU:  QFN64,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-MUR: QFN64,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325PA:      N/A,    Fmax=20 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325PA-AU:   TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325PA-AUR:  TQFP64, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325PA-MU:   VQFN64, Fmax=20 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega325PA-MUR:  VQFN64, Fmax=20 MHz, T=[N/A,     N/A], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 117;
     signature              = 0x1e 0x95 0x0d;
 ;
@@ -11948,7 +12034,7 @@ part parent "m165" # m3250
         "ATmega3250-16AU:  TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega3250-16AUR: TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega3250V-8AU:  TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3250V-8AUR: TQFP100, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3250V-8AUR: TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 146;
     n_interrupts           = 25;
     boot_section_size      = 512;
@@ -12009,7 +12095,7 @@ part parent "m3250" # m3250p
     desc                   = "ATmega3250P";
     id                     = "m3250p";
     variants               =
-        "ATmega3250P:        TQFP100, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250P:        TQFP100, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega3250P-20AU:   TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega3250P-20AUR:  TQFP100, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
         "ATmega3250PV-10AU:  TQFP100, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
@@ -12026,9 +12112,10 @@ part parent "m3250" # m3250a
     desc                   = "ATmega3250A";
     id                     = "m3250a";
     variants               =
-        "ATmega3250A:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3250A-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3250A-AUR: TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3250A-AN:  TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-ANR: TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-AU:  TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250A-AUR: TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 147;
 ;
 
@@ -12040,9 +12127,10 @@ part parent "m3250" # m3250pa
     desc                   = "ATmega3250PA";
     id                     = "m3250pa";
     variants               =
-        "ATmega3250PA:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3250PA-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3250PA-AUR: TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3250PA-AN:  TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-ANR: TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-AU:  TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3250PA-AUR: TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 149;
     signature              = 0x1e 0x95 0x0e;
 ;
@@ -12055,15 +12143,15 @@ part parent "m165" # m645
     desc                   = "ATmega645";
     id                     = "m645";
     variants               =
-        "ATmega645:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega645:       N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega645-16AU:  TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega645-16AUR: TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega645-16MU:  MLF64,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATmega645-16MUR: VQFN64, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATmega645-16MUR: VQFN64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega645V-8AU:  TQFP64, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega645V-8AUR: TQFP64, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega645V-8AUR: TQFP64, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATmega645V-8MU:  MLF64,  Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega645V-8MUR: VQFN64, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega645V-8MUR: VQFN64, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 132;
     boot_section_size      = 1024;
 #   stk500_devcode         = 0x??; # No STK500v1 support?
@@ -12132,11 +12220,10 @@ part parent "m645" # m645p
     desc                   = "ATmega645P";
     id                     = "m645p";
     variants               =
-        "ATmega645P:     N/A,    Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATmega645P-AU:  TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega645P-AUR: TQFP64, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega645P-AUR: TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATmega645P-MU:  QFN64,  Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega645P-MUR: VQFN64, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega645P-MUR: VQFN64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 134;
     signature              = 0x1e 0x96 0x0d;
 ;
@@ -12151,9 +12238,9 @@ part parent "m645" # m645a
     variants               =
         "ATmega645A:     N/A,    Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATmega645A-AU:  TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega645A-AUR: TQFP64, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega645A-AUR: TQFP64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATmega645A-MU:  VQFN64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega645A-MUR: VQFN64, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega645A-MUR: VQFN64, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 133;
 ;
 
@@ -12165,11 +12252,11 @@ part parent "m165" # m6450
     desc                   = "ATmega6450";
     id                     = "m6450";
     variants               =
-        "ATmega6450:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega6450:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega6450-16AU:  TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATmega6450-16AUR: TQFP100, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATmega6450-16AUR: TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega6450V-8AU:  TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega6450V-8AUR: TQFP100, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega6450V-8AUR: TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 154;
     n_interrupts           = 25;
     boot_section_size      = 1024;
@@ -12237,9 +12324,8 @@ part parent "m6450" # m6450p
     desc                   = "ATmega6450P";
     id                     = "m6450p";
     variants               =
-        "ATmega6450P:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATmega6450P-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega6450P-AUR: TQFP100, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega6450P-AUR: TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 156;
     signature              = 0x1e 0x96 0x0e;
 ;
@@ -12252,7 +12338,6 @@ part parent "m6450" # m6450a
     desc                   = "ATmega6450A";
     id                     = "m6450a";
     variants               =
-        "ATmega6450A:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATmega6450A-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATmega6450A-AUR: TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 155;
@@ -13322,11 +13407,11 @@ part parent "m169" # m3290
     desc                   = "ATmega3290";
     id                     = "m3290";
     variants               =
-        "ATmega3290:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega3290-16AU:  TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATmega3290-16AUR: TQFP100, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATmega3290-16AUR: TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega3290V-8AU:  TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3290V-8AUR: TQFP100, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3290V-8AUR: TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 150;
     n_interrupts           = 25;
@@ -13379,11 +13464,15 @@ part parent "m3290" # m3290p
     desc                   = "ATmega3290P";
     id                     = "m3290p";
     variants               =
-        "ATmega3290P:        TQFP100, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3290P-20AU:   TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATmega3290P-20AUR:  TQFP100, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
-        "ATmega3290PV-10AU:  TQFP100, Fmax=10 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3290PV-10AUR: TQFP100, Fmax=10 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3290P:        TQFP100, Fmax=20 MHz, T=[N/A,     N/A], Vcc=[N/A,     N/A]",
+        "ATmega3290P-20AN:   TQFP64,  Fmax=10 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290P-20ANR:  TQFP64,  Fmax=10 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290P-20AU:   TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega3290P-20AUR:  TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[2.7 V, 5.5 V]",
+        "ATmega3290P-20MN:   MLF64,   Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290P-20MNR:  MLF64,   Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290PV-10AU:  TQFP100, Fmax=10 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290PV-10AUR: TQFP100, Fmax=10 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 152;
     signature              = 0x1e 0x95 0x0c;
 
@@ -13401,9 +13490,10 @@ part parent "m3290" # m3290a
     desc                   = "ATmega3290A";
     id                     = "m3290a";
     variants               =
-        "ATmega3290A:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3290A-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3290A-AUR: TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
+        "ATmega3290A-AN:  TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290A-ANR: TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290A-AU:  TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290A-AUR: TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 151;
 
     memory "eeprom"
@@ -13420,9 +13510,10 @@ part parent "m3290" # m3290pa
     desc                   = "ATmega3290PA";
     id                     = "m3290pa";
     variants               =
-        "ATmega3290PA:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3290PA-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega3290PA-AUR: TQFP100, Fmax=N/A,    T=[N/A,    N/A], Vcc=[N/A,     N/A]";
+        "ATmega3290PA-AN:  TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290PA-ANR: TQFP100, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290PA-AU:  TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "ATmega3290PA-AUR: TQFP100, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 153;
     signature              = 0x1e 0x95 0x0c;
 
@@ -13544,11 +13635,11 @@ part parent "m169" # m6490
     desc                   = "ATmega6490";
     id                     = "m6490";
     variants               =
-        "ATmega6490:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
+        "ATmega6490:       N/A,     Fmax=16 MHz, T=[N/A,    N/A], Vcc=[N/A,     N/A]",
         "ATmega6490-16AU:  TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[4.5 V, 5.5 V]",
-        "ATmega6490-16AUR: TQFP100, Fmax=16 MHz, T=[N/A,    N/A], Vcc=[2.7 V, 5.5 V]",
+        "ATmega6490-16AUR: TQFP100, Fmax=16 MHz, T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
         "ATmega6490V-8AU:  TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[2.7 V, 5.5 V]",
-        "ATmega6490V-8AUR: TQFP100, Fmax=8 MHz,  T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega6490V-8AUR: TQFP100, Fmax=8 MHz,  T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVPP | PM_JTAG;
     mcuid                  = 157;
     n_interrupts           = 25;
@@ -13602,7 +13693,6 @@ part parent "m6490" # m6490p
     desc                   = "ATmega6490P";
     id                     = "m6490p";
     variants               =
-        "ATmega6490P:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATmega6490P-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
         "ATmega6490P-AUR: TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 159;
@@ -13622,9 +13712,8 @@ part parent "m6490" # m6490a
     desc                   = "ATmega6490A";
     id                     = "m6490a";
     variants               =
-        "ATmega6490A:     N/A,     Fmax=N/A,    T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]",
         "ATmega6490A-AU:  TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]",
-        "ATmega6490A-AUR: TQFP100, Fmax=20 MHz, T=[N/A,    N/A], Vcc=[1.8 V, 5.5 V]";
+        "ATmega6490A-AUR: TQFP100, Fmax=20 MHz, T=[-40 C, 85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 158;
 
     memory "eeprom"
@@ -13641,11 +13730,10 @@ part parent ".classic" # m8hva
     desc                   = "ATmega8HVA";
     id                     = "m8hva";
     variants               =
-        "ATmega8HVA:       N/A,     Fmax=N/A,   T=[N/A,    N/A], Vcc=[1.8 V, 4.5 V]",
-        "ATmega8HVA-4CKU:  WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]",
-        "ATmega8HVA-4CKUR: WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]",
-        "ATmega8HVA-4TU:   TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]",
-        "ATmega8HVA-4TUR:  TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]";
+        "ATmega8HVA-4CKU:  WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]",
+        "ATmega8HVA-4CKUR: WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]",
+        "ATmega8HVA-4TU:   TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]",
+        "ATmega8HVA-4TUR:  TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]";
     prog_modes             = PM_SPM | PM_ISP | PM_HVSP | PM_debugWIRE;
     mcuid                  = 47;
     archnum                = 4;
@@ -13753,11 +13841,10 @@ part parent "m8hva" # m16hva
     desc                   = "ATmega16HVA";
     id                     = "m16hva";
     variants               =
-        "ATmega16HVA:       N/A,     Fmax=N/A,   T=[N/A,    N/A], Vcc=[1.8 V, 4.5 V]",
-        "ATmega16HVA-4CKU:  WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]",
-        "ATmega16HVA-4CKUR: WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]",
-        "ATmega16HVA-4TU:   TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]",
-        "ATmega16HVA-4TUR:  TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V,   9 V]";
+        "ATmega16HVA-4CKU:  WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]",
+        "ATmega16HVA-4CKUR: WFLGA36, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]",
+        "ATmega16HVA-4TU:   TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]",
+        "ATmega16HVA-4TUR:  TSSOP28, Fmax=4 MHz, T=[-20 C, 85 C], Vcc=[1.8 V, 9 V]";
     mcuid                  = 51;
     archnum                = 5;
     signature              = 0x1e 0x94 0x0c;
@@ -14137,7 +14224,7 @@ part parent "m16hvb" # m16hvbrevb
     desc                   = "ATmega16HVBrevB";
     id                     = "m16hvbrevb";
     variants               =
-        "ATmega16HVBrevB: N/A, Fmax=N/A, T=[N/A, N/A], Vcc=[3.0 V, 4.5 V]";
+        "ATMEGA16HVB-8X3: TSSOP44, Fmax=8 MHz, T=[-40 C, 85 C], Vcc=[3.0 V, 4.5 V]";
     mcuid                  = 53;
 ;
 
@@ -14183,7 +14270,7 @@ part parent "m32hvb" # m32hvbrevb
     desc                   = "ATmega32HVBrevB";
     id                     = "m32hvbrevb";
     variants               =
-        "ATmega32HVBrevB: N/A, Fmax=N/A, T=[N/A, N/A], Vcc=[3.0 V, 4.5 V]";
+        "ATMEGA32HVB-8X3: TSSOP44, Fmax=8 MHz, T=[-40 C, 85 C], Vcc=[3.0 V, 4.5 V]";
     mcuid                  = 61;
 ;
 
@@ -21237,17 +21324,17 @@ part parent ".avrdx" # 32da28
     desc                   = "AVR32DA28";
     id                     = "32da28";
     variants               =
-        "AVR32DA28:       SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28-E/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28-E/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28-E/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28T-E/SO: SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28T-E/SS: SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28T-I/SO: SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA28T-I/SS: SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DA28-E/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28-E/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28-E/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28-SPDIP/SSOP/SOIC: DIP28,   Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28T-E/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28T-E/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28T-I/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA28T-I/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 338;
     n_interrupts           = 41;
@@ -21289,15 +21376,15 @@ part parent ".avrdx" # 32da32
     desc                   = "AVR32DA32";
     id                     = "32da32";
     variants               =
-        "AVR32DA32:        QFN32,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32-E/PT:   TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32-E/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32-I/PT:   TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32-I/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32T-E/PT:  TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32T-E/RXB: VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32T-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA32T-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DA32-E/PT:      TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32-E/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32-VQFN/TQFP: QFP32,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32T-E/PT:     TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32T-E/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32T-I/PT:     TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA32T-I/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 342;
     n_interrupts           = 44;
@@ -21339,15 +21426,15 @@ part parent ".avrdx" # 32da48
     desc                   = "AVR32DA48";
     id                     = "32da48";
     variants               =
-        "AVR32DA48:        QFN48,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48-E/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48-E/PT:   TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48-I/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48-I/PT:   TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48T-E/6LX: VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48T-E/PT:  TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48T-I/6LX: VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DA48T-I/PT:  TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DA48-E/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48-E/PT:      TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48-I/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48-I/PT:      TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48-VQFN/TQFP: QFP48,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48T-E/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48T-E/PT:     TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48T-I/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DA48T-I/PT:     TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 346;
     n_interrupts           = 61;
@@ -21389,17 +21476,17 @@ part parent ".avrdx" # 64da28
     desc                   = "AVR64DA28";
     id                     = "64da28";
     variants               =
-        "AVR64DA28:       SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28-E/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28-E/SP:  SPDIP28, Fmax=N/A,    T=[N/A,     N/A], Vcc=[N/A,     N/A]",
-        "AVR64DA28-E/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28T-E/SO: SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28T-E/SS: SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28T-I/SO: SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA28T-I/SS: SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DA28-E/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28-E/SP:            SPDIP28, Fmax=N/A,    T=[N/A,     N/A], Vcc=[N/A,     N/A]",
+        "AVR64DA28-E/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28-SPDIP/SSOP/SOIC: DIP28,   Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28T-E/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28T-E/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28T-I/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA28T-I/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 351;
     n_interrupts           = 41;
@@ -21441,15 +21528,15 @@ part parent ".avrdx" # 64da32
     desc                   = "AVR64DA32";
     id                     = "64da32";
     variants               =
-        "AVR64DA32:        QFN32,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32-E/PT:   TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32-E/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32-I/PT:   TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32-I/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32T-E/PT:  TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32T-E/RXB: VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32T-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA32T-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DA32-E/PT:      TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32-E/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32-VQFN/TQFP: QFP32,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32T-E/PT:     TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32T-E/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32T-I/PT:     TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA32T-I/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 355;
     n_interrupts           = 44;
@@ -21491,15 +21578,15 @@ part parent ".avrdx" # 64da48
     desc                   = "AVR64DA48";
     id                     = "64da48";
     variants               =
-        "AVR64DA48:        QFN48,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48-E/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48-E/PT:   TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48-I/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48-I/PT:   TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48T-E/6LX: VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48T-E/PT:  TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48T-I/6LX: VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA48T-I/PT:  TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DA48-E/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48-E/PT:      TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48-I/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48-I/PT:      TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48-VQFN/TQFP: QFP48,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48T-E/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48T-E/PT:     TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48T-I/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA48T-I/PT:     TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 359;
     n_interrupts           = 58;
@@ -21541,15 +21628,15 @@ part parent ".avrdx" # 64da64
     desc                   = "AVR64DA64";
     id                     = "64da64";
     variants               =
-        "AVR64DA64:       QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64-E/MR:  QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64-E/PT:  TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64-I/MR:  QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64-I/PT:  TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64T-E/MR: QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64T-E/PT: TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64T-I/MR: QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DA64T-I/PT: TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DA64-E/MR:      QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64-E/PT:      TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64-I/MR:      QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64-I/PT:      TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64-VQFN/TQFP: QFP64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64T-E/MR:     QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64T-E/PT:     TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64T-I/MR:     QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DA64T-I/PT:     TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 362;
     n_interrupts           = 64;
@@ -21591,17 +21678,17 @@ part parent ".avrdx" # 128da28
     desc                   = "AVR128DA28";
     id                     = "128da28";
     variants               =
-        "AVR128DA28:       SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28-E/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28-E/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28-E/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28T-E/SO: SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28T-E/SS: SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28T-I/SO: SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA28T-I/SS: SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA28-E/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28-E/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28-E/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28-SPDIP/SSOP/SOIC: DIP28,   Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28T-E/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28T-E/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28T-I/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA28T-I/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 364;
     n_interrupts           = 41;
@@ -21643,15 +21730,15 @@ part parent ".avrdx" # 128da32
     desc                   = "AVR128DA32";
     id                     = "128da32";
     variants               =
-        "AVR128DA32:        QFN32,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32-E/PT:   TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32-E/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32-I/PT:   TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32-I/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32T-E/PT:  TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32T-E/RXB: VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32T-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA32T-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA32-E/PT:      TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32-E/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32-VQFN/TQFP: QFP32,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32T-E/PT:     TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32T-E/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32T-I/PT:     TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA32T-I/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 366;
     n_interrupts           = 44;
@@ -21693,15 +21780,15 @@ part parent ".avrdx" # 128da48
     desc                   = "AVR128DA48";
     id                     = "128da48";
     variants               =
-        "AVR128DA48:        QFN48,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48-E/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48-E/PT:   TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48-I/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48-I/PT:   TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48T-E/6LX: VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48T-E/PT:  TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48T-I/6LX: VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA48T-I/PT:  TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA48-E/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48-E/PT:      TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48-I/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48-I/PT:      TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48-VQFN/TQFP: QFP48,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48T-E/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48T-E/PT:     TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48T-I/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA48T-I/PT:     TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 368;
     n_interrupts           = 58;
@@ -21743,15 +21830,15 @@ part parent ".avrdx" # 128da64
     desc                   = "AVR128DA64";
     id                     = "128da64";
     variants               =
-        "AVR128DA64:       QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64-E/MR:  QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64-E/PT:  TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64-I/MR:  QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64-I/PT:  TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64T-E/MR: QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64T-E/PT: TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64T-I/MR: QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DA64T-I/PT: TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA64-E/MR:      QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64-E/PT:      TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64-I/MR:      QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64-I/PT:      TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64-VQFN/TQFP: QFP64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64T-E/MR:     QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64T-E/PT:     TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64T-I/MR:     QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DA64T-I/PT:     TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     family_id              = "    AVR";
     mcuid                  = 370;
     n_interrupts           = 64;
@@ -21793,7 +21880,7 @@ part parent "128da28" # 128da28s
     desc                   = "AVR128DA28S";
     id                     = "128da28s";
     variants               =
-        "AVR128DA28S-SPDIP: SOIC28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA28S-SPDIP: DIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 394;
     signature              = 0x1e 0x97 0x12;
 
@@ -21818,7 +21905,7 @@ part parent "128da32" # 128da32s
     desc                   = "AVR128DA32S";
     id                     = "128da32s";
     variants               =
-        "AVR128DA32S-VQFN/TQFP: QFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA32S-VQFN/TQFP: QFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 395;
     signature              = 0x1e 0x97 0x11;
 
@@ -21843,7 +21930,7 @@ part parent "128da48" # 128da48s
     desc                   = "AVR128DA48S";
     id                     = "128da48s";
     variants               =
-        "AVR128DA48S-VQFN/TQFP: QFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA48S-VQFN/TQFP: QFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 396;
     signature              = 0x1e 0x97 0x10;
 
@@ -21868,7 +21955,7 @@ part parent "128da64" # 128da64s
     desc                   = "AVR128DA64S";
     id                     = "128da64s";
     variants               =
-        "AVR128DA64S-VQFN/TQFP: QFN64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DA64S-VQFN/TQFP: QFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 397;
     signature              = 0x1e 0x97 0x0f;
 
@@ -21893,17 +21980,17 @@ part parent ".avrdx" # 32db28
     desc                   = "AVR32DB28";
     id                     = "32db28";
     variants               =
-        "AVR32DB28:       SOIC28,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28-E/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28-E/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28-E/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28T-E/SO: SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28T-E/SS: SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28T-I/SO: SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB28T-I/SS: SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DB28-E/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28-E/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28-E/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28-SPDIP/SSOP/SOIC: DIP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28T-E/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28T-E/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28T-I/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB28T-I/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 339;
     n_interrupts           = 42;
     signature              = 0x1e 0x95 0x37;
@@ -21939,15 +22026,15 @@ part parent ".avrdx" # 32db32
     desc                   = "AVR32DB32";
     id                     = "32db32";
     variants               =
-        "AVR32DB32:        QFN32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32-E/PT:   TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32-E/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32-I/PT:   TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32-I/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32T-E/PT:  TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32T-E/RXB: VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32T-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB32T-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DB32-E/PT:      TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32-E/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32T-E/PT:     TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32T-E/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32T-I/PT:     TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB32T-I/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 343;
     n_interrupts           = 44;
     signature              = 0x1e 0x95 0x36;
@@ -21983,15 +22070,15 @@ part parent ".avrdx" # 32db48
     desc                   = "AVR32DB48";
     id                     = "32db48";
     variants               =
-        "AVR32DB48:        QFN48,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48-E/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48-E/PT:   TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48-I/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48-I/PT:   TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48T-E/6LX: VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48T-E/PT:  TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48T-I/6LX: VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DB48T-I/PT:  TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DB48-E/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48-E/PT:      TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48-I/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48-I/PT:      TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48-VQFN/TQFP: QFP48,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48T-E/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48T-E/PT:     TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48T-I/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DB48T-I/PT:     TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 347;
     n_interrupts           = 61;
     signature              = 0x1e 0x95 0x35;
@@ -22027,17 +22114,17 @@ part parent ".avrdx" # 64db28
     desc                   = "AVR64DB28";
     id                     = "64db28";
     variants               =
-        "AVR64DB28:       SOIC28,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28-E/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28-E/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28-E/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28T-E/SO: SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28T-E/SS: SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28T-I/SO: SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB28T-I/SS: SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DB28-E/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28-E/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28-E/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28-SPDIP/SSOP/SOIC: DIP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28T-E/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28T-E/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28T-I/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB28T-I/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 352;
     n_interrupts           = 42;
     signature              = 0x1e 0x96 0x19;
@@ -22073,15 +22160,15 @@ part parent ".avrdx" # 64db32
     desc                   = "AVR64DB32";
     id                     = "64db32";
     variants               =
-        "AVR64DB32:        QFN32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32-E/PT:   TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32-E/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32-I/PT:   TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32-I/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32T-E/PT:  TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32T-E/RXB: VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32T-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB32T-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DB32-E/PT:      TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32-E/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32T-E/PT:     TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32T-E/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32T-I/PT:     TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB32T-I/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 356;
     n_interrupts           = 44;
     signature              = 0x1e 0x96 0x18;
@@ -22117,15 +22204,15 @@ part parent ".avrdx" # 64db48
     desc                   = "AVR64DB48";
     id                     = "64db48";
     variants               =
-        "AVR64DB48:        QFN48,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48-E/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48-E/PT:   TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48-I/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48-I/PT:   TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48T-E/6LX: VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48T-E/PT:  TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48T-I/6LX: VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB48T-I/PT:  TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DB48-E/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48-E/PT:      TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48-I/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48-I/PT:      TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48-VQFN/TQFP: QFP48,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48T-E/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48T-E/PT:     TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48T-I/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB48T-I/PT:     TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 360;
     n_interrupts           = 61;
     signature              = 0x1e 0x96 0x17;
@@ -22161,15 +22248,15 @@ part parent ".avrdx" # 64db64
     desc                   = "AVR64DB64";
     id                     = "64db64";
     variants               =
-        "AVR64DB64:       QFN64,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64-E/MR:  QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64-E/PT:  TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64-I/MR:  QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64-I/PT:  TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64T-E/MR: QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64T-E/PT: TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64T-I/MR: QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DB64T-I/PT: TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DB64-E/MR:      QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64-E/PT:      TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64-I/MR:      QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64-I/PT:      TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64-VQFN/TQFP: QFP64,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64T-E/MR:     QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64T-E/PT:     TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64T-I/MR:     QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DB64T-I/PT:     TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 363;
     n_interrupts           = 65;
     signature              = 0x1e 0x96 0x16;
@@ -22205,17 +22292,17 @@ part parent ".avrdx" # 128db28
     desc                   = "AVR128DB28";
     id                     = "128db28";
     variants               =
-        "AVR128DB28:       SOIC28,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28-E/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28-E/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28-E/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28T-E/SO: SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28T-E/SS: SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28T-I/SO: SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB28T-I/SS: SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DB28-E/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28-E/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28-E/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28-SPDIP/SSOP/SOIC: DIP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28T-E/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28T-E/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28T-I/SO:           SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB28T-I/SS:           SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 365;
     n_interrupts           = 42;
     signature              = 0x1e 0x97 0x0e;
@@ -22251,15 +22338,15 @@ part parent ".avrdx" # 128db32
     desc                   = "AVR128DB32";
     id                     = "128db32";
     variants               =
-        "AVR128DB32:        QFN32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32-E/PT:   TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32-E/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32-I/PT:   TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32-I/RXB:  VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32T-E/PT:  TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32T-E/RXB: VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32T-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB32T-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DB32-E/PT:      TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32-E/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32T-E/PT:     TQFP32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32T-E/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32T-I/PT:     TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB32T-I/RXB:    VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 367;
     n_interrupts           = 44;
     signature              = 0x1e 0x97 0x0d;
@@ -22295,15 +22382,15 @@ part parent ".avrdx" # 128db48
     desc                   = "AVR128DB48";
     id                     = "128db48";
     variants               =
-        "AVR128DB48:        QFN48,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48-E/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48-E/PT:   TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48-I/6LX:  VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48-I/PT:   TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48T-E/6LX: VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48T-E/PT:  TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48T-I/6LX: VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB48T-I/PT:  TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DB48-E/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48-E/PT:      TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48-I/6LX:     VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48-I/PT:      TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48-VQFN/TQFP: QFP48,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48T-E/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48T-E/PT:     TQFP48, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48T-I/6LX:    VQFN48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB48T-I/PT:     TQFP48, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 369;
     n_interrupts           = 61;
     signature              = 0x1e 0x97 0x0c;
@@ -22339,15 +22426,15 @@ part parent ".avrdx" # 128db64
     desc                   = "AVR128DB64";
     id                     = "128db64";
     variants               =
-        "AVR128DB64:       QFN64,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64-E/MR:  QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64-E/PT:  TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64-I/MR:  QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64-I/PT:  TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64T-E/MR: QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64T-E/PT: TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64T-I/MR: QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR128DB64T-I/PT: TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR128DB64-E/MR:      QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64-E/PT:      TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64-I/MR:      QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64-I/PT:      TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64-VQFN/TQFP: QFP64,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64T-E/MR:     QFN64,  Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64T-E/PT:     TQFP64, Fmax=24 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64T-I/MR:     QFN64,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR128DB64T-I/PT:     TQFP64, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 371;
     n_interrupts           = 65;
     signature              = 0x1e 0x97 0x0b;
@@ -22383,8 +22470,8 @@ part parent ".avrdx" # 16dd14
     desc                   = "AVR16DD14";
     id                     = "16dd14";
     variants               =
-        "AVR16DD14:      SOIC14, Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD14-SOIC: DIP14,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 329;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22426,9 +22513,10 @@ part parent ".avrdx" # 16dd20
     desc                   = "AVR16DD20";
     id                     = "16dd20";
     variants               =
-        "AVR16DD20:       QFN20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
         "AVR16DD20-I/REB: VQFN20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD20-I/SO:  SOIC20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16DD20-I/SO:  SOIC20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD20-SOIC:  DIP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD20-VQFN:  QFP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 330;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22470,11 +22558,12 @@ part parent ".avrdx" # 16dd28
     desc                   = "AVR16DD28";
     id                     = "16dd28";
     variants               =
-        "AVR16DD28:       SOIC28,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD28-I/STX: N/A,     Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16DD28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD28-I/STX:           N/A,     Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD28-SPDIP/SSOP/SOIC: DIP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD28-VQFN:            QFP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 331;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22516,9 +22605,9 @@ part parent ".avrdx" # 16dd32
     desc                   = "AVR16DD32";
     id                     = "16dd32";
     variants               =
-        "AVR16DD32:       QFN32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD32-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16DD32-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16DD32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16DD32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 333;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22560,8 +22649,8 @@ part parent ".avrdx" # 32dd14
     desc                   = "AVR32DD14";
     id                     = "32dd14";
     variants               =
-        "AVR32DD14:      SOIC14, Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD14-SOIC: DIP14,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 336;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22603,9 +22692,10 @@ part parent ".avrdx" # 32dd20
     desc                   = "AVR32DD20";
     id                     = "32dd20";
     variants               =
-        "AVR32DD20:       QFN20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
         "AVR32DD20-I/REB: VQFN20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD20-I/SO:  SOIC20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DD20-I/SO:  SOIC20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD20-SOIC:  DIP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD20-VQFN:  QFP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 337;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22647,11 +22737,12 @@ part parent ".avrdx" # 32dd28
     desc                   = "AVR32DD28";
     id                     = "32dd28";
     variants               =
-        "AVR32DD28:       SOIC28,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD28-I/STX: N/A,     Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DD28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD28-I/STX:           N/A,     Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD28-SPDIP/SSOP/SOIC: DIP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD28-VQFN:            QFP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 340;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22693,9 +22784,9 @@ part parent ".avrdx" # 32dd32
     desc                   = "AVR32DD32";
     id                     = "32dd32";
     variants               =
-        "AVR32DD32:       QFN32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD32-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32DD32-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32DD32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32DD32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 344;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22737,8 +22828,8 @@ part parent ".avrdx" # 64dd14
     desc                   = "AVR64DD14";
     id                     = "64dd14";
     variants               =
-        "AVR64DD14:      SOIC14, Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DD14-I/SL: SOIC14, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD14-SOIC: DIP14,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 349;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22780,8 +22871,8 @@ part parent ".avrdx" # 64dd20
     desc                   = "AVR64DD20";
     id                     = "64dd20";
     variants               =
-        "AVR64DD20:      QFN20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD20-I/SO: SOIC20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DD20-I/SO: SOIC20, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD20-SOIC: DIP20,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 350;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22823,11 +22914,12 @@ part parent ".avrdx" # 64dd28
     desc                   = "AVR64DD28";
     id                     = "64dd28";
     variants               =
-        "AVR64DD28:       SOIC28,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD28-I/SO:  SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD28-I/SP:  SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD28-I/SS:  SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD28-I/STX: VQFN28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DD28-I/SO:            SOIC28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD28-I/SP:            SPDIP28, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD28-I/SS:            SSOP28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD28-I/STX:           VQFN28,  Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD28-SPDIP/SSOP/SOIC: DIP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD28-VQFN:            QFP28,   Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 353;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -22869,9 +22961,9 @@ part parent ".avrdx" # 64dd32
     desc                   = "AVR64DD32";
     id                     = "64dd32";
     variants               =
-        "AVR64DD32:       QFN32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD32-I/PT:  TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64DD32-I/RXB: VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64DD32-I/PT:      TQFP32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD32-I/RXB:     VQFN32, Fmax=24 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64DD32-VQFN/TQFP: QFP32,  Fmax=32 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 357;
     n_interrupts           = 36;
     hvupdi_variant         = 2;
@@ -23261,7 +23353,8 @@ part parent ".avrex" # 16ea28
     desc                   = "AVR16EA28";
     id                     = "16ea28";
     variants               =
-        "AVR16EA28: SOIC28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16EA28-SSOP/SPDIP: DIP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16EA28-VQFN:       QFP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 332;
     n_interrupts           = 43;
     signature              = 0x1e 0x94 0x37;
@@ -23298,7 +23391,7 @@ part parent ".avrex" # 16ea32
     desc                   = "AVR16EA32";
     id                     = "16ea32";
     variants               =
-        "AVR16EA32: VQFN32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16EA32-VQFN/TQFP: QFP32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 334;
     n_interrupts           = 43;
     signature              = 0x1e 0x94 0x36;
@@ -23335,7 +23428,7 @@ part parent ".avrex" # 16ea48
     desc                   = "AVR16EA48";
     id                     = "16ea48";
     variants               =
-        "AVR16EA48: VQFN48, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16EA48-VQFN/TQFP: QFP48, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 335;
     n_interrupts           = 45;
     signature              = 0x1e 0x94 0x35;
@@ -23372,7 +23465,8 @@ part parent ".avrex" # 32ea28
     desc                   = "AVR32EA28";
     id                     = "32ea28";
     variants               =
-        "AVR32EA28: SOIC28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32EA28-SSOP/SPDIP: DIP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32EA28-VQFN:       QFP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 341;
     n_interrupts           = 43;
     signature              = 0x1e 0x95 0x3e;
@@ -23409,7 +23503,7 @@ part parent ".avrex" # 32ea32
     desc                   = "AVR32EA32";
     id                     = "32ea32";
     variants               =
-        "AVR32EA32: VQFN32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32EA32-VQFN/TQFP: QFP32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 345;
     n_interrupts           = 43;
     signature              = 0x1e 0x95 0x3d;
@@ -23446,7 +23540,7 @@ part parent ".avrex" # 32ea48
     desc                   = "AVR32EA48";
     id                     = "32ea48";
     variants               =
-        "AVR32EA48: VQFN48, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32EA48-VQFN/TQFP: QFP48, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 348;
     n_interrupts           = 45;
     signature              = 0x1e 0x95 0x3c;
@@ -23483,9 +23577,10 @@ part parent ".avrex" # 64ea28
     desc                   = "AVR64EA28";
     id                     = "64ea28";
     variants               =
-        "AVR64EA28:      SOIC28,  Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64EA28-I/SP: SPDIP28, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64EA28-I/SS: SSOP28,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64EA28-I/SP:       SPDIP28, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64EA28-I/SS:       SSOP28,  Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64EA28-SSOP/SPDIP: DIP28,   Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64EA28-VQFN:       QFP28,   Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 354;
     n_interrupts           = 43;
     signature              = 0x1e 0x96 0x20;
@@ -23522,9 +23617,9 @@ part parent ".avrex" # 64ea32
     desc                   = "AVR64EA32";
     id                     = "64ea32";
     variants               =
-        "AVR64EA32:       VQFN32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64EA32-I/PT:  TQFP32, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64EA32-I/RXB: VQFN32, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64EA32-I/PT:      TQFP32, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64EA32-I/RXB:     VQFN32, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64EA32-VQFN/TQFP: QFP32,  Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 358;
     n_interrupts           = 43;
     signature              = 0x1e 0x96 0x1f;
@@ -23561,9 +23656,9 @@ part parent ".avrex" # 64ea48
     desc                   = "AVR64EA48";
     id                     = "64ea48";
     variants               =
-        "AVR64EA48:       VQFN48, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64EA48-I/6LX: VQFN48, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR64EA48-I/PT:  TQFP48, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR64EA48-I/6LX:     VQFN48, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64EA48-I/PT:      TQFP48, Fmax=20 MHz, T=[-40 C,  85 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR64EA48-VQFN/TQFP: QFP48,  Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 361;
     n_interrupts           = 45;
     signature              = 0x1e 0x96 0x1e;
@@ -23600,7 +23695,7 @@ part parent ".avrex" # 16eb14
     desc                   = "AVR16EB14";
     id                     = "16eb14";
     variants               =
-        "AVR16EB14-SOIC/TSSOP: SOIC14, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16EB14-SOIC/TSSOP: DIP14, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 380;
     n_interrupts           = 31;
     signature              = 0x1e 0x94 0x49;
@@ -23676,8 +23771,8 @@ part parent "16eb14" # 16eb20
     desc                   = "AVR16EB20";
     id                     = "16eb20";
     variants               =
-        "AVR16EB20-SSOP: SOIC20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16EB20-VQFN: VQFN20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16EB20-SSOP: DIP20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16EB20-VQFN: QFP20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 381;
     signature              = 0x1e 0x94 0x40;
 ;
@@ -23690,8 +23785,8 @@ part parent "16eb14" # 16eb28
     desc                   = "AVR16EB28";
     id                     = "16eb28";
     variants               =
-        "AVR16EB28-SSOP/SPDIP: SOIC28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR16EB28-VQFN:       VQFN28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16EB28-SSOP/SPDIP: DIP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR16EB28-VQFN:       QFP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 382;
     signature              = 0x1e 0x94 0x3f;
 ;
@@ -23704,7 +23799,7 @@ part parent "16eb14" # 16eb32
     desc                   = "AVR16EB32";
     id                     = "16eb32";
     variants               =
-        "AVR16EB32-VQFN/TQFP: VQFN32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR16EB32-VQFN/TQFP: QFP32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 383;
     signature              = 0x1e 0x94 0x3e;
 ;
@@ -23717,7 +23812,7 @@ part parent "16eb14" # 32eb14
     desc                   = "AVR32EB14";
     id                     = "32eb14";
     variants               =
-        "AVR32EB14-SOIC/TSSOP: SOIC14, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32EB14-SOIC/TSSOP: DIP14, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 398;
     signature              = 0x1e 0x95 0x2d;
 
@@ -23739,7 +23834,7 @@ part parent "16eb20" # 32eb20
     desc                   = "AVR32EB20";
     id                     = "32eb20";
     variants               =
-        "AVR32EB20-SSOP: SOIC20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32EB20-SSOP: DIP20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 399;
     signature              = 0x1e 0x95 0x2c;
 
@@ -23761,8 +23856,8 @@ part parent "16eb28" # 32eb28
     desc                   = "AVR32EB28";
     id                     = "32eb28";
     variants               =
-        "AVR32EB28-SSOP/SPDIP: SOIC28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
-        "AVR32EB28-VQFN:       VQFN28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32EB28-SSOP/SPDIP: DIP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]",
+        "AVR32EB28-VQFN:       QFP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 400;
     signature              = 0x1e 0x95 0x2b;
 
@@ -23784,7 +23879,7 @@ part parent "16eb32" # 32eb32
     desc                   = "AVR32EB32";
     id                     = "32eb32";
     variants               =
-        "AVR32EB32-VQFN/TQFP: VQFN32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
+        "AVR32EB32-VQFN/TQFP: QFP32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 401;
     signature              = 0x1e 0x95 0x2a;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -49,7 +49,7 @@ avrdude_conf_version = "@AVRDUDE_FULL_VERSION@";
 #       usbvendor = <vendorname> ;                # USB Vendor Name
 #       usbproduct = <productname> ;              # USB Product Name
 #       usbsn    = <serialno> ;                   # USB Serial Number
-#       hvupdi_support = <num> [, <num>, ... ] ;  # UPDI HV Variants Support
+#       hvupdi_support = <num> [, <num>, ... ] ;  # HV support for enabling UPDI
 #   ;
 #
 #   # Notes
@@ -110,7 +110,7 @@ avrdude_conf_version = "@AVRDUDE_FULL_VERSION@";
 #       n_page_erase     = <num>;                 # if set, number of pages erased during SPM erase
 #       n_boot_sections  = <num>;                 # Number of boot sections
 #       boot_section_size = <num>;                # Size of (smallest) boot section, if any
-#       hvupdi_variant   = <num> ;                # numeric -1 (n/a) or 0..2
+#       hvupdi_variant   = <num> ;                # numeric: -1 or 0..3; how to enable UPDI with HV
 #       stk500_devcode   = <num> ;                # numeric
 #       avr910_devcode   = <num> ;                # numeric
 #       is_at90s1200     = <yes/no> ;             # AT90S1200 part

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -3668,7 +3668,7 @@ programmer
     usbvendor = <vendorname>;                # USB Vendor Name
     usbproduct = <productname>;              # USB Product Name
     usbsn    = <serialno>;                   # USB Serial Number
-    hvupdi_support = <num> [, <num>, ... ];  # UPDI HV Variants Support
+    hvupdi_support = <num> [, <num>, ... ];  # HV support for enabling UPDI
 ;
 @end smallexample
 
@@ -3836,7 +3836,7 @@ part
     n_page_erase     = <num>;                 # if set, number of pages erased during SPM erase
     n_boot_sections  = <num>;                 # Number of boot sections
     boot_section_size = <num>;                # Size of (smallest) boot section, if any
-    hvupdi_variant   = <num>;                 # numeric -1 (n/a) or 0..2
+    hvupdi_variant   = <num>;                 # numeric: -1 or 0..3; how to enable UPDI with HV
     stk500_devcode   = <num>;                 # numeric
     avr910_devcode   = <num>;                 # numeric
     is_at90s1200     = <yes/no>;              # AT90S1200 part

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1246,11 +1246,11 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
 
     // Generate UPDI high-voltage pulse if user asks for it and hardware supports it
-    if(my.use_hvupdi == true && p->hvupdi_variant != HV_UPDI_VARIANT_1) {
+    if(my.use_hvupdi == true && p->hvupdi_variant != UPDI_ENABLE_ALWAYS) {
       parm[0] = PARM3_UPDI_HV_NONE;
       for(LNODEID ln = lfirst(pgm->hvupdi_support); ln; ln = lnext(ln)) {
         if(*(int *) ldata(ln) == p->hvupdi_variant) {
-          pmsg_notice("sending HV pulse to targets %s pin\n", p->hvupdi_variant == HV_UPDI_VARIANT_0? "UPDI": "RESET");
+          pmsg_notice("sending HV pulse to targets %s pin\n", p->hvupdi_variant == UPDI_ENABLE_HV_UPDI? "UPDI": "RESET");
           parm[0] = PARM3_UPDI_HV_SIMPLE_PULSE;
           break;
         }

--- a/src/jtag3_private.h
+++ b/src/jtag3_private.h
@@ -470,6 +470,6 @@ struct updi_device_desc {
 
   unsigned char address_mode;   // 0x00 = 16-bit mode, 0x01 = 24-bit mode
 
-  unsigned char hvupdi_variant; // Indicates the target UPDI HV implementation
+  unsigned char hvupdi_variant; // How the target's UPDI can be enabled with HV
 };
 #endif                          // JTAG3_PRIVATE_EXPORTED

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -11,8 +11,8 @@
  * Published under GNU General Public License, version 3 (GPL-3.0)
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
- * v 1.40
- * 16.11.2024
+ * v 1.41
+ * 28.02.2025
  *
  */
 
@@ -73,12 +73,24 @@ typedef struct {                // Value of -1 typically means unknown
   const Configitem *cfgtable;   // Configuration bitfield table
   uint16_t nregisters;          // Number of I/O registers
   const Register_file *regf;    // Register file
+  uint8_t numuarts;             // Number of UART interfaces
+  uint8_t uarttype;             // UARTTYPE_UNKNOWN, _NONE, _CLASSIC, _LIN, XMEGA, _AVR8X
+  uint8_t has_u2x;              // 1 = 2x speed possible (8 samples), 0 = 1x speed only
+  uint8_t brr_nbits;            // Number of baud rate divisor bits (integer part)
+  uint8_t brr_nfraction;        // Number of bits for fractional part of baud rate divisor
 } Avrintel;
 
 #define F_AVR8L               1 // TPI programming, ATtiny(4|5|9|10|20|40|102|104)
 #define F_AVR8                2 // ISP programming with SPI, "classic" AVRs
 #define F_XMEGA               4 // PDI programming, ATxmega family
 #define F_AVR8X               8 // UPDI programming, newer 8-bit MCUs
+
+#define UARTTYPE_UNKNOWN    (-1)
+#define UARTTYPE_NONE         0
+#define UARTTYPE_CLASSIC      1
+#define UARTTYPE_LIN          2
+#define UARTTYPE_XMEGA        3
+#define UARTTYPE_AVR8X        4
 
 #define UB_N_MCU           2040 // mcuid is in 0..2039
 

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -11,7 +11,7 @@
  * Published under GNU General Public License, version 3 (GPL-3.0)
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
- * v 1.41
+ * v 1.42
  * 28.02.2025
  *
  */
@@ -94,7 +94,7 @@ typedef struct {                // Value of -1 typically means unknown
 
 #define UB_N_MCU           2040 // mcuid is in 0..2039
 
-extern const Avrintel uP_table[402];
+extern const Avrintel uP_table[412];
 
 
 // MCU id: running number in arbitrary order; once assigned never change for backward compatibility
@@ -457,37 +457,47 @@ extern const Avrintel uP_table[402];
 #define id_avr32dd20       337u
 #define id_avr32du20       391u
 #define id_avr32eb20       399u
+#define id_avr32sd20       402u
 #define id_avr32da28       338u
+#define id_avr32da28s      405u
 #define id_avr32db28       339u
 #define id_avr32dd28       340u
 #define id_avr32du28       392u
 #define id_avr32ea28       341u
 #define id_avr32eb28       400u
+#define id_avr32sd28       403u
 #define id_avr32da32       342u
+#define id_avr32da32s      406u
 #define id_avr32db32       343u
 #define id_avr32dd32       344u
 #define id_avr32du32       393u
 #define id_avr32ea32       345u
 #define id_avr32eb32       401u
+#define id_avr32sd32       404u
 #define id_avr32da48       346u
+#define id_avr32da48s      407u
 #define id_avr32db48       347u
 #define id_avr32ea48       348u
 #define id_avr64dd14       349u
 #define id_avr64dd20       350u
 #define id_avr64da28       351u
+#define id_avr64da28s      408u
 #define id_avr64db28       352u
 #define id_avr64dd28       353u
 #define id_avr64du28       384u
 #define id_avr64ea28       354u
 #define id_avr64da32       355u
+#define id_avr64da32s      409u
 #define id_avr64db32       356u
 #define id_avr64dd32       357u
 #define id_avr64du32       385u
 #define id_avr64ea32       358u
 #define id_avr64da48       359u
+#define id_avr64da48s      410u
 #define id_avr64db48       360u
 #define id_avr64ea48       361u
 #define id_avr64da64       362u
+#define id_avr64da64s      411u
 #define id_avr64db64       363u
 #define id_avr128da28      364u
 #define id_avr128da28s     394u
@@ -845,37 +855,47 @@ extern const Avrintel uP_table[402];
 #define vts_avr32dd20        36
 #define vts_avr32du20        34
 #define vts_avr32eb20        31
+#define vts_avr32sd20        50
 #define vts_avr32da28        41
+#define vts_avr32da28s       41
 #define vts_avr32db28        42
 #define vts_avr32dd28        36
 #define vts_avr32du28        34
 #define vts_avr32ea28        43
 #define vts_avr32eb28        31
+#define vts_avr32sd28        54
 #define vts_avr32da32        44
+#define vts_avr32da32s       44
 #define vts_avr32db32        44
 #define vts_avr32dd32        36
 #define vts_avr32du32        34
 #define vts_avr32ea32        43
 #define vts_avr32eb32        31
+#define vts_avr32sd32        56
 #define vts_avr32da48        61
+#define vts_avr32da48s       61
 #define vts_avr32db48        61
 #define vts_avr32ea48        45
 #define vts_avr64dd14        36
 #define vts_avr64dd20        36
 #define vts_avr64da28        41
+#define vts_avr64da28s       41
 #define vts_avr64db28        42
 #define vts_avr64dd28        36
 #define vts_avr64du28        34
 #define vts_avr64ea28        43
 #define vts_avr64da32        44
+#define vts_avr64da32s       44
 #define vts_avr64db32        44
 #define vts_avr64dd32        36
 #define vts_avr64du32        34
 #define vts_avr64ea32        43
 #define vts_avr64da48        58
+#define vts_avr64da48s       58
 #define vts_avr64db48        61
 #define vts_avr64ea48        45
 #define vts_avr64da64        64
+#define vts_avr64da64s       64
 #define vts_avr64db64        65
 #define vts_avr128da28       41
 #define vts_avr128da28s      41
@@ -1212,10 +1232,10 @@ extern const Avrintel uP_table[402];
 #define vbu_atmega3209       40
 #define vbu_atmega4808       36
 #define vbu_atmega4809       40
-#define vbu_avr16dd14        36
+#define vbu_avr16dd14        30
 #define vbu_avr16du14        34
 #define vbu_avr16eb14        31
-#define vbu_avr16dd20        36
+#define vbu_avr16dd20        30
 #define vbu_avr16du20        34
 #define vbu_avr16eb20        31
 #define vbu_avr16dd28        36
@@ -1227,43 +1247,53 @@ extern const Avrintel uP_table[402];
 #define vbu_avr16ea32        43
 #define vbu_avr16eb32        31
 #define vbu_avr16ea48        45
-#define vbu_avr32dd14        36
+#define vbu_avr32dd14        30
 #define vbu_avr32du14        34
 #define vbu_avr32eb14        31
-#define vbu_avr32dd20        36
+#define vbu_avr32dd20        30
 #define vbu_avr32du20        34
 #define vbu_avr32eb20        31
+#define vbu_avr32sd20        50
 #define vbu_avr32da28        41
+#define vbu_avr32da28s       41
 #define vbu_avr32db28        42
 #define vbu_avr32dd28        36
 #define vbu_avr32du28        34
 #define vbu_avr32ea28        43
 #define vbu_avr32eb28        31
+#define vbu_avr32sd28        54
 #define vbu_avr32da32        41
+#define vbu_avr32da32s       41
 #define vbu_avr32db32        44
 #define vbu_avr32dd32        36
 #define vbu_avr32du32        34
 #define vbu_avr32ea32        43
 #define vbu_avr32eb32        31
+#define vbu_avr32sd32        56
 #define vbu_avr32da48        58
+#define vbu_avr32da48s       58
 #define vbu_avr32db48        59
 #define vbu_avr32ea48        45
-#define vbu_avr64dd14        36
-#define vbu_avr64dd20        36
+#define vbu_avr64dd14        30
+#define vbu_avr64dd20        30
 #define vbu_avr64da28        41
+#define vbu_avr64da28s       41
 #define vbu_avr64db28        42
 #define vbu_avr64dd28        36
 #define vbu_avr64du28        34
 #define vbu_avr64ea28        43
 #define vbu_avr64da32        41
+#define vbu_avr64da32s       41
 #define vbu_avr64db32        44
 #define vbu_avr64dd32        36
 #define vbu_avr64du32        34
 #define vbu_avr64ea32        43
 #define vbu_avr64da48        58
+#define vbu_avr64da48s       58
 #define vbu_avr64db48        59
 #define vbu_avr64ea48        45
 #define vbu_avr64da64        64
+#define vbu_avr64da64s       64
 #define vbu_avr64db64        65
 #define vbu_avr128da28       41
 #define vbu_avr128da28s      41
@@ -1714,25 +1744,33 @@ extern const char * const    vtab_avr16eb32[31];
 #define vtab_avr16eb20       vtab_avr16eb32
 #define vtab_avr16eb14       vtab_avr16eb32
 
+extern const char * const    vtab_avr32sd20[50];
+
+extern const char * const    vtab_avr32sd28[54];
+
 extern const char * const    vtab_avr32eb32[31];
 #define vtab_avr32eb28       vtab_avr32eb32
 #define vtab_avr32eb20       vtab_avr32eb32
 #define vtab_avr32eb14       vtab_avr32eb32
 
-extern const char * const    vtab_avr32da48[61];
+extern const char * const    vtab_avr32sd32[56];
+
+extern const char * const    vtab_avr32da48s[61];
+#define vtab_avr32da48       vtab_avr32da48s
+
+extern const char * const    vtab_avr64dd20[36];
+#define vtab_avr64dd14       vtab_avr64dd20
+#define vtab_avr32dd20       vtab_avr64dd20
+#define vtab_avr32dd14       vtab_avr64dd20
+#define vtab_avr16dd20       vtab_avr64dd20
+#define vtab_avr16dd14       vtab_avr64dd20
 
 extern const char * const    vtab_avr64dd32[36];
 #define vtab_avr64dd28       vtab_avr64dd32
-#define vtab_avr64dd20       vtab_avr64dd32
-#define vtab_avr64dd14       vtab_avr64dd32
 #define vtab_avr32dd32       vtab_avr64dd32
 #define vtab_avr32dd28       vtab_avr64dd32
-#define vtab_avr32dd20       vtab_avr64dd32
-#define vtab_avr32dd14       vtab_avr64dd32
 #define vtab_avr16dd32       vtab_avr64dd32
 #define vtab_avr16dd28       vtab_avr64dd32
-#define vtab_avr16dd20       vtab_avr64dd32
-#define vtab_avr16dd14       vtab_avr64dd32
 
 extern const char * const    vtab_avr64du32[34];
 #define vtab_avr64du28       vtab_avr64du32
@@ -1758,7 +1796,9 @@ extern const char * const    vtab_avr64ea48[45];
 
 extern const char * const    vtab_avr128da28s[41];
 #define vtab_avr128da28      vtab_avr128da28s
+#define vtab_avr64da28s      vtab_avr128da28s
 #define vtab_avr64da28       vtab_avr128da28s
+#define vtab_avr32da28s      vtab_avr128da28s
 #define vtab_avr32da28       vtab_avr128da28s
 
 extern const char * const    vtab_avr128db28[42];
@@ -1767,7 +1807,9 @@ extern const char * const    vtab_avr128db28[42];
 
 extern const char * const    vtab_avr128da32s[44];
 #define vtab_avr128da32      vtab_avr128da32s
+#define vtab_avr64da32s      vtab_avr128da32s
 #define vtab_avr64da32       vtab_avr128da32s
+#define vtab_avr32da32s      vtab_avr128da32s
 #define vtab_avr32da32       vtab_avr128da32s
 
 extern const char * const    vtab_avr128db32[44];
@@ -1776,6 +1818,7 @@ extern const char * const    vtab_avr128db32[44];
 
 extern const char * const    vtab_avr128da48s[58];
 #define vtab_avr128da48      vtab_avr128da48s
+#define vtab_avr64da48s      vtab_avr128da48s
 #define vtab_avr64da48       vtab_avr128da48s
 
 extern const char * const    vtab_avr128db48[61];
@@ -1784,6 +1827,7 @@ extern const char * const    vtab_avr128db48[61];
 
 extern const char * const    vtab_avr128da64s[64];
 #define vtab_avr128da64      vtab_avr128da64s
+#define vtab_avr64da64s      vtab_avr128da64s
 #define vtab_avr64da64       vtab_avr128da64s
 
 extern const char * const    vtab_avr128db64[65];
@@ -2265,6 +2309,10 @@ extern const Configitem    cfgtab_avr16eb14[18];
 #define cfgtab_avr32eb28     cfgtab_avr16eb14
 #define cfgtab_avr32eb32     cfgtab_avr16eb14
 
+extern const Configitem    cfgtab_avr32sd20[18];
+#define cfgtab_avr32sd28     cfgtab_avr32sd20
+#define cfgtab_avr32sd32     cfgtab_avr32sd20
+
 extern const Configitem    cfgtab_avr32da28[15];
 #define cfgtab_avr32da32     cfgtab_avr32da28
 #define cfgtab_avr32da48     cfgtab_avr32da28
@@ -2277,6 +2325,18 @@ extern const Configitem    cfgtab_avr32da28[15];
 #define cfgtab_avr128da48    cfgtab_avr32da28
 #define cfgtab_avr128da64    cfgtab_avr32da28
 
+extern const Configitem    cfgtab_avr32da28s[17];
+#define cfgtab_avr32da32s    cfgtab_avr32da28s
+#define cfgtab_avr32da48s    cfgtab_avr32da28s
+#define cfgtab_avr64da28s    cfgtab_avr32da28s
+#define cfgtab_avr64da32s    cfgtab_avr32da28s
+#define cfgtab_avr64da48s    cfgtab_avr32da28s
+#define cfgtab_avr64da64s    cfgtab_avr32da28s
+#define cfgtab_avr128da28s   cfgtab_avr32da28s
+#define cfgtab_avr128da32s   cfgtab_avr32da28s
+#define cfgtab_avr128da48s   cfgtab_avr32da28s
+#define cfgtab_avr128da64s   cfgtab_avr32da28s
+
 extern const Configitem    cfgtab_avr32db28[16];
 #define cfgtab_avr32db32     cfgtab_avr32db28
 #define cfgtab_avr32db48     cfgtab_avr32db28
@@ -2288,11 +2348,6 @@ extern const Configitem    cfgtab_avr32db28[16];
 #define cfgtab_avr128db32    cfgtab_avr32db28
 #define cfgtab_avr128db48    cfgtab_avr32db28
 #define cfgtab_avr128db64    cfgtab_avr32db28
-
-extern const Configitem    cfgtab_avr128da28s[17];
-#define cfgtab_avr128da32s   cfgtab_avr128da28s
-#define cfgtab_avr128da48s   cfgtab_avr128da28s
-#define cfgtab_avr128da64s   cfgtab_avr128da28s
 
 // I/O Register files
 
@@ -2363,18 +2418,9 @@ extern const Register_file rgftab_attiny1624[307];
 #define rgftab_attiny824     rgftab_attiny1624
 #define rgftab_attiny3224    rgftab_attiny1624
 
-extern const Register_file rgftab_avr32dd14[401];
+extern const Register_file rgftab_avr32dd14[390];
 #define rgftab_avr16dd14     rgftab_avr32dd14
-#define rgftab_avr16dd20     rgftab_avr32dd14
-#define rgftab_avr16dd28     rgftab_avr32dd14
-#define rgftab_avr16dd32     rgftab_avr32dd14
-#define rgftab_avr32dd20     rgftab_avr32dd14
-#define rgftab_avr32dd28     rgftab_avr32dd14
-#define rgftab_avr32dd32     rgftab_avr32dd14
 #define rgftab_avr64dd14     rgftab_avr32dd14
-#define rgftab_avr64dd20     rgftab_avr32dd14
-#define rgftab_avr64dd28     rgftab_avr32dd14
-#define rgftab_avr64dd32     rgftab_avr32dd14
 
 extern const Register_file rgftab_avr64ea48[502];
 #define rgftab_avr16ea48     rgftab_avr64ea48
@@ -2749,13 +2795,17 @@ extern const Register_file rgftab_atmega3208[406];
 extern const Register_file rgftab_atmega3209[432];
 #define rgftab_atmega4809    rgftab_atmega3209
 
-extern const Register_file rgftab_avr16du14[371];
+extern const Register_file rgftab_avr16du14[370];
 #define rgftab_avr32du14     rgftab_avr16du14
 
-extern const Register_file rgftab_avr16eb14[391];
+extern const Register_file rgftab_avr16eb14[390];
 #define rgftab_avr32eb14     rgftab_avr16eb14
 
-extern const Register_file rgftab_avr16du20[372];
+extern const Register_file rgftab_avr16dd20[391];
+#define rgftab_avr32dd20     rgftab_avr16dd20
+#define rgftab_avr64dd20     rgftab_avr16dd20
+
+extern const Register_file rgftab_avr16du20[371];
 #define rgftab_avr16du28     rgftab_avr16du20
 #define rgftab_avr16du32     rgftab_avr16du20
 #define rgftab_avr32du20     rgftab_avr16du20
@@ -2764,12 +2814,19 @@ extern const Register_file rgftab_avr16du20[372];
 #define rgftab_avr64du28     rgftab_avr16du20
 #define rgftab_avr64du32     rgftab_avr16du20
 
-extern const Register_file rgftab_avr16eb20[393];
+extern const Register_file rgftab_avr16eb20[391];
 #define rgftab_avr16eb28     rgftab_avr16eb20
 #define rgftab_avr16eb32     rgftab_avr16eb20
 #define rgftab_avr32eb20     rgftab_avr16eb20
 #define rgftab_avr32eb28     rgftab_avr16eb20
 #define rgftab_avr32eb32     rgftab_avr16eb20
+
+extern const Register_file rgftab_avr16dd28[401];
+#define rgftab_avr16dd32     rgftab_avr16dd28
+#define rgftab_avr32dd28     rgftab_avr16dd28
+#define rgftab_avr32dd32     rgftab_avr16dd28
+#define rgftab_avr64dd28     rgftab_avr16dd28
+#define rgftab_avr64dd32     rgftab_avr16dd28
 
 extern const Register_file rgftab_avr16ea28[444];
 #define rgftab_avr16ea32     rgftab_avr16ea28
@@ -2778,42 +2835,61 @@ extern const Register_file rgftab_avr16ea28[444];
 #define rgftab_avr64ea28     rgftab_avr16ea28
 #define rgftab_avr64ea32     rgftab_avr16ea28
 
-extern const Register_file rgftab_avr32da28[432];
+extern const Register_file rgftab_avr32sd20[543];
 
-extern const Register_file rgftab_avr32db28[462];
+extern const Register_file rgftab_avr32da28[432];
+#define rgftab_avr32da28s    rgftab_avr32da28
+#define rgftab_avr64da28     rgftab_avr32da28
+#define rgftab_avr64da28s    rgftab_avr32da28
+
+extern const Register_file rgftab_avr32db28[461];
 #define rgftab_avr64db28     rgftab_avr32db28
-#define rgftab_avr128db28    rgftab_avr32db28
+
+extern const Register_file rgftab_avr32sd28[562];
 
 extern const Register_file rgftab_avr32da32[447];
+#define rgftab_avr32da32s    rgftab_avr32da32
+#define rgftab_avr64da32     rgftab_avr32da32
+#define rgftab_avr64da32s    rgftab_avr32da32
 
-extern const Register_file rgftab_avr32db32[477];
+extern const Register_file rgftab_avr32db32[476];
 #define rgftab_avr64db32     rgftab_avr32db32
-#define rgftab_avr128db32    rgftab_avr32db32
+
+extern const Register_file rgftab_avr32sd32[577];
 
 extern const Register_file rgftab_avr32da48[610];
+#define rgftab_avr32da48s    rgftab_avr32da48
 
-extern const Register_file rgftab_avr32db48[643];
+extern const Register_file rgftab_avr32db48[642];
 #define rgftab_avr64db48     rgftab_avr32db48
-#define rgftab_avr128db48    rgftab_avr32db48
 
-extern const Register_file rgftab_avr64da28[433];
-#define rgftab_avr128da28    rgftab_avr64da28
-#define rgftab_avr128da28s   rgftab_avr64da28
+extern const Register_file rgftab_avr64da48[600];
+#define rgftab_avr64da48s    rgftab_avr64da48
 
-extern const Register_file rgftab_avr64da32[448];
-#define rgftab_avr128da32    rgftab_avr64da32
-#define rgftab_avr128da32s   rgftab_avr64da32
+extern const Register_file rgftab_avr64da64[658];
+#define rgftab_avr64da64s    rgftab_avr64da64
 
-extern const Register_file rgftab_avr64da48[601];
-#define rgftab_avr128da48    rgftab_avr64da48
-#define rgftab_avr128da48s   rgftab_avr64da48
+extern const Register_file rgftab_avr64db64[697];
 
-extern const Register_file rgftab_avr64da64[659];
-#define rgftab_avr128da64    rgftab_avr64da64
-#define rgftab_avr128da64s   rgftab_avr64da64
+extern const Register_file rgftab_avr128da28[433];
+#define rgftab_avr128da28s   rgftab_avr128da28
 
-extern const Register_file rgftab_avr64db64[698];
-#define rgftab_avr128db64    rgftab_avr64db64
+extern const Register_file rgftab_avr128db28[462];
+
+extern const Register_file rgftab_avr128da32[448];
+#define rgftab_avr128da32s   rgftab_avr128da32
+
+extern const Register_file rgftab_avr128db32[477];
+
+extern const Register_file rgftab_avr128da48[601];
+#define rgftab_avr128da48s   rgftab_avr128da48
+
+extern const Register_file rgftab_avr128db48[643];
+
+extern const Register_file rgftab_avr128da64[659];
+#define rgftab_avr128da64s   rgftab_avr128da64
+
+extern const Register_file rgftab_avr128db64[698];
 
 int upidxmcuid(int mcuid);
 int upidxsig(const uint8_t *sigs);

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -11,8 +11,8 @@
  * Published under GNU General Public License, version 3 (GPL-3.0)
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
- * v 1.42
- * 28.02.2025
+ * v 1.43
+ * 11.03.2025
  *
  */
 
@@ -50,6 +50,16 @@ typedef struct {
   const char *caption;          // Expanded semantic name
 } Register_file;
 
+typedef struct {
+  char letter;                  // Port letter (one of 16 possible: A-H, J-N, P-R)
+  uint16_t diraddr;             // Address of port direction register in IO memory
+  uint16_t dirmask;             // Used bits of port direction register
+  uint16_t outaddr;             // Address of port output register in IO memory
+  uint16_t outmask;             // Used bits of port output register
+  uint16_t inaddr;              // Address of port input register in IO memory
+  uint16_t inmask;              // Used bits of port input register
+} Port_bits;
+
 typedef struct {                // Value of -1 typically means unknown
   const char *name;             // Name of part
   uint16_t mcuid;               // ID of MCU in 0..2039
@@ -78,6 +88,8 @@ typedef struct {                // Value of -1 typically means unknown
   uint8_t has_u2x;              // 1 = 2x speed possible (8 samples), 0 = 1x speed only
   uint8_t brr_nbits;            // Number of baud rate divisor bits (integer part)
   uint8_t brr_nfraction;        // Number of bits for fractional part of baud rate divisor
+  uint8_t nports;               // Number of port registers (one per letter A-H, J-N, P-R)
+  const Port_bits *ports;       // Port list
 } Avrintel;
 
 #define F_AVR8L               1 // TPI programming, ATtiny(4|5|9|10|20|40|102|104)
@@ -1833,56 +1845,57 @@ extern const char * const    vtab_avr128da64s[64];
 extern const char * const    vtab_avr128db64[65];
 #define vtab_avr64db64       vtab_avr128db64
 
+
 // Configuration table names
 
-extern const Configitem    cfgtab_atmega328[14];
+extern const Configitem      cfgtab_atmega328[14];
 #define cfgtab_atmega328p    cfgtab_atmega328
 #define cfgtab_ata6614q      cfgtab_atmega328
 
-extern const Configitem    cfgtab_atmega16m1[17];
+extern const Configitem      cfgtab_atmega16m1[17];
 
-extern const Configitem    cfgtab_atmega16hva2[9];
+extern const Configitem      cfgtab_atmega16hva2[9];
 
-extern const Configitem    cfgtab_atmega32hvbrevb[12];
+extern const Configitem      cfgtab_atmega32hvbrevb[12];
 
-extern const Configitem    cfgtab_atmega64hve[13];
+extern const Configitem      cfgtab_atmega64hve[13];
 
-extern const Configitem    cfgtab_atmega328pb[15];
+extern const Configitem      cfgtab_atmega328pb[15];
 
-extern const Configitem    cfgtab_atmega8515[13];
+extern const Configitem      cfgtab_atmega8515[13];
 
-extern const Configitem    cfgtab_attiny102[5];
+extern const Configitem      cfgtab_attiny102[5];
 #define cfgtab_attiny104     cfgtab_attiny102
 
-extern const Configitem    cfgtab_attiny28[3];
+extern const Configitem      cfgtab_attiny28[3];
 
-extern const Configitem    cfgtab_attiny441[14];
+extern const Configitem      cfgtab_attiny441[14];
 #define cfgtab_attiny841     cfgtab_attiny441
 
-extern const Configitem    cfgtab_at90pwm2[18];
+extern const Configitem      cfgtab_at90pwm2[18];
 #define cfgtab_at90pwm3      cfgtab_at90pwm2
 
-extern const Configitem    cfgtab_at90pwm81[19];
+extern const Configitem      cfgtab_at90pwm81[19];
 #define cfgtab_at90pwm161    cfgtab_at90pwm81
 
-extern const Configitem    cfgtab_at90can128[15];
+extern const Configitem      cfgtab_at90can128[15];
 
-extern const Configitem    cfgtab_at90usb162[15];
+extern const Configitem      cfgtab_at90usb162[15];
 #define cfgtab_atmega16u2    cfgtab_at90usb162
 #define cfgtab_at90usb82     cfgtab_at90usb162
 
-extern const Configitem    cfgtab_at90s1200[3];
+extern const Configitem      cfgtab_at90s1200[3];
 
-extern const Configitem    cfgtab_at90s2313[3];
+extern const Configitem      cfgtab_at90s2313[3];
 #define cfgtab_at90s4414     cfgtab_at90s2313
 #define cfgtab_at90s4434     cfgtab_at90s2313
 #define cfgtab_at90s8515     cfgtab_at90s2313
 #define cfgtab_at90s8535     cfgtab_at90s2313
 
-extern const Configitem    cfgtab_ata5700m322[9];
+extern const Configitem      cfgtab_ata5700m322[9];
 #define cfgtab_ata5702m322   cfgtab_ata5700m322
 
-extern const Configitem    cfgtab_ata5781[11];
+extern const Configitem      cfgtab_ata5781[11];
 #define cfgtab_ata5782       cfgtab_ata5781
 #define cfgtab_ata5783       cfgtab_ata5781
 #define cfgtab_ata5831       cfgtab_ata5781
@@ -1893,17 +1906,17 @@ extern const Configitem    cfgtab_ata5781[11];
 #define cfgtab_ata8510       cfgtab_ata5781
 #define cfgtab_ata8515       cfgtab_ata5781
 
-extern const Configitem    cfgtab_ata5790[11];
+extern const Configitem      cfgtab_ata5790[11];
 #define cfgtab_ata5791       cfgtab_ata5790
 
-extern const Configitem    cfgtab_ata6285[17];
+extern const Configitem      cfgtab_ata6285[17];
 #define cfgtab_ata6286       cfgtab_ata6285
 
-extern const Configitem    cfgtab_atxmega16e5[17];
+extern const Configitem      cfgtab_atxmega16e5[17];
 #define cfgtab_atxmega8e5    cfgtab_atxmega16e5
 #define cfgtab_atxmega32e5   cfgtab_atxmega16e5
 
-extern const Configitem    cfgtab_atxmega128a3[16];
+extern const Configitem      cfgtab_atxmega128a3[16];
 #define cfgtab_atxmega64a1   cfgtab_atxmega128a3
 #define cfgtab_atxmega64a3   cfgtab_atxmega128a3
 #define cfgtab_atxmega128a1  cfgtab_atxmega128a3
@@ -1912,7 +1925,7 @@ extern const Configitem    cfgtab_atxmega128a3[16];
 #define cfgtab_atxmega256a3  cfgtab_atxmega128a3
 #define cfgtab_atxmega256a3b cfgtab_atxmega128a3
 
-extern const Configitem    cfgtab_atxmega128a3u[17];
+extern const Configitem      cfgtab_atxmega128a3u[17];
 #define cfgtab_atxmega16a4u  cfgtab_atxmega128a3u
 #define cfgtab_atxmega32a4u  cfgtab_atxmega128a3u
 #define cfgtab_atxmega64a1u  cfgtab_atxmega128a3u
@@ -1924,7 +1937,7 @@ extern const Configitem    cfgtab_atxmega128a3u[17];
 #define cfgtab_atxmega256a3bu cfgtab_atxmega128a3u
 #define cfgtab_atxmega256a3u cfgtab_atxmega128a3u
 
-extern const Configitem    cfgtab_attiny204[23];
+extern const Configitem      cfgtab_attiny204[23];
 #define cfgtab_attiny202     cfgtab_attiny204
 #define cfgtab_attiny212     cfgtab_attiny204
 #define cfgtab_attiny214     cfgtab_attiny204
@@ -1944,7 +1957,7 @@ extern const Configitem    cfgtab_attiny204[23];
 #define cfgtab_attiny3216    cfgtab_attiny204
 #define cfgtab_attiny3217    cfgtab_attiny204
 
-extern const Configitem    cfgtab_attiny1624[16];
+extern const Configitem      cfgtab_attiny1624[16];
 #define cfgtab_attiny424     cfgtab_attiny1624
 #define cfgtab_attiny426     cfgtab_attiny1624
 #define cfgtab_attiny427     cfgtab_attiny1624
@@ -1957,7 +1970,7 @@ extern const Configitem    cfgtab_attiny1624[16];
 #define cfgtab_attiny3226    cfgtab_attiny1624
 #define cfgtab_attiny3227    cfgtab_attiny1624
 
-extern const Configitem    cfgtab_avr32dd14[17];
+extern const Configitem      cfgtab_avr32dd14[17];
 #define cfgtab_avr16dd14     cfgtab_avr32dd14
 #define cfgtab_avr16dd20     cfgtab_avr32dd14
 #define cfgtab_avr16dd28     cfgtab_avr32dd14
@@ -1970,7 +1983,7 @@ extern const Configitem    cfgtab_avr32dd14[17];
 #define cfgtab_avr64dd28     cfgtab_avr32dd14
 #define cfgtab_avr64dd32     cfgtab_avr32dd14
 
-extern const Configitem    cfgtab_avr64ea48[16];
+extern const Configitem      cfgtab_avr64ea48[16];
 #define cfgtab_avr16ea28     cfgtab_avr64ea48
 #define cfgtab_avr16ea32     cfgtab_avr64ea48
 #define cfgtab_avr16ea48     cfgtab_avr64ea48
@@ -1980,48 +1993,48 @@ extern const Configitem    cfgtab_avr64ea48[16];
 #define cfgtab_avr64ea28     cfgtab_avr64ea48
 #define cfgtab_avr64ea32     cfgtab_avr64ea48
 
-extern const Configitem    cfgtab_atmega103comp[15];
+extern const Configitem      cfgtab_atmega103comp[15];
 
-extern const Configitem    cfgtab_at90scr100h[13];
+extern const Configitem      cfgtab_at90scr100h[13];
 #define cfgtab_at90scr100    cfgtab_at90scr100h
 
-extern const Configitem    cfgtab_atmega161comp[15];
+extern const Configitem      cfgtab_atmega161comp[15];
 
-extern const Configitem    cfgtab_at90s8535comp[13];
+extern const Configitem      cfgtab_at90s8535comp[13];
 
-extern const Configitem    cfgtab_attiny4[4];
+extern const Configitem      cfgtab_attiny4[4];
 #define cfgtab_attiny5       cfgtab_attiny4
 #define cfgtab_attiny9       cfgtab_attiny4
 #define cfgtab_attiny10      cfgtab_attiny4
 
-extern const Configitem    cfgtab_attiny20[5];
+extern const Configitem      cfgtab_attiny20[5];
 #define cfgtab_attiny40      cfgtab_attiny20
 
-extern const Configitem    cfgtab_attiny11[4];
+extern const Configitem      cfgtab_attiny11[4];
 
-extern const Configitem    cfgtab_attiny12[6];
+extern const Configitem      cfgtab_attiny12[6];
 
-extern const Configitem    cfgtab_attiny13[10];
+extern const Configitem      cfgtab_attiny13[10];
 #define cfgtab_attiny13a     cfgtab_attiny13
 
-extern const Configitem    cfgtab_attiny15[6];
+extern const Configitem      cfgtab_attiny15[6];
 
-extern const Configitem    cfgtab_attiny22[3];
+extern const Configitem      cfgtab_attiny22[3];
 
-extern const Configitem    cfgtab_attiny24[11];
+extern const Configitem      cfgtab_attiny24[11];
 #define cfgtab_attiny24a     cfgtab_attiny24
 #define cfgtab_attiny44      cfgtab_attiny24
 #define cfgtab_attiny44a     cfgtab_attiny24
 #define cfgtab_attiny84      cfgtab_attiny24
 #define cfgtab_attiny84a     cfgtab_attiny24
 
-extern const Configitem    cfgtab_attiny25[11];
+extern const Configitem      cfgtab_attiny25[11];
 #define cfgtab_attiny45      cfgtab_attiny25
 #define cfgtab_attiny85      cfgtab_attiny25
 
-extern const Configitem    cfgtab_attiny26[8];
+extern const Configitem      cfgtab_attiny26[8];
 
-extern const Configitem    cfgtab_attiny43u[11];
+extern const Configitem      cfgtab_attiny43u[11];
 #define cfgtab_attiny261     cfgtab_attiny43u
 #define cfgtab_attiny261a    cfgtab_attiny43u
 #define cfgtab_attiny461     cfgtab_attiny43u
@@ -2029,10 +2042,10 @@ extern const Configitem    cfgtab_attiny43u[11];
 #define cfgtab_attiny861     cfgtab_attiny43u
 #define cfgtab_attiny861a    cfgtab_attiny43u
 
-extern const Configitem    cfgtab_attiny48[11];
+extern const Configitem      cfgtab_attiny48[11];
 #define cfgtab_attiny88      cfgtab_attiny48
 
-extern const Configitem    cfgtab_attiny87[11];
+extern const Configitem      cfgtab_attiny87[11];
 #define cfgtab_attiny167     cfgtab_attiny87
 #define cfgtab_ata5272       cfgtab_attiny87
 #define cfgtab_ata5505       cfgtab_attiny87
@@ -2040,96 +2053,96 @@ extern const Configitem    cfgtab_attiny87[11];
 #define cfgtab_ata6617c      cfgtab_attiny87
 #define cfgtab_ata664251     cfgtab_attiny87
 
-extern const Configitem    cfgtab_attiny828[16];
+extern const Configitem      cfgtab_attiny828[16];
 #define cfgtab_attiny828r    cfgtab_attiny828
 
-extern const Configitem    cfgtab_attiny1634[13];
+extern const Configitem      cfgtab_attiny1634[13];
 #define cfgtab_attiny1634r   cfgtab_attiny1634
 
-extern const Configitem    cfgtab_attiny2313[11];
+extern const Configitem      cfgtab_attiny2313[11];
 
-extern const Configitem    cfgtab_attiny2313a[11];
+extern const Configitem      cfgtab_attiny2313a[11];
 #define cfgtab_attiny4313    cfgtab_attiny2313a
 
-extern const Configitem    cfgtab_atmega8[13];
+extern const Configitem      cfgtab_atmega8[13];
 #define cfgtab_atmega8a      cfgtab_atmega8
 
-extern const Configitem    cfgtab_atmega8hva[7];
+extern const Configitem      cfgtab_atmega8hva[7];
 #define cfgtab_atmega16hva   cfgtab_atmega8hva
 
-extern const Configitem    cfgtab_atmega8u2[15];
+extern const Configitem      cfgtab_atmega8u2[15];
 
-extern const Configitem    cfgtab_atmega16[13];
+extern const Configitem      cfgtab_atmega16[13];
 #define cfgtab_atmega16a     cfgtab_atmega16
 
-extern const Configitem    cfgtab_atmega16hvb[12];
+extern const Configitem      cfgtab_atmega16hvb[12];
 
-extern const Configitem    cfgtab_atmega16hvbrevb[12];
+extern const Configitem      cfgtab_atmega16hvbrevb[12];
 
-extern const Configitem    cfgtab_atmega16u4[15];
+extern const Configitem      cfgtab_atmega16u4[15];
 
-extern const Configitem    cfgtab_atmega32[13];
+extern const Configitem      cfgtab_atmega32[13];
 #define cfgtab_atmega32a     cfgtab_atmega32
 
-extern const Configitem    cfgtab_atmega32hvb[12];
+extern const Configitem      cfgtab_atmega32hvb[12];
 
-extern const Configitem    cfgtab_atmega32c1[17];
+extern const Configitem      cfgtab_atmega32c1[17];
 #define cfgtab_atmega32m1    cfgtab_atmega32c1
 
-extern const Configitem    cfgtab_atmega32u2[15];
+extern const Configitem      cfgtab_atmega32u2[15];
 
-extern const Configitem    cfgtab_atmega32u4[15];
+extern const Configitem      cfgtab_atmega32u4[15];
 
-extern const Configitem    cfgtab_atmega32u6[15];
+extern const Configitem      cfgtab_atmega32u6[15];
 
-extern const Configitem    cfgtab_atmega48[11];
+extern const Configitem      cfgtab_atmega48[11];
 #define cfgtab_atmega48a     cfgtab_atmega48
 #define cfgtab_atmega48p     cfgtab_atmega48
 #define cfgtab_atmega48pa    cfgtab_atmega48
 
-extern const Configitem    cfgtab_atmega48pb[11];
+extern const Configitem      cfgtab_atmega48pb[11];
 
-extern const Configitem    cfgtab_atmega64[15];
+extern const Configitem      cfgtab_atmega64[15];
 #define cfgtab_atmega64a     cfgtab_atmega64
 
-extern const Configitem    cfgtab_atmega64c1[17];
+extern const Configitem      cfgtab_atmega64c1[17];
 #define cfgtab_atmega64m1    cfgtab_atmega64c1
 
-extern const Configitem    cfgtab_atmega64hve2[13];
+extern const Configitem      cfgtab_atmega64hve2[13];
 #define cfgtab_atmega32hve2  cfgtab_atmega64hve2
 
-extern const Configitem    cfgtab_atmega64rfr2[14];
+extern const Configitem      cfgtab_atmega64rfr2[14];
 #define cfgtab_atmega644rfr2 cfgtab_atmega64rfr2
 
-extern const Configitem    cfgtab_atmega88[14];
+extern const Configitem      cfgtab_atmega88[14];
 #define cfgtab_atmega88a     cfgtab_atmega88
 #define cfgtab_atmega88p     cfgtab_atmega88
 #define cfgtab_atmega88pa    cfgtab_atmega88
 #define cfgtab_ata6612c      cfgtab_atmega88
 
-extern const Configitem    cfgtab_atmega88pb[14];
+extern const Configitem      cfgtab_atmega88pb[14];
 
-extern const Configitem    cfgtab_atmega103[4];
+extern const Configitem      cfgtab_atmega103[4];
 
-extern const Configitem    cfgtab_atmega128[15];
+extern const Configitem      cfgtab_atmega128[15];
 #define cfgtab_atmega128a    cfgtab_atmega128
 
-extern const Configitem    cfgtab_atmega128rfa1[14];
+extern const Configitem      cfgtab_atmega128rfa1[14];
 
-extern const Configitem    cfgtab_atmega128rfr2[14];
+extern const Configitem      cfgtab_atmega128rfr2[14];
 #define cfgtab_atmega1284rfr2 cfgtab_atmega128rfr2
 
-extern const Configitem    cfgtab_atmega161[7];
+extern const Configitem      cfgtab_atmega161[7];
 
-extern const Configitem    cfgtab_atmega162[15];
+extern const Configitem      cfgtab_atmega162[15];
 
-extern const Configitem    cfgtab_atmega163[9];
+extern const Configitem      cfgtab_atmega163[9];
 
-extern const Configitem    cfgtab_atmega164a[14];
+extern const Configitem      cfgtab_atmega164a[14];
 #define cfgtab_atmega164p    cfgtab_atmega164a
 #define cfgtab_atmega164pa   cfgtab_atmega164a
 
-extern const Configitem    cfgtab_atmega165[15];
+extern const Configitem      cfgtab_atmega165[15];
 #define cfgtab_atmega165a    cfgtab_atmega165
 #define cfgtab_atmega165p    cfgtab_atmega165
 #define cfgtab_atmega165pa   cfgtab_atmega165
@@ -2138,26 +2151,26 @@ extern const Configitem    cfgtab_atmega165[15];
 #define cfgtab_atmega169p    cfgtab_atmega165
 #define cfgtab_atmega169pa   cfgtab_atmega165
 
-extern const Configitem    cfgtab_atmega168[14];
+extern const Configitem      cfgtab_atmega168[14];
 #define cfgtab_atmega168a    cfgtab_atmega168
 #define cfgtab_atmega168p    cfgtab_atmega168
 #define cfgtab_atmega168pa   cfgtab_atmega168
 #define cfgtab_ata6613c      cfgtab_atmega168
 
-extern const Configitem    cfgtab_atmega168pb[14];
+extern const Configitem      cfgtab_atmega168pb[14];
 
-extern const Configitem    cfgtab_atmega256rfr2[14];
+extern const Configitem      cfgtab_atmega256rfr2[14];
 #define cfgtab_atmega2564rfr2 cfgtab_atmega256rfr2
 
-extern const Configitem    cfgtab_atmega323[12];
+extern const Configitem      cfgtab_atmega323[12];
 
-extern const Configitem    cfgtab_atmega324a[14];
+extern const Configitem      cfgtab_atmega324a[14];
 #define cfgtab_atmega324p    cfgtab_atmega324a
 #define cfgtab_atmega324pa   cfgtab_atmega324a
 
-extern const Configitem    cfgtab_atmega324pb[15];
+extern const Configitem      cfgtab_atmega324pb[15];
 
-extern const Configitem    cfgtab_atmega325[15];
+extern const Configitem      cfgtab_atmega325[15];
 #define cfgtab_atmega325a    cfgtab_atmega325
 #define cfgtab_atmega325p    cfgtab_atmega325
 #define cfgtab_atmega325pa   cfgtab_atmega325
@@ -2174,16 +2187,16 @@ extern const Configitem    cfgtab_atmega325[15];
 #define cfgtab_atmega3290p   cfgtab_atmega325
 #define cfgtab_atmega3290pa  cfgtab_atmega325
 
-extern const Configitem    cfgtab_atmega406[10];
+extern const Configitem      cfgtab_atmega406[10];
 
-extern const Configitem    cfgtab_atmega640[14];
+extern const Configitem      cfgtab_atmega640[14];
 
-extern const Configitem    cfgtab_atmega644[14];
+extern const Configitem      cfgtab_atmega644[14];
 #define cfgtab_atmega644a    cfgtab_atmega644
 #define cfgtab_atmega644p    cfgtab_atmega644
 #define cfgtab_atmega644pa   cfgtab_atmega644
 
-extern const Configitem    cfgtab_atmega645[15];
+extern const Configitem      cfgtab_atmega645[15];
 #define cfgtab_atmega645a    cfgtab_atmega645
 #define cfgtab_atmega645p    cfgtab_atmega645
 #define cfgtab_atmega649     cfgtab_atmega645
@@ -2196,58 +2209,58 @@ extern const Configitem    cfgtab_atmega645[15];
 #define cfgtab_atmega6490a   cfgtab_atmega645
 #define cfgtab_atmega6490p   cfgtab_atmega645
 
-extern const Configitem    cfgtab_atmega1280[14];
+extern const Configitem      cfgtab_atmega1280[14];
 #define cfgtab_atmega1281    cfgtab_atmega1280
 
-extern const Configitem    cfgtab_atmega1284[14];
+extern const Configitem      cfgtab_atmega1284[14];
 #define cfgtab_atmega1284p   cfgtab_atmega1284
 
-extern const Configitem    cfgtab_atmega2560[14];
+extern const Configitem      cfgtab_atmega2560[14];
 #define cfgtab_atmega2561    cfgtab_atmega2560
 
-extern const Configitem    cfgtab_atmega8535[13];
+extern const Configitem      cfgtab_atmega8535[13];
 
-extern const Configitem    cfgtab_at90pwm1[17];
+extern const Configitem      cfgtab_at90pwm1[17];
 
-extern const Configitem    cfgtab_at90pwm2b[18];
+extern const Configitem      cfgtab_at90pwm2b[18];
 #define cfgtab_at90pwm3b     cfgtab_at90pwm2b
 
-extern const Configitem    cfgtab_at90can32[15];
+extern const Configitem      cfgtab_at90can32[15];
 
-extern const Configitem    cfgtab_at90can64[15];
+extern const Configitem      cfgtab_at90can64[15];
 
-extern const Configitem    cfgtab_at90pwm216[18];
+extern const Configitem      cfgtab_at90pwm216[18];
 
-extern const Configitem    cfgtab_at90pwm316[18];
+extern const Configitem      cfgtab_at90pwm316[18];
 
-extern const Configitem    cfgtab_at90usb646[15];
+extern const Configitem      cfgtab_at90usb646[15];
 #define cfgtab_at90usb647    cfgtab_at90usb646
 
-extern const Configitem    cfgtab_at90usb1286[15];
+extern const Configitem      cfgtab_at90usb1286[15];
 #define cfgtab_at90usb1287   cfgtab_at90usb1286
 
-extern const Configitem    cfgtab_at90s2323[3];
+extern const Configitem      cfgtab_at90s2323[3];
 
-extern const Configitem    cfgtab_at90s2333[5];
+extern const Configitem      cfgtab_at90s2333[5];
 
-extern const Configitem    cfgtab_at90s2343[3];
+extern const Configitem      cfgtab_at90s2343[3];
 
-extern const Configitem    cfgtab_at90s4433[5];
+extern const Configitem      cfgtab_at90s4433[5];
 
-extern const Configitem    cfgtab_at90s8515comp[13];
+extern const Configitem      cfgtab_at90s8515comp[13];
 
-extern const Configitem    cfgtab_ata5787[11];
+extern const Configitem      cfgtab_ata5787[11];
 #define cfgtab_ata5835       cfgtab_ata5787
 
-extern const Configitem    cfgtab_ata5790n[10];
+extern const Configitem      cfgtab_ata5790n[10];
 #define cfgtab_ata5795       cfgtab_ata5790n
 
-extern const Configitem    cfgtab_ata6289[17];
+extern const Configitem      cfgtab_ata6289[17];
 
-extern const Configitem    cfgtab_atxmega16a4[16];
+extern const Configitem      cfgtab_atxmega16a4[16];
 #define cfgtab_atxmega32a4   cfgtab_atxmega16a4
 
-extern const Configitem    cfgtab_atxmega16c4[15];
+extern const Configitem      cfgtab_atxmega16c4[15];
 #define cfgtab_atxmega16d4   cfgtab_atxmega16c4
 #define cfgtab_atxmega32c3   cfgtab_atxmega16c4
 #define cfgtab_atxmega32d3   cfgtab_atxmega16c4
@@ -2266,21 +2279,21 @@ extern const Configitem    cfgtab_atxmega16c4[15];
 #define cfgtab_atxmega384c3  cfgtab_atxmega16c4
 #define cfgtab_atxmega384d3  cfgtab_atxmega16c4
 
-extern const Configitem    cfgtab_atxmega64b1[17];
+extern const Configitem      cfgtab_atxmega64b1[17];
 #define cfgtab_atxmega64b3   cfgtab_atxmega64b1
 #define cfgtab_atxmega128b1  cfgtab_atxmega64b1
 #define cfgtab_atxmega128b3  cfgtab_atxmega64b1
 
-extern const Configitem    cfgtab_attiny416auto[23];
+extern const Configitem      cfgtab_attiny416auto[23];
 
-extern const Configitem    cfgtab_attiny804[15];
+extern const Configitem      cfgtab_attiny804[15];
 #define cfgtab_attiny806     cfgtab_attiny804
 #define cfgtab_attiny807     cfgtab_attiny804
 #define cfgtab_attiny1604    cfgtab_attiny804
 #define cfgtab_attiny1606    cfgtab_attiny804
 #define cfgtab_attiny1607    cfgtab_attiny804
 
-extern const Configitem    cfgtab_atmega808[15];
+extern const Configitem      cfgtab_atmega808[15];
 #define cfgtab_atmega809     cfgtab_atmega808
 #define cfgtab_atmega1608    cfgtab_atmega808
 #define cfgtab_atmega1609    cfgtab_atmega808
@@ -2289,7 +2302,7 @@ extern const Configitem    cfgtab_atmega808[15];
 #define cfgtab_atmega4808    cfgtab_atmega808
 #define cfgtab_atmega4809    cfgtab_atmega808
 
-extern const Configitem    cfgtab_avr16du14[20];
+extern const Configitem      cfgtab_avr16du14[20];
 #define cfgtab_avr16du20     cfgtab_avr16du14
 #define cfgtab_avr16du28     cfgtab_avr16du14
 #define cfgtab_avr16du32     cfgtab_avr16du14
@@ -2300,7 +2313,7 @@ extern const Configitem    cfgtab_avr16du14[20];
 #define cfgtab_avr64du28     cfgtab_avr16du14
 #define cfgtab_avr64du32     cfgtab_avr16du14
 
-extern const Configitem    cfgtab_avr16eb14[18];
+extern const Configitem      cfgtab_avr16eb14[18];
 #define cfgtab_avr16eb20     cfgtab_avr16eb14
 #define cfgtab_avr16eb28     cfgtab_avr16eb14
 #define cfgtab_avr16eb32     cfgtab_avr16eb14
@@ -2309,11 +2322,11 @@ extern const Configitem    cfgtab_avr16eb14[18];
 #define cfgtab_avr32eb28     cfgtab_avr16eb14
 #define cfgtab_avr32eb32     cfgtab_avr16eb14
 
-extern const Configitem    cfgtab_avr32sd20[18];
+extern const Configitem      cfgtab_avr32sd20[18];
 #define cfgtab_avr32sd28     cfgtab_avr32sd20
 #define cfgtab_avr32sd32     cfgtab_avr32sd20
 
-extern const Configitem    cfgtab_avr32da28[15];
+extern const Configitem      cfgtab_avr32da28[15];
 #define cfgtab_avr32da32     cfgtab_avr32da28
 #define cfgtab_avr32da48     cfgtab_avr32da28
 #define cfgtab_avr64da28     cfgtab_avr32da28
@@ -2325,7 +2338,7 @@ extern const Configitem    cfgtab_avr32da28[15];
 #define cfgtab_avr128da48    cfgtab_avr32da28
 #define cfgtab_avr128da64    cfgtab_avr32da28
 
-extern const Configitem    cfgtab_avr32da28s[17];
+extern const Configitem      cfgtab_avr32da28s[17];
 #define cfgtab_avr32da32s    cfgtab_avr32da28s
 #define cfgtab_avr32da48s    cfgtab_avr32da28s
 #define cfgtab_avr64da28s    cfgtab_avr32da28s
@@ -2337,7 +2350,7 @@ extern const Configitem    cfgtab_avr32da28s[17];
 #define cfgtab_avr128da48s   cfgtab_avr32da28s
 #define cfgtab_avr128da64s   cfgtab_avr32da28s
 
-extern const Configitem    cfgtab_avr32db28[16];
+extern const Configitem      cfgtab_avr32db28[16];
 #define cfgtab_avr32db32     cfgtab_avr32db28
 #define cfgtab_avr32db48     cfgtab_avr32db28
 #define cfgtab_avr64db28     cfgtab_avr32db28
@@ -2349,191 +2362,192 @@ extern const Configitem    cfgtab_avr32db28[16];
 #define cfgtab_avr128db48    cfgtab_avr32db28
 #define cfgtab_avr128db64    cfgtab_avr32db28
 
+
 // I/O Register files
 
-extern const Register_file rgftab_atmega328[81];
+extern const Register_file   rgftab_atmega328[81];
 #define rgftab_atmega328p    rgftab_atmega328
 
-extern const Register_file rgftab_atmega16m1[136];
+extern const Register_file   rgftab_atmega16m1[136];
 #define rgftab_atmega32m1    rgftab_atmega16m1
 
-extern const Register_file rgftab_atmega32hvbrevb[91];
+extern const Register_file   rgftab_atmega32hvbrevb[91];
 #define rgftab_atmega16hvb   rgftab_atmega32hvbrevb
 #define rgftab_atmega16hvbrevb rgftab_atmega32hvbrevb
 #define rgftab_atmega32hvb   rgftab_atmega32hvbrevb
 
-extern const Register_file rgftab_atmega328pb[123];
+extern const Register_file   rgftab_atmega328pb[123];
 
-extern const Register_file rgftab_atmega8515[52];
+extern const Register_file   rgftab_atmega8515[52];
 
-extern const Register_file rgftab_attiny102[55];
+extern const Register_file   rgftab_attiny102[55];
 #define rgftab_attiny104     rgftab_attiny102
 
-extern const Register_file rgftab_attiny28[20];
+extern const Register_file   rgftab_attiny28[20];
 
-extern const Register_file rgftab_attiny441[101];
+extern const Register_file   rgftab_attiny441[101];
 #define rgftab_attiny841     rgftab_attiny441
 
-extern const Register_file rgftab_at90pwm81[84];
+extern const Register_file   rgftab_at90pwm81[84];
 
-extern const Register_file rgftab_at90can128[137];
+extern const Register_file   rgftab_at90can128[137];
 #define rgftab_at90can32     rgftab_at90can128
 #define rgftab_at90can64     rgftab_at90can128
 
-extern const Register_file rgftab_at90usb162[92];
+extern const Register_file   rgftab_at90usb162[92];
 #define rgftab_at90usb82     rgftab_at90usb162
 
-extern const Register_file rgftab_ata5700m322[337];
+extern const Register_file   rgftab_ata5700m322[337];
 
-extern const Register_file rgftab_ata5781[262];
+extern const Register_file   rgftab_ata5781[262];
 #define rgftab_ata5782       rgftab_ata5781
 #define rgftab_ata5783       rgftab_ata5781
 #define rgftab_ata8210       rgftab_ata5781
 #define rgftab_ata8215       rgftab_ata5781
 
-extern const Register_file rgftab_ata5790[112];
+extern const Register_file   rgftab_ata5790[112];
 
-extern const Register_file rgftab_ata6285[79];
+extern const Register_file   rgftab_ata6285[79];
 #define rgftab_ata6286       rgftab_ata6285
 
-extern const Register_file rgftab_atxmega16e5[438];
+extern const Register_file   rgftab_atxmega16e5[438];
 #define rgftab_atxmega8e5    rgftab_atxmega16e5
 #define rgftab_atxmega32e5   rgftab_atxmega16e5
 
-extern const Register_file rgftab_atxmega128a3[680];
+extern const Register_file   rgftab_atxmega128a3[680];
 #define rgftab_atxmega64a3   rgftab_atxmega128a3
 #define rgftab_atxmega192a3  rgftab_atxmega128a3
 #define rgftab_atxmega256a3  rgftab_atxmega128a3
 
-extern const Register_file rgftab_atxmega128a3u[792];
+extern const Register_file   rgftab_atxmega128a3u[792];
 #define rgftab_atxmega64a3u  rgftab_atxmega128a3u
 #define rgftab_atxmega192a3u rgftab_atxmega128a3u
 #define rgftab_atxmega256a3u rgftab_atxmega128a3u
 
-extern const Register_file rgftab_attiny204[235];
+extern const Register_file   rgftab_attiny204[235];
 #define rgftab_attiny404     rgftab_attiny204
 
-extern const Register_file rgftab_attiny1624[307];
+extern const Register_file   rgftab_attiny1624[307];
 #define rgftab_attiny424     rgftab_attiny1624
 #define rgftab_attiny824     rgftab_attiny1624
 #define rgftab_attiny3224    rgftab_attiny1624
 
-extern const Register_file rgftab_avr32dd14[390];
+extern const Register_file   rgftab_avr32dd14[390];
 #define rgftab_avr16dd14     rgftab_avr32dd14
 #define rgftab_avr64dd14     rgftab_avr32dd14
 
-extern const Register_file rgftab_avr64ea48[502];
+extern const Register_file   rgftab_avr64ea48[502];
 #define rgftab_avr16ea48     rgftab_avr64ea48
 #define rgftab_avr32ea48     rgftab_avr64ea48
 
-extern const Register_file rgftab_attiny4[36];
+extern const Register_file   rgftab_attiny4[36];
 #define rgftab_attiny9       rgftab_attiny4
 
-extern const Register_file rgftab_attiny5[41];
+extern const Register_file   rgftab_attiny5[41];
 #define rgftab_attiny10      rgftab_attiny5
 
-extern const Register_file rgftab_attiny20[61];
+extern const Register_file   rgftab_attiny20[61];
 
-extern const Register_file rgftab_attiny40[63];
+extern const Register_file   rgftab_attiny40[63];
 
-extern const Register_file rgftab_attiny11[14];
+extern const Register_file   rgftab_attiny11[14];
 
-extern const Register_file rgftab_attiny12[18];
+extern const Register_file   rgftab_attiny12[18];
 
-extern const Register_file rgftab_attiny13[35];
+extern const Register_file   rgftab_attiny13[35];
 
-extern const Register_file rgftab_attiny13a[37];
+extern const Register_file   rgftab_attiny13a[37];
 
-extern const Register_file rgftab_attiny15[28];
+extern const Register_file   rgftab_attiny15[28];
 
-extern const Register_file rgftab_attiny24[55];
+extern const Register_file   rgftab_attiny24[55];
 #define rgftab_attiny24a     rgftab_attiny24
 
-extern const Register_file rgftab_attiny25[55];
+extern const Register_file   rgftab_attiny25[55];
 
-extern const Register_file rgftab_attiny26[37];
+extern const Register_file   rgftab_attiny26[37];
 
-extern const Register_file rgftab_attiny43u[54];
+extern const Register_file   rgftab_attiny43u[54];
 
-extern const Register_file rgftab_attiny44[55];
+extern const Register_file   rgftab_attiny44[55];
 #define rgftab_attiny44a     rgftab_attiny44
 
-extern const Register_file rgftab_attiny45[55];
+extern const Register_file   rgftab_attiny45[55];
 #define rgftab_attiny85      rgftab_attiny45
 
-extern const Register_file rgftab_attiny48[74];
+extern const Register_file   rgftab_attiny48[74];
 
-extern const Register_file rgftab_attiny84[55];
+extern const Register_file   rgftab_attiny84[55];
 #define rgftab_attiny84a     rgftab_attiny84
 
-extern const Register_file rgftab_attiny87[80];
+extern const Register_file   rgftab_attiny87[80];
 #define rgftab_attiny167     rgftab_attiny87
 
-extern const Register_file rgftab_attiny88[74];
+extern const Register_file   rgftab_attiny88[74];
 
-extern const Register_file rgftab_attiny261[63];
+extern const Register_file   rgftab_attiny261[63];
 #define rgftab_attiny261a    rgftab_attiny261
 
-extern const Register_file rgftab_attiny461[63];
+extern const Register_file   rgftab_attiny461[63];
 #define rgftab_attiny461a    rgftab_attiny461
 
-extern const Register_file rgftab_attiny828[94];
+extern const Register_file   rgftab_attiny828[94];
 
-extern const Register_file rgftab_attiny861[63];
+extern const Register_file   rgftab_attiny861[63];
 #define rgftab_attiny861a    rgftab_attiny861
 
-extern const Register_file rgftab_attiny1634[89];
+extern const Register_file   rgftab_attiny1634[89];
 
-extern const Register_file rgftab_attiny2313[54];
+extern const Register_file   rgftab_attiny2313[54];
 
-extern const Register_file rgftab_attiny2313a[58];
+extern const Register_file   rgftab_attiny2313a[58];
 
-extern const Register_file rgftab_attiny4313[58];
+extern const Register_file   rgftab_attiny4313[58];
 
-extern const Register_file rgftab_atmega8[61];
+extern const Register_file   rgftab_atmega8[61];
 #define rgftab_atmega8a      rgftab_atmega8
 
-extern const Register_file rgftab_atmega8hva[74];
+extern const Register_file   rgftab_atmega8hva[74];
 #define rgftab_atmega16hva   rgftab_atmega8hva
 
-extern const Register_file rgftab_atmega8u2[92];
+extern const Register_file   rgftab_atmega8u2[92];
 #define rgftab_atmega16u2    rgftab_atmega8u2
 #define rgftab_atmega32u2    rgftab_atmega8u2
 
-extern const Register_file rgftab_atmega16[70];
+extern const Register_file   rgftab_atmega16[70];
 
-extern const Register_file rgftab_atmega16a[70];
+extern const Register_file   rgftab_atmega16a[70];
 
-extern const Register_file rgftab_atmega16u4[139];
+extern const Register_file   rgftab_atmega16u4[139];
 #define rgftab_atmega32u4    rgftab_atmega16u4
 
-extern const Register_file rgftab_atmega32[68];
+extern const Register_file   rgftab_atmega32[68];
 
-extern const Register_file rgftab_atmega32a[66];
+extern const Register_file   rgftab_atmega32a[66];
 
-extern const Register_file rgftab_atmega32c1[117];
+extern const Register_file   rgftab_atmega32c1[117];
 
-extern const Register_file rgftab_atmega48[81];
+extern const Register_file   rgftab_atmega48[81];
 #define rgftab_atmega48p     rgftab_atmega48
 
-extern const Register_file rgftab_atmega48a[82];
+extern const Register_file   rgftab_atmega48a[82];
 #define rgftab_atmega48pa    rgftab_atmega48a
 
-extern const Register_file rgftab_atmega48pb[95];
+extern const Register_file   rgftab_atmega48pb[95];
 
-extern const Register_file rgftab_atmega64[103];
+extern const Register_file   rgftab_atmega64[103];
 #define rgftab_atmega64a     rgftab_atmega64
 
-extern const Register_file rgftab_atmega64c1[122];
+extern const Register_file   rgftab_atmega64c1[122];
 
-extern const Register_file rgftab_atmega64m1[136];
+extern const Register_file   rgftab_atmega64m1[136];
 
-extern const Register_file rgftab_atmega64hve2[89];
+extern const Register_file   rgftab_atmega64hve2[89];
 
-extern const Register_file rgftab_atmega64rfr2[269];
+extern const Register_file   rgftab_atmega64rfr2[269];
 #define rgftab_atmega644rfr2 rgftab_atmega64rfr2
 
-extern const Register_file rgftab_atmega88[81];
+extern const Register_file   rgftab_atmega88[81];
 #define rgftab_atmega88a     rgftab_atmega88
 #define rgftab_atmega88p     rgftab_atmega88
 #define rgftab_atmega88pa    rgftab_atmega88
@@ -2542,222 +2556,222 @@ extern const Register_file rgftab_atmega88[81];
 #define rgftab_atmega168p    rgftab_atmega88
 #define rgftab_atmega168pa   rgftab_atmega88
 
-extern const Register_file rgftab_atmega88pb[95];
+extern const Register_file   rgftab_atmega88pb[95];
 #define rgftab_atmega168pb   rgftab_atmega88pb
 
-extern const Register_file rgftab_atmega128[103];
+extern const Register_file   rgftab_atmega128[103];
 
-extern const Register_file rgftab_atmega128a[103];
+extern const Register_file   rgftab_atmega128a[103];
 
-extern const Register_file rgftab_atmega128rfa1[237];
+extern const Register_file   rgftab_atmega128rfa1[237];
 
-extern const Register_file rgftab_atmega128rfr2[270];
+extern const Register_file   rgftab_atmega128rfr2[270];
 #define rgftab_atmega1284rfr2 rgftab_atmega128rfr2
 
-extern const Register_file rgftab_atmega162[79];
+extern const Register_file   rgftab_atmega162[79];
 
-extern const Register_file rgftab_atmega164a[96];
+extern const Register_file   rgftab_atmega164a[96];
 #define rgftab_atmega164p    rgftab_atmega164a
 #define rgftab_atmega164pa   rgftab_atmega164a
 #define rgftab_atmega324a    rgftab_atmega164a
 #define rgftab_atmega324p    rgftab_atmega164a
 #define rgftab_atmega324pa   rgftab_atmega164a
 
-extern const Register_file rgftab_atmega165a[86];
+extern const Register_file   rgftab_atmega165a[86];
 #define rgftab_atmega165p    rgftab_atmega165a
 #define rgftab_atmega165pa   rgftab_atmega165a
 
-extern const Register_file rgftab_atmega169a[106];
+extern const Register_file   rgftab_atmega169a[106];
 #define rgftab_atmega169p    rgftab_atmega169a
 #define rgftab_atmega169pa   rgftab_atmega169a
 
-extern const Register_file rgftab_atmega256rfr2[271];
+extern const Register_file   rgftab_atmega256rfr2[271];
 
-extern const Register_file rgftab_atmega324pb[134];
+extern const Register_file   rgftab_atmega324pb[134];
 
-extern const Register_file rgftab_atmega325[86];
+extern const Register_file   rgftab_atmega325[86];
 #define rgftab_atmega325a    rgftab_atmega325
 #define rgftab_atmega325p    rgftab_atmega325
 #define rgftab_atmega325pa   rgftab_atmega325
 
-extern const Register_file rgftab_atmega329[106];
+extern const Register_file   rgftab_atmega329[106];
 
-extern const Register_file rgftab_atmega329a[106];
+extern const Register_file   rgftab_atmega329a[106];
 #define rgftab_atmega329pa   rgftab_atmega329a
 
-extern const Register_file rgftab_atmega329p[106];
+extern const Register_file   rgftab_atmega329p[106];
 
-extern const Register_file rgftab_atmega406[79];
+extern const Register_file   rgftab_atmega406[79];
 
-extern const Register_file rgftab_atmega640[160];
+extern const Register_file   rgftab_atmega640[160];
 
-extern const Register_file rgftab_atmega644[88];
+extern const Register_file   rgftab_atmega644[88];
 
-extern const Register_file rgftab_atmega644a[93];
+extern const Register_file   rgftab_atmega644a[93];
 #define rgftab_atmega644p    rgftab_atmega644a
 #define rgftab_atmega644pa   rgftab_atmega644a
 
-extern const Register_file rgftab_atmega645[86];
+extern const Register_file   rgftab_atmega645[86];
 #define rgftab_atmega645a    rgftab_atmega645
 #define rgftab_atmega645p    rgftab_atmega645
 
-extern const Register_file rgftab_atmega649[106];
+extern const Register_file   rgftab_atmega649[106];
 #define rgftab_atmega649a    rgftab_atmega649
 #define rgftab_atmega649p    rgftab_atmega649
 
-extern const Register_file rgftab_atmega1280[161];
+extern const Register_file   rgftab_atmega1280[161];
 #define rgftab_atmega2560    rgftab_atmega1280
 
-extern const Register_file rgftab_atmega1281[138];
+extern const Register_file   rgftab_atmega1281[138];
 
-extern const Register_file rgftab_atmega1284[104];
+extern const Register_file   rgftab_atmega1284[104];
 #define rgftab_atmega1284p   rgftab_atmega1284
 
-extern const Register_file rgftab_atmega2561[139];
+extern const Register_file   rgftab_atmega2561[139];
 
-extern const Register_file rgftab_atmega2564rfr2[271];
+extern const Register_file   rgftab_atmega2564rfr2[271];
 
-extern const Register_file rgftab_atmega3250[94];
+extern const Register_file   rgftab_atmega3250[94];
 #define rgftab_atmega3250a   rgftab_atmega3250
 #define rgftab_atmega3250p   rgftab_atmega3250
 #define rgftab_atmega3250pa  rgftab_atmega3250
 
-extern const Register_file rgftab_atmega3290[118];
+extern const Register_file   rgftab_atmega3290[118];
 #define rgftab_atmega3290a   rgftab_atmega3290
 
-extern const Register_file rgftab_atmega3290p[118];
+extern const Register_file   rgftab_atmega3290p[118];
 
-extern const Register_file rgftab_atmega3290pa[118];
+extern const Register_file   rgftab_atmega3290pa[118];
 
-extern const Register_file rgftab_atmega6450[94];
+extern const Register_file   rgftab_atmega6450[94];
 #define rgftab_atmega6450a   rgftab_atmega6450
 #define rgftab_atmega6450p   rgftab_atmega6450
 
-extern const Register_file rgftab_atmega6490[118];
+extern const Register_file   rgftab_atmega6490[118];
 #define rgftab_atmega6490a   rgftab_atmega6490
 #define rgftab_atmega6490p   rgftab_atmega6490
 
-extern const Register_file rgftab_atmega8535[67];
+extern const Register_file   rgftab_atmega8535[67];
 
-extern const Register_file rgftab_at90pwm1[92];
+extern const Register_file   rgftab_at90pwm1[92];
 
-extern const Register_file rgftab_at90pwm2b[100];
+extern const Register_file   rgftab_at90pwm2b[100];
 
-extern const Register_file rgftab_at90pwm3[115];
+extern const Register_file   rgftab_at90pwm3[115];
 
-extern const Register_file rgftab_at90pwm3b[115];
+extern const Register_file   rgftab_at90pwm3b[115];
 
-extern const Register_file rgftab_at90pwm161[86];
+extern const Register_file   rgftab_at90pwm161[86];
 
-extern const Register_file rgftab_at90pwm216[102];
+extern const Register_file   rgftab_at90pwm216[102];
 
-extern const Register_file rgftab_at90pwm316[117];
+extern const Register_file   rgftab_at90pwm316[117];
 
-extern const Register_file rgftab_at90usb646[157];
+extern const Register_file   rgftab_at90usb646[157];
 #define rgftab_at90usb647    rgftab_at90usb646
 #define rgftab_at90usb1287   rgftab_at90usb646
 
-extern const Register_file rgftab_at90usb1286[132];
+extern const Register_file   rgftab_at90usb1286[132];
 
-extern const Register_file rgftab_ata5272[80];
+extern const Register_file   rgftab_ata5272[80];
 #define rgftab_ata5505       rgftab_ata5272
 
-extern const Register_file rgftab_ata5702m322[378];
+extern const Register_file   rgftab_ata5702m322[378];
 
-extern const Register_file rgftab_ata5787[292];
+extern const Register_file   rgftab_ata5787[292];
 
-extern const Register_file rgftab_ata5790n[117];
+extern const Register_file   rgftab_ata5790n[117];
 #define rgftab_ata5791       rgftab_ata5790n
 
-extern const Register_file rgftab_ata5795[84];
+extern const Register_file   rgftab_ata5795[84];
 
-extern const Register_file rgftab_ata5831[279];
+extern const Register_file   rgftab_ata5831[279];
 #define rgftab_ata5832       rgftab_ata5831
 #define rgftab_ata5833       rgftab_ata5831
 #define rgftab_ata8510       rgftab_ata5831
 #define rgftab_ata8515       rgftab_ata5831
 
-extern const Register_file rgftab_ata5835[307];
+extern const Register_file   rgftab_ata5835[307];
 
-extern const Register_file rgftab_ata6612c[81];
+extern const Register_file   rgftab_ata6612c[81];
 #define rgftab_ata6613c      rgftab_ata6612c
 
-extern const Register_file rgftab_ata6614q[81];
+extern const Register_file   rgftab_ata6614q[81];
 
-extern const Register_file rgftab_ata6616c[81];
+extern const Register_file   rgftab_ata6616c[81];
 #define rgftab_ata6617c      rgftab_ata6616c
 #define rgftab_ata664251     rgftab_ata6616c
 
-extern const Register_file rgftab_atxmega16a4[553];
+extern const Register_file   rgftab_atxmega16a4[553];
 #define rgftab_atxmega32a4   rgftab_atxmega16a4
 
-extern const Register_file rgftab_atxmega16a4u[630];
+extern const Register_file   rgftab_atxmega16a4u[630];
 #define rgftab_atxmega32a4u  rgftab_atxmega16a4u
 
-extern const Register_file rgftab_atxmega16c4[482];
+extern const Register_file   rgftab_atxmega16c4[482];
 #define rgftab_atxmega32c4   rgftab_atxmega16c4
 
-extern const Register_file rgftab_atxmega16d4[460];
+extern const Register_file   rgftab_atxmega16d4[460];
 #define rgftab_atxmega32d4   rgftab_atxmega16d4
 
-extern const Register_file rgftab_atxmega32c3[569];
+extern const Register_file   rgftab_atxmega32c3[569];
 #define rgftab_atxmega64c3   rgftab_atxmega32c3
 #define rgftab_atxmega128c3  rgftab_atxmega32c3
 #define rgftab_atxmega192c3  rgftab_atxmega32c3
 #define rgftab_atxmega256c3  rgftab_atxmega32c3
 
-extern const Register_file rgftab_atxmega32d3[567];
+extern const Register_file   rgftab_atxmega32d3[567];
 #define rgftab_atxmega64d3   rgftab_atxmega32d3
 #define rgftab_atxmega128d3  rgftab_atxmega32d3
 #define rgftab_atxmega192d3  rgftab_atxmega32d3
 #define rgftab_atxmega256d3  rgftab_atxmega32d3
 
-extern const Register_file rgftab_atxmega64a1[814];
+extern const Register_file   rgftab_atxmega64a1[814];
 #define rgftab_atxmega128a1  rgftab_atxmega64a1
 
-extern const Register_file rgftab_atxmega64a1u[943];
+extern const Register_file   rgftab_atxmega64a1u[943];
 #define rgftab_atxmega128a1u rgftab_atxmega64a1u
 
-extern const Register_file rgftab_atxmega64b1[574];
+extern const Register_file   rgftab_atxmega64b1[574];
 #define rgftab_atxmega128b1  rgftab_atxmega64b1
 
-extern const Register_file rgftab_atxmega64b3[458];
+extern const Register_file   rgftab_atxmega64b3[458];
 #define rgftab_atxmega128b3  rgftab_atxmega64b3
 
-extern const Register_file rgftab_atxmega64a4u[632];
+extern const Register_file   rgftab_atxmega64a4u[632];
 #define rgftab_atxmega128a4u rgftab_atxmega64a4u
 
-extern const Register_file rgftab_atxmega64d4[460];
+extern const Register_file   rgftab_atxmega64d4[460];
 #define rgftab_atxmega128d4  rgftab_atxmega64d4
 
-extern const Register_file rgftab_atxmega256a3b[665];
+extern const Register_file   rgftab_atxmega256a3b[665];
 
-extern const Register_file rgftab_atxmega256a3bu[780];
+extern const Register_file   rgftab_atxmega256a3bu[780];
 
-extern const Register_file rgftab_atxmega384c3[603];
+extern const Register_file   rgftab_atxmega384c3[603];
 
-extern const Register_file rgftab_atxmega384d3[560];
+extern const Register_file   rgftab_atxmega384d3[560];
 
-extern const Register_file rgftab_attiny202[217];
+extern const Register_file   rgftab_attiny202[217];
 #define rgftab_attiny402     rgftab_attiny202
 
-extern const Register_file rgftab_attiny212[247];
+extern const Register_file   rgftab_attiny212[247];
 #define rgftab_attiny412     rgftab_attiny212
 
-extern const Register_file rgftab_attiny214[265];
+extern const Register_file   rgftab_attiny214[265];
 #define rgftab_attiny414     rgftab_attiny214
 
-extern const Register_file rgftab_attiny406[253];
+extern const Register_file   rgftab_attiny406[253];
 
-extern const Register_file rgftab_attiny416[283];
+extern const Register_file   rgftab_attiny416[283];
 
-extern const Register_file rgftab_attiny416auto[283];
+extern const Register_file   rgftab_attiny416auto[283];
 
-extern const Register_file rgftab_attiny417[283];
+extern const Register_file   rgftab_attiny417[283];
 #define rgftab_attiny816     rgftab_attiny417
 #define rgftab_attiny817     rgftab_attiny417
 
-extern const Register_file rgftab_attiny426[308];
+extern const Register_file   rgftab_attiny426[308];
 #define rgftab_attiny427     rgftab_attiny426
 #define rgftab_attiny826     rgftab_attiny426
 #define rgftab_attiny827     rgftab_attiny426
@@ -2766,46 +2780,46 @@ extern const Register_file rgftab_attiny426[308];
 #define rgftab_attiny3226    rgftab_attiny426
 #define rgftab_attiny3227    rgftab_attiny426
 
-extern const Register_file rgftab_attiny804[255];
+extern const Register_file   rgftab_attiny804[255];
 #define rgftab_attiny806     rgftab_attiny804
 #define rgftab_attiny807     rgftab_attiny804
 #define rgftab_attiny1604    rgftab_attiny804
 #define rgftab_attiny1606    rgftab_attiny804
 #define rgftab_attiny1607    rgftab_attiny804
 
-extern const Register_file rgftab_attiny814[265];
+extern const Register_file   rgftab_attiny814[265];
 
-extern const Register_file rgftab_attiny1614[308];
+extern const Register_file   rgftab_attiny1614[308];
 
-extern const Register_file rgftab_attiny1616[326];
+extern const Register_file   rgftab_attiny1616[326];
 #define rgftab_attiny1617    rgftab_attiny1616
 
-extern const Register_file rgftab_attiny3216[326];
+extern const Register_file   rgftab_attiny3216[326];
 #define rgftab_attiny3217    rgftab_attiny3216
 
-extern const Register_file rgftab_atmega808[406];
+extern const Register_file   rgftab_atmega808[406];
 #define rgftab_atmega1608    rgftab_atmega808
 
-extern const Register_file rgftab_atmega809[432];
+extern const Register_file   rgftab_atmega809[432];
 #define rgftab_atmega1609    rgftab_atmega809
 
-extern const Register_file rgftab_atmega3208[406];
+extern const Register_file   rgftab_atmega3208[406];
 #define rgftab_atmega4808    rgftab_atmega3208
 
-extern const Register_file rgftab_atmega3209[432];
+extern const Register_file   rgftab_atmega3209[432];
 #define rgftab_atmega4809    rgftab_atmega3209
 
-extern const Register_file rgftab_avr16du14[370];
+extern const Register_file   rgftab_avr16du14[370];
 #define rgftab_avr32du14     rgftab_avr16du14
 
-extern const Register_file rgftab_avr16eb14[390];
+extern const Register_file   rgftab_avr16eb14[390];
 #define rgftab_avr32eb14     rgftab_avr16eb14
 
-extern const Register_file rgftab_avr16dd20[391];
+extern const Register_file   rgftab_avr16dd20[391];
 #define rgftab_avr32dd20     rgftab_avr16dd20
 #define rgftab_avr64dd20     rgftab_avr16dd20
 
-extern const Register_file rgftab_avr16du20[371];
+extern const Register_file   rgftab_avr16du20[371];
 #define rgftab_avr16du28     rgftab_avr16du20
 #define rgftab_avr16du32     rgftab_avr16du20
 #define rgftab_avr32du20     rgftab_avr16du20
@@ -2814,82 +2828,528 @@ extern const Register_file rgftab_avr16du20[371];
 #define rgftab_avr64du28     rgftab_avr16du20
 #define rgftab_avr64du32     rgftab_avr16du20
 
-extern const Register_file rgftab_avr16eb20[391];
+extern const Register_file   rgftab_avr16eb20[391];
 #define rgftab_avr16eb28     rgftab_avr16eb20
 #define rgftab_avr16eb32     rgftab_avr16eb20
 #define rgftab_avr32eb20     rgftab_avr16eb20
 #define rgftab_avr32eb28     rgftab_avr16eb20
 #define rgftab_avr32eb32     rgftab_avr16eb20
 
-extern const Register_file rgftab_avr16dd28[401];
+extern const Register_file   rgftab_avr16dd28[401];
 #define rgftab_avr16dd32     rgftab_avr16dd28
 #define rgftab_avr32dd28     rgftab_avr16dd28
 #define rgftab_avr32dd32     rgftab_avr16dd28
 #define rgftab_avr64dd28     rgftab_avr16dd28
 #define rgftab_avr64dd32     rgftab_avr16dd28
 
-extern const Register_file rgftab_avr16ea28[444];
+extern const Register_file   rgftab_avr16ea28[444];
 #define rgftab_avr16ea32     rgftab_avr16ea28
 #define rgftab_avr32ea28     rgftab_avr16ea28
 #define rgftab_avr32ea32     rgftab_avr16ea28
 #define rgftab_avr64ea28     rgftab_avr16ea28
 #define rgftab_avr64ea32     rgftab_avr16ea28
 
-extern const Register_file rgftab_avr32sd20[543];
+extern const Register_file   rgftab_avr32sd20[543];
 
-extern const Register_file rgftab_avr32da28[432];
+extern const Register_file   rgftab_avr32da28[432];
 #define rgftab_avr32da28s    rgftab_avr32da28
 #define rgftab_avr64da28     rgftab_avr32da28
 #define rgftab_avr64da28s    rgftab_avr32da28
 
-extern const Register_file rgftab_avr32db28[461];
+extern const Register_file   rgftab_avr32db28[461];
 #define rgftab_avr64db28     rgftab_avr32db28
 
-extern const Register_file rgftab_avr32sd28[562];
+extern const Register_file   rgftab_avr32sd28[562];
 
-extern const Register_file rgftab_avr32da32[447];
+extern const Register_file   rgftab_avr32da32[447];
 #define rgftab_avr32da32s    rgftab_avr32da32
 #define rgftab_avr64da32     rgftab_avr32da32
 #define rgftab_avr64da32s    rgftab_avr32da32
 
-extern const Register_file rgftab_avr32db32[476];
+extern const Register_file   rgftab_avr32db32[476];
 #define rgftab_avr64db32     rgftab_avr32db32
 
-extern const Register_file rgftab_avr32sd32[577];
+extern const Register_file   rgftab_avr32sd32[577];
 
-extern const Register_file rgftab_avr32da48[610];
+extern const Register_file   rgftab_avr32da48[610];
 #define rgftab_avr32da48s    rgftab_avr32da48
 
-extern const Register_file rgftab_avr32db48[642];
+extern const Register_file   rgftab_avr32db48[642];
 #define rgftab_avr64db48     rgftab_avr32db48
 
-extern const Register_file rgftab_avr64da48[600];
+extern const Register_file   rgftab_avr64da48[600];
 #define rgftab_avr64da48s    rgftab_avr64da48
 
-extern const Register_file rgftab_avr64da64[658];
+extern const Register_file   rgftab_avr64da64[658];
 #define rgftab_avr64da64s    rgftab_avr64da64
 
-extern const Register_file rgftab_avr64db64[697];
+extern const Register_file   rgftab_avr64db64[697];
 
-extern const Register_file rgftab_avr128da28[433];
+extern const Register_file   rgftab_avr128da28[433];
 #define rgftab_avr128da28s   rgftab_avr128da28
 
-extern const Register_file rgftab_avr128db28[462];
+extern const Register_file   rgftab_avr128db28[462];
 
-extern const Register_file rgftab_avr128da32[448];
+extern const Register_file   rgftab_avr128da32[448];
 #define rgftab_avr128da32s   rgftab_avr128da32
 
-extern const Register_file rgftab_avr128db32[477];
+extern const Register_file   rgftab_avr128db32[477];
 
-extern const Register_file rgftab_avr128da48[601];
+extern const Register_file   rgftab_avr128da48[601];
 #define rgftab_avr128da48s   rgftab_avr128da48
 
-extern const Register_file rgftab_avr128db48[643];
+extern const Register_file   rgftab_avr128db48[643];
 
-extern const Register_file rgftab_avr128da64[659];
+extern const Register_file   rgftab_avr128da64[659];
 #define rgftab_avr128da64s   rgftab_avr128da64
 
-extern const Register_file rgftab_avr128db64[698];
+extern const Register_file   rgftab_avr128db64[698];
+
+
+// Ports
+
+extern const Port_bits       ports_atmega328[3];
+#define ports_atmega48       ports_atmega328
+#define ports_atmega48a      ports_atmega328
+#define ports_atmega48p      ports_atmega328
+#define ports_atmega48pa     ports_atmega328
+#define ports_atmega88       ports_atmega328
+#define ports_atmega88a      ports_atmega328
+#define ports_atmega88p      ports_atmega328
+#define ports_atmega88pa     ports_atmega328
+#define ports_atmega168      ports_atmega328
+#define ports_atmega168a     ports_atmega328
+#define ports_atmega168p     ports_atmega328
+#define ports_atmega168pa    ports_atmega328
+#define ports_atmega328p     ports_atmega328
+#define ports_ata6612c       ports_atmega328
+#define ports_ata6613c       ports_atmega328
+#define ports_ata6614q       ports_atmega328
+
+extern const Port_bits       ports_atmega16m1[4];
+#define ports_at90pwm2       ports_atmega16m1
+#define ports_atmega32c1     ports_atmega16m1
+#define ports_atmega32m1     ports_atmega16m1
+#define ports_atmega64c1     ports_atmega16m1
+#define ports_atmega64m1     ports_atmega16m1
+#define ports_at90pwm2b      ports_atmega16m1
+#define ports_at90pwm3       ports_atmega16m1
+#define ports_at90pwm3b      ports_atmega16m1
+#define ports_at90pwm216     ports_atmega16m1
+#define ports_at90pwm316     ports_atmega16m1
+
+extern const Port_bits       ports_atmega16hva2[3];
+#define ports_atmega8hva     ports_atmega16hva2
+#define ports_atmega16hva    ports_atmega16hva2
+
+extern const Port_bits       ports_atmega32hvbrevb[3];
+#define ports_atmega16hvb    ports_atmega32hvbrevb
+#define ports_atmega16hvbrevb ports_atmega32hvbrevb
+#define ports_atmega32hvb    ports_atmega32hvbrevb
+
+extern const Port_bits       ports_atmega64hve[2];
+#define ports_atmega64hve2   ports_atmega64hve
+
+extern const Port_bits       ports_atmega328pb[4];
+#define ports_atmega48pb     ports_atmega328pb
+#define ports_atmega88pb     ports_atmega328pb
+#define ports_atmega168pb    ports_atmega328pb
+
+extern const Port_bits       ports_atmega8515[5];
+#define ports_atmega161      ports_atmega8515
+#define ports_atmega162      ports_atmega8515
+
+extern const Port_bits       ports_attiny102[2];
+
+extern const Port_bits       ports_attiny28[3];
+
+extern const Port_bits       ports_attiny441[2];
+#define ports_attiny24       ports_attiny441
+#define ports_attiny24a      ports_attiny441
+#define ports_attiny44       ports_attiny441
+#define ports_attiny44a      ports_attiny441
+#define ports_attiny84       ports_attiny441
+#define ports_attiny84a      ports_attiny441
+#define ports_attiny841      ports_attiny441
+
+extern const Port_bits       ports_at90pwm81[3];
+#define ports_at90pwm1       ports_at90pwm81
+#define ports_at90pwm161     ports_at90pwm81
+
+extern const Port_bits       ports_at90can128[7];
+#define ports_atmega165      ports_at90can128
+#define ports_at90can32      ports_at90can128
+#define ports_at90can64      ports_at90can128
+
+extern const Port_bits       ports_at90usb162[3];
+#define ports_atmega8u2      ports_at90usb162
+#define ports_atmega16u2     ports_at90usb162
+#define ports_atmega32u2     ports_at90usb162
+#define ports_at90usb82      ports_at90usb162
+
+extern const Port_bits       ports_at90s1200[2];
+#define ports_at90s2313      ports_at90s1200
+
+extern const Port_bits       ports_ata5790[3];
+#define ports_ata5790n       ports_ata5790
+#define ports_ata5791        ports_ata5790
+
+extern const Port_bits       ports_ata6285[3];
+#define ports_ata5702m322    ports_ata6285
+#define ports_ata6286        ports_ata6285
+
+extern const Port_bits       ports_atxmega16e5[4];
+#define ports_atxmega8e5     ports_atxmega16e5
+#define ports_atxmega32e5    ports_atxmega16e5
+
+extern const Port_bits       ports_atxmega128a3u[7];
+#define ports_atxmega32c3    ports_atxmega128a3u
+#define ports_atxmega32d3    ports_atxmega128a3u
+#define ports_atxmega64a3u   ports_atxmega128a3u
+#define ports_atxmega64c3    ports_atxmega128a3u
+#define ports_atxmega64d3    ports_atxmega128a3u
+#define ports_atxmega128c3   ports_atxmega128a3u
+#define ports_atxmega128d3   ports_atxmega128a3u
+#define ports_atxmega192a3u  ports_atxmega128a3u
+#define ports_atxmega192d3   ports_atxmega128a3u
+#define ports_atxmega256a3u  ports_atxmega128a3u
+#define ports_atxmega256c3   ports_atxmega128a3u
+#define ports_atxmega256d3   ports_atxmega128a3u
+#define ports_atxmega384c3   ports_atxmega128a3u
+#define ports_atxmega384d3   ports_atxmega128a3u
+
+extern const Port_bits       ports_attiny204[2];
+#define ports_attiny1624     ports_attiny204
+#define ports_attiny214      ports_attiny204
+#define ports_attiny404      ports_attiny204
+#define ports_attiny414      ports_attiny204
+#define ports_attiny424      ports_attiny204
+#define ports_attiny804      ports_attiny204
+#define ports_attiny814      ports_attiny204
+#define ports_attiny824      ports_attiny204
+#define ports_attiny1604     ports_attiny204
+#define ports_attiny1614     ports_attiny204
+#define ports_attiny3224     ports_attiny204
+
+extern const Port_bits       ports_avr32dd14[4];
+#define ports_avr16dd14      ports_avr32dd14
+#define ports_avr64dd14      ports_avr32dd14
+
+extern const Port_bits       ports_avr64ea48[6];
+#define ports_avr16ea48      ports_avr64ea48
+#define ports_avr32ea48      ports_avr64ea48
+
+extern const Port_bits       ports_attiny4[1];
+#define ports_attiny5        ports_attiny4
+#define ports_attiny9        ports_attiny4
+#define ports_attiny10       ports_attiny4
+
+extern const Port_bits       ports_attiny20[2];
+
+extern const Port_bits       ports_attiny40[3];
+
+extern const Port_bits       ports_attiny104[2];
+
+extern const Port_bits       ports_attiny11[1];
+#define ports_attiny12       ports_attiny11
+#define ports_attiny15       ports_attiny11
+
+extern const Port_bits       ports_attiny13[1];
+#define ports_attiny13a      ports_attiny13
+#define ports_attiny25       ports_attiny13
+#define ports_attiny45       ports_attiny13
+#define ports_attiny85       ports_attiny13
+
+extern const Port_bits       ports_attiny22[1];
+#define ports_at90s2343      ports_attiny22
+
+extern const Port_bits       ports_attiny26[2];
+#define ports_attiny43u      ports_attiny26
+#define ports_attiny261      ports_attiny26
+#define ports_attiny261a     ports_attiny26
+#define ports_attiny461      ports_attiny26
+#define ports_attiny461a     ports_attiny26
+#define ports_attiny861      ports_attiny26
+#define ports_attiny861a     ports_attiny26
+
+extern const Port_bits       ports_attiny48[4];
+#define ports_attiny88       ports_attiny48
+
+extern const Port_bits       ports_attiny87[2];
+#define ports_attiny167      ports_attiny87
+#define ports_ata5272        ports_attiny87
+#define ports_ata5505        ports_attiny87
+#define ports_ata6616c       ports_attiny87
+#define ports_ata6617c       ports_attiny87
+#define ports_ata664251      ports_attiny87
+
+extern const Port_bits       ports_attiny828[4];
+
+extern const Port_bits       ports_attiny1634[3];
+
+extern const Port_bits       ports_attiny2313[3];
+#define ports_attiny2313a    ports_attiny2313
+#define ports_attiny4313     ports_attiny2313
+
+extern const Port_bits       ports_atmega8[3];
+#define ports_atmega8a       ports_atmega8
+
+extern const Port_bits       ports_atmega16[4];
+#define ports_atmega16a      ports_atmega16
+#define ports_atmega32       ports_atmega16
+#define ports_atmega32a      ports_atmega16
+#define ports_atmega163      ports_atmega16
+#define ports_atmega323      ports_atmega16
+#define ports_atmega8535     ports_atmega16
+#define ports_at90s4414      ports_atmega16
+#define ports_at90s4434      ports_atmega16
+#define ports_at90s8515      ports_atmega16
+#define ports_at90s8535      ports_atmega16
+
+extern const Port_bits       ports_atmega16u4[5];
+#define ports_atmega32u4     ports_atmega16u4
+
+extern const Port_bits       ports_atmega32u6[6];
+#define ports_at90usb646     ports_atmega32u6
+#define ports_at90usb647     ports_atmega32u6
+#define ports_at90usb1286    ports_atmega32u6
+#define ports_at90usb1287    ports_atmega32u6
+
+extern const Port_bits       ports_atmega64[7];
+#define ports_atmega64a      ports_atmega64
+#define ports_atmega128      ports_atmega64
+#define ports_atmega128a     ports_atmega64
+
+extern const Port_bits       ports_atmega64rfr2[7];
+#define ports_atmega128rfa1  ports_atmega64rfr2
+#define ports_atmega128rfr2  ports_atmega64rfr2
+#define ports_atmega169pa    ports_atmega64rfr2
+#define ports_atmega256rfr2  ports_atmega64rfr2
+#define ports_atmega644rfr2  ports_atmega64rfr2
+#define ports_atmega1281     ports_atmega64rfr2
+#define ports_atmega1284rfr2 ports_atmega64rfr2
+#define ports_atmega2561     ports_atmega64rfr2
+#define ports_atmega2564rfr2 ports_atmega64rfr2
+
+extern const Port_bits       ports_atmega103[6];
+
+extern const Port_bits       ports_atmega164a[4];
+#define ports_atmega164p     ports_atmega164a
+#define ports_atmega164pa    ports_atmega164a
+#define ports_atmega324a     ports_atmega164a
+#define ports_atmega324p     ports_atmega164a
+#define ports_atmega324pa    ports_atmega164a
+#define ports_atmega644      ports_atmega164a
+#define ports_atmega644a     ports_atmega164a
+#define ports_atmega644p     ports_atmega164a
+#define ports_atmega644pa    ports_atmega164a
+#define ports_atmega1284     ports_atmega164a
+#define ports_atmega1284p    ports_atmega164a
+
+extern const Port_bits       ports_atmega165a[7];
+#define ports_atmega165p     ports_atmega165a
+#define ports_atmega165pa    ports_atmega165a
+#define ports_atmega169      ports_atmega165a
+#define ports_atmega169a     ports_atmega165a
+#define ports_atmega169p     ports_atmega165a
+#define ports_atmega325      ports_atmega165a
+#define ports_atmega325a     ports_atmega165a
+#define ports_atmega325p     ports_atmega165a
+#define ports_atmega325pa    ports_atmega165a
+#define ports_atmega329      ports_atmega165a
+#define ports_atmega329a     ports_atmega165a
+#define ports_atmega329p     ports_atmega165a
+#define ports_atmega329pa    ports_atmega165a
+#define ports_atmega645      ports_atmega165a
+#define ports_atmega645a     ports_atmega165a
+#define ports_atmega645p     ports_atmega165a
+#define ports_atmega649      ports_atmega165a
+#define ports_atmega649a     ports_atmega165a
+#define ports_atmega649p     ports_atmega165a
+
+extern const Port_bits       ports_atmega324pb[5];
+
+extern const Port_bits       ports_atmega406[4];
+
+extern const Port_bits       ports_atmega640[11];
+#define ports_atmega1280     ports_atmega640
+#define ports_atmega2560     ports_atmega640
+
+extern const Port_bits       ports_atmega3250[9];
+#define ports_atmega3250a    ports_atmega3250
+#define ports_atmega3250p    ports_atmega3250
+#define ports_atmega3250pa   ports_atmega3250
+#define ports_atmega3290     ports_atmega3250
+#define ports_atmega3290a    ports_atmega3250
+#define ports_atmega3290p    ports_atmega3250
+#define ports_atmega3290pa   ports_atmega3250
+#define ports_atmega6450     ports_atmega3250
+#define ports_atmega6450a    ports_atmega3250
+#define ports_atmega6450p    ports_atmega3250
+#define ports_atmega6490     ports_atmega3250
+#define ports_atmega6490a    ports_atmega3250
+#define ports_atmega6490p    ports_atmega3250
+
+extern const Port_bits       ports_at90scr100[5];
+
+extern const Port_bits       ports_at90s2323[1];
+
+extern const Port_bits       ports_at90s2333[3];
+#define ports_at90s4433      ports_at90s2333
+
+extern const Port_bits       ports_ata5782[2];
+#define ports_ata5831        ports_ata5782
+#define ports_ata8210        ports_ata5782
+#define ports_ata8510        ports_ata5782
+
+extern const Port_bits       ports_ata5795[3];
+
+extern const Port_bits       ports_ata6289[3];
+
+extern const Port_bits       ports_atxmega16a4u[6];
+#define ports_atxmega16c4    ports_atxmega16a4u
+#define ports_atxmega16d4    ports_atxmega16a4u
+#define ports_atxmega32a4u   ports_atxmega16a4u
+#define ports_atxmega32c4    ports_atxmega16a4u
+#define ports_atxmega32d4    ports_atxmega16a4u
+#define ports_atxmega64a4u   ports_atxmega16a4u
+#define ports_atxmega64d4    ports_atxmega16a4u
+#define ports_atxmega128a4u  ports_atxmega16a4u
+#define ports_atxmega128d4   ports_atxmega16a4u
+
+extern const Port_bits       ports_atxmega64a1u[11];
+#define ports_atxmega128a1u  ports_atxmega64a1u
+
+extern const Port_bits       ports_atxmega64b1[8];
+#define ports_atxmega128b1   ports_atxmega64b1
+
+extern const Port_bits       ports_atxmega64b3[6];
+#define ports_atxmega128b3   ports_atxmega64b3
+
+extern const Port_bits       ports_atxmega256a3bu[7];
+
+extern const Port_bits       ports_attiny202[1];
+#define ports_attiny212      ports_attiny202
+#define ports_attiny402      ports_attiny202
+#define ports_attiny412      ports_attiny202
+
+extern const Port_bits       ports_attiny406[3];
+#define ports_attiny416      ports_attiny406
+#define ports_attiny416auto  ports_attiny406
+#define ports_attiny426      ports_attiny406
+#define ports_attiny806      ports_attiny406
+#define ports_attiny816      ports_attiny406
+#define ports_attiny826      ports_attiny406
+#define ports_attiny1606     ports_attiny406
+#define ports_attiny1616     ports_attiny406
+#define ports_attiny1626     ports_attiny406
+#define ports_attiny3216     ports_attiny406
+#define ports_attiny3226     ports_attiny406
+
+extern const Port_bits       ports_attiny417[3];
+#define ports_attiny427      ports_attiny417
+#define ports_attiny807      ports_attiny417
+#define ports_attiny817      ports_attiny417
+#define ports_attiny827      ports_attiny417
+#define ports_attiny1607     ports_attiny417
+#define ports_attiny1617     ports_attiny417
+#define ports_attiny1627     ports_attiny417
+#define ports_attiny3217     ports_attiny417
+#define ports_attiny3227     ports_attiny417
+
+extern const Port_bits       ports_atmega808[4];
+#define ports_atmega1608     ports_atmega808
+#define ports_atmega3208     ports_atmega808
+#define ports_atmega4808     ports_atmega808
+#define ports_avr32da32      ports_atmega808
+#define ports_avr32da32s     ports_atmega808
+#define ports_avr64da32      ports_atmega808
+#define ports_avr64da32s     ports_atmega808
+#define ports_avr128da32     ports_atmega808
+#define ports_avr128da32s    ports_atmega808
+
+extern const Port_bits       ports_atmega809[6];
+#define ports_atmega1609     ports_atmega809
+#define ports_atmega3209     ports_atmega809
+#define ports_atmega4809     ports_atmega809
+#define ports_avr32da48      ports_atmega809
+#define ports_avr32da48s     ports_atmega809
+#define ports_avr32db48      ports_atmega809
+#define ports_avr64da48      ports_atmega809
+#define ports_avr64da48s     ports_atmega809
+#define ports_avr64db48      ports_atmega809
+#define ports_avr128da48     ports_atmega809
+#define ports_avr128da48s    ports_atmega809
+#define ports_avr128db48     ports_atmega809
+
+extern const Port_bits       ports_avr16du14[4];
+#define ports_avr32du14      ports_avr16du14
+
+extern const Port_bits       ports_avr16eb14[4];
+#define ports_avr32eb14      ports_avr16eb14
+
+extern const Port_bits       ports_avr16dd20[4];
+#define ports_avr32dd20      ports_avr16dd20
+#define ports_avr32sd20      ports_avr16dd20
+#define ports_avr64dd20      ports_avr16dd20
+
+extern const Port_bits       ports_avr16du20[4];
+#define ports_avr32du20      ports_avr16du20
+
+extern const Port_bits       ports_avr16eb20[4];
+#define ports_avr32eb20      ports_avr16eb20
+
+extern const Port_bits       ports_avr16dd28[4];
+#define ports_avr32dd28      ports_avr16dd28
+#define ports_avr32sd28      ports_avr16dd28
+#define ports_avr64dd28      ports_avr16dd28
+
+extern const Port_bits       ports_avr16du28[4];
+#define ports_avr32du28      ports_avr16du28
+#define ports_avr64du28      ports_avr16du28
+
+extern const Port_bits       ports_avr16ea28[4];
+#define ports_avr16eb28      ports_avr16ea28
+#define ports_avr32ea28      ports_avr16ea28
+#define ports_avr32eb28      ports_avr16ea28
+#define ports_avr64ea28      ports_avr16ea28
+
+extern const Port_bits       ports_avr16dd32[4];
+#define ports_avr32dd32      ports_avr16dd32
+#define ports_avr32sd32      ports_avr16dd32
+#define ports_avr64dd32      ports_avr16dd32
+
+extern const Port_bits       ports_avr16du32[4];
+#define ports_avr32du32      ports_avr16du32
+#define ports_avr64du32      ports_avr16du32
+
+extern const Port_bits       ports_avr16ea32[4];
+#define ports_avr16eb32      ports_avr16ea32
+#define ports_avr32ea32      ports_avr16ea32
+#define ports_avr32eb32      ports_avr16ea32
+#define ports_avr64ea32      ports_avr16ea32
+
+extern const Port_bits       ports_avr32da28[4];
+#define ports_avr32da28s     ports_avr32da28
+#define ports_avr64da28      ports_avr32da28
+#define ports_avr64da28s     ports_avr32da28
+#define ports_avr128da28     ports_avr32da28
+#define ports_avr128da28s    ports_avr32da28
+
+extern const Port_bits       ports_avr32db28[4];
+#define ports_avr64db28      ports_avr32db28
+#define ports_avr128db28     ports_avr32db28
+
+extern const Port_bits       ports_avr32db32[4];
+#define ports_avr64db32      ports_avr32db32
+#define ports_avr128db32     ports_avr32db32
+
+extern const Port_bits       ports_avr64da64[7];
+#define ports_avr64da64s     ports_avr64da64
+#define ports_avr64db64      ports_avr64da64
+#define ports_avr128da64     ports_avr64da64
+#define ports_avr128da64s    ports_avr64da64
+#define ports_avr128db64     ports_avr64da64
 
 int upidxmcuid(int mcuid);
 int upidxsig(const uint8_t *sigs);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -19,6 +19,9 @@
 #ifndef libavrdude_h
 #define libavrdude_h
 
+// #define TO_BE_DEPRECATED_IN_2026
+// #define TO_BE_DEPRECATED_IN_2027
+
 #include <stdio.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -280,9 +283,15 @@ typedef struct opcode {
 #define both_awire(pgm, p)     (!!(joint_pm(pgm, p) & PM_aWire))
 #define both_classic(pgm, p)   (!!(joint_pm(pgm, p) & PM_Classic))
 
-#define HV_UPDI_VARIANT_0     0 // Shared UPDI/GPIO/RESET pin, HV on UPDI pin (tinyAVR0/1/2)
-#define HV_UPDI_VARIANT_1     1 // Dedicated UPDI pin, no HV (megaAVR0/AVR-Dx)
-#define HV_UPDI_VARIANT_2     2 // Shared UPDI pin, HV on _RESET (AVR-DD/AVR-Ex)
+#define UPDI_ENABLE_HV_UPDI   0 // Shared UPDI/GPIO/RESET pin, HV on UPDI pin (tinyAVR0/1/2)
+#define UPDI_ENABLE_ALWAYS    1 // Dedicated UPDI pin, no HV needed (megaAVR0/AVR-DA/DB)
+#define UPDI_ENABLE_HV_RESET  2 // Shared UPDI/GPIO pin, HV on RESET (AVR-DD/DUEA/EB)
+
+#ifndef TO_BE_DEPRECATED_IN_2027
+#define HV_UPDI_VARIANT_0     UPDI_ENABLE_HV_UPDI
+#define HV_UPDI_VARIANT_1     UPDI_ENABLE_ALWAYS
+#define HV_UPDI_VARIANT_2     UPDI_ENABLE_HV_RESET
+#endif
 
 #define HAS_SUFFER            1
 #define HAS_VTARG_SWITCH      2
@@ -322,7 +331,7 @@ typedef struct avrpart {
   int n_page_erase;             // If set, number of pages erased during NVM erase
   int n_boot_sections;          // Number of boot sections
   int boot_section_size;        // Size of (smallest) boot section, if any
-  int hvupdi_variant;           // HV pulse on UPDI pin, no pin or RESET pin
+  int hvupdi_variant;           // HV pulse: on UPDI pin (0), not needed (1), on RESET (2/3)
   int stk500_devcode;           // Stk500 device code
   int avr910_devcode;           // Avr910 device code
   int chip_erase_delay;         // Microseconds
@@ -989,7 +998,7 @@ typedef struct programmer {
   const char *usbsn;
   const char *usbvendor;
   const char *usbproduct;
-  LISTID hvupdi_support;        // List of UPDI HV variants the tool supports, see HV_UPDI_VARIANT_x
+  LISTID hvupdi_support;        // List of UPDI HV variants the tool supports, see UPDI_ENABLE_x
 
   // Values below are not set by config_gram.y; ensure fd is first for dev_pgm_raw()
   union filedescriptor fd;

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -830,9 +830,9 @@ static int pickit5_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if(my.hvupdi_enabled > 0) {
-    if(p->hvupdi_variant == 0)
+    if(p->hvupdi_variant == UPDI_ENABLE_HV_UPDI)
       pmsg_notice("high-voltage SYSCFG0 override on UPDI pin enabled\n");
-    if(p->hvupdi_variant == 2)
+    if(p->hvupdi_variant == UPDI_ENABLE_HV_RESET)
       pmsg_notice("high-voltage SYSCFG0 override on RST pin enabled\n");
   }
 
@@ -937,11 +937,11 @@ static int pickit5_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
   const unsigned char *enter_prog = my.scripts.EnterProgMode;
   unsigned int enter_prog_len = my.scripts.EnterProgMode_len;
 
-  if(my.hvupdi_enabled && (my.pgm_type != PGM_TYPE_SNAP)) {   // SNAP has no HV generation
-    if(p->hvupdi_variant == HV_UPDI_VARIANT_0) {        // High voltage generation on UPDI line
+  if(my.hvupdi_enabled && (my.pgm_type != PGM_TYPE_SNAP)) { // SNAP has no HV generation
+    if(p->hvupdi_variant == UPDI_ENABLE_HV_UPDI) {          // High voltage generation on UPDI line
       enter_prog = my.scripts.EnterProgModeHvSp;
       enter_prog_len = my.scripts.EnterProgModeHvSp_len;
-    } else if(p->hvupdi_variant == HV_UPDI_VARIANT_2) { // High voltage generation on RST line
+    } else if(p->hvupdi_variant == UPDI_ENABLE_HV_RESET) {  // High voltage generation on RST line
       enter_prog = my.scripts.EnterProgModeHvSpRst;
       enter_prog_len = my.scripts.EnterProgModeHvSpRst_len;
     }
@@ -1358,11 +1358,11 @@ static int pickit5_read_dev_id(const PROGRAMMER *pgm, const AVRPART *p) {
     if(len == 0x03 || len == 0x04) {  // just DevId or UPDI with revision
       memcpy(my.devID, &my.rxBuf[24], len);
     } else {
-      if(my.hvupdi_enabled && p->hvupdi_variant == HV_UPDI_VARIANT_2) {
-        pmsg_info("failed to get DeviceID with activated HV Pulse on RST");
+      if(my.hvupdi_enabled && p->hvupdi_variant == UPDI_ENABLE_HV_RESET) {
+        pmsg_info("failed to get DeviceID with activated HV Pulse on RST\n");
          msg_info("if the wiring is correct, try connecting a 16 V, 1 uF cap between RST and GND\n");
       } else {
-        pmsg_error("length (%u) mismatch of returned Device ID.\n", len);
+        pmsg_error("length (%u) mismatch of returned Device ID\n", len);
       }
       return -1;
     }


### PR DESCRIPTION
This PR
 - Adds UART info to `avrintel.c`
 - Updates `avrintel.c` from ATDF files
 - Updates variants in `avrdude.conf` from ATDF files
 - Adds AVR64DA28S, AVR64DA32S, AVR64DA48S and AVR64DA64S
 - Adds AVR32DA28S, AVR32DA32S and AVR32DA48S
 - Adds AVR32SD20, AVR32SD28, AVR32SD32

The last one addresses  #1952

@askn37 Are you available for review?  
