### PR TITLE
Update build.yml to disable Python Binding build for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,6 +349,7 @@ jobs:
           -D CMAKE_CXX_FLAGS_RELWITHDEBINFO="/MT /GL /Zi /O2 /Ob1 /DNDEBUG"
           -D CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO="/DEBUG /INCREMENTAL:NO /LTCG /OPT:REF /OPT:ICF"
           -D HAVE_LIBREADLINE=HAVE_LIBREADLINE-NOTFOUND
+          -D SWIG_EXECUTABLE=SWIG_EXECUTABLE-NOTFOUND
           -D USE_EXTERNAL_LIBS=1
           -B build
       - name: Build
@@ -426,6 +427,7 @@ jobs:
           -G"MSYS Makefiles"
           -D DEBUG_CMAKE=1
           -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -D SWIG_EXECUTABLE=SWIG_EXECUTABLE-NOTFOUND
           -B build
       - name: Build
         run: cmake --build build


### PR DESCRIPTION
This is a workaround for Issue #2017.