### PR TITLE
Add `HAS_BITCLOCK_ADJ`

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -112,9 +112,11 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
 }
 
 static int arduino_open(PROGRAMMER *pgm, const char *port) {
-  union pinfo pinfo;
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   pgm->port = port;
+  union pinfo pinfo;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
   if(serial_open(port, pinfo, &pgm->fd) == -1) {

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -113,7 +113,7 @@ static int arduino_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const
 
 static int arduino_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   pgm->port = port;
   union pinfo pinfo;

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -334,6 +334,11 @@ static int avr910_open(PROGRAMMER *pgm, const char *port) {
 
   (void) avr910_drain(pgm, 0);
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   return 0;
 }
 

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -325,11 +325,8 @@ static int avr910_open(PROGRAMMER *pgm, const char *port) {
     pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   union pinfo pinfo;
-  if(pgm->baudrate == 0)
-    pgm->baudrate = 19200;
-
   pgm->port = port;
-  pinfo.serialinfo.baud = pgm->baudrate;
+  pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 19200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
   if(serial_open(port, pinfo, &pgm->fd) < 0)
     return -1;

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -321,10 +321,8 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 }
 
 static int avr910_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   union pinfo pinfo;
   if(pgm->baudrate == 0)

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -321,8 +321,12 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 }
 
 static int avr910_open(PROGRAMMER *pgm, const char *port) {
-  union pinfo pinfo;
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
 
+  union pinfo pinfo;
   if(pgm->baudrate == 0)
     pgm->baudrate = 19200;
 
@@ -333,11 +337,6 @@ static int avr910_open(PROGRAMMER *pgm, const char *port) {
     return -1;
 
   (void) avr910_drain(pgm, 0);
-
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
 
   return 0;
 }

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -322,7 +322,7 @@ static int avr910_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 
 static int avr910_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   union pinfo pinfo;
   if(pgm->baudrate == 0)

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -82,6 +82,8 @@ avrdude_conf_version = "@AVRDUDE_FULL_VERSION@";
 #   #    can clock an AVR directly through its XTAL1 pin
 #   #  - HAS_VAREF_ADJ: Programmer has an adjustable analog reference voltage that
 #   #    can be controlled with Avrdude
+#   #  - HAS_BITCLOCK_ADJ: Programmer has an adjustable bitclock that
+#   #    can be controlled with Avrdude using -B
 #   #
 #   # (3) To invert the polarity of a pin use a tilde: ~<num>
 #   #     To invert the polarity of all pins in a list use ~(<num1> [, <num2> ... ])
@@ -1034,6 +1036,7 @@ programmer # avrftdi
     desc                   = "FT2232H/D based generic programmer";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6010;
@@ -1118,6 +1121,7 @@ programmer # ft2232h_jtag
     desc                   = "FT2232H based generic JTAG programmer";
     type                   = "avrftdi_jtag";
     prog_modes             = PM_JTAG;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6010;
@@ -1161,6 +1165,7 @@ programmer # jtagkey
     desc                   = "Amontec JTAGKey/JTAGKey-Tiny/JTAGKey2";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
 #   Note: This PID is used in all JTAGKey variants
@@ -1187,6 +1192,7 @@ programmer # ft232h
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
     is_serialadapter       = yes;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6014;
@@ -1207,6 +1213,7 @@ programmer # ft232h_jtag
     desc                   = "FT232H based generic JTAG programmer";
     type                   = "avrftdi_jtag";
     prog_modes             = PM_JTAG;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6014;
@@ -1283,6 +1290,8 @@ programmer # openmoko
     desc                   = "Openmoko debug board (v3)";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
+    connection_type        = usb;
     usbvid                 = 0x1457;
     usbpid                 = 0x5118;
     usbdev                 = "A";
@@ -1304,6 +1313,7 @@ programmer # lm3s811
     desc                   = "Luminary Micro LM3S811 Eval Board (Rev. A)";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0xbcd9;
@@ -1387,6 +1397,7 @@ programmer # ktlink
     desc                   = "KT-LINK FT2232H: IO switching, voltage buffers";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0xbbe2;
@@ -1411,6 +1422,7 @@ programmer # digilent-hs2
     desc                   = "Digilent JTAG HS2 (MPSSE)";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6014;
@@ -1434,6 +1446,7 @@ programmer # flyswatter2
     desc                   = "TinCan Tools Flyswatter 2";
     type                   = "avrftdi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6010;
@@ -1484,6 +1497,7 @@ programmer # serprog
     desc                   = "Program via the Serprog protocol from Flashrom";
     type                   = "serprog";
     prog_modes             = PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1498,6 +1512,7 @@ programmer # avrisp
     desc                   = "Serial Atmel AVR ISP using STK500";
     type                   = "stk500";
     prog_modes             = PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1510,6 +1525,7 @@ programmer # avrispv2
     desc                   = "Serial Atmel AVR ISP using STK500v2";
     type                   = "stk500v2";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1526,7 +1542,7 @@ programmer # avrispmkII
     desc                   = "USB Atmel AVR ISP mkII";
     type                   = "stk500v2";
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2104;
@@ -1557,6 +1573,7 @@ programmer # buspirate
     desc                   = "The Bus Pirate in AVR programming mode";
     type                   = "buspirate";
     prog_modes             = PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1595,7 +1612,7 @@ programmer # stk500
     desc                   = "Atmel STK500 (probes v2 first then v1)";
     type                   = "stk500generic";
     prog_modes             = PM_ISP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1612,7 +1629,7 @@ programmer # stk500v1
     desc                   = "Atmel STK500 v1";
     type                   = "stk500";
     prog_modes             = PM_ISP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1648,6 +1665,7 @@ programmer # mib510
     desc                   = "Crossbow MIB510 programming board";
     type                   = "stk500";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1662,7 +1680,7 @@ programmer # stk500v2
     desc                   = "Atmel STK500 v2";
     type                   = "stk500v2";
     prog_modes             = PM_TPI | PM_ISP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1675,7 +1693,7 @@ programmer # stk500pp
     desc                   = "Atmel STK500 v2 in parallel programming mode";
     type                   = "stk500pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1688,7 +1706,7 @@ programmer # stk500hvsp
     desc                   = "Atmel STK500 v2 in HV serial programming mode";
     type                   = "stk500hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = serial;
 ;
 
@@ -1705,7 +1723,7 @@ programmer # stk600
     desc                   = "Atmel STK600";
     type                   = "stk600";
     prog_modes             = PM_TPI | PM_ISP | PM_PDI;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2106;
@@ -1720,7 +1738,7 @@ programmer # stk600pp
     desc                   = "Atmel STK600 in parallel programming mode";
     type                   = "stk600pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2106;
@@ -1735,7 +1753,7 @@ programmer # stk600hvsp
     desc                   = "Atmel STK600 in HV serial programming mode";
     type                   = "stk600hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2106;
@@ -1771,6 +1789,7 @@ programmer # ft245r
     desc                   = "FT245R based generic programmer";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6001;
@@ -1790,6 +1809,7 @@ programmer # ft232r
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
     is_serialadapter       = yes;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403; # For use as serial adapter
     usbpid                 = 0x6001; # "
@@ -1810,6 +1830,7 @@ programmer # bwmega
     desc                   = "BitWizard ftdi_atmega builtin programmer";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6001;
@@ -1835,6 +1856,7 @@ programmer # arduino-ft232r
     desc                   = "Arduino: FT232R connected to ISP";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6001;
@@ -1856,6 +1878,7 @@ programmer # tc2030
     desc                   = "Tag-Connect TC2030";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6001;
@@ -1882,6 +1905,7 @@ programmer # uncompatino
     desc                   = "uncompatino with all pairs of pins shorted";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6001;
@@ -1916,6 +1940,7 @@ programmer # ttl232r
     desc                   = "FTDI TTL232R-5V with ICSP adapter";
     type                   = "ftdi_syncbb";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x0403;
     usbpid                 = 0x6001;
@@ -1958,6 +1983,7 @@ programmer # usbasp
     desc                   = "USBasp ISP and TPI programmer";
     type                   = "usbasp";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x16c0; # VOTI
     usbpid                 = 0x05dc; # Obdev's free shared PID
@@ -1981,6 +2007,7 @@ programmer # nibobee
     desc                   = "NIBObee";
     type                   = "usbasp";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x16c0; # VOTI
     usbpid                 = 0x092f; # NIBObee PID
@@ -1997,6 +2024,7 @@ programmer # usbasp-clone
     desc                   = "Any usbasp clone with correct VID/PID";
     type                   = "usbasp";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x16c0; # VOTI
     usbpid                 = 0x05dc; # Obdev's free shared PID
@@ -2018,6 +2046,7 @@ programmer # usbtiny
     desc                   = "USBtiny simple USB programmer";
     type                   = "usbtiny";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x1781;
     usbpid                 = 0x0c9f;
@@ -2067,6 +2096,7 @@ programmer # arduinoisp
     desc                   = "Arduino-branded USBtiny ISP Programmer";
     type                   = "usbtiny";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x2341;
     usbpid                 = 0x0049;
@@ -2084,6 +2114,7 @@ programmer # arduinoisporg
     desc                   = "Arduino-branded USBtiny ISP Programmer";
     type                   = "usbtiny";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x2a03;
     usbpid                 = 0x0049;
@@ -2101,6 +2132,7 @@ programmer # ehajo-isp
     desc                   = "AVR ISP programmer from eHaJo.de";
     type                   = "usbtiny";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x16d0;
     usbpid                 = 0x0ba5;
@@ -2120,6 +2152,7 @@ programmer # iseavrprog
     desc                   = "AVR ISP programmer from iascaled.com";
     type                   = "usbtiny";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x1209;
     usbpid                 = 0x6570;
@@ -2258,7 +2291,7 @@ programmer # jtagmkI
     desc                   = "Atmel JTAG ICE mkI";
     type                   = "jtagmki";
     prog_modes             = PM_JTAGmkI;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = serial;
     baudrate               = 115200;    # default is 115200
 ;
@@ -2288,7 +2321,7 @@ programmer # jtagmkII
     desc                   = "Atmel JTAG ICE mkII";
     type                   = "jtagmkii";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     baudrate               = 19200;    # default is 19200
     usbvid                 = 0x03eb;
@@ -2325,7 +2358,7 @@ programmer # jtag2isp
     desc                   = "Atmel JTAG ICE mkII in ISP mode";
     type                   = "jtagmkii_isp";
     prog_modes             = PM_TPI | PM_ISP;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     baudrate               = 115200;
     usbvid                 = 0x03eb;
@@ -2399,7 +2432,7 @@ programmer # dragon_jtag
     desc                   = "Atmel AVR Dragon in JTAG mode";
     type                   = "dragon_jtag";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     baudrate               = 115200;
     usbvid                 = 0x03eb;
@@ -2417,7 +2450,7 @@ programmer # dragon_isp
     desc                   = "Atmel AVR Dragon in ISP mode";
     type                   = "dragon_isp";
     prog_modes             = PM_TPI | PM_ISP;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     baudrate               = 115200;
     usbvid                 = 0x03eb;
@@ -2435,7 +2468,7 @@ programmer # dragon_pp
     desc                   = "Atmel AVR Dragon in PP mode";
     type                   = "dragon_pp";
     prog_modes             = PM_HVPP;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     baudrate               = 115200;
     usbvid                 = 0x03eb;
@@ -2453,7 +2486,7 @@ programmer # dragon_hvsp
     desc                   = "Atmel AVR Dragon in HVSP mode";
     type                   = "dragon_hvsp";
     prog_modes             = PM_HVSP;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     baudrate               = 115200;
     usbvid                 = 0x03eb;
@@ -2519,7 +2552,7 @@ programmer # jtag3
     desc                   = "Atmel AVR JTAGICE3 in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
@@ -2534,7 +2567,7 @@ programmer # jtag3pdi
     desc                   = "Atmel AVR JTAGICE3 in PDI mode";
     type                   = "jtagice3_pdi";
     prog_modes             = PM_PDI;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
@@ -2549,7 +2582,7 @@ programmer # jtag3updi
     desc                   = "Atmel AVR JTAGICE3 in UPDI mode";
     type                   = "jtagice3_updi";
     prog_modes             = PM_UPDI;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
@@ -2580,7 +2613,7 @@ programmer # jtag3isp
     desc                   = "Atmel AVR JTAGICE3 in ISP mode";
     type                   = "jtagice3_isp";
     prog_modes             = PM_ISP;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2110, 0x2140;
@@ -2606,7 +2639,7 @@ programmer # xplainedpro
     desc                   = "Atmel XplainedPro in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2111;
@@ -2621,7 +2654,7 @@ programmer # xplainedpro_pdi
     desc                   = "Atmel XplainedPro in PDI mode";
     type                   = "jtagice3_pdi";
     prog_modes             = PM_PDI;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2111;
@@ -2637,7 +2670,7 @@ programmer # xplainedpro_updi
     desc                   = "Atmel XplainedPro in UPDI mode";
     type                   = "jtagice3_updi";
     prog_modes             = PM_UPDI;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2111;
@@ -2670,7 +2703,7 @@ programmer # xplainedmini
     desc                   = "Atmel XplainedMini in ISP mode";
     type                   = "jtagice3_isp";
     prog_modes             = PM_ISP;
-    extra_features         = HAS_SUFFER | HAS_VTARG_SWITCH;
+    extra_features         = HAS_SUFFER | HAS_VTARG_SWITCH | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2145;
@@ -2708,7 +2741,7 @@ programmer # xplainedmini_updi
     desc                   = "Atmel XplainedMini in UPDI mode";
     type                   = "jtagice3_updi";
     prog_modes             = PM_UPDI;
-    extra_features         = HAS_SUFFER | HAS_VTARG_SWITCH;
+    extra_features         = HAS_SUFFER | HAS_VTARG_SWITCH | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2145;
@@ -2752,7 +2785,7 @@ programmer # atmelice
     desc                   = "Atmel-ICE in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2141;
@@ -2790,6 +2823,7 @@ programmer parent "atmelice" # atmelice_dw
     desc                   = "Atmel-ICE in debugWIRE mode";
     type                   = "jtagice3_dw";
     prog_modes             = PM_debugWIRE;
+    extra_features         = HAS_VTARG_READ;
 ;
 
 #------------------------------------------------------------
@@ -2807,15 +2841,12 @@ programmer parent "atmelice" # atmelice_isp
 # atmelice_tpi
 #------------------------------------------------------------
 
-programmer # atmelice_tpi
+programmer parent "atmelice" # atmelice_tpi
     id                     = "atmelice_tpi";
     desc                   = "Atmel-ICE in TPI mode";
     type                   = "jtagice3_tpi";
     prog_modes             = PM_TPI;
     extra_features         = HAS_VTARG_READ;
-    connection_type        = usb;
-    usbvid                 = 0x03eb;
-    usbpid                 = 0x2141;
 ;
 
 #------------------------------------------------------------
@@ -2846,7 +2877,7 @@ programmer # powerdebugger
     desc                   = "Atmel PowerDebugger in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG | PM_AVR32JTAG;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2144;
@@ -2884,6 +2915,7 @@ programmer parent "powerdebugger" # powerdebugger_dw
     desc                   = "Atmel PowerDebugger in debugWire mode";
     type                   = "jtagice3_dw";
     prog_modes             = PM_debugWIRE;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
 ;
 
 #------------------------------------------------------------
@@ -2906,6 +2938,7 @@ programmer parent "powerdebugger" # powerdebugger_tpi
     desc                   = "Atmel PowerDebugger in TPI mode";
     type                   = "jtagice3_tpi";
     prog_modes             = PM_TPI;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
 ;
 
 #------------------------------------------------------------
@@ -2948,7 +2981,7 @@ programmer # pickit4
     desc                   = "MPLAB(R) PICkit 4 in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
@@ -3000,6 +3033,7 @@ programmer parent "pickit4" # pickit4_tpi
     desc                   = "MPLAB(R) PICkit 4 in TPI mode";
     type                   = "jtagice3_tpi";
     prog_modes             = PM_TPI;
+    extra_features         = HAS_VTARG_READ | HAS_VTARG_READ;
 ;
 
 # End of "Atmel" Mode
@@ -3015,7 +3049,7 @@ programmer # pickit4_mplab
     desc                   = "MPLAB(R) PICkit 4 in JTAG Mode";
     type                   = "pickit5";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-    extra_features         = HAS_VTARG_SWITCH | HAS_VTARG_ADJ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_SWITCH | HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x04d8;
     usbpid                 = 0x9012; # PK4 (MPLAB mode)
@@ -3114,7 +3148,7 @@ programmer # pickit5
     desc                   = "MPLAB(R) PICkit 5 in JTAG Mode";
     type                   = "pickit5";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-    extra_features         = HAS_VTARG_SWITCH | HAS_VTARG_ADJ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_SWITCH | HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x04d8;
     usbpid                 = 0x9036; # PK5
@@ -3209,7 +3243,7 @@ programmer # pickit_basic
     desc                   = "MPLAB(R) PICkit Basic in JTAG Mode";
     type                   = "pickit5";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-#   extra_features         = HAS_VTARG_READ;    # At the time of testing, this was not working
+#   extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ; # At the time of testing, HAS_VTARG_READ was not working
     connection_type        = usb;
     usbvid                 = 0x04d8;
     usbpid                 = 0x9055;    # PK Basic
@@ -3307,7 +3341,7 @@ programmer # snap
     desc                   = "MPLAB(R) SNAP in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2180, 0x217f, 0x2181;
@@ -3363,6 +3397,19 @@ programmer parent "snap" # snap_tpi
     desc                   = "MPLAB(R) SNAP in TPI mode";
     type                   = "jtagice3_tpi";
     prog_modes             = PM_TPI;
+    extra_features         = HAS_VTARG_READ;
+;
+
+#------------------------------------------------------------
+# snap_dw
+#------------------------------------------------------------
+
+programmer parent "snap" # snap_dw
+    id                     = "snap_dw";
+    desc                   = "MPLAB(R) SNAP in debugWire mode";
+    type                   = "jtagice3_dw";
+    prog_modes             = PM_debugWIRE;
+    extra_features         = HAS_VTARG_READ;
 ;
 
 # End of "Atmel" mode
@@ -3378,7 +3425,7 @@ programmer # snap_mplab
     desc                   = "MPLAB(R) SNAP in JTAG mode";
     type                   = "pickit5";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-    extra_features         = HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x9018;    # SNAP (mplab mode)
@@ -3448,7 +3495,7 @@ programmer # pkobn_updi
     desc                   = "Curiosity nano (nEDBG) in UPDI mode";
     type                   = "jtagice3_updi";
     prog_modes             = PM_UPDI;
-    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2175;
@@ -3492,6 +3539,7 @@ programmer # pickit2
     desc                   = "Microchip PICkit 2 programmer in ISP mode";
     type                   = "pickit2";
     prog_modes             = PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x04d8;
     usbpid                 = 0x0033;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -866,6 +866,7 @@ programmer # linuxspi
     desc                   = "Use Linux SPI device in /dev/spidev*";
     type                   = "linuxspi";
     prog_modes             = PM_TPI | PM_ISP;
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = spi;
     reset                  = 25;    # Pi GPIO number - this is J8:22
 ;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2982,7 +2982,7 @@ programmer # pickit4
     desc                   = "MPLAB(R) PICkit 4 in JTAG mode";
     type                   = "jtagice3";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-    extra_features         = HAS_VTARG_READ | HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
+    extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;
     usbpid                 = 0x2177, 0x2178, 0x2179;
@@ -3034,7 +3034,7 @@ programmer parent "pickit4" # pickit4_tpi
     desc                   = "MPLAB(R) PICkit 4 in TPI mode";
     type                   = "jtagice3_tpi";
     prog_modes             = PM_TPI;
-    extra_features         = HAS_VTARG_READ | HAS_VTARG_READ;
+    extra_features         = HAS_VTARG_READ;
 ;
 
 # End of "Atmel" Mode

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3244,7 +3244,7 @@ programmer # pickit_basic
     desc                   = "MPLAB(R) PICkit Basic in JTAG Mode";
     type                   = "pickit5";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-#   extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ; # At the time of testing, HAS_VTARG_READ was not working
+    extra_features         = HAS_BITCLOCK_ADJ; # HAS_VTARG_READ was not working yet
     connection_type        = usb;
     usbvid                 = 0x04d8;
     usbpid                 = 0x9055;    # PK Basic

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1236,7 +1236,7 @@ programmer # ft232h_jtag
 # Pin J2-10 (AD3) is RESET
 # Pin J2-6 is GND
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
-# a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
+# a 16 MHz Atmega1280 to program reliably.  The 232H is conveniently 5 V tolerant.
 
 programmer parent "ft232h" # um232h
     id                     = "um232h";
@@ -1254,7 +1254,7 @@ programmer parent "ft232h" # um232h
 # Brown (Pin 5) is RESET
 # Black (Pin 10) is GND
 # Use the -b flag to set the SPI clock rate eg -b 3750000 is the fastest I could get
-# a 16MHz Atmega1280 to program reliably.  The 232H is conveniently 5V tolerant.
+# a 16 MHz Atmega1280 to program reliably.  The 232H is conveniently 5 V tolerant.
 
 programmer parent "um232h" # c232hm
     id                     = "c232hm";

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -702,18 +702,18 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 
   write_flush(pdata);
 
-  if(pgm->extra_features & HAS_BITCLOCK_ADJ) {
-    if(pgm->baudrate && pgm->bitclock && (int) (1.0/pgm->bitclock) != pgm->baudrate)
-      pmsg_warning("both -b baud and -B bitrate set; ignoring -B\n");
-    set_frequency(pdata,
-      pgm->baudrate? pgm->baudrate:
-      pgm->bitclock? (int) (1.0/pgm->bitclock):
-      150000
-    );
-  } else if(pgm->baudrate || pgm->bitclock) {
-    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring %s\n",
-      pgmid, pgm->baudrate && pgm->bitclock? "-b and -B": pgm->baudrate? "-b": "-B");
-  }
+  if(pgm->baudrate || pgm->bitclock)
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
+
+  if(pgm->baudrate && pgm->bitclock && (int) (1.0/pgm->bitclock) != pgm->baudrate)
+    pmsg_warning("both -b baudrate and -B bitrate set; ignoring -B\n");
+
+  set_frequency(pdata,
+    pgm->baudrate? pgm->baudrate:
+    pgm->bitclock? (int) (1.0/pgm->bitclock):
+    150000
+  );
 
   // Set pin limit depending on chip type
   switch(pdata->ftdic->type) {

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -710,9 +710,9 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
     else
       set_frequency(pdata, pgm->baudrate? pgm->baudrate: 150000);
   } else if(pgm->baudrate || pgm->bitclock) {
-    pmsg_warning("%s does not support adjustable bitclock speed. Ignoring %s \n",
-      pgmid ,pgm->baudrate && pgm->bitclock? "-b and -B flags": pgm->baudrate? "-b flag": "-B flag");
-    }
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring %s\n",
+      pgmid, pgm->baudrate && pgm->bitclock? "-b and -B": pgm->baudrate? "-b": "-B");
+  }
 
   // Set pin limit depending on chip type
   switch(pdata->ftdic->type) {

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -703,6 +703,8 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
   write_flush(pdata);
 
   if(pgm->extra_features & HAS_BITCLOCK_ADJ) {
+    if(pgm->baudrate && pgm->bitclock && (int) (1.0/pgm->bitclock) != pgm->baudrate)
+      pmsg_warning("both -b baud and -B bitrate set; ignoring -B\n");
     if(pgm->baudrate)
       set_frequency(pdata, pgm->baudrate);
     else if(pgm->bitclock)

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -798,7 +798,7 @@ static int avrftdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     // Use speed optimization with CAUTION
     usleep(20*1000);
 
-    // Giving rst-pulse of at least 2 avr-clock-cycles, for security (2us @ 1MHz)
+    // Giving rst-pulse of at least 2 avr-clock-cycles, for security (2 us @ 1 MHz)
     set_pin(pgm, PIN_AVR_RESET, ON);
     usleep(20*1000);
 

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -705,12 +705,11 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->extra_features & HAS_BITCLOCK_ADJ) {
     if(pgm->baudrate && pgm->bitclock && (int) (1.0/pgm->bitclock) != pgm->baudrate)
       pmsg_warning("both -b baud and -B bitrate set; ignoring -B\n");
-    if(pgm->baudrate)
-      set_frequency(pdata, pgm->baudrate);
-    else if(pgm->bitclock)
-      set_frequency(pdata, (uint32_t) (1.0f/pgm->bitclock));
-    else
-      set_frequency(pdata, pgm->baudrate? pgm->baudrate: 150000);
+    set_frequency(pdata,
+      pgm->baudrate? pgm->baudrate:
+      pgm->bitclock? (int) (1.0/pgm->bitclock):
+      150000
+    );
   } else if(pgm->baudrate || pgm->bitclock) {
     pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring %s\n",
       pgmid, pgm->baudrate && pgm->bitclock? "-b and -B": pgm->baudrate? "-b": "-B");

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -702,13 +702,17 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 
   write_flush(pdata);
 
-  if(pgm->baudrate) {
-    set_frequency(pdata, pgm->baudrate);
-  } else if(pgm->bitclock) {
-    set_frequency(pdata, (uint32_t) (1.0f/pgm->bitclock));
-  } else {
-    set_frequency(pdata, pgm->baudrate? pgm->baudrate: 150000);
-  }
+  if(pgm->extra_features & HAS_BITCLOCK_ADJ) {
+    if(pgm->baudrate)
+      set_frequency(pdata, pgm->baudrate);
+    else if(pgm->bitclock)
+      set_frequency(pdata, (uint32_t) (1.0f/pgm->bitclock));
+    else
+      set_frequency(pdata, pgm->baudrate? pgm->baudrate: 150000);
+  } else if(pgm->baudrate || pgm->bitclock) {
+    pmsg_warning("%s does not support adjustable bitclock speed. Ignoring %s \n",
+      pgmid ,pgm->baudrate && pgm->bitclock? "-b and -B flags": pgm->baudrate? "-b flag": "-B flag");
+    }
 
   // Set pin limit depending on chip type
   switch(pdata->ftdic->type) {

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -707,7 +707,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
       pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   if(pgm->baudrate && pgm->bitclock && (int) (1.0/pgm->bitclock) != pgm->baudrate)
-    pmsg_warning("both -b baudrate and -B bitrate set; ignoring -B\n");
+    pmsg_warning("both -b baudrate and -B bitrate set; using -b\n");
 
   set_frequency(pdata,
     pgm->baudrate? pgm->baudrate:

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -156,8 +156,8 @@ static unsigned char bitbang_txrx(const PROGRAMMER *pgm, unsigned char byte) {
      * if and only if T>t_CLCL (t_CLCL=clock period of target system).
      *
      * Due to the delay introduced by "IN" and "OUT"-commands, T is greater
-     * than 1us (more like 2us) on x86-architectures. So programming works
-     * safely down to 1MHz target clock.
+     * than 1us (more like 2 us) on x86-architectures. So programming works
+     * safely down to 1 MHz target clock.
      */
 
     b = (byte >> i) & 0x01;

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -441,10 +441,12 @@ static int buspirate_verifyconfig(const PROGRAMMER *pgm) {
 
 // ====== Programmer methods =======
 static int buspirate_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ)) {
-      pmsg_warning("%s does not support adjustable bitclock speed using -B.\n", pgmid);
-      imsg_warning("Ignoring -B flag. Use -x help to view alternative SPI clock options\n");
+  if(pgm->bitclock) {
+    if(str_eq(pgm->type, "buspirate_bb"))
+      pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
+    else {
+      pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+      imsg_warning("Use -x help to view alternative SPI clock options\n");
     }
   }
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -443,9 +443,9 @@ static int buspirate_verifyconfig(const PROGRAMMER *pgm) {
 static int buspirate_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock) {
     if(str_caseeq(pgm->type, "BusPirate_BB"))
-      pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B; use -i instead\n", pgm->type);
+      pmsg_warning("-c %s does not support adjustable bitclock speed using -B; use -i instead\n", pgmid);
     else {
-      pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+      pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
       imsg_warning("use -x help to view alternative SPI clock options\n");
     }
   }

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -568,7 +568,7 @@ static int buspirate_start_mode_bin(PROGRAMMER *pgm) {
     unsigned short pwm_duty;
     unsigned short pwm_period;
 
-    pwm_period = 16000/(my.cpufreq) - 1; // Oscillator runs at 32MHz, we don't use a prescaler
+    pwm_period = 16000/(my.cpufreq) - 1; // Oscillator runs at 32 MHz, we don't use a prescaler
     pwm_duty = pwm_period/2;  // 50% duty cycle
 
     msg_notice2("setting up PWM for cpufreq\n");

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -457,6 +457,13 @@ static int buspirate_open(PROGRAMMER *pgm, const char *port) {
   // Drain any extraneous input
   serial_drain(&pgm->fd, 0);
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ)) {
+      pmsg_warning("%s does not support adjustable bitclock speed using -B.\n", pgmid);
+      imsg_warning("Ignoring -B flag. Use -x help to view alternative SPI clock options\n");
+    }
+  }
+
   return 0;
 }
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -442,11 +442,11 @@ static int buspirate_verifyconfig(const PROGRAMMER *pgm) {
 // ====== Programmer methods =======
 static int buspirate_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock) {
-    if(str_eq(pgm->type, "buspirate_bb"))
-      pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
+    if(str_caseeq(pgm->type, "BusPirate_BB"))
+      pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B; use -i instead\n", pgm->type);
     else {
       pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
-      imsg_warning("Use -x help to view alternative SPI clock options\n");
+      imsg_warning("use -x help to view alternative SPI clock options\n");
     }
   }
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -450,12 +450,8 @@ static int buspirate_open(PROGRAMMER *pgm, const char *port) {
     }
   }
 
-  // BusPirate runs at 115200 by default
-  if(pgm->baudrate == 0)
-    pgm->baudrate = 115200;
-
   union pinfo pinfo;
-  pinfo.serialinfo.baud = pgm->baudrate;
+  pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
   pgm->port = port;
   if(serial_open(port, pinfo, &pgm->fd) == -1) {

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -441,12 +441,18 @@ static int buspirate_verifyconfig(const PROGRAMMER *pgm) {
 
 // ====== Programmer methods =======
 static int buspirate_open(PROGRAMMER *pgm, const char *port) {
-  union pinfo pinfo;
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ)) {
+      pmsg_warning("%s does not support adjustable bitclock speed using -B.\n", pgmid);
+      imsg_warning("Ignoring -B flag. Use -x help to view alternative SPI clock options\n");
+    }
+  }
 
   // BusPirate runs at 115200 by default
   if(pgm->baudrate == 0)
     pgm->baudrate = 115200;
 
+  union pinfo pinfo;
   pinfo.serialinfo.baud = pgm->baudrate;
   pinfo.serialinfo.cflags = SERIAL_8N1;
   pgm->port = port;
@@ -456,13 +462,6 @@ static int buspirate_open(PROGRAMMER *pgm, const char *port) {
 
   // Drain any extraneous input
   serial_drain(&pgm->fd, 0);
-
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ)) {
-      pmsg_warning("%s does not support adjustable bitclock speed using -B.\n", pgmid);
-      imsg_warning("Ignoring -B flag. Use -x help to view alternative SPI clock options\n");
-    }
-  }
 
   return 0;
 }

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -322,7 +322,7 @@ static void butterfly_enable(PROGRAMMER *pgm, const AVRPART *p) {
 
 static int butterfly_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   pgm->port = port;
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -326,17 +326,11 @@ static int butterfly_open(PROGRAMMER *pgm, const char *port) {
 
   pgm->port = port;
 
-  // If baudrate was not specified use 19200 Baud
-  if(pgm->baudrate == 0)
-    pgm->baudrate = 19200;
   union pinfo pinfo;
-  pinfo.serialinfo.baud = pgm->baudrate;
+  pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 19200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
+  if(serial_open(port, pinfo, &pgm->fd) == -1)
     return -1;
-  }
-
-
 
   if(my.autoreset) {
     // This code assumes a negative-logic USB to TTL serial adapter

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -321,10 +321,8 @@ static void butterfly_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int butterfly_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   pgm->port = port;
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -321,24 +321,24 @@ static void butterfly_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int butterfly_open(PROGRAMMER *pgm, const char *port) {
-  union pinfo pinfo;
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
 
   pgm->port = port;
 
   // If baudrate was not specified use 19200 Baud
-  if(pgm->baudrate == 0) {
+  if(pgm->baudrate == 0)
     pgm->baudrate = 19200;
-  }
+  union pinfo pinfo;
   pinfo.serialinfo.baud = pgm->baudrate;
   pinfo.serialinfo.cflags = SERIAL_8N1;
   if(serial_open(port, pinfo, &pgm->fd) == -1) {
     return -1;
   }
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+
 
   if(my.autoreset) {
     // This code assumes a negative-logic USB to TTL serial adapter

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -335,6 +335,11 @@ static int butterfly_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   if(my.autoreset) {
     // This code assumes a negative-logic USB to TTL serial adapter
     // Set RTS/DTR high to discharge the series-capacitor, if present

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -251,10 +251,8 @@ static int ch341a_open(PROGRAMMER *pgm, const char *port) {
     return -1;
   }
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   return 0;
 }

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -250,6 +250,12 @@ static int ch341a_open(PROGRAMMER *pgm, const char *port) {
     libusb_exit(my.ctx);
     return -1;
   }
+
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   return 0;
 }
 

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -252,7 +252,7 @@ static int ch341a_open(PROGRAMMER *pgm, const char *port) {
   }
 
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   return 0;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -348,6 +348,7 @@ TOKEN *new_constant(const char *con) {
     str_eq(con, "HAS_VTARG_READ")? HAS_VTARG_READ:
     str_eq(con, "HAS_FOSC_ADJ")? HAS_FOSC_ADJ:
     str_eq(con, "HAS_VAREF_ADJ")? HAS_VAREF_ADJ:
+    str_eq(con, "HAS_BITCLOCK_ADJ")? HAS_BITCLOCK_ADJ:
     str_eq(con, "pseudo")? 2:
     str_eq(con, "yes") || str_eq(con, "true")? 1: str_eq(con, "no") || str_eq(con, "false")? 0: (assigned = 0);
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -145,6 +145,8 @@ static char *extra_features_str(int m) {
     strcat(mode, " | HAS_FOSC_ADJ");
   if(m & HAS_VAREF_ADJ)
     strcat(mode, " | HAS_VAREF_ADJ");
+  if(m & HAS_BITCLOCK_ADJ)
+    strcat(mode, " | HAS_BITCLOCK_ADJ");
 
   return mode + (mode[1] == 0? 0: 4);
 }

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -728,6 +728,9 @@ static void dryrun_disable(const PROGRAMMER *pgm) {
 }
 
 static int dryrun_open(PROGRAMMER *pgm, const char *port) {
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+
   pmsg_debug("%s(%s)\n", __func__, port? port: "NULL");
 
   return 0;

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -729,7 +729,7 @@ static void dryrun_disable(const PROGRAMMER *pgm) {
 
 static int dryrun_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   pmsg_debug("%s(%s)\n", __func__, port? port: "NULL");
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -181,6 +181,12 @@ void flip1_initpgm(PROGRAMMER *pgm) {
 
 static int flip1_open(PROGRAMMER *pgm, const char *port_spec) {
   FLIP1(pgm)->dfu = dfu_open(port_spec);
+
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   return (FLIP1(pgm)->dfu != NULL)? 0: -1;
 }
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -181,7 +181,7 @@ void flip1_initpgm(PROGRAMMER *pgm) {
 
 static int flip1_open(PROGRAMMER *pgm, const char *port_spec) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   FLIP1(pgm)->dfu = dfu_open(port_spec);
   return (FLIP1(pgm)->dfu != NULL)? 0: -1;

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -180,10 +180,8 @@ void flip1_initpgm(PROGRAMMER *pgm) {
 #ifdef HAVE_LIBUSB
 
 static int flip1_open(PROGRAMMER *pgm, const char *port_spec) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   FLIP1(pgm)->dfu = dfu_open(port_spec);
   return (FLIP1(pgm)->dfu != NULL)? 0: -1;

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -180,13 +180,12 @@ void flip1_initpgm(PROGRAMMER *pgm) {
 #ifdef HAVE_LIBUSB
 
 static int flip1_open(PROGRAMMER *pgm, const char *port_spec) {
-  FLIP1(pgm)->dfu = dfu_open(port_spec);
-
   if(pgm->bitclock != 0.0) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
       pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
   }
 
+  FLIP1(pgm)->dfu = dfu_open(port_spec);
   return (FLIP1(pgm)->dfu != NULL)? 0: -1;
 }
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -178,13 +178,12 @@ void flip2_initpgm(PROGRAMMER *pgm) {
 }
 
 static int flip2_open(PROGRAMMER *pgm, const char *port_spec) {
-  FLIP2(pgm)->dfu = dfu_open(port_spec);
-
   if(pgm->bitclock != 0.0) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
       pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
   }
 
+  FLIP2(pgm)->dfu = dfu_open(port_spec);
   return (FLIP2(pgm)->dfu != NULL)? 0: -1;
 }
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -179,6 +179,12 @@ void flip2_initpgm(PROGRAMMER *pgm) {
 
 static int flip2_open(PROGRAMMER *pgm, const char *port_spec) {
   FLIP2(pgm)->dfu = dfu_open(port_spec);
+
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   return (FLIP2(pgm)->dfu != NULL)? 0: -1;
 }
 

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -179,7 +179,7 @@ void flip2_initpgm(PROGRAMMER *pgm) {
 
 static int flip2_open(PROGRAMMER *pgm, const char *port_spec) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   FLIP2(pgm)->dfu = dfu_open(port_spec);
   return (FLIP2(pgm)->dfu != NULL)? 0: -1;

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -178,10 +178,8 @@ void flip2_initpgm(PROGRAMMER *pgm) {
 }
 
 static int flip2_open(PROGRAMMER *pgm, const char *port_spec) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   FLIP2(pgm)->dfu = dfu_open(port_spec);
   return (FLIP2(pgm)->dfu != NULL)? 0: -1;

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -363,7 +363,7 @@ static int ft245r_set_bitclock(const PROGRAMMER *pgm) {
       pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   if(pgm->baudrate && pgm->bitclock && (int) (1.0/pgm->bitclock) != pgm->baudrate)
-    pmsg_warning("both -b baudrate and -B bitrate set; ignoring -b\n");
+    pmsg_warning("both -b baudrate and -B bitrate set; using -B\n");
 
   // 150000 should work for all ftdi chips and the internal clock of 1 MHz
   rate = pgm->bitclock? (int) (1.0/pgm->bitclock): pgm->baudrate? pgm->baudrate: 150000;

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -113,12 +113,12 @@ void ft245r_initpgm(PROGRAMMER *pgm) {
 
 /*
  * Some revisions of the FTDI chips mess up the timing in bitbang mode unless
- * the bitclock is set to the max (3MHz).  For example, see:
+ * the bitclock is set to the max (3 MHz).  For example, see:
  *
  * http://www.ftdichip.com/Support/Documents/TechnicalNotes/TN_120_FT232R%20Errata%20Technical%20Note.pdf
  *
  * To work around this problem, set the macro below to 1 to always set the
- * bitclock to 3MHz and then issue the same byte repeatedly to get the desired
+ * bitclock to 3 MHz and then issue the same byte repeatedly to get the desired
  * timing.
  *
 */
@@ -364,7 +364,7 @@ static int ft245r_set_bitclock(const PROGRAMMER *pgm) {
   } else if(pgm->baudrate) {
     rate = pgm->baudrate;
   } else {
-    rate = 150000;              // Should work for all ftdi chips and the avr default internal clock of 1MHz
+    rate = 150000;              // Should work for all ftdi chips and the internal clock of 1 MHz
   }
 
 #if FT245R_BITBANG_VARIABLE_PULSE_WIDTH_WORKAROUND

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1060,9 +1060,9 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     return -1;
 
 
-  if(pgm->bitclock != 0.0 && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  else {
+  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
+    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+
     if(conn == PARM3_CONN_PDI || conn == PARM3_CONN_UPDI)
       my.set_sck = jtag3_set_sck_xmega_pdi;
     else if(conn == PARM3_CONN_JTAG) {
@@ -1080,7 +1080,6 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       if(my.set_sck(pgm, parm) < 0)
         return -1;
     }
-  }
 
 
   if(conn == PARM3_CONN_JTAG) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1059,7 +1059,6 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if(jtag3_setparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, parm, 1) < 0)
     return -1;
 
-
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
     pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1059,9 +1059,6 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if(jtag3_setparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, parm, 1) < 0)
     return -1;
 
-  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
-
   if(conn == PARM3_CONN_PDI || conn == PARM3_CONN_UPDI)
     my.set_sck = jtag3_set_sck_xmega_pdi;
   else if(conn == PARM3_CONN_JTAG) {
@@ -1074,6 +1071,8 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if(pgm->bitclock && my.set_sck) {
     unsigned int clock = 1E-3/pgm->bitclock;  // kHz
 
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     pmsg_notice2("%s(): trying to set JTAG clock to %u kHz\n", __func__, clock);
     parm[0] = clock & 0xff;
     parm[1] = (clock >> 8) & 0xff;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1071,7 +1071,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       else
         my.set_sck = jtag3_set_sck_mega_jtag;
     }
-    if(pgm->bitclock != 0.0 && my.set_sck != NULL) {
+    if(pgm->bitclock && my.set_sck != NULL) {
       unsigned int clock = 1E-3/pgm->bitclock;  // kHz
 
       pmsg_notice2("%s(): trying to set JTAG clock to %u kHz\n", __func__, clock);

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1061,7 +1061,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
 
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   if(conn == PARM3_CONN_PDI || conn == PARM3_CONN_UPDI)
     my.set_sck = jtag3_set_sck_xmega_pdi;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1063,23 +1063,23 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
     pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
 
-    if(conn == PARM3_CONN_PDI || conn == PARM3_CONN_UPDI)
-      my.set_sck = jtag3_set_sck_xmega_pdi;
-    else if(conn == PARM3_CONN_JTAG) {
-      if(is_pdi(p))
-        my.set_sck = jtag3_set_sck_xmega_jtag;
-      else
-        my.set_sck = jtag3_set_sck_mega_jtag;
-    }
-    if(pgm->bitclock && my.set_sck != NULL) {
-      unsigned int clock = 1E-3/pgm->bitclock;  // kHz
+  if(conn == PARM3_CONN_PDI || conn == PARM3_CONN_UPDI)
+    my.set_sck = jtag3_set_sck_xmega_pdi;
+  else if(conn == PARM3_CONN_JTAG) {
+    if(is_pdi(p))
+      my.set_sck = jtag3_set_sck_xmega_jtag;
+    else
+      my.set_sck = jtag3_set_sck_mega_jtag;
+  }
+  if(pgm->bitclock && my.set_sck != NULL) {
+    unsigned int clock = 1E-3/pgm->bitclock;  // kHz
 
-      pmsg_notice2("%s(): trying to set JTAG clock to %u kHz\n", __func__, clock);
-      parm[0] = clock & 0xff;
-      parm[1] = (clock >> 8) & 0xff;
-      if(my.set_sck(pgm, parm) < 0)
-        return -1;
-    }
+    pmsg_notice2("%s(): trying to set JTAG clock to %u kHz\n", __func__, clock);
+    parm[0] = clock & 0xff;
+    parm[1] = (clock >> 8) & 0xff;
+    if(my.set_sck(pgm, parm) < 0)
+      return -1;
+  }
 
 
   if(conn == PARM3_CONN_JTAG) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1071,7 +1071,8 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     else
       my.set_sck = jtag3_set_sck_mega_jtag;
   }
-  if(pgm->bitclock && my.set_sck != NULL) {
+
+  if(pgm->bitclock && my.set_sck) {
     unsigned int clock = 1E-3/pgm->bitclock;  // kHz
 
     pmsg_notice2("%s(): trying to set JTAG clock to %u kHz\n", __func__, clock);
@@ -1080,7 +1081,6 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if(my.set_sck(pgm, parm) < 0)
       return -1;
   }
-
 
   if(conn == PARM3_CONN_JTAG) {
     pmsg_notice2("%s(): trying to set JTAG daisy-chain info to %d,%d,%d,%d\n", __func__,

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -452,14 +452,12 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     }
   }
 
-  if(pgm->bitclock != 0.0) {
+  if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-    else {
-      pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
-      if(jtagmkI_set_sck_period(pgm, pgm->bitclock) != 0)
-        return -1;
-    }
+      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
+    if(jtagmkI_set_sck_period(pgm, pgm->bitclock) != 0)
+      return -1;
   }
 
   cmd[0] = CMD_STOP;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -453,9 +453,13 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if(pgm->bitclock != 0.0) {
-    pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
-    if(jtagmkI_set_sck_period(pgm, pgm->bitclock) != 0)
-      return -1;
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+    else {
+      pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
+      if(jtagmkI_set_sck_period(pgm, pgm->bitclock) != 0)
+        return -1;
+    }
   }
 
   cmd[0] = CMD_STOP;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -454,7 +454,7 @@ static int jtagmkI_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
     if(jtagmkI_set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1200,7 +1200,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if(pgm->bitclock) {
     if(pgm->flag & PGM_FL_IS_JTAG) {
       if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-        pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+        pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
       pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
       if(jtagmkII_set_sck_period(pgm, pgm->bitclock) != 0)
         return -1;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1197,6 +1197,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         serial_setparams(&pgm->fd, pgm->baudrate, SERIAL_8N1);
     }
   }
+
   if(pgm->bitclock) {
     if(pgm->flag & PGM_FL_IS_JTAG) {
       if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1205,7 +1205,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       if(jtagmkII_set_sck_period(pgm, pgm->bitclock) != 0)
         return -1;
     } else {
-      pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+      pmsg_warning("-c %s is not known to support adjustable bitclock speed; ignoring -B\n", pgmid);
     }
   }
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1197,10 +1197,14 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         serial_setparams(&pgm->fd, pgm->baudrate, SERIAL_8N1);
     }
   }
-  if((pgm->flag & PGM_FL_IS_JTAG) && pgm->bitclock != 0.0) {
-    pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
-    if(jtagmkII_set_sck_period(pgm, pgm->bitclock) != 0)
-      return -1;
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+    else if(pgm->flag & PGM_FL_IS_JTAG) {
+      pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
+      if(jtagmkII_set_sck_period(pgm, pgm->bitclock) != 0)
+        return -1;
+    }
   }
 
   if((pgm->flag & PGM_FL_IS_JTAG) && jtagmkII_setparm(pgm, PAR_DAISY_CHAIN_INFO, my.jtagchain) < 0) {

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1197,13 +1197,15 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         serial_setparams(&pgm->fd, pgm->baudrate, SERIAL_8N1);
     }
   }
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-    else if(pgm->flag & PGM_FL_IS_JTAG) {
+  if(pgm->bitclock) {
+    if(pgm->flag & PGM_FL_IS_JTAG) {
+      if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+        pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
       pmsg_notice2("%s(): trying to set JTAG clock period to %.1f us\n", __func__, pgm->bitclock);
       if(jtagmkII_set_sck_period(pgm, pgm->bitclock) != 0)
         return -1;
+    } else {
+      pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
     }
   }
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -170,7 +170,7 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
 
 
 (?x: PM_(SPM|TPI|ISP|PDI|UPDI|HVSP|HVPP|debugWIRE|JTAG|JTAGmkI|XMEGAJTAG|AVR32JTAG|aWire) |
- HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ|FOSC_ADJ|VAREF_ADJ) |
+ HAS_(SUFFER|VTARG_SWITCH|VTARG_ADJ|VTARG_READ|FOSC_ADJ|VAREF_ADJ|BITCLOCK_ADJ) |
  yes|no|pseudo | true|false ) { /* Constants */
   yylval = new_constant(yytext);
   return TKN_NUMBER;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -300,6 +300,7 @@ typedef struct opcode {
 #define HAS_VTARG_READ        8
 #define HAS_FOSC_ADJ         16
 #define HAS_VAREF_ADJ        32
+#define HAS_BITCLOCK_ADJ     64
 
 #define AVR_FAMILYIDLEN       7
 #define AVR_SIBLEN           32

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -561,16 +561,17 @@ static void linuxgpio_libgpiod_display(const PROGRAMMER *pgm, const char *p) {
 }
 
 static int linuxgpio_libgpiod_open(PROGRAMMER *pgm, const char *port) {
-  int i;
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;
 
-  for(i = 0; i < N_PINS; ++i)
+  for(int i = 0; i < N_PINS; ++i)
     linuxgpio_libgpiod_lines[i] = NULL;
 
   // Avrdude assumes that if a pin number is invalid it means not used/available
-  for(i = 1; i < N_PINS; i++) { // The pin enumeration in libavrdude.h starts with PPI_AVR_VCC = 1
+  for(int i = 1; i < N_PINS; i++) { // The pin enumeration in libavrdude.h starts with PPI_AVR_VCC = 1
     int r;
     int gpio_num;
 

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -562,7 +562,7 @@ static void linuxgpio_libgpiod_display(const PROGRAMMER *pgm, const char *p) {
 
 static int linuxgpio_libgpiod_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -579,6 +579,11 @@ static int micronucleus_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int micronucleus_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("micronucleus_open(\"%s\")\n", port);
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   struct pdata *pdata = &my;
   const char *bus_name = NULL;
   char *dev_name = NULL;

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -580,7 +580,7 @@ static int micronucleus_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("micronucleus_open(\"%s\")\n", port);
 
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   struct pdata *pdata = &my;
   const char *bus_name = NULL;

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -579,10 +579,8 @@ static int micronucleus_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int micronucleus_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("micronucleus_open(\"%s\")\n", port);
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   struct pdata *pdata = &my;
   const char *bus_name = NULL;

--- a/src/par.c
+++ b/src/par.c
@@ -226,9 +226,8 @@ static void par_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int par_open(PROGRAMMER *pgm, const char *port) {
-
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed using -B; use -i instead\n", pgmid);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;

--- a/src/par.c
+++ b/src/par.c
@@ -226,12 +226,9 @@ static void par_enable(PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int par_open(PROGRAMMER *pgm, const char *port) {
-  int rc;
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed using -B. Use -i instead\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;
@@ -243,7 +240,7 @@ static int par_open(PROGRAMMER *pgm, const char *port) {
   }
 
   // Save pin values, so they can be restored when device is closed
-  rc = ppi_getall(&pgm->fd, PPIDATA);
+  int rc = ppi_getall(&pgm->fd, PPIDATA);
   if(rc < 0) {
     pmsg_error("unable to read status of ppi data port\n");
     return -1;

--- a/src/par.c
+++ b/src/par.c
@@ -228,6 +228,11 @@ static void par_enable(PROGRAMMER *pgm, const AVRPART *p) {
 static int par_open(PROGRAMMER *pgm, const char *port) {
   int rc;
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed using -B. Use -i instead\n", pgmid);
+  }
+
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1011,7 +1011,7 @@ static int pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
 
       int clock_period = MIN(1000000/clock_rate, 255);        // Max period is 255
 
-      clock_rate = (int) (1000000/(clock_period + 5e-7));     // Assume highest speed is 2MHz
+      clock_rate = (int) (1000000/(clock_period + 5e-7));     // Assume highest speed is 2 MHz
 
       pmsg_notice2("%s(): effective clock rate set to 0x%02x\n", __func__, clock_rate);
       my.clock_period = clock_period;

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -169,7 +169,7 @@ static void pickit2_teardown(PROGRAMMER *pgm) {
 }
 
 static int pickit2_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
+  if((pgm->ispdelay > 0 || pgm->bitclock > 0) && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
     pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
 #ifdef WIN32

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -170,7 +170,7 @@ static void pickit2_teardown(PROGRAMMER *pgm) {
 
 static int pickit2_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
 #ifdef WIN32
   my.usb_handle = open_hid(PICKIT2_VID, PICKIT2_PID);

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -203,6 +203,9 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
   }
 #endif
 
+  if(pgm->ispdelay > 0 && pgm->bitclock > 0.0)
+    pmsg_warning("both -i delay and -B bitrate set; ignoring -B\n");
+
   if(pgm->ispdelay > 0) {
     my.clock_period = MIN(pgm->ispdelay, 255);
   } else if(pgm->bitclock > 0.0) {

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -204,7 +204,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
 #endif
 
   if(pgm->ispdelay > 0 && pgm->bitclock > 0.0)
-    pmsg_warning("both -i delay and -B bitrate set; ignoring -B\n");
+    pmsg_warning("both -i delay and -B bitrate set; using -i\n");
 
   if(pgm->ispdelay > 0) {
     my.clock_period = MIN(pgm->ispdelay, 255);

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -169,6 +169,8 @@ static void pickit2_teardown(PROGRAMMER *pgm) {
 }
 
 static int pickit2_open(PROGRAMMER *pgm, const char *port) {
+  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
+    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
 
 #ifdef WIN32
   my.usb_handle = open_hid(PICKIT2_VID, PICKIT2_PID);

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -849,6 +849,8 @@ static int pickit5_updi_init(const PROGRAMMER *pgm, const AVRPART *p, double v_t
     return -1;
   }
 
+  if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
   unsigned int baud = my.actual_pgm_clk;
   if(baud < 300) {              // Better be safe than sorry
     pmsg_warning("UPDI needs a higher clock for operation, increasing UPDI to 300 Hz\n");
@@ -1011,6 +1013,9 @@ static int pickit5_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       return -1;
     }
   } else {
+
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
     // JTAG __requires__ setting the speed before program enable
     pickit5_set_sck_period(pgm, 1.0 / my.actual_pgm_clk);

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -947,7 +947,7 @@ static int pickit5_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   // Now we try to figure out if we have to supply power from PICkit
   double v_target = 3.30; // Placeholder in case no VTARG Read
-  if(pgm->extra_features & HAS_VTARG_READ){  // If not supported (PK Basic), use a place
+  if(pgm->extra_features & HAS_VTARG_READ) {  // If not supported (PK Basic), use a place
 
     pickit5_get_vtarget(pgm, &v_target);
     if(v_target < 1.8) {

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -220,6 +220,11 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   int flags;
   int r;
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed using -B. Use -i instead\n", pgmid);
+  }
+
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;
 

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -220,10 +220,8 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   int flags;
   int r;
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed using -B. Use -i instead\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -221,7 +221,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   int r;
 
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed using -B; use -i instead\n", pgmid);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -230,7 +230,7 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   HANDLE hComPort = INVALID_HANDLE_VALUE;
 
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed using -B; use -i instead\n", pgmid);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -229,6 +229,11 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   LPVOID lpMsgBuf;
   HANDLE hComPort = INVALID_HANDLE_VALUE;
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed using -B. Use -i instead\n", pgmid);
+  }
+
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;
 

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -229,10 +229,8 @@ static int serbb_open(PROGRAMMER *pgm, const char *port) {
   LPVOID lpMsgBuf;
   HANDLE hComPort = INVALID_HANDLE_VALUE;
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed using -B. Use -i instead\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed using -B. Use -i instead\n", pgm->type);
 
   if(bitbang_check_prerequisites(pgm) < 0)
     return -1;

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -59,7 +59,7 @@ static void serialupdi_teardown(PROGRAMMER *pgm) {
 
 static int serialupdi_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s sets its UPDI speed using -b [baudrate]. Ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s sets its UPDI speed using -b baudrate; ignoring -B\n", pgmid);
 
   pgm->port = port;
   return updi_link_open(pgm);

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -59,6 +59,12 @@ static void serialupdi_teardown(PROGRAMMER *pgm) {
 
 static int serialupdi_open(PROGRAMMER *pgm, const char *port) {
   pgm->port = port;
+
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s sets its UPDI speed using -b [baudrate]. Ignoring -B flag\n", pgmid);
+  }
+
   return updi_link_open(pgm);
 }
 

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -58,13 +58,10 @@ static void serialupdi_teardown(PROGRAMMER *pgm) {
 }
 
 static int serialupdi_open(PROGRAMMER *pgm, const char *port) {
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s sets its UPDI speed using -b [baudrate]. Ignoring -B\n", pgm->type);
+
   pgm->port = port;
-
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s sets its UPDI speed using -b [baudrate]. Ignoring -B flag\n", pgmid);
-  }
-
   return updi_link_open(pgm);
 }
 

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -166,7 +166,6 @@ static bool is_serprog_cmd_supported(const unsigned char *cmd_bitmap, unsigned c
 
 static int serprog_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
-
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
@@ -287,8 +286,9 @@ static int serprog_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   unsigned char buf[32];
 
   // Set SPI clock frequency
-  
-  if(is_serprog_cmd_supported(my.cmd_bitmap, S_CMD_S_SPI_FREQ)) {
+  if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+    pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  else if(is_serprog_cmd_supported(my.cmd_bitmap, S_CMD_S_SPI_FREQ)) {
     memset(buf, 0, sizeof buf);
     uint32_t frequency = pgm->bitclock > 0? 1/pgm->bitclock: part->factory_fcpu > 0? part->factory_fcpu/4: 250000;
 

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -165,9 +165,6 @@ static bool is_serprog_cmd_supported(const unsigned char *cmd_bitmap, unsigned c
 // Programmer lifecycle handlers
 
 static int serprog_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
-
   union pinfo pinfo;
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -289,9 +289,9 @@ static int serprog_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   unsigned char buf[32];
 
   // Set SPI clock frequency
-  if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
   if(is_serprog_cmd_supported(my.cmd_bitmap, S_CMD_S_SPI_FREQ)) {
+    if(pgm->bitclock > 0 && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     memset(buf, 0, sizeof buf);
     uint32_t frequency = pgm->bitclock > 0? 1/pgm->bitclock: part->factory_fcpu > 0? part->factory_fcpu/4: 250000;
 

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -165,6 +165,9 @@ static bool is_serprog_cmd_supported(const unsigned char *cmd_bitmap, unsigned c
 // Programmer lifecycle handlers
 
 static int serprog_open(PROGRAMMER *pgm, const char *port) {
+  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
+    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+
   union pinfo pinfo;
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
@@ -287,8 +290,8 @@ static int serprog_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
 
   // Set SPI clock frequency
   if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  else if(is_serprog_cmd_supported(my.cmd_bitmap, S_CMD_S_SPI_FREQ)) {
+    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+  if(is_serprog_cmd_supported(my.cmd_bitmap, S_CMD_S_SPI_FREQ)) {
     memset(buf, 0, sizeof buf);
     uint32_t frequency = pgm->bitclock > 0? 1/pgm->bitclock: part->factory_fcpu > 0? part->factory_fcpu/4: 250000;
 

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -287,6 +287,7 @@ static int serprog_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
   unsigned char buf[32];
 
   // Set SPI clock frequency
+  
   if(is_serprog_cmd_supported(my.cmd_bitmap, S_CMD_S_SPI_FREQ)) {
     memset(buf, 0, sizeof buf);
     uint32_t frequency = pgm->bitclock > 0? 1/pgm->bitclock: part->factory_fcpu > 0? part->factory_fcpu/4: 250000;

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -166,7 +166,7 @@ static bool is_serprog_cmd_supported(const unsigned char *cmd_bitmap, unsigned c
 
 static int serprog_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   union pinfo pinfo;
   pgm->port = port;
@@ -290,7 +290,7 @@ static int serprog_initialize(const PROGRAMMER *pgm, const AVRPART *part) {
 
   // Set SPI clock frequency
   if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
   if(is_serprog_cmd_supported(my.cmd_bitmap, S_CMD_S_SPI_FREQ)) {
     memset(buf, 0, sizeof buf);
     uint32_t frequency = pgm->bitclock > 0? 1/pgm->bitclock: part->factory_fcpu > 0? part->factory_fcpu/4: 250000;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -859,11 +859,15 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
   if(stk500_getsync(pgm) < 0)
     return -1;
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-    else if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
-      return -1;
+  if(pgm->bitclock) {
+    if(str_eq(pgm->type, "arduino_as_isp")) // The Arduino as ISP will crash if we change the bitclock
+      pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    else {
+      if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+        pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
+        return -1;
+    }
   }
 
   return 0;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -860,7 +860,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
     return -1;
 
   if(pgm->bitclock) {
-    if(str_eq(pgm->type, "arduino_as_isp")) // The Arduino as ISP will crash if we change the bitclock
+    if(str_caseeq(pgmid, "arduino_as_isp")) // The Arduino as ISP will crash if we change the bitclock
       pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
     else {
       if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -860,7 +860,9 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
     return -1;
 
   if(pgm->bitclock != 0.0) {
-    if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+    else if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -861,7 +861,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
 
   if(pgm->bitclock) {
     if(str_eq(pgm->type, "arduino_as_isp")) // The Arduino as ISP will crash if we change the bitclock
-      pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+      pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
     else {
       if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
         pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -859,15 +859,12 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
   if(stk500_getsync(pgm) < 0)
     return -1;
 
-  if(pgm->bitclock) {
-    if(str_caseeq(pgmid, "arduino_as_isp")) // The Arduino as ISP will crash if we change the bitclock
+  if(pgm->bitclock) {           // Set bitclock if programmer can do so
+    // Arduino as ISP will crash on changing the bitclock: HAS_BITCLOCK_ADJ bit is not set
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
       pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
-    else {
-      if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-        pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
-      if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
-        return -1;
-    }
+    else if(pgm->set_sck_period(pgm, pgm->bitclock))
+      return -1;
   }
 
   return 0;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -864,7 +864,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
       pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
     else {
       if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-        pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+        pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
       if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
         return -1;
     }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2154,7 +2154,9 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
     return -1;
 
   if(pgm->bitclock != 0.0) {
-    if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+    else if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2153,10 +2153,10 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
   if(stk500v2_drain(pgm, 0) < 0 || stk500v2_getsync(pgm) < 0 || stk500v2_drain(pgm, 0) < 0)
     return -1;
 
-  if(pgm->bitclock != 0.0) {
+  if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-    else if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
+      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2213,7 +2213,9 @@ static int stk600_open(PROGRAMMER *pgm, const char *port) {
   if(stk500v2_drain(pgm, 0) < 0 || stk500v2_getsync(pgm) < 0 || stk500v2_drain(pgm, 0) < 0)
     return -1;
 
-  if(pgm->bitclock != 0.0) {
+  if(pgm->bitclock) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -3933,7 +3935,9 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
 
   my.pgmtype = PGMTYPE_JTAGICE_MKII;
 
-  if(pgm->bitclock != 0.0) {
+  if(pgm->bitclock) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -4028,7 +4032,9 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
 
   my.pgmtype = PGMTYPE_JTAGICE_MKII;
 
-  if(pgm->bitclock != 0.0) {
+  if(pgm->bitclock) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -4099,7 +4105,9 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
   pgm_free(pgmcp);
   my.pgmtype = PGMTYPE_JTAGICE_MKII;
 
-  if(pgm->bitclock != 0.0) {
+  if(pgm->bitclock) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -4136,7 +4144,9 @@ static int stk500v2_jtag3_open(PROGRAMMER *pgm, const char *port) {
 
   my.pgmtype = PGMTYPE_JTAGICE3;
 
-  if(pgm->bitclock != 0.0) {
+  if(pgm->bitclock) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2155,7 +2155,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
 
   if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -2215,7 +2215,7 @@ static int stk600_open(PROGRAMMER *pgm, const char *port) {
 
   if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -3937,7 +3937,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
 
   if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -4034,7 +4034,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
 
   if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -4107,7 +4107,7 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
 
   if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }
@@ -4146,7 +4146,7 @@ static int stk500v2_jtag3_open(PROGRAMMER *pgm, const char *port) {
 
   if(pgm->bitclock) {
     if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     if(pgm->set_sck_period(pgm, pgm->bitclock) != 0)
       return -1;
   }

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -307,6 +307,11 @@ static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int teensy_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("teensy_open(\"%s\")\n", port);
 
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   struct pdata *pdata = &my;
   const char *bus_name = NULL;
   char *dev_name = NULL;

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -307,10 +307,8 @@ static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 static int teensy_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("teensy_open(\"%s\")\n", port);
 
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   struct pdata *pdata = &my;
   const char *bus_name = NULL;

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -308,7 +308,7 @@ static int teensy_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("teensy_open(\"%s\")\n", port);
 
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   struct pdata *pdata = &my;
   const char *bus_name = NULL;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2227,10 +2227,8 @@ static void urclock_disable(const PROGRAMMER *pgm) {
 
 
 static int urclock_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   union pinfo pinfo;
   pgm->port = port;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2228,7 +2228,7 @@ static void urclock_disable(const PROGRAMMER *pgm) {
 
 static int urclock_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   union pinfo pinfo;
   pgm->port = port;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2227,8 +2227,12 @@ static void urclock_disable(const PROGRAMMER *pgm) {
 
 
 static int urclock_open(PROGRAMMER *pgm, const char *port) {
-  union pinfo pinfo;
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
 
+  union pinfo pinfo;
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -622,6 +622,9 @@ static int usbOpenDevice(const PROGRAMMER *pgm, usb_dev_handle ** device, int ve
 static int usbasp_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("usbasp_open(\"%s\")\n", port);
 
+  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
+    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+
   // usb_init will be done in usbOpenDevice
   LNODEID usbpid = lfirst(pgm->usbpid);
   int pid, vid;

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -623,7 +623,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("usbasp_open(\"%s\")\n", port);
 
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   // usb_init will be done in usbOpenDevice
   LNODEID usbpid = lfirst(pgm->usbpid);

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -286,9 +286,6 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   char *dev_name = NULL;
   int vid, pid;
 
-  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
-
   // If no -P was given or '-P usb' was given
   if(str_eq(name, "usb"))
     name = NULL;
@@ -405,6 +402,8 @@ static int usbtiny_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   // Check for bit-clock and tell the usbtiny to adjust itself
   if(pgm->bitclock > 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
     // -B option specified: convert to valid range for sck_period
     usbtiny_set_sck_period(pgm, pgm->bitclock);
   } else {

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -287,7 +287,7 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   int vid, pid;
 
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
-    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+    pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   // If no -P was given or '-P usb' was given
   if(str_eq(name, "usb"))

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -286,6 +286,9 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *name) {
   char *dev_name = NULL;
   int vid, pid;
 
+  if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
+    pmsg_warning("setting bitclock despite missing HAS_BITCLOCK_ADJ setting in extra_features\n");
+
   // If no -P was given or '-P usb' was given
   if(str_eq(name, "usb"))
     name = NULL;

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -135,6 +135,11 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 }
 
 static int wiring_open(PROGRAMMER *pgm, const char *port) {
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   int timetosnooze;
   union pinfo pinfo;
 

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -135,10 +135,8 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 }
 
 static int wiring_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   int timetosnooze;
   union pinfo pinfo;

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -136,7 +136,7 @@ static int wiring_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 
 static int wiring_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   int timetosnooze;
   union pinfo pinfo;

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1416,10 +1416,8 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
 }
 
 static int xbee_open(PROGRAMMER *pgm, const char *port) {
-  if(pgm->bitclock != 0.0) {
-    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
-      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
-  }
+  if(pgm->bitclock)
+    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
 
   union pinfo pinfo;
 

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1045,13 +1045,13 @@ static int xbeedev_open(const char *port, union pinfo pinfo, union filedescripto
      * In this mode, we are NOT talking to an XBee, we are talking directly to
      * an AVR device that thinks it is talking to an XBee itself.
      *
-     * Because, an XBee is a 3.3V device defaulting to 9600baud, and the
-     * Atmel328P is only rated at a maximum clock rate of 8MHz with a 3.3V
+     * Because, an XBee is a 3.3V device defaulting to 9600 baud, and the
+     * Atmel328P is only rated at a maximum clock rate of 8 MHz with a 3.3 V
      * supply, so there's a high likelihood a remote Atmel328P will be clocked
-     * at 8MHz.
+     * at 8 MHz.
      *
      * With a direct connection, there's a good chance we're talking to an
-     * Arduino clocked at 16MHz with an XBee-enabled chip plugged in.  The
+     * Arduino clocked at 16 MHz with an XBee-enabled chip plugged in.  The
      * doubled clock rate means a doubled serial rate.  Double 9600 baud ==
      * 19200 baud.
      */

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1417,7 +1417,7 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
 
 static int xbee_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock)
-    pmsg_warning("programmer type %s does not support adjustable bitclock speed; ignoring -B\n", pgm->type);
+    pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   union pinfo pinfo;
 

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1416,6 +1416,11 @@ static int xbee_getsync(const PROGRAMMER *pgm) {
 }
 
 static int xbee_open(PROGRAMMER *pgm, const char *port) {
+  if(pgm->bitclock != 0.0) {
+    if(!(pgm->extra_features & HAS_BITCLOCK_ADJ))
+      pmsg_warning("%s does not support adjustable bitclock speed. Ignoring -B flag\n", pgmid);
+  }
+
   union pinfo pinfo;
 
   pgm->port = port;


### PR DESCRIPTION
This is a crude and preliminary PR to address the underlying issue pointed out in #1978. I want your honest opinions, and don't hesitate to push changes directly to my branch if there are things that should be done differently.

One thing we'll have to address: how should we deal with programmers that _has_ to set a bitclock value regardless of whether the user provided a -B value (USBasp and USBtiny, for instance)? If the user, for some reason, removes `HAS_BITCLOCK_ADJ` from avrdude.conf, the programmer will most likely not work anymore because it doesn't get a default bitclock value from Avrdude.

So please test, review, comment, and push changes!