### PR TITLE
Add missing `pickit4_dw` and `snap_mplab_dw` programmer options

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3482,6 +3482,16 @@ programmer parent "snap_mplab" # snap_mplab_isp
 ;
 
 #------------------------------------------------------------
+# snap_mplab_dw
+#------------------------------------------------------------
+
+programmer parent "snap_mplab" # snap_mplab_dw
+    id                     = "snap_mplab_dw";
+    desc                   = "MPLAB(R) SNAP in dW Mode";
+    prog_modes             = PM_debugWIRE;
+;
+
+#------------------------------------------------------------
 # snap_mplab_tpi
 #------------------------------------------------------------
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3037,6 +3037,17 @@ programmer parent "pickit4" # pickit4_tpi
     extra_features         = HAS_VTARG_READ;
 ;
 
+#------------------------------------------------------------
+# pickit4_dw
+#------------------------------------------------------------
+
+programmer parent "pickit4" # pickit4_dw
+    id                     = "pickit4_dw";
+    desc                   = "MPLAB(R) PICkit 4 in debugWire mode";
+    type                   = "jtagice3_dw";
+    prog_modes             = PM_debugWIRE;
+;
+
 # End of "Atmel" Mode
 #
 # Begin of "MPLAB" Mode


### PR DESCRIPTION
Both programmer options tested and verified to work.

```
$ avrdude -csnap_mplab_dw -pattiny13 -v
Avrdude version 8.0-20250618 (c77bade2)
Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

System wide configuration file is /usr/local/etc/avrdude.conf
User configuration file /Users/hans/.avrduderc does not exist

Using port            : usb
Using programmer      : snap_mplab_dw
Usbdev_open(): found MPLAB? Snap ICD, serno: BUR183076609
AVR part              : ATtiny13
Programming modes     : SPM, ISP, HVSP, debugWIRE
Programmer type       : pickit5
Description           : MPLAB(R) SNAP in dW Mode
Application version   : 02.01.06
Serial number         : BUR183076609
Target Vdd: 3.30 V, target current: 0 mA
External voltage detected: will not supply power

AVR device initialized and ready to accept instructions
Device signature = 1E 90 07 (ATtiny13, ATtiny13A)

Avrdude done.  Thank you.


$ avrdude -cpickit4_dw -pattiny13 -v
Avrdude version 8.0-20250618 (c77bade2)
Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

System wide configuration file is /usr/local/etc/avrdude.conf
User configuration file /Users/hans/.avrduderc does not exist

Using port            : usb
Using programmer      : pickit4_dw
AVR part              : ATtiny13
Programming modes     : SPM, ISP, HVSP, debugWIRE
Programmer type       : JTAGICE3_DW
Description           : MPLAB(R) PICkit 4 in debugWire mode
ICE HW version        : 4
ICE FW version        : 1.15 (rel. 20)
Serial number         : BUR204071896
Vtarget               : 5.20 V

JTAG ID returned: 0x07 0x90 0x00 0x00

AVR device initialized and ready to accept instructions
Device signature = 1E 90 07 (ATtiny13, ATtiny13A)

Avrdude done.  Thank you.
```