### PR TITLE
Toughen command-line parsing before auto-erase

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -302,11 +302,10 @@ static int memadd(AVRMEM **mlist, int nm, int not, AVRMEM *m) {
  *
  * Memory list can be sth like ee,fl,all,-cal,efuse. -mem or /mem removes it
  * from the list. Normal use is to pass NULL for dry and let the function write
- * to *np and *rwvsoftfail indicating unknown memories for this part. If dry is
- * set then -1 will be written to *dry when a generally unknown memory is used.
+ * to *np and *rwvsoftp indicating unknown memories for this part. If dry is
+ * set then an error code will be written to *dry if an unknown memory is used.
  */
 AVRMEM **memory_list(const char *mstr, const PROGRAMMER *pgm, const AVRPART *p, int *np, int *rwvsoftp, int *dry) {
-
   int not, nm = (lsize(p->mem) + 1)*((int) str_numc(mstr, ',') + 1);  // Upper limit
   AVRMEM *m, **umemlist = mmt_malloc(nm*sizeof *umemlist);
   char *dstr = mmt_strdup(mstr), *s = dstr, *e;
@@ -389,6 +388,7 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
     return 0;
   }
 
+  // Construct, check and free memory list storing an error code, if any, in ret
   mmt_free(memory_list(upd->memstr, NULL, p, NULL, NULL, &ret));
 
   known = 0;

--- a/src/update.c
+++ b/src/update.c
@@ -411,8 +411,8 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
       errno = 0;
       if(!known && !update_is_readable(upd->filename)) {
         ioerror("readable", upd);
-        ret = LIBAVRDUDE_SOFTFAIL; // Even so it might still be there later on
-        known = 1;              // Pretend we know it, so no auto detect needed
+        ret = LIBAVRDUDE_GENERAL_FAILURE;
+        known = 1;              // Pretend we know it, so auto detect is not carried out
       }
     }
   }
@@ -422,8 +422,8 @@ int update_dryrun(const AVRPART *p, UPDATE *upd) {
       pmsg_error("cannot auto detect file format for stdin/out, specify explicitly\n");
       ret = LIBAVRDUDE_GENERAL_FAILURE;
     } else if((format_detect = fileio_fmt_autodetect(upd->filename)) < 0) {
-      pmsg_warning("cannot determine file format for %s, specify explicitly\n", upd->filename);
-      ret = LIBAVRDUDE_SOFTFAIL;
+      pmsg_error("cannot determine file format for %s, specify explicitly\n", upd->filename);
+      ret = LIBAVRDUDE_GENERAL_FAILURE;
     } else {
       // Set format now (but might be wrong in edge cases, where user needs to specify explicity)
       upd->format = format_detect;


### PR DESCRIPTION
I reviewed command-line parsing following [this discussion](https://github.com/avrdudes/avrdude/discussions/1956#discussioncomment-13354172). There is a mechanism in place that checks for (some) errors before actually commencing programming. This PR toughens the checks to avoid auto-erase, eg, in a case where the input file does not exist.

Using this PR
```
$ avrdude -c dryrun -qq -p m328p -U nonexiting.hex
OS error: file nonexiting.hex is not readable: No such file or directory
```