### PR TITLE
Update deploy.yml to use download-artifact@v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           - { arch: arm64 }
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: avrdude-msvc-${{matrix.arch}}
 


### PR DESCRIPTION
download-artifact@v2 has been deprecated.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/