### PR TITLE
Fix apptable size for x128a4/u

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -17609,8 +17609,9 @@ part parent ".xmega-ab" # x128a4
     ;
 
     memory "apptable"
+        size               = 8192;
         page_size          = 512;
-        offset             = 0x81f000;
+        offset             = 0x81e000;
     ;
 
     memory "boot"
@@ -17693,7 +17694,8 @@ part parent ".xmega-ab" # x128a4u
     ;
 
     memory "apptable"
-        offset             = 0x81f000;
+        size               = 8192;
+        offset             = 0x81e000;
     ;
 
     memory "boot"


### PR DESCRIPTION
This PR corrects the apptable sizes for ATmega128A4U and ATmega128A4.

I read in the AVR 1316 AN  for XMEGAs that the application table size will always be the same as the boot section size (a fun fact!). I quickly checked:
```
$ for i in apptable boot; do avrdude -qqp*/PAt | grep $i.size | cut -f1,2,4,5 | sort > /tmp/${i::1}; done
$ diff /tmp/[ab]
6,7c6,7
< .ptmm	ATxmega128A4	size	4096
< .ptmm	ATxmega128A4U	size	4096
---
> .ptmm	ATxmega128A4	size	8192
> .ptmm	ATxmega128A4U	size	8192
```

Manually checking the respective datasheets, AVRDUDE actually had the apptable size wrong.