### PR TITLE
Fix buspirate fallback to byte write

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1122,12 +1122,14 @@ int avr_write_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m, int 
 
         if(auto_erase && pgm->page_erase && !mem_is_eeprom(cm))
           rc = pgm->page_erase(pgm, p, cm, pageaddr);
-        if(rc >= 0)
+        if(pgm->paged_write && (rc >= 0))
           rc = pgm->paged_write(pgm, p, cm, cm->page_size, pageaddr, cm->page_size);
-        if(rc < 0)
+        if(!pgm->paged_write || (rc < 0))
           failure = 1;          // Paged write failed, fall back to byte-at-a-time write below
-        nwritten++;
-        report_progress(nwritten, npages, NULL);
+        else {
+          nwritten++;
+          report_progress(nwritten, npages, NULL);
+        }
       } else {
         pmsg_debug("%s(): skipping page %u: no interesting data\n", __func__, pageaddr/cm->page_size);
       }


### PR DESCRIPTION
The buspirate logic tries to detect different versions of supported features by the buspirate. One case is that the buspirate does not support paged writes, in this case the pgm->paged_write function pointer is set to NULL. However, the avr_write code unconditionally calls pgm->paged_write and crashes the avrdude.

This change checks if the paged_write pointer is still set and falls back to byte-by-byte write if not. This allows for byte-by-byte write, while still using paged_read for verification.