### PR TITLE
Alias PICkit Basic programmer names

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3204,8 +3204,8 @@ programmer parent "pickit5" # pickit5_pdi
 # pickit_basic_mplab / pickit_basic_mplab_jtag
 #------------------------------------------------------------
 
-programmer # pickit_basic_mplab
-    id                     = "pickit_basic_mplab", "pickit_basic_mplab_jtag";
+programmer # pickit_basic
+    id                     = "pickit_basic", "pickit_basic_mplab", "pickit_basic_jtag", "pickit_basic_mplab_jtag";
     desc                   = "MPLAB(R) PICkit Basic in JTAG Mode";
     type                   = "pickit5";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
@@ -3219,8 +3219,8 @@ programmer # pickit_basic_mplab
 # pickit_basic_updi
 #------------------------------------------------------------
 
-programmer parent "pickit_basic_mplab" # pickit_basic_mplab_updi
-    id                     = "pickit_basic_mplab_updi";
+programmer parent "pickit_basic_mplab" # pickit_basic_updi
+    id                     = "pickit_basic_updi", "pickit_basic_mplab_updi";
     desc                   = "MPLAB(R) PICkit Basic in UPDI Mode";
     prog_modes             = PM_UPDI;
     hvupdi_support         = 1;     # Dedicated reset and updi pin only
@@ -3230,8 +3230,8 @@ programmer parent "pickit_basic_mplab" # pickit_basic_mplab_updi
 # pickit_basic_isp
 #------------------------------------------------------------
 
-programmer parent "pickit_basic_mplab" # pickit_basic_mplab_isp
-    id                     = "pickit_basic_mplab_isp";
+programmer parent "pickit_basic_mplab" # pickit_basic_isp
+    id                     = "pickit_basic_isp", "pickit_basic_mplab_isp";
     desc                   = "MPLAB(R) PICkit Basic in ISP Mode";
     prog_modes             = PM_ISP;
 ;
@@ -3240,8 +3240,8 @@ programmer parent "pickit_basic_mplab" # pickit_basic_mplab_isp
 # pickit_basic_dw
 #------------------------------------------------------------
 
-programmer parent "pickit_basic_mplab" # pickit_basic_mplab_dw
-    id                     = "pickit_basic_mplab_dw";
+programmer parent "pickit_basic_mplab" # pickit_basic_dw
+    id                     = "pickit_basic_dw", "pickit_basic_mplab_dw";
     desc                   = "MPLAB(R) PICkit Basic in dW Mode";
     prog_modes             = PM_debugWIRE;
 ;
@@ -3250,8 +3250,8 @@ programmer parent "pickit_basic_mplab" # pickit_basic_mplab_dw
 # pickit_basic_tpi
 #------------------------------------------------------------
 
-programmer parent "pickit_basic_mplab" # pickit_basic_mplab_tpi
-    id                     = "pickit_basic_mplab_tpi";
+programmer parent "pickit_basic_mplab" # pickit_basic_tpi
+    id                     = "pickit_basic_tpi", "pickit_basic_mplab_tpi";
     desc                   = "MPLAB(R) PICkit Basic in TPI Mode";
     prog_modes             = PM_TPI;
 ;
@@ -3261,7 +3261,7 @@ programmer parent "pickit_basic_mplab" # pickit_basic_mplab_tpi
 #------------------------------------------------------------
 
 programmer parent "pickit_basic_mplab" # pickit_basic_pdi
-    id                     = "pickit_basic_pdi";
+    id                     = "pickit_basic_pdi", "pickit_basic_mplab_pdi";
     desc                   = "MPLAB(R) PICkit Basic in PDI Mode";
     prog_modes             = PM_PDI;
 ;


### PR DESCRIPTION
The PICkit Basic `-c` programmer names are mildly inconsistent: most have the `mplab` element, one doesn't. This PR ensures PICkit Basic `-c` programmer names can be use in long form (with `mplab`) and short form (without). Please have a look @MX682X and @MCUdude. Thanks!