### PR TITLE
Remove #include "usbdevs.h" from libavrdude.h

### DIFF
--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -50,6 +50,7 @@
 
 #include "developer_opts.h"
 #include "developer_opts_private.h"
+#include "usbdevs.h"
 
 // Inject part parameters into a semi-automated rewrite of avrdude.conf
 //  - Add entries to the tables below; they get written on -p*/si or -c*/si

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1844,7 +1844,7 @@ typedef struct {
   Dis_symbol *dis_symbols;
 
   // Static variables from usb_libusb.c
-#include "usbdevs.h"
+#define USBDEV_MAX_XFER_3         912 // Trust compiler complains if usbdevs.h redefines this
   char usb_buf[USBDEV_MAX_XFER_3];
   int usb_buflen, usb_bufptr;   // @@@ Check whether usb_buflen needs initialising with -1
   int usb_interface;


### PR DESCRIPTION
Someone using libavrdude would need usbdevs.h. This PR removes the inclusion of usbdevs.h from libavrdude.h. Usbdevs.h isn't really needed for the library...