### PR TITLE
CMakeLists.txt: allow disabling Python support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(USE_EXTERNAL_LIBS "Use external libraries from AVRDUDE GitHub repositorie
 option(USE_LIBUSBWIN32 "Prefer libusb-win32 over libusb" OFF)
 option(DEBUG_CMAKE "Enable debugging output for this CMake project" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(ENABLE_PYTHON_SUPPORT "Enable Python support" ON)
 
 if(WIN32)
     # Prefer static libraries over DLLs on Windows
@@ -281,14 +282,16 @@ if(HAVE_LINUXGPIO)
 endif()
 
 # -------------------------------------
-# Find SWIG
-find_package(SWIG 4.0 COMPONENTS python)
-if(SWIG_FOUND)
-  find_package(Python3 COMPONENTS Interpreter Development)
-  if(PYTHON3_FOUND)
-    set(HAVE_SWIG 1)
-  else()
-    message(STATUS "Found SWIG but no Python3 header/library; cannot use SWIG")
+# Find SWIG/Python3 if needed
+if(ENABLE_PYTHON_SUPPORT)
+  find_package(SWIG 4.0 COMPONENTS python)
+  if(SWIG_FOUND)
+    find_package(Python3 COMPONENTS Interpreter Development)
+    if(PYTHON3_FOUND)
+      set(HAVE_SWIG 1)
+    else()
+      message(STATUS "Found SWIG but no Python3 header/library; cannot use SWIG")
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(USE_EXTERNAL_LIBS "Use external libraries from AVRDUDE GitHub repositorie
 option(USE_LIBUSBWIN32 "Prefer libusb-win32 over libusb" OFF)
 option(DEBUG_CMAKE "Enable debugging output for this CMake project" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
-option(ENABLE_PYTHON_SUPPORT "Enable Python support" ON)
+option(FORCE_DISABLE_PYTHON_SUPPORT "Option to explicitly disable Python support" OFF)
 
 if(WIN32)
     # Prefer static libraries over DLLs on Windows
@@ -283,24 +283,36 @@ endif()
 
 # -------------------------------------
 # Find SWIG/Python3 if needed
-option(FORCE_DISABLE_PYTHON_SUPPORT "Option to explicitly disable Python support" OFF)
 
 if(NOT FORCE_DISABLE_PYTHON_SUPPORT)
-  if(SWIG_FOUND)
-  find_package(SWIG 4.0 COMPONENTS python)
-  if(SWIG_FOUND)
-    find_package(Python3 COMPONENTS Interpreter Development)
-    if(PYTHON3_FOUND)
-      set(HAVE_SWIG 1)
-      message(STATUS "Python support enabled")
+    # Search for SWIG first
+    find_package(SWIG 4.0 COMPONENTS python)
+    
+    if(SWIG_FOUND)
+        # Apply the PR #2099 strategy fixes here to ensure correct Python detection
+        set(Python3_FIND_STRATEGY LOCATION)
+        set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+        
+        find_package(Python3 COMPONENTS Interpreter Development)
+        
+        if(Python3_FOUND)
+            set(HAVE_SWIG 1)
+            message(STATUS "Python support enabled")
+            
+            # Helper to find site-packages (from your PR #2099 snippet)
+            execute_process(
+                COMMAND ${Python3_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])" 
+                OUTPUT_VARIABLE PYTHON_SITE_PACKAGES 
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+        else()
+            message(STATUS "SWIG found, but Python3 headers/library missing; Python support disabled")
+        endif()
     else()
-      message(STATUS "Found SWIG but no Python3 header/library; cannot use SWIG")
+        message(STATUS "SWIG not found; Python support disabled")
     endif()
-  else()
-    message(STATUS "SWIG not found, Python support disabled")
-  endif()
 else()
-  message(STATUS "Python support explicitly disabled via FORCE_DISABLE_PYTHON_SUPPORT")
+    message(STATUS "Python support explicitly disabled via FORCE_DISABLE_PYTHON_SUPPORT")
 endif()
 
 # =====================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,16 +283,24 @@ endif()
 
 # -------------------------------------
 # Find SWIG/Python3 if needed
-if(ENABLE_PYTHON_SUPPORT)
+option(FORCE_DISABLE_PYTHON_SUPPORT "Option to explicitly disable Python support" OFF)
+
+if(NOT FORCE_DISABLE_PYTHON_SUPPORT)
+  if(SWIG_FOUND)
   find_package(SWIG 4.0 COMPONENTS python)
   if(SWIG_FOUND)
     find_package(Python3 COMPONENTS Interpreter Development)
     if(PYTHON3_FOUND)
       set(HAVE_SWIG 1)
+      message(STATUS "Python support enabled")
     else()
       message(STATUS "Found SWIG but no Python3 header/library; cannot use SWIG")
     endif()
+  else()
+    message(STATUS "SWIG not found, Python support disabled")
   endif()
+else()
+  message(STATUS "Python support explicitly disabled via FORCE_DISABLE_PYTHON_SUPPORT")
 endif()
 
 # =====================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,21 +285,15 @@ endif()
 # Find SWIG/Python3 if needed
 
 if(NOT FORCE_DISABLE_PYTHON_SUPPORT)
-    # Search for SWIG first
     find_package(SWIG 4.0 COMPONENTS python)
     
     if(SWIG_FOUND)
-        # Apply the PR #2099 strategy fixes here to ensure correct Python detection
         set(Python3_FIND_STRATEGY LOCATION)
         set(Python3_FIND_UNVERSIONED_NAMES FIRST)
-        
         find_package(Python3 COMPONENTS Interpreter Development)
-        
         if(Python3_FOUND)
             set(HAVE_SWIG 1)
             message(STATUS "Python support enabled")
-            
-            # Helper to find site-packages (from your PR #2099 snippet)
             execute_process(
                 COMMAND ${Python3_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])" 
                 OUTPUT_VARIABLE PYTHON_SITE_PACKAGES 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -419,8 +419,6 @@ install(FILES "avrdude.1"
 	)
 
 if(HAVE_SWIG)
-    execute_process(COMMAND ${Python3_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])"
-                    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
     install(TARGETS swig_avrdude DESTINATION ${PYTHON_SITE_PACKAGES})
     install(FILES ${CMAKE_BINARY_DIR}/src/swig_avrdude.py DESTINATION ${PYTHON_SITE_PACKAGES})
     install(DIRECTORY python/ DESTINATION ${CMAKE_INSTALL_DATADIR}/avrdude FILES_MATCHING PATTERN "*.ui")


### PR DESCRIPTION
In some cases, even if Swig is found and Python3 is found, it may not be desirable to build Python support in avrdude, so this commit adds an ENABLE_PYTHON_SUPPORT option to be able to explicitly disable using Python support (unfortunately CMake doesn't allow passing arguments that would prevent it from finding Swig/Python 3 if available).

To preserve existing behavior, this option defaults to enabled (ON).