### PR TITLE
Only offer terminal disasm for 8-bit AVRs

### DIFF
--- a/src/avr_opcodes.c
+++ b/src/avr_opcodes.c
@@ -671,10 +671,12 @@ int avr_get_archlevel(const AVRPART *p) {
 
   if(!ret) {                    // Non-TPI classic part
     switch(p->archnum) {
+    case -1:                    // Not 8-bit AVR: return 0
+      break;
     case 1:
       ret = PART_AVR1;
       break;
-    default:                   // If AVRDUE doesn't know, it's probably rare & old
+    default:                    // If AVRDUE doesn't know, it's probably rare & old
     case 2:
       ret = PART_AVR2;
       break;
@@ -683,7 +685,7 @@ int avr_get_archlevel(const AVRPART *p) {
       break;
     case 3:
     case 31:
-    case 35:                   // Sic
+    case 35:                    // Sic
       ret = PART_AVR3;
       break;
       break;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -107,7 +107,7 @@ avrdude_conf_version = "@AVRDUDE_FULL_VERSION@";
 #       family_id        = <id> ;                 # quoted string, eg, "megaAVR" or "tinyAVR"
 #       prog_modes       = PM_<i/f> {| PM_<i/f>}  # interfaces, eg, PM_SPM|PM_ISP|PM_HVPP|PM_debugWIRE
 #       mcuid            = <num>;                 # unique id in 0..2039 for 8-bit AVRs
-#       archnum          = <num>;                 # avr-gcc architecture number for the part
+#       archnum          = <num>;                 # avr-gcc architecture number; -1 if not 8-bit AVR
 #       n_interrupts     = <num>;                 # number of interrupts, used for vector bootloaders
 #       n_page_erase     = <num>;                 # if set, number of pages erased during SPM erase
 #       n_boot_sections  = <num>;                 # Number of boot sections
@@ -15963,7 +15963,7 @@ part parent "m328" # lgt328p
 # AT89S51
 #------------------------------------------------------------
 
-# Nonstandard part
+# MCS-51 family part
 #   - Tested with -c avrisp
 #   - USBASP programmers may require different firmware
 
@@ -15977,7 +15977,7 @@ part # 89S51
         "AT89S51-24PU: PDIP40, Fmax=24 MHz, T=[-40 C, 85 C], Vcc=[4 V, 5.5 V]";
     prog_modes             = PM_ISP | PM_HVPP;
     mcuid                  = 372;
-    archnum                = 1;
+    archnum                = -1; # Not 8-bit AVR
     stk500_devcode         = 0xe0;
     chip_erase_delay       = 250000;
     signature              = 0x1e 0x51 0x06;
@@ -18819,6 +18819,7 @@ part # uc3a0512
         "AT32UC3A0512AU-ALUT:  LQFP144,  Fmax=66 MHz, T=[-40 C, 85 C], Vcc=[1.65 V, 3.6 V]";
     prog_modes             = PM_AVR32JTAG | PM_aWire;
     signature              = 0xed 0xc0 0x3f;
+    archnum                = -1; # Not 8-bit AVR
 
     memory "flash"
         paged              = yes;

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -3926,7 +3926,7 @@ part
     family_id        = <id>;                  # quoted string, e.g., "megaAVR" or "tinyAVR"
     prog_modes       = PM_<i/f> @{| PM_<i/f>@}  # interfaces, e.g., PM_SPM|PM_ISP|PM_HVPP|PM_debugWIRE
     mcuid            = <num>;                 # unique id in 0..2039 for 8-bit AVRs
-    archnum          = <num>;                 # avr-gcc architecture number for the part
+    archnum          = <num>;                 # avr-gcc architecture number; -1 if not 8-bit AVR
     n_interrupts     = <num>;                 # number of interrupts, used for vector bootloaders
     n_page_erase     = <num>;                 # if set, number of pages erased during SPM erase
     n_boot_sections  = <num>;                 # Number of boot sections

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -12,7 +12,7 @@
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
  * v 1.44
- * 23.04.2025
+ * 05.06.2025
  *
  */
 
@@ -71,7 +71,7 @@ typedef struct {
 typedef struct {                // Value of -1 typically means unknown
   const char *name;             // Name of part
   uint16_t mcuid;               // ID of MCU in 0..2039
-  uint8_t  avrarch;             // F_AVR8L, F_AVR8, F_XMEGA or F_AVR8X
+  uint8_t  avrarch;             // F_AVR8L, F_AVR8, F_XMEGA, F_AVR8X or F_MCS51
   uint8_t sigs[3];              // Signature bytes
   int32_t flashoffset;          // Flash offset in dual-chip MCUs (not flash->offset)
   int32_t flashsize;            // Flash size
@@ -128,6 +128,7 @@ typedef enum {
 #define F_AVR8                2 // ISP programming with SPI, "classic" AVRs
 #define F_XMEGA               4 // PDI programming, ATxmega family
 #define F_AVR8X               8 // UPDI programming, newer 8-bit MCUs
+#define F_MCS51              16 // ISP programming, MCS-51 family (not AVR8)
 
 #define UARTTYPE_UNKNOWN    (-1)
 #define UARTTYPE_NONE         0
@@ -320,8 +321,6 @@ extern const Avrintel uP_table[412];
 #define id_at43usb355      163u
 #define id_at76c711        164u
 #define id_at86rf401       165u
-#define id_at89s51         372u
-#define id_at89s52         373u
 #define id_at90pwm1        166u
 #define id_at90pwm2        167u
 #define id_at90pwm2b       168u
@@ -563,6 +562,8 @@ extern const Avrintel uP_table[412];
 #define id_avr128da64      370u
 #define id_avr128da64s     397u
 #define id_avr128db64      371u
+#define id_at89s51         372u
+#define id_at89s52         373u
 
 
 // Interrupt vector table sizes (number of vectors)

--- a/src/term.c
+++ b/src/term.c
@@ -2574,6 +2574,15 @@ static int cmd_varef(const PROGRAMMER *pgm, const AVRPART *p, int argc, const ch
   return 0;
 }
 
+// Is the i-th command of the cmd[] list available for programmer and part?
+static int is_available(const PROGRAMMER *pgm, const AVRPART *p, int i) {
+  if(!*(void (**)(void)) ((char *) pgm + cmd[i].fnoff))
+    return 0;
+  if(cmd[i].func == cmd_disasm && p->archnum < 0) // Disasm only covers 8-bit AVRs
+    return 0;
+  return 1;
+}
+
 static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
   if(argc > 1) {
     msg_error("Syntax: help\n" "Function: show help message for terminal commands\n");
@@ -2582,7 +2591,7 @@ static int cmd_help(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
 
   term_out("Valid commands:\n");
   for(int i = 0; i < NCMDS; i++) {
-    if(!*(void (**)(void)) ((char *) pgm + cmd[i].fnoff))
+    if(!is_available(pgm, p, i))
       continue;
     term_out("  %-7s : ", cmd[i].name);
     term_out(cmd[i].desc, cmd[i].name);
@@ -2756,7 +2765,7 @@ static int do_cmd(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char 
   len = strlen(argv[0]);
   matches = 0;
   for(int i = 0; i < NCMDS; i++)
-    if(*(void (**)(void)) ((char *) pgm + cmd[i].fnoff))
+    if(is_available(pgm, p, i))
       if(len && strncasecmp(argv[0], cmd[i].name, len) == 0) {  // Partial initial match
         hold = i;
         matches++;
@@ -2772,7 +2781,7 @@ static int do_cmd(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char 
   pmsg_error("(cmd) command %s is %s", argv[0], matches > 1? "ambiguous": "invalid");
   if(matches > 1)
     for(int ch = ':', i = 0; i < NCMDS; i++)
-      if(*(void (**)(void)) ((char *) pgm + cmd[i].fnoff))
+      if(is_available(pgm, p, i))
         if(len && strncasecmp(argv[0], cmd[i].name, len) == 0)
           msg_error("%c %s", ch, cmd[i].name), ch = ',';
   msg_error("\n");

--- a/src/term.c
+++ b/src/term.c
@@ -93,7 +93,7 @@ static int cmd_quell(const PROGRAMMER *pgm, const AVRPART *p, int argc, const ch
 #define _fo(x) offsetof(PROGRAMMER, x)
 
 // List of commands; don't add a command starting with e: main.c relies on e expanding to erase
-struct command cmd[] = {
+static const struct command cmd[] = {
   {"dump", cmd_dump, _fo(read_byte_cached), "display a memory section as hex dump"},
   {"read", cmd_dump, _fo(read_byte_cached), "alias for dump"},
   {"disasm", cmd_disasm, _fo(read_byte_cached), "disassemble a memory section"},


### PR DESCRIPTION
Currently, terminal `disasm` is offered for all parts, but it [should only be offered for 8-bit AVRs](https://github.com/avrdudes/avrdude/discussions/2003#discussioncomment-13377316). 

Without this PR:
```
$ avrdude -qq -c dryrun -p at89s51 -T "write flash 0 0xcfff; disasm flash 0 2"

Label0:                                         ; Rjmp from L000
L000: ff cf        rjmp    Label0               ; L000
```

With this PR
```
$ avrdude -qq -c dryrun -p at89s51 -T "write flash 0 0xcfff; disasm flash 0 2"
Error: (cmd) command disasm is invalid
```