### PR TITLE
Use verbosity levels consistently

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -60,40 +60,56 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
 #define msg_warning(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_WARNING, __VA_ARGS__)
 #define msg_info(...)       avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_INFO, __VA_ARGS__)
 #define msg_notice(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_NOTICE, __VA_ARGS__)
-#define msg_notice2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_NOTICE2, __VA_ARGS__)
-#define msg_debug(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_DEBUG, __VA_ARGS__)
-#define msg_trace(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_TRACE, __VA_ARGS__)
-#define msg_trace2(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_TRACE2, __VA_ARGS__)
+#define msg_notice2(...)    do { if(verblevel >=  MSG_NOTICE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_NOTICE2, __VA_ARGS__); } while(0)
+#define msg_debug(...)      do { if(verblevel >=  MSG_DEBUG) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_DEBUG, __VA_ARGS__); } while(0)
+#define msg_trace(...)      do { if(verblevel >=  MSG_TRACE) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_TRACE, __VA_ARGS__); } while(0)
+#define msg_trace2(...)     do { if(verblevel >=  MSG_TRACE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_TRACE2, __VA_ARGS__); } while(0)
 
 #define pmsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_EXT_ERROR, __VA_ARGS__)
 #define pmsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_ERROR, __VA_ARGS__)
 #define pmsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FUNCTION|MSG2_FILELINE|MSG2_TYPE|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_WARNING, __VA_ARGS__)
 #define pmsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)
 #define pmsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE, __VA_ARGS__)
-#define pmsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__)
-#define pmsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__)
-#define pmsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__)
-#define pmsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__)
+#define pmsg_notice2(...)   do { if(verblevel >=  MSG_NOTICE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__); } while(0)
+#define pmsg_debug(...)     do { if(verblevel >=  MSG_DEBUG) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__); } while(0)
+#define pmsg_trace(...)     do { if(verblevel >=  MSG_TRACE) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__); } while(0)
+#define pmsg_trace2(...)    do { if(verblevel >=  MSG_TRACE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_UCFIRST|MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__); } while(0)
 
 #define imsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_EXT_ERROR, __VA_ARGS__)
 #define imsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_ERROR, __VA_ARGS__)
 #define imsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_WARNING, __VA_ARGS__)
 #define imsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)
 #define imsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE, __VA_ARGS__)
-#define imsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__)
-#define imsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__)
-#define imsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__)
-#define imsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__)
+#define imsg_notice2(...)   do { if(verblevel >=  MSG_NOTICE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__); } while(0)
+#define imsg_debug(...)     do { if(verblevel >=  MSG_DEBUG) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__); } while(0)
+#define imsg_trace(...)     do { if(verblevel >=  MSG_TRACE) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__); } while(0)
+#define imsg_trace2(...)    do { if(verblevel >=  MSG_TRACE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__); } while(0)
 
 #define lmsg_ext_error(...) avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_EXT_ERROR, __VA_ARGS__)
 #define lmsg_error(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_ERROR, __VA_ARGS__)
 #define lmsg_warning(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_WARNING, __VA_ARGS__)
 #define lmsg_info(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)
 #define lmsg_notice(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_NOTICE, __VA_ARGS__)
-#define lmsg_notice2(...)   avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__)
-#define lmsg_debug(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__)
-#define lmsg_trace(...)     avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__)
-#define lmsg_trace2(...)    avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__)
+#define lmsg_notice2(...)   do { if(verblevel >=  MSG_NOTICE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_NOTICE2, __VA_ARGS__); } while(0)
+#define lmsg_debug(...)     do { if(verblevel >=  MSG_DEBUG) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_DEBUG, __VA_ARGS__); } while(0)
+#define lmsg_trace(...)     do { if(verblevel >=  MSG_TRACE) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_TRACE, __VA_ARGS__); } while(0)
+#define lmsg_trace2(...)    do { if(verblevel >=  MSG_TRACE2) \
+  avrdude_message2(stderr, __LINE__, __FILE__, __func__, MSG2_LEFT_MARGIN, MSG_TRACE2, __VA_ARGS__); } while(0)
 
 #define term_out(...)       avrdude_message2(stdout, __LINE__, __FILE__, __func__, MSG2_FLUSH, MSG_INFO, __VA_ARGS__)
 #define lterm_out(...)      avrdude_message2(stdout, __LINE__, __FILE__, __func__, MSG2_FLUSH|MSG2_LEFT_MARGIN, MSG_INFO, __VA_ARGS__)

--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -51,6 +51,9 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func, int 
 #endif
   ;
 
+// Reduce effective verbosity level by number of -q options above one
+#define verblevel (quell_progress < 2? verbose: verbose + 1 - quell_progress)
+
 // Shortcuts
 #define msg_ext_error(...)  avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_EXT_ERROR, __VA_ARGS__)
 #define msg_error(...)      avrdude_message2(stderr, __LINE__, __FILE__, __func__, 0, MSG_ERROR, __VA_ARGS__)

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -568,9 +568,9 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 
   Avrftdi_data *pdata = to_pdata(pgm);
 
-  bool pin_check_mpsse = (0 == avrftdi_check_pins_mpsse(pgm, verbose >= MSG_TRACE));
+  bool pin_check_mpsse = (0 == avrftdi_check_pins_mpsse(pgm, verblevel >= MSG_TRACE));
 
-  bool pin_check_bitbanging = (0 == avrftdi_check_pins_bb(pgm, verbose >= MSG_TRACE));
+  bool pin_check_bitbanging = (0 == avrftdi_check_pins_bb(pgm, verblevel >= MSG_TRACE));
 
   if(!pin_check_mpsse && !pin_check_bitbanging) {
     pmsg_error("no valid pin configuration found\n");
@@ -896,7 +896,7 @@ static int avrftdi_lext(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m
   avr_set_bits(m->op[AVR_OP_LOAD_EXT_ADDR], buf);
   avr_set_addr(m->op[AVR_OP_LOAD_EXT_ADDR], buf, address);
 
-  if(verbose >= MSG_TRACE2)
+  if(verblevel >= MSG_TRACE2)
     buf_dump(buf, sizeof(buf), "load extended address command", 0, 16*3);
 
   if(0 > avrftdi_transmit(pgm, MPSSE_DO_WRITE, buf, buf, 4))
@@ -1020,7 +1020,7 @@ static int avrftdi_flash_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
   if(poll_index + 1 > addr) {
     buf_size = bufptr - buf;
 
-    if(verbose >= MSG_TRACE2)
+    if(verblevel >= MSG_TRACE2)
       buf_dump(buf, buf_size, "command buffer", 0, 16*2);
 
     pmsg_notice("transmitting buffer of size: %d\n", buf_size);
@@ -1089,14 +1089,14 @@ static int avrftdi_flash_read(const PROGRAMMER *pgm, const AVRPART *p, const AVR
    * if there was an error, we did not see, memory validation will
    * subsequently fail.
    */
-  if(verbose >= MSG_TRACE2) {
+  if(verblevel >= MSG_TRACE2) {
     buf_dump(o_buf, sizeof(o_buf), "o_buf", 0, 32);
   }
 
   if(0 > avrftdi_transmit(pgm, MPSSE_DO_READ | MPSSE_DO_WRITE, o_buf, i_buf, len*4))
     return -1;
 
-  if(verbose >= MSG_TRACE2) {
+  if(verblevel >= MSG_TRACE2) {
     buf_dump(i_buf, sizeof(i_buf), "i_buf", 0, 32);
   }
 
@@ -1115,7 +1115,7 @@ static int avrftdi_flash_read(const PROGRAMMER *pgm, const AVRPART *p, const AVR
     avr_get_output(readop, &i_buf[byte*4], &m->buf[addr + byte]);
   }
 
-  if(verbose >= MSG_TRACE2)
+  if(verblevel >= MSG_TRACE2)
     buf_dump(&m->buf[addr], page_size, "page:", 0, 32);
 
   return len;

--- a/src/avrpart.c
+++ b/src/avrpart.c
@@ -1148,7 +1148,7 @@ void avr_display(FILE *f, const PROGRAMMER *pgm, const AVRPART *p, const char *p
   fprintf(f, "%sAVR part              : %s\n", prefix, p->desc);
   fprintf(f, "%sProgramming modes     : %s\n", prefix, str_prog_modes(p->prog_modes));
 
-  if(verbose > 1) {
+  if(verbose >= MSG_NOTICE2) {
     avr_mem_display(f, pgm, p, prefix);
     avr_variants_display(f, p, prefix);
   }

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -295,7 +295,7 @@ int bitbang_cmd(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned char *
     res[i] = bitbang_txrx(pgm, cmd[i]);
   }
 
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("%s(): [ ", __func__);
     for(i = 0; i < 4; i++)
       msg_debug("%02X ", cmd[i]);
@@ -324,7 +324,7 @@ int bitbang_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd, int cmd_len
     res[i] = r;
   }
 
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("%s(): [ ", __func__);
     for(i = 0; i < cmd_len; i++)
       msg_debug("%02X ", cmd[i]);
@@ -352,7 +352,7 @@ int bitbang_spi(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned char *
 
   pgm->setpin(pgm, PIN_LED_PGM, 1);
 
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("%s(): [ ", __func__);
     for(i = 0; i < count; i++)
       msg_debug("%02X ", cmd[i]);

--- a/src/config.c
+++ b/src/config.c
@@ -1077,7 +1077,7 @@ void cfg_update_mcuid(AVRPART *part) {
   for(size_t i = 0; i < sizeof uP_table/sizeof *uP_table; i++) {
     if(str_caseeq(part->desc, uP_table[i].name)) {
       if(part->mcuid != (int) uP_table[i].mcuid) {
-        if(part->mcuid >= 0 && verbose >= MSG_DEBUG)
+        if(part->mcuid >= 0 && verblevel >= MSG_DEBUG)
           yywarning("overwriting mcuid of part %s to be %d", part->desc, uP_table[i].mcuid);
         part->mcuid = uP_table[i].mcuid;
       }

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1181,7 +1181,7 @@ void dev_output_part_defs(char *partdesc) {
             n = 1 << c;
           }
           dev_info(".cfgt\t%s\t%d\t%s\n", p->desc, n, cp->name);
-          if(cp->vlist && verbose)
+          if(cp->vlist && verbose > 0)
             for(int k = 0; k < cp->nvalues; k++)
               dev_info(".cfgv\t%s\t\tvalue\t%d\t%s\n", p->desc, cp->vlist[k].value, cp->vlist[k].label);
         }

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -782,7 +782,7 @@ static int ft245r_cmd_tpi(const PROGRAMMER *pgm, const unsigned char *cmd,
   for(i = 0; i < res_len; ++i)
     if((ret = ft245r_tpi_rx(pgm, &res[i])) < 0)
       break;
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("%s: [ ", __func__);
     for(i = 0; i < cmd_len; i++)
       msg_debug("%02X ", cmd[i]);

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -237,7 +237,7 @@ static void jtag3_print_data(unsigned char *b, size_t s) {
 }
 
 static void jtag3_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
-  if(verbose >= MSG_TRACE) {
+  if(verblevel >= MSG_TRACE) {
     size_t i;
 
     msg_trace("Raw message:\n");
@@ -365,7 +365,7 @@ static int jtag3_errcode(int reason) {
 }
 
 static void jtag3_prevent(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
-  if(verbose >= MSG_TRACE) {
+  if(verblevel >= MSG_TRACE) {
     size_t i;
 
     msg_trace("Raw event:\n");
@@ -482,7 +482,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
   unsigned char status[USBDEV_MAX_XFER_3];
   int rv;
 
-  if(verbose >= MSG_TRACE) {
+  if(verblevel >= MSG_TRACE) {
     memset(buf, 0, USBDEV_MAX_XFER_3);
     memset(status, 0, USBDEV_MAX_XFER_3);
   }
@@ -562,7 +562,7 @@ static int jtag3_edbg_prepare(const PROGRAMMER *pgm) {
   msg_debug("\n");
   pmsg_debug("jtag3_edbg_prepare()\n");
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     memset(buf, 0, USBDEV_MAX_XFER_3);
 
   buf[0] = CMSISDAP_CMD_CONNECT;
@@ -607,7 +607,7 @@ static int jtag3_edbg_signoff(const PROGRAMMER *pgm) {
   msg_debug("\n");
   pmsg_debug("jtag3_edbg_signoff()\n");
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     memset(buf, 0, USBDEV_MAX_XFER_3);
 
   buf[0] = CMSISDAP_CMD_LED;
@@ -780,7 +780,7 @@ int jtag3_recv(const PROGRAMMER *pgm, unsigned char **msg) {
       return rv;
 
     if((rv & USB_RECV_FLAG_EVENT) != 0) {
-      if(verbose >= MSG_DEBUG)
+      if(verblevel >= MSG_DEBUG)
         jtag3_prevent(pgm, *msg, rv & USB_RECV_LENGTH_MASK);
 
       mmt_free(*msg);
@@ -831,7 +831,7 @@ int jtag3_command(const PROGRAMMER *pgm, unsigned char *cmd, unsigned int cmdlen
     if(status == 0)
       mmt_free(*resp);
     return LIBAVRDUDE_GENERAL_FAILURE;
-  } else if(verbose >= MSG_DEBUG) {
+  } else if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtag3_prmsg(pgm, *resp, status);
   } else {

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -105,7 +105,7 @@ static void u16_to_b2(unsigned char *b, unsigned short l) {
 }
 
 static void jtagmkI_prmsg(const PROGRAMMER *pgm, unsigned char *data, size_t len) {
-  if(verbose >= MSG_TRACE) {
+  if(verblevel >= MSG_TRACE) {
     msg_trace("Raw message:\n");
 
     size_t i;
@@ -185,7 +185,7 @@ static int jtagmkI_recv(const PROGRAMMER *pgm, unsigned char *buf, size_t len) {
     pmsg_error("unable to send command to serial port\n");
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkI_prmsg(pgm, buf, len);
   }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -262,7 +262,7 @@ static void jtagmkII_print_memory(unsigned char *b, size_t s) {
 static void jtagmkII_prmsg(const PROGRAMMER *pgm_unused, unsigned char *data, size_t len) {
   size_t i;
 
-  if(verbose >= MSG_TRACE) {
+  if(verblevel >= MSG_TRACE) {
     msg_trace("Raw message:\n");
 
     for(i = 0; i < len; i++) {
@@ -553,8 +553,7 @@ static int jtagmkII_recv_frame(const PROGRAMMER *pgm, unsigned char **msg, unsig
         buf[l++] = c;
       if(state == sCSUM2 && buf) {
         if(crcverify(buf, msglen + 10)) {
-          if(verbose >= 9)
-            pmsg_trace2("%s(): CRC OK", __func__);
+          pmsg_trace2("%s(): CRC OK", __func__);
           state = sDONE;
         } else {
           pmsg_error("wrong checksum\n");
@@ -605,7 +604,7 @@ int jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg) {
        */
       memmove(*msg, *msg + 8, rv);
 
-      if(verbose >= MSG_TRACE)
+      if(verblevel >= MSG_TRACE)
         trace_buffer(__func__, *msg, rv);
 
       return rv;
@@ -648,7 +647,7 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
     status = jtagmkII_recv(pgm, &resp);
     if(status <= 0) {
       pmsg_warning("attempt %d of %d: sign-on command: status %d\n", tries + 1, MAXTRIES, status);
-    } else if(verbose >= MSG_DEBUG) {
+    } else if(verblevel >= MSG_DEBUG) {
       msg_debug("\n");
       jtagmkII_prmsg(pgm, resp, status);
     } else
@@ -777,7 +776,7 @@ retry:
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -815,7 +814,7 @@ static int jtagmkII_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -895,7 +894,7 @@ static void jtagmkII_set_devdescr(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -965,7 +964,7 @@ static void jtagmkII_set_xmega_params(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -1003,7 +1002,7 @@ static int jtagmkII_reset(const PROGRAMMER *pgm, unsigned char flags) {
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -1041,7 +1040,7 @@ static int jtagmkII_program_enable(const PROGRAMMER *pgm) {
       pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
       return -1;
     }
-    if(verbose >= MSG_DEBUG) {
+    if(verblevel >= MSG_DEBUG) {
       msg_debug("\n");
       jtagmkII_prmsg(pgm, resp, status);
     } else
@@ -1086,7 +1085,7 @@ static int jtagmkII_program_disable(const PROGRAMMER *pgm) {
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -1704,7 +1703,7 @@ void jtagmkII_close(PROGRAMMER *pgm) {
       msg_notice2("\n");
       pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     } else {
-      if(verbose >= MSG_DEBUG) {
+      if(verblevel >= MSG_DEBUG) {
         msg_debug("\n");
         jtagmkII_prmsg(pgm, resp, status);
       } else
@@ -1727,7 +1726,7 @@ void jtagmkII_close(PROGRAMMER *pgm) {
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -1835,7 +1834,7 @@ retry:
     serial_recv_timeout = otimeout;
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -1943,7 +1942,7 @@ static int jtagmkII_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const A
       serial_recv_timeout = otimeout;
       return -1;
     }
-    if(verbose >= MSG_DEBUG) {
+    if(verblevel >= MSG_DEBUG) {
       msg_debug("\n");
       jtagmkII_prmsg(pgm, resp, status);
     } else
@@ -2031,7 +2030,7 @@ static int jtagmkII_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AV
       serial_recv_timeout = otimeout;
       return -1;
     }
-    if(verbose >= MSG_DEBUG) {
+    if(verblevel >= MSG_DEBUG) {
       msg_debug("\n");
       jtagmkII_prmsg(pgm, resp, status);
     } else
@@ -2224,7 +2223,7 @@ retry:
       resp = 0;
     goto fail;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -2340,7 +2339,7 @@ retry:
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     goto fail;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -2426,7 +2425,7 @@ int jtagmkII_getparm(const PROGRAMMER *pgm, unsigned char parm, unsigned char *v
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -2522,7 +2521,7 @@ static int jtagmkII_setparm(const PROGRAMMER *pgm, unsigned char parm, unsigned 
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return -1;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -3323,7 +3322,7 @@ static void jtagmkII_close32(PROGRAMMER *pgm) {
     pmsg_error("timeout/error communicating with programmer (status %d)\n", status);
     return;
   }
-  if(verbose >= MSG_DEBUG) {
+  if(verblevel >= MSG_DEBUG) {
     msg_debug("\n");
     jtagmkII_prmsg(pgm, resp, status);
   } else
@@ -3393,7 +3392,7 @@ static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p_unused,
     if(status < 0)
       gotoerr;
 
-    if(verbose >= MSG_DEBUG) {
+    if(verblevel >= MSG_DEBUG) {
       msg_debug("\n");
       jtagmkII_prmsg(pgm, resp, status);
     } else
@@ -3497,7 +3496,7 @@ static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p_unused
       if(status < 0)
         gotoerr;
 
-      if(verbose >= MSG_DEBUG) {
+      if(verblevel >= MSG_DEBUG) {
         msg_debug("\n");
         jtagmkII_prmsg(pgm, resp, status);
       } else

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -778,8 +778,8 @@ int pgm_fill_old_pins(PROGRAMMER *const pgm);
  * @li any mandatory pin is not set all.
  *
  * In case of any error it report the wrong function and the pin numbers
- * For verbose >= MSG_NOTICE2 it also reports the possible correct value
- * For verbose >= MSG_DEBUG it shows also which pins were ok
+ * For verblevel >= MSG_NOTICE2 it also reports the possible correct value
+ * For verblevel >= MSG_DEBUG it shows also which pins were ok
  *
  * @param[in] pgm the programmer to check
  * @param[in] checklist the constraint for the pins

--- a/src/main.c
+++ b/src/main.c
@@ -117,7 +117,7 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func,
     fflush(stderr);
   }
   // Reduce effective verbosity level by number of -q above one when printing to stderr
-  if((quell_progress < 2 || fp != stderr? verbose: verbose + 1 - quell_progress) >= msglvl) {
+  if((fp == stderr? verblevel: verbose) >= msglvl) {
     if(msgmode & MSG2_LEFT_MARGIN && !bols[bi].bol) {
       fprintf(fp, "\n");
       bols[bi].bol = 1;
@@ -145,7 +145,7 @@ int avrdude_message2(FILE *fp, int lno, const char *file, const char *func,
           fprintf(fp, " %s", mt);
         bols[bi].bol = 0;
       }
-      if(verbose >= MSG_NOTICE2) {
+      if(verblevel >= MSG_NOTICE2) {
         const char *bfname = strrchr(file, '/');        // Only print basename
 
 #if defined (WIN32)
@@ -1467,11 +1467,9 @@ int main(int argc, char *argv[]) {
   }
 
   // Open the programmer
-  if(verbose > 0) {
-    if(!is_dryrun)
-      pmsg_notice("using port            : %s\n", port);
-    pmsg_notice("using programmer      : %s\n", pgmid);
-  }
+  if(!is_dryrun)
+    pmsg_notice("using port            : %s\n", port);
+  pmsg_notice("using programmer      : %s\n", pgmid);
 
   if(baudrate && !pgm->baudrate && !default_baudrate) { // None set
     pmsg_notice("setting baud rate     : %d\n", baudrate);

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -2282,7 +2282,7 @@ static int usbdev_bulk_recv(const union filedescriptor *fd, unsigned char *buf, 
     i += amnt;
   }
 
-  if(verbose > 4)
+  if(verblevel >= MSG_TRACE2)
     trace_buffer(__func__, p, i);
 
   return 0;
@@ -2315,7 +2315,7 @@ static int usbdev_bulk_send(const union filedescriptor *fd, const unsigned char 
     i += tx_size;
   } while(mlen > 0);
 
-  if(verbose > 3)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, p, i);
   return 0;
 }

--- a/src/pindefs.c
+++ b/src/pindefs.c
@@ -208,8 +208,8 @@ const char *pinmask_to_str(const Pinmask *const pinmask) {
  * @li any mandatory pin is not set all.
  *
  * In case of any error it report the wrong function and the pin numbers
- * For verbose >= MSG_NOTICE2 it also reports the possible correct values
- * For verbose >= MSG_DEBUG it shows also which pins were ok
+ * For verblevel >= MSG_NOTICE2 it also reports the possible correct values
+ * For verblevel >= MSG_DEBUG it shows also which pins were ok
  *
  * @param[in] pgm the programmer to check
  * @param[in] checklist the constraint for the pins

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -226,7 +226,7 @@ static int avrdoper_send(const union filedescriptor *fdp, const unsigned char *b
     pmsg_error("%s() called with too large buflen = %lu\n", __func__, (unsigned long) buflen);
     return -1;
   }
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     dumpBlock("Send", buf, buflen);
   while(buflen > 0) {
     unsigned char buffer[256];
@@ -300,7 +300,7 @@ static int avrdoper_recv(const union filedescriptor *fdp, unsigned char *buf, si
     remaining -= len;
     cx->sad_avrdoperRxPosition += len;
   }
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     dumpBlock("Receive", buf, buflen);
   return 0;
 }

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -425,7 +425,7 @@ static void ser_rawclose(union filedescriptor *fd) {
 static int ser_send(const union filedescriptor *fd, const unsigned char *buf, size_t len) {
   int rc;
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, buf, len);
 
   while(len) {
@@ -481,7 +481,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
     len += rc;
   }
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, buf, len);
 
   return 0;

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -314,7 +314,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char *buf, si
   if(!len)
     return 0;
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, buf, len);
 
   while(len) {
@@ -351,7 +351,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char *buf, si
   if(!len)
     return 0;
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, buf, len);
 
   // Set minimum r/w timeout to 2000 ms or higher to cater for 110 baud or faster
@@ -429,7 +429,7 @@ static int net_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
     len += rc;
   }
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, buf, len);
 
   return 0;
@@ -473,7 +473,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
     return -1;
   }
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, buf, read);
 
   return 0;

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -278,7 +278,7 @@ static int usbhid_send(const union filedescriptor *fd, const unsigned char *bp, 
   if(rv != tx_size + 1)
     pmsg_error("short write to USB: %d bytes out of %d written\n", rv, tx_size + 1);
 
-  if(verbose >= MSG_TRACE2)
+  if(verblevel >= MSG_TRACE2)
     trace_buffer(__func__, bp, tx_size);
 
   return 0;
@@ -298,7 +298,7 @@ static int usbhid_recv(const union filedescriptor *fd, unsigned char *buf, size_
   else if((size_t) i != nbytes)
     pmsg_error("short read, read only %d out of %lu bytes\n", i, (unsigned long) nbytes);
 
-  if(verbose >= MSG_TRACE2 && i > 0)
+  if(verblevel >= MSG_TRACE2 && i > 0)
     trace_buffer(__func__, p, i);
 
   return rv;

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -297,7 +297,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
     mlen -= tx_size;
   } while(mlen > 0);
 
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, p, i);
   return 0;
 }
@@ -347,7 +347,7 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
     i += amnt;
   }
 
-  if(verbose >= MSG_TRACE2)
+  if(verblevel >= MSG_TRACE2)
     trace_buffer(__func__, p, i);
 
   return 0;
@@ -422,7 +422,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
  *
  */
 printout:
-  if(verbose >= MSG_TRACE)
+  if(verblevel >= MSG_TRACE)
     trace_buffer(__func__, p, n & USB_RECV_LENGTH_MASK);
 
   return n;

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -374,7 +374,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
   unsigned char receive, unsigned char functionid, const unsigned char *send, unsigned char *buffer, int buffersize) {
   int nbytes;
 
-  if(verbose >= MSG_TRACE) {
+  if(verblevel >= MSG_TRACE) {
     pmsg_trace("usbasp_transmit(\"%s\", 0x%02x, 0x%02x, 0x%02x, 0x%02x)\n",
       usbasp_get_funcname(functionid), send[0], send[1], send[2], send[3]);
     if(!receive && buffersize > 0) {
@@ -406,7 +406,7 @@ static int usbasp_transmit(const PROGRAMMER *pgm,
   }
 #endif
 
-  if(verbose >= MSG_TRACE && receive && nbytes > 0) {
+  if(verblevel >= MSG_TRACE && receive && nbytes > 0) {
     int i;
 
     imsg_trace("<= ");
@@ -753,7 +753,7 @@ static int usbasp_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 // SPI specific functions
 static int usbasp_spi_cmd(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned char *res) {
   pmsg_debug("usbasp_spi_cmd(0x%02x, 0x%02x, 0x%02x, 0x%02x)%s",
-    cmd[0], cmd[1], cmd[2], cmd[3], verbose >= MSG_TRACE? " ...\n": "");
+    cmd[0], cmd[1], cmd[2], cmd[3], verblevel >= MSG_TRACE? " ...\n": "");
 
   int nbytes = usbasp_transmit(pgm, 1, USBASP_FUNC_TRANSMIT, cmd, res, 4);
 


### PR DESCRIPTION
This PR
  - Defines `verblevel` as `verbose` reduced by the number of CLI `-q` options above one
  - Guards notice, debugging and trace messages with the right `verblevel`
  - Utilise effective verbosity level `verblevel` instead of `verbose` where appropriate
 
The effects of this PR are subtle and should not be noticeable to the user. It prevents numerous notice, debugging and trace messages being executed during the AVRDUDE run only to return without any printout. Should be (ever so slightly) more efficient. The only situations where the output differs once this PR is applied pertain to calls from the user with many `-v` and `-q` options. Remember, AVRDUDE messaging let `-q` options reduce the effective verbosity given by `-v`. Some `-c` programmers did not use the AVRDUDE messaging but rolled their own typically with constructs like
```
   if(verbose >= MSG_DEBUG2)
      show_buffer_contents();
```
By replacing `verbose` with `verblevel` these messages are now brought inline with what `msg_debug2()` would do (which only prints output when `verblevel >= MSG_DEBUG2`).

Messaging got just that little more systematic.