### PR TITLE
Adding pkg-config as a Linux build dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           build-essential
           automake
           libtool
+          pkg-config
           flex
           bison
           libelf-dev
@@ -95,6 +96,7 @@ jobs:
           sudo apt-get install -y
           build-essential
           cmake
+          pkg-config
           flex
           bison
           libelf-dev
@@ -167,6 +169,7 @@ jobs:
           apt-get install -y
           git
           cmake
+          pkg-config
           flex
           bison
           crossbuild-essential-${{matrix.arch}}


### PR DESCRIPTION
This will fix the warnings in the container based cross build for i386, armhf and arm64 Linux.
```
  linux:
    runs-on: ubuntu-latest
    container: debian:11
    strategy:
      matrix:
        include:
          - { arch: i386, processor: i686, prefix: i686-linux-gnu, inc-lib: i386-linux-gnu }
          - { arch: armhf, processor: armhf, prefix: arm-linux-gnueabihf, inc-lib: arm-linux-gnueabihf }
          - { arch: arm64, processor: aarch64, prefix: aarch64-linux-gnu, inc-lib: aarch64-linux-gnu }
```

Current git main:
https://github.com/avrdudes/avrdude/actions/runs/15734446611/job/44343291592
```
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE) 
CMake Warning at CMakeLists.txt:279 (message):
  For using libgpiod, pkg-config would be required which is not available.
```

With this PR, it can find pkg-config. But it does not really enable the libgpiod build, probably a cross-build limitation.
```
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2") 
-- Checking for module 'libgpiod'...
-- Could not find module 'libgpiod', proceeding without.
```