### PR TITLE
Extend -c urclock to work with lower baud rates

### DIFF
--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2208,6 +2208,9 @@ static int urclock_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 static void urclock_disable(const PROGRAMMER *pgm) {
   unsigned char buf[16];
 
+  if(ur.urprotocol)
+    return;
+
   buf[0] = Cmnd_STK_LEAVE_PROGMODE;
   buf[1] = Sync_CRC_EOP;
 


### PR DESCRIPTION
 - Lengthen receive timeouts for lower baud rates
 - Skip unnecessary disable() call
 - Read in chunks that bootloader can send within WDT timeout

This fixes `-c urclock` to work with low-baud-rate urboot bootloaders.