### PR TITLE
Update whereami.[ch] from github source

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1156,7 +1156,8 @@ static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
       continue;
 
     pmsg_debug("considering PT_LOAD program header entry #%d\n", (int) i);
-    imsg_debug("p_vaddr 0x%x, p_paddr 0x%x, p_filesz %d\n", ph[i].p_vaddr, ph[i].p_paddr, ph[i].p_filesz);
+    imsg_debug("p_vaddr 0x%lx, p_paddr 0x%lx, p_filesz %ld\n",
+     (unsigned long) ph[i].p_vaddr, (unsigned long) ph[i].p_paddr, (unsigned long) ph[i].p_filesz);
 
     Elf_Scn *scn = NULL;
 
@@ -1182,7 +1183,7 @@ static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
       const char *sname = sndx? elf_strptr(e, sndx, sh->sh_name): "*unknown*";
       unsigned int lma = ph[i].p_paddr + sh->sh_offset - ph[i].p_offset;
 
-      pmsg_debug("found section %s, LMA 0x%x, sh_size %u\n", sname, lma, sh->sh_size);
+      pmsg_debug("found section %s, LMA 0x%x, sh_size %lu\n", sname, lma, (unsigned long) sh->sh_size);
 
       if(!(lma >= low && lma + sh->sh_size < high)) {
         pmsg_debug("skipping %s (inappropriate for %s)\n", sname, mem->desc);
@@ -1197,8 +1198,8 @@ static int elf2b(const char *infile, FILE *inf, const AVRMEM *mem,
        * obtained above.
        */
       if(mem->size != 1 && sh->sh_size > (unsigned) mem->size) {
-        pmsg_error("section %s of size %u does not fit into %s of size %d\n",
-          sname, sh->sh_size, mem->desc, mem->size);
+        pmsg_error("section %s of size %lu does not fit into %s of size %d\n",
+          sname, (unsigned long) sh->sh_size, mem->desc, mem->size);
         rv = -1;
         continue;
       }

--- a/src/main.c
+++ b/src/main.c
@@ -1052,28 +1052,19 @@ int main(int argc, char *argv[]) {
      * Executable abspath: Determine the absolute path to avrdude executable.
      * This will be used to locate the avrdude.conf file later.
      */
-    int executable_dirpath_len;
-    int executable_abspath_len = wai_getExecutablePath(executable_abspath,
-      PATH_MAX,
+    int executable_dirpath_len = 0;
+    int executable_abspath_len = wai_getExecutablePath(executable_abspath, PATH_MAX,
       &executable_dirpath_len);
 
-    if(
-      (executable_abspath_len != -1) &&
-      (executable_abspath_len != 0) && (executable_dirpath_len != -1) && (executable_dirpath_len != 0)
-      ) {
-      // All requirements satisfied, executable path was found
+    if(executable_abspath_len > 0 && executable_dirpath_len > 0) {
       executable_abspath_found = true;
-
-      // Make sure the string is null terminated
       executable_abspath[executable_abspath_len] = '\0';
-
       replace_backslashes(executable_abspath);
 
       // Define executable_dirpath to be the path to the parent folder of the executable
       strcpy(executable_dirpath, executable_abspath);
       executable_dirpath[executable_dirpath_len] = '\0';
 
-      // Debug output
       msg_trace2("executable_abspath = %s\n", executable_abspath);
       msg_trace2("executable_abspath_len = %i\n", executable_abspath_len);
       msg_trace2("executable_dirpath = %s\n", executable_dirpath);

--- a/src/whereami.c
+++ b/src/whereami.c
@@ -737,7 +737,18 @@ extern "C" {
 
 #else
 
-#error unsupported platform
+  WAI_FUNCSPEC int WAI_PREFIX(getExecutablePath)(char *out, int capacity, int *dirname_length) {
+    if(dirname_length)
+      *dirname_length = -1;
+    return -1;
+  }
+
+  WAI_NOINLINE WAI_FUNCSPEC int WAI_PREFIX(getModulePath)(char *out, int capacity, int *dirname_length) {
+    if(dirname_length)
+      *dirname_length = -1;
+    return -1;
+  }
+
 #endif
 
 #ifdef __cplusplus

--- a/src/whereami.c
+++ b/src/whereami.c
@@ -24,13 +24,12 @@ extern "C" {
 
 #if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
 #include <stdlib.h>
+#include "avrdude.h"
+#include "libavrdude.h"
 
 #ifndef PATH_MAX
 #define PATH_MAX _MAX_PATH
 #endif
-
-#include "avrdude.h"
-#include "libavrdude.h"
 #endif
 
 #if !defined(WAI_MALLOC)

--- a/src/whereami.c
+++ b/src/whereami.c
@@ -13,6 +13,15 @@
 extern "C" {
 #endif
 
+#if defined(__linux__) || defined(__CYGWIN__)
+#undef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#elif defined(__APPLE__)
+#undef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE
+#define _DARWIN_BETTER_REALPATH
+#endif
+
 #if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
 #include <stdlib.h>
 
@@ -72,7 +81,13 @@ extern "C" {
 #pragma warning(pop)
 #endif
 
+#if (_MSC_VER >= 1900)
 #include <stdbool.h>
+#else
+#define bool int
+#define false 0
+#define true 1
+#endif
 
   static int WAI_PREFIX(getModulePath_) (HMODULE module, char *out, int capacity, int *dirname_length) {
     wchar_t buffer1[MAX_PATH];
@@ -234,6 +249,11 @@ extern "C" {
 #endif
 #endif
 
+#if !defined(WAI_STRINGIZE)
+#define WAI_STRINGIZE(s)
+#define WAI_STRINGIZE_(s) #s
+#endif
+
 #if defined(__ANDROID__) || defined(ANDROID)
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -252,21 +272,20 @@ extern "C" {
         break;
 
       for(;;) {
-        char buffer[PATH_MAX < 1024? 1024: PATH_MAX];
-        uint64_t low, high;
+        char buffer[128 + PATH_MAX];
+        uintptr_t low, high;
         char perms[5];
         uint64_t offset;
-        uint32_t major, minor;
-        char path[PATH_MAX];
-        uint32_t inode;
+        uint32_t major, minor, inode;
+        char path[PATH_MAX + 1];
 
         if(!fgets(buffer, sizeof(buffer), maps))
           break;
 
-        if(sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n",
-          &low, &high, perms, &offset, &major, &minor, &inode, path) == 8) {
-
-          uint64_t addr = (uintptr_t) WAI_RETURN_ADDRESS();
+        if(sscanf(buffer, "%" SCNxPTR "-%" SCNxPTR " %s %" SCNx64 " %x:%x %u %" WAI_STRINGIZE(PATH_MAX) "[^\n]\n", &low, &high,
+            perms, &offset, &major, &minor, &inode, path) == 8) {
+          void *_addr = WAI_RETURN_ADDRESS();
+          uintptr_t addr = (uintptr_t) _addr;
 
           if(low <= addr && addr <= high) {
             char *resolved;
@@ -353,7 +372,6 @@ extern "C" {
 
 #elif defined(__APPLE__)
 
-#define _DARWIN_BETTER_REALPATH
 #include <mach-o/dyld.h>
 #include <limits.h>
 #include <stdlib.h>

--- a/src/whereami.h
+++ b/src/whereami.h
@@ -32,7 +32,8 @@ extern "C" {
  * @param out destination buffer, optional
  * @param capacity destination buffer capacity
  * @param dirname_length optional recipient for the length of the dirname part
- *   of the path.
+ *   of the path. Available only when `capacity` is large enough to retrieve the
+ *   path.
  *
  * @return the length of the executable path on success (without a terminal NUL
  * character), otherwise `-1`
@@ -52,7 +53,8 @@ extern "C" {
  * @param out destination buffer, optional
  * @param capacity destination buffer capacity
  * @param dirname_length optional recipient for the length of the dirname part
- *   of the path.
+ *   of the path. Available only when `capacity` is large enough to retrieve the
+ *   path.
  *
  * @return the length of the module path on success (without a terminal NUL
  * character), otherwise `-1`


### PR DESCRIPTION
The source library `whereami.[ch]` was included some 5 years ago. This PR updates them from the current [githib source](https://github.com/gpakosz/whereami) and makes changes to `whereami.[ch]` that #2079 and #2080 felt where necessary to support illumos and Haiku OS.