### PR TITLE
Remove `PM_TPI` from `-c stk600` prog modes

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -1723,7 +1723,7 @@ programmer # stk600
     id                     = "stk600";
     desc                   = "Atmel STK600";
     type                   = "stk600";
-    prog_modes             = PM_TPI | PM_ISP | PM_PDI;
+    prog_modes             = PM_ISP | PM_PDI;
     extra_features         = HAS_VTARG_ADJ | HAS_VTARG_READ | HAS_FOSC_ADJ | HAS_VAREF_ADJ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x03eb;


### PR DESCRIPTION
While the STK600 protocol supports TPI (and JTAG and UPDI), the current AVRDUDE implementation for stk600 doesn't. This PR adjusts the prog modes in avrdude.conf accordingly.