### PR TITLE
Add ATmegaS128 and ATmegaS64M1

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -21356,9 +21356,9 @@ part parent "m64m1" # ms64m1
     desc                   = "ATmegaS64M1";
     id                     = "ms64m1";
     variants               =
-        "ATmegaS64M1-KH-E:  CQFP32, Fmax=8 MHz, T=[-55 C, 125 C], Vcc=[3.6 V, 3.6 V]",
-        "ATmegaS64M1-KH-MQ: CQFP32, Fmax=8 MHz, T=[-55 C, 125 C], Vcc=[3.6 V, 3.6 V]",
-        "ATmegaS64M1-KH-SV: CQFP32, Fmax=8 MHz, T=[-55 C, 125 C], Vcc=[3.6 V, 3.6 V]",
+        "ATmegaS64M1-KH-E:  CQFP32, Fmax=8 MHz, T=[-55 C, 125 C], Vcc=[3.0 V, 3.6 V]",
+        "ATmegaS64M1-KH-MQ: CQFP32, Fmax=8 MHz, T=[-55 C, 125 C], Vcc=[3.0 V, 3.6 V]",
+        "ATmegaS64M1-KH-SV: CQFP32, Fmax=8 MHz, T=[-55 C, 125 C], Vcc=[3.0 V, 3.6 V]",
         "ATmegaS64M1-MA-HP: TQFP32, Fmax=8 MHz, T=[-55 C, 125 C], Vcc=[3.0 V, 3.6 V]";
     mcuid                  = 412;
     chip_erase_delay       = 10500;


### PR DESCRIPTION
These new classic parts have arrived with a certain degree of radiation tolerance. Since you asked: The datasheet claims
 - No Single Event Latch-up (SEL) below a LET threshold of 62.5 MeV/mg/cm2@125 °C 
 - Tested up to a Total Ionizing Dose (TID) of 30 KRads(Si) according to MIL-STD-883 Method 1019 

Yes, me neither.

It's an interesting (`ATmega103` compatibility mode still available and selectable by a fuse for the `ATmegaS128`) but probably quite logical choice for manufacturing new parts with hardened radiation tolerance. `ATmegaS64M1` is a large automotive part with hardware LIN support.

Turns out the datasheet for `ATmegaS64M1` has a different write delays for  CE and flash/fuses,  so it *is* justified to give this one a new entry in `avrdude.conf`. To all programming intents and purposes the `ATmegaS128` is the same as the `ATmega128`, but I still suggest the part gets its own entry simply b/c it has it's own .atdf file (the criterion I have been following so far), even though the respective .atdf files only differ in the part name and available variants (wd<sub>flash</sub> is not described in the .atdf).