### PR TITLE
Disassemble elpm/eijmp/eicall for all XMEGAs

### DIFF
--- a/src/avr_opcodes.c
+++ b/src/avr_opcodes.c
@@ -705,12 +705,12 @@ int avr_get_archlevel(const AVRPART *p) {
 
   AVRMEM *mem = avr_locate_flash(p);
 
-  if(mem) {                     // Add opcodes needed for large parts in any case
+  if(mem) {                     // Add opcodes needed for large parts (XMEGAs count as large)
     if(mem->size > 8192)
       ret |= OP_AVR_M;          // JMP, CALL
-    if(mem->size > 65536)
+    if(mem->size > 65536 || is_pdi(p))
       ret |= OP_AVR_L;          // ELPM
-    if(mem->size > 128*1024)
+    if(mem->size > 128*1024 || is_pdi(p))
       ret |= OP_AVR_XL;         // EIJMP, EICALL
   }
 


### PR DESCRIPTION
This PR disassembles the elpm/eijmp/ecall opcodes for all XMEGAs.

Although technically the elpm opcode is only necessary for parts in excess of 64 kB flash, and eijmp/eicall will only be needed when flash exceeds 128 kB, all XMEGAs irrespective of size seem to have the RAMP[XYZ] and EIND registers. Sample code provided by Microchip (eg, AN8070 on self-prgramming XMEGAs) uses the elpm opcode throughout as do bootloaders for XMEGAs that use this sample code, eg. xboot.
