### PR TITLE
Read target voltage using `-x vtarg`

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -1658,13 +1658,12 @@ High-voltage UPDI programming is used to enable a UPDI pin that has previously
 been set to RESET or GPIO mode. Use
 .Ar -x hvupdi
 to enable high-voltage UPDI initialization for targets that supports this.
-.It Ar vtarg=VALUE, vtarg
+.It Ar vtarg
+Read the target voltage.
+.It Ar vtarg=VALUE
 .Nm Power Debugger only
 .sp 0.5
 The voltage generator can be enabled by setting a target voltage.
-The current set-voltage can be read by
-.Ar -x vtarg
-alone.
 .It Ar help
 Show help menu and exit.
 .El
@@ -1683,12 +1682,16 @@ when in AVR mode. Use
 for switching to AVR mode, or
 .Ar -x mode=mplab
 for switching (back) to MPLAB mode.
+.It Ar vtarg
+Read the target voltage.
 .It Ar help
 Show help menu and exit.
 .El
 .It Ar PICkit 5
 .It Ar PICkit 4 (PIC mode)
 .Bl -tag -offset indent -width indent
+.It Ar vtarg
+Read the target voltage.
 .It Ar vtarg=<voltage>
 Specify a voltage between 1.8 and 5.5 V that the programmer should supply
 to the target. If there is already a valid voltage applied to the VTG Pin,

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -3255,7 +3255,7 @@ programmer # pickit_basic
     desc                   = "MPLAB(R) PICkit Basic in JTAG mode";
     type                   = "pickit5";
     prog_modes             = PM_JTAG | PM_XMEGAJTAG;
-    extra_features         = HAS_BITCLOCK_ADJ; # HAS_VTARG_READ was not working yet
+    extra_features         = HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     usbvid                 = 0x04d8;
     usbpid                 = 0x9055;    # PK Basic

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -1432,11 +1432,14 @@ High-voltage UPDI programming is used to enable a UPDI pin that has previously
 been set to RESET or GPIO mode. Use @code{-x hvupdi} to enable high-voltage UPDI
 initialization for supported targets.
 
-@item vtarg=VALUE, vtarg
+@item vtarg
+Read the target voltage.
+
+@item vtarg=VALUE
 @var{Power Debugger only}
 @*
 The voltage generator can be enabled by setting a target voltage.
-The current set-voltage can be read by @code{-x vtarg} alone.
+
 
 @end table
 
@@ -1453,14 +1456,15 @@ The current set-voltage can be read by @code{-x vtarg} alone.
 
 The PICkit 4 and MPLAB(R) SNAP programmers accept the following extended parameters:
 @table @code
+@item vtarg
+Read the target voltage.
 @item mode=avr
 Switch programmer to AVR mode, then exit unless it was already in AVR mode
 @item mode=<mplab|pic>
 Switch programmer to MPLAB aka PIC mode, then exit
 @end table
 
-The PICkit 4 and MPLAB(R) SNAP programmer can only be utilised by AVRDUDE
-when in AVR mode. Use @code{-x mode=avr} for switching to AVR mode, or
+Use @code{-x mode=avr} for switching to AVR mode, or
 @code{-x mode=mplab} for switching (back) to MPLAB mode.
 
 @cindex Option @code{-x} PICkit 5
@@ -1474,6 +1478,8 @@ when in AVR mode. Use @code{-x mode=avr} for switching to AVR mode, or
 
 The PICkit 5 and PICkit 4 (MPLAB Mode) programmer can accept following extended parameters
 @table @code
+@item vtarg
+Read the target voltage.
 @item vtarg=VALUE
 Specify a voltage between 1.8 and 5.5@w{ }V that the programmer should supply
 to the target. If there is already a valid voltage applied to the VTG Pin,

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1622,10 +1622,6 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       msg_error("  -x vtarg_switch        Read on-board target voltage switch state\n");
       msg_error("  -x vtarg_switch=<0|1>  Set on-board target voltage switch state\n");
     }
-    if(pgm->extra_features & HAS_VTARG_ADJ) {
-      msg_error("  -x vtarg               Read on-board target supply voltage\n");
-      msg_error("  -x vtarg=<dbl>         Set on-board target supply voltage to <dbl> V\n");
-    }
     if(pgm->extra_features & HAS_VTARG_READ)
       msg_error("  -x vtarg               Read on-board target supply voltage\n");
     if(pgm->extra_features & HAS_VTARG_ADJ)

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1097,10 +1097,10 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       MEDBG_REG_SUFFER_OFFSET, my.suffer_data, 1) < 0) {
       return -1;
     }
-    if(!my.suffer_set)
+    if(my.suffer_get)
       msg_info("SUFFER register value read as 0x%02x\n", my.suffer_data[0]);
     // Write new SUFFER value
-    else {
+    if(my.suffer_set) {
       if(jtag3_setparm(pgm, SCOPE_EDBG, MEDBG_REG_SUFFER_BANK + 0x10,
         MEDBG_REG_SUFFER_OFFSET, my.suffer_data + 1, 1) < 0) {
         return -1;
@@ -1116,11 +1116,11 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       EDBG_CONTROL_TARGET_POWER, my.vtarg_switch_data, 1) < 0) {
       return -1;
     }
-    if(!my.vtarg_switch_set)
+    if(my.vtarg_switch_get)
       msg_info("Vtarg switch setting read as %u: target power is switched %s\n", my.vtarg_switch_data[0],
         my.vtarg_switch_data[0]? "on": "off");
     // Write Vtarg switch value
-    else {
+    if(my.vtarg_switch_set) {
       if(jtag3_setparm(pgm, SCOPE_EDBG, EDBG_CTXT_CONTROL,
         EDBG_CONTROL_TARGET_POWER, my.vtarg_switch_data + 1, 1) < 0) {
         return -1;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1146,7 +1146,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if(my.vtarg_get)
       msg_info("Target voltage value read as %.2fV\n", vtarg_read);
     // Write target voltage value
-    else {
+    if(my.vtarg_set) {
       u16_to_b2(buf, (unsigned) (my.vtarg_data*1000));
       msg_info("Changing target voltage from %.2f to %.2fV\n", vtarg_read, my.vtarg_data);
       if(jtag3_setparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, sizeof(buf)) < 0) {
@@ -1579,8 +1579,6 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
         rv = -1;
         break;
       }
-      rv = -1;
-      break;
     }
 
     if(str_starts(extended_param, "mode") && (str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))) {
@@ -2931,7 +2929,7 @@ static int jtag3_initialize_tpi(const PROGRAMMER *pgm, const AVRPART *p) {
     if(my.vtarg_get)
       msg_info("Target voltage value read as %.2fV\n", vtarg_read);
     // Write target voltage value
-    else {
+    if(my.vtarg_set) {
       u16_to_b2(buf, (unsigned) (my.vtarg_data*1000));
       msg_info("Changing target voltage from %.2f to %.2fV\n", vtarg_read, my.vtarg_data);
       if(jtag3_setparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, sizeof(buf)) < 0) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1139,7 +1139,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     // Read current target voltage set value
     unsigned char buf[2];
 
-    if(jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
+    if(jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
       return -1;
     double vtarg_read = b2_to_u16(buf)/1000.0;
 
@@ -1567,12 +1567,16 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
           my.vtarg_set = true;
           continue;
         }
+        pmsg_error("invalid setting in -x %s; use or -x vtarg=<dbl>\n", extended_param);
+        rv = -1;
+        break;
+      }
+      if(pgm->extra_features & HAS_VTARG_READ) {
         // Get target voltage
-        else if(str_eq(extended_param, "vtarg")) {
+        if(str_eq(extended_param, "vtarg")) {
           my.vtarg_get = true;
           continue;
         }
-        pmsg_error("invalid setting in -x %s; use -x vtarg or -x vtarg=<dbl>\n", extended_param);
         rv = -1;
         break;
       }
@@ -1622,6 +1626,10 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       msg_error("  -x vtarg               Read on-board target supply voltage\n");
       msg_error("  -x vtarg=<dbl>         Set on-board target supply voltage to <dbl> V\n");
     }
+    if(pgm->extra_features & HAS_VTARG_READ)
+      msg_error("  -x vtarg               Read on-board target supply voltage\n");
+    if(pgm->extra_features & HAS_VTARG_ADJ)
+      msg_error("  -x vtarg=<dbl>         Set on-board target supply voltage to <dbl> V\n");
     if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap")) {
       msg_error("  -x mode=avr            Set programmer to AVR mode and exit if it was not\n");
       msg_error("  -x mode=<mplab|pic>    Set programmer to MPLAB aka PIC mode and exit\n");

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1552,6 +1552,14 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if(str_starts(extended_param, "vtarg")) {
+      if(pgm->extra_features & HAS_VTARG_READ) {
+        // Get target voltage
+        if(str_eq(extended_param, "vtarg")) {
+          my.vtarg_get = true;
+          continue;
+        }
+      }
+
       if(pgm->extra_features & HAS_VTARG_ADJ) {
         // Set target voltage
         if(str_starts(extended_param, "vtarg=")) {
@@ -1567,19 +1575,12 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
           my.vtarg_set = true;
           continue;
         }
-        pmsg_error("invalid setting in -x %s; use or -x vtarg=<dbl>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x vtarg=<dbl>\n", extended_param);
         rv = -1;
         break;
       }
-      if(pgm->extra_features & HAS_VTARG_READ) {
-        // Get target voltage
-        if(str_eq(extended_param, "vtarg")) {
-          my.vtarg_get = true;
-          continue;
-        }
-        rv = -1;
-        break;
-      }
+      rv = -1;
+      break;
     }
 
     if(str_starts(extended_param, "mode") && (str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))) {

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2922,7 +2922,7 @@ static int jtag3_initialize_tpi(const PROGRAMMER *pgm, const AVRPART *p) {
     // Read current target voltage set value
     unsigned char buf[2];
 
-    if(jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
+    if(jtag3_getparm(pgm, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
       return -1;
     double vtarg_read = b2_to_u16(buf)/1000.0;
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1566,12 +1566,12 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
           double vtarg_set_val = 0;
           int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
 
-          my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
           if(sscanf_success < 1 || vtarg_set_val < 0) {
             pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
+          my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
           my.vtarg_set = true;
           continue;
         }

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -71,10 +71,10 @@
 #define ERROR_SCRIPT_DEVICE_LOCKED  (LIBAVRDUDE_BEYOND_ERRS - 5)
 #define ERROR_SCRIPT_EXECUTION      (LIBAVRDUDE_BEYOND_ERRS - 6)
 
-
-#define can_power_target(pgm) (!!(pgm->extra_features & HAS_VTARG_ADJ))
-#define can_gen_hv_pulse(pgm) (!!(pgm->extra_features & HAS_VTARG_ADJ))  // Currently, with the 4
-#define can_do_ptg(pgm)       (can_power_target(pgm)) //  supported ICDs, it is enough to figure this out
+#define can_read_target_power(pgm)  (!!(pgm->extra_features & HAS_VTARG_READ))
+#define can_power_target(pgm)       (!!(pgm->extra_features & HAS_VTARG_ADJ))
+#define can_gen_hv_pulse(pgm)       (!!(pgm->extra_features & HAS_VTARG_ADJ))  // Currently, with the 4
+#define can_do_ptg(pgm)             (can_power_target(pgm)) //  supported ICDs, it is enough to figure this out
 
 // Private data for this programmer
 struct pdata {
@@ -84,6 +84,7 @@ struct pdata {
   unsigned char keep_power;     // 0: No power on exit / 1: Keeps supplying power on exit
   double target_voltage;        // Voltage to supply to target
 
+  bool get_vcc;
   double measured_vcc;          // This and below for print_params()
   unsigned int measured_current;
   unsigned int actual_pgm_clk;
@@ -381,6 +382,14 @@ static int pickit5_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       my.target_voltage = voltage;
       continue;
     }
+    if(str_eq(extended_param, "vtarg")) {
+      if(!can_read_target_power(pgm)) {
+        pmsg_warning("programmer does not support target voltage reading, continuing\n");
+        continue;
+      }
+      my.get_vcc = true;
+      continue;
+    }
     if(str_starts(extended_param, "hvupdi")) {
       if(can_gen_hv_pulse(pgm))
         for(LNODEID ln = lfirst(pgm->hvupdi_support); ln; ln = lnext(ln)) {
@@ -393,6 +402,8 @@ static int pickit5_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
 
     if(str_eq(extended_param, "help")) {
       msg_error("%s -c %s extended options:\n", progname, pgmid);
+      if(can_read_target_power(pgm))
+        msg_error("  -x vtarg        Read target supply voltage\n");
       if(can_power_target(pgm))
         msg_error("  -x vtarg=<dbl>  Enable power output; <dbl> must be in [1.8, 5.5] V\n");
       if(can_gen_hv_pulse(pgm))
@@ -1064,6 +1075,8 @@ static int pickit5_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
   if(pgm->extra_features & HAS_VTARG_READ) { // If not supported (PK Basic), use a place
     pickit5_get_vtarget(pgm, &v_target);
+    if(my.get_vcc)
+      msg_info("Target voltage value read as %1.2fV\n", my.measured_vcc);
     if(v_target < 1.8) {
       if(my.power_source == POWER_SOURCE_NONE) {
         pmsg_warning("no external voltage detected but continuing anyway\n");

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -624,23 +624,32 @@ static int stk500_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
     }
 
     if(str_starts(extended_param, "vtarg")) {
-      if((pgm->extra_features & HAS_VTARG_ADJ) && (str_starts(extended_param, "vtarg="))) {
-        // Set target voltage
-        double vtarg_set_val = -1;      // Default = invlid value
-        int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
-
-        my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
-        if(sscanf_success < 1 || vtarg_set_val < 0) {
-          pmsg_error("invalid target voltage in -x %s\n", extended_param);
-          rv = -1;
-          break;
-        }
-        my.vtarg_set = true;
-        continue;
-      } else if((pgm->extra_features & HAS_VTARG_READ) && str_eq(extended_param, "vtarg")) {
+      if(pgm->extra_features & HAS_VTARG_READ) {
         // Get target voltage
-        my.vtarg_get = true;
-        continue;
+        if(str_eq(extended_param, "vtarg")) {
+          my.vtarg_get = true;
+          continue;
+        }
+      }
+
+      if(pgm->extra_features & HAS_VTARG_ADJ) {
+        // Set target voltage
+        if(str_starts(extended_param, "vtarg=")) {
+          double vtarg_set_val = -1;    // Default = invalid value
+          int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
+
+          if(sscanf_success < 1 || vtarg_set_val < 0) {
+            pmsg_error("invalid value in -x %s\n", extended_param);
+            rv = -1;
+            break;
+          }
+          my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
+          my.vtarg_set = true;
+          continue;
+        }
+        pmsg_error("invalid setting in -x %s; use -x vtarg=<dbl>\n", extended_param);
+        rv = -1;
+        break;
       }
     }
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -546,7 +546,7 @@ retry:
     if(my.varef_get)
       msg_info("Analog reference voltage value read as %.2f V\n", (varef_read/10.0));
     // Write analog reference voltage
-    else {
+    if(my.varef_set) {
       msg_info("Changing analog reference voltage from %.2f V to %.2f V\n", (varef_read/10.0), my.varef_data);
       if(pgm->set_varef(pgm, 0, my.varef_data) < 0)
         return -1;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -528,7 +528,7 @@ retry:
     if(my.vtarg_get)
       msg_info("Target voltage value read as %.2f V\n", (vtarg_read/10.0));
     // Write target voltage value
-    else {
+    if(my.vtarg_set) {
       msg_info("Changing target voltage from %.2f V to %.2f V\n", (vtarg_read/10.0), my.vtarg_data);
       if(pgm->set_vtarget(pgm, my.vtarg_data) < 0)
         return -1;
@@ -596,7 +596,7 @@ retry:
     if(my.fosc_get)
       msg_info("Oscillator currently set to %.3f %s\n", f_get, unit_get);
     // Write target voltage value
-    else {
+    if(my.fosc_set) {
       const char *unit_set;
       double f_set = f_to_kHz_MHz(my.fosc_data, &unit_set);
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1728,6 +1728,14 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     const char *extended_param = ldata(ln);
 
     if(str_starts(extended_param, "vtarg")) {
+      if(pgm->extra_features & HAS_VTARG_READ) {
+        // Get target voltage
+        if(str_eq(extended_param, "vtarg")) {
+          my.vtarg_get = true;
+          continue;
+        }
+      }
+
       if(pgm->extra_features & HAS_VTARG_ADJ) {
         // Set target voltage
         if(str_starts(extended_param, "vtarg=")) {
@@ -1743,19 +1751,12 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           my.vtarg_set = true;
           continue;
         }
-        pmsg_error("invalid setting in -x %s; use or -x vtarg=<dbl>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x vtarg=<dbl>\n", extended_param);
         rv = -1;
         break;
       }
-      if(pgm->extra_features & HAS_VTARG_READ) {
-        // Get target voltage
-        if(str_eq(extended_param, "vtarg")) {
-          my.vtarg_get = true;
-          continue;
-        }
-        rv = -1;
-        break;
-      }
+      rv = -1;
+      break;
     }
 
     if(str_starts(extended_param, "varef")) {
@@ -1988,6 +1989,14 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
     }
 
     if(str_starts(extended_param, "vtarg")) {
+      if(pgm->extra_features & HAS_VTARG_READ) {
+        // Get target voltage
+        if(str_eq(extended_param, "vtarg")) {
+          my.vtarg_get = true;
+          continue;
+        }
+      }
+
       if(pgm->extra_features & HAS_VTARG_ADJ) {
         // Set target voltage
         if(str_starts(extended_param, "vtarg=")) {
@@ -2003,19 +2012,12 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
           my.vtarg_set = true;
           continue;
         }
-        pmsg_error("invalid setting in -x %s; use or -x vtarg=<dbl>\n", extended_param);
+        pmsg_error("invalid setting in -x %s; use -x vtarg=<dbl>\n", extended_param);
         rv = -1;
         break;
       }
-      if(pgm->extra_features & HAS_VTARG_READ) {
-        // Get target voltage
-        if(str_eq(extended_param, "vtarg")) {
-          my.vtarg_get = true;
-          continue;
-        }
-        rv = -1;
-        break;
-      }
+      rv = -1;
+      break;
     }
 
     if(str_starts(extended_param, "mode") && (str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))) {

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3773,7 +3773,7 @@ static void stk500v2_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp
   int decimals;
   const char *unit;
 
-  if(pgm->extra_features & HAS_VTARG_READ) {
+  if(pgm->extra_features & HAS_VTARG_READ && my.pgmtype != PGMTYPE_JTAGICE3) {
     fmsg_out(fp, "%sVtarget               : %.1f V\n", p, stk500v2_vtarget_value(pgm));
   }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1386,12 +1386,12 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     // Read current target voltage set value
     unsigned char buf[2];
 
-    if(jtag3_getparm(pgmcp, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, 2) < 0)
+    if(jtag3_getparm(pgmcp, SCOPE_GENERAL, 1, PARM3_VTARGET, buf, 2) < 0)
       return -1;
     double vtarg_read = b2_to_u16(buf)/1000.0;
 
     if(my.vtarg_get)
-      msg_info("Target voltage value read as %.2f V\n", vtarg_read);
+      msg_info("Target voltage value read as %.2f V\n", b2_to_u16(buf)/1000.0);
     // Write target voltage value
     else {
       u16_to_b2(buf, (unsigned) (my.vtarg_data*1000));
@@ -1886,10 +1886,10 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    if(pgm->extra_features & HAS_VTARG_ADJ) {
-      msg_error("  -x vtarg          Read target supply voltage\n");
-      msg_error("  -x vtarg=<dbl>    Set target supply voltage to <dbl> V\n");
-    }
+    if(pgm->extra_features & HAS_VTARG_READ)
+      msg_error("  -x vtarg          Read on-board target supply voltage\n");
+    if(pgm->extra_features & HAS_VTARG_ADJ)
+      msg_error("  -x vtarg=<dbl>    Set on-board target supply voltage to <dbl> V\n");
     if(pgm->extra_features & HAS_VAREF_ADJ) {
       if(str_contains(pgm->type, "STK500")) {
         msg_error("  -x varef          Read analog reference voltage\n");
@@ -1996,12 +1996,16 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
           my.vtarg_set = true;
           continue;
         }
+        pmsg_error("invalid setting in -x %s; use or -x vtarg=<dbl>\n", extended_param);
+        rv = -1;
+        break;
+      }
+      if(pgm->extra_features & HAS_VTARG_READ) {
         // Get target voltage
-        else if(str_eq(extended_param, "vtarg")) {
+        if(str_eq(extended_param, "vtarg")) {
           my.vtarg_get = true;
           continue;
         }
-        pmsg_error("invalid setting in -x %s; use -x vtarg or -x vtarg=<dbl>\n", extended_param);
         rv = -1;
         break;
       }
@@ -2041,10 +2045,10 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
       msg_error("  -x vtarg_switch        Read on-board target voltage switch state\n");
       msg_error("  -x vtarg_switch=<0..1> Set on-board target voltage switch state\n");
     }
-    if(pgm->extra_features & HAS_VTARG_ADJ) {
+    if(pgm->extra_features & HAS_VTARG_READ)
       msg_error("  -x vtarg               Read on-board target supply voltage\n");
+    if(pgm->extra_features & HAS_VTARG_ADJ)
       msg_error("  -x vtarg=<dbl>         Set on-board target supply voltage to <dbl> V\n");
-    }
     if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
       msg_error("  -x mode=avr|pic        Set programmer to AVR or PIC mode, then exit\n");
     msg_error("  -x help                Show this help menu and exit\n");

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -3577,14 +3577,14 @@ static void stk500v2_display(const PROGRAMMER *pgm, const char *p) {
     msg_info("%sHW version            : %d\n", p, hdw);
     if(pgm->usbsn && *pgm->usbsn)
       msg_info("%sSerial number         : %s\n", p, pgm->usbsn);
-    msg_info("%sFW Version Controller : %d.%02d\n", p, maj, min);
+    msg_info("%sFW version controller : %d.%02d\n", p, maj, min);
     if(my.pgmtype == PGMTYPE_STK600) {
       stk500v2_getparm(pgm, PARAM_SW_MAJOR_PERIPHERY1, &maj_s1);
       stk500v2_getparm(pgm, PARAM_SW_MINOR_PERIPHERY1, &min_s1);
       stk500v2_getparm(pgm, PARAM_SW_MAJOR_PERIPHERY2, &maj_s2);
       stk500v2_getparm(pgm, PARAM_SW_MINOR_PERIPHERY2, &min_s2);
-      msg_info("%sFW Version Periphery 1: %d.%02d\n", p, maj_s1, min_s1);
-      msg_info("%sFW Version Periphery 2: %d.%02d\n", p, maj_s2, min_s2);
+      msg_info("%sFW version periphery 1: %d.%02d\n", p, maj_s1, min_s1);
+      msg_info("%sFW version periphery 2: %d.%02d\n", p, maj_s2, min_s2);
     }
   }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1740,12 +1740,12 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           double vtarg_set_val = -1;    // Default = invalid value
           int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
 
-          my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
           if(sscanf_success < 1 || vtarg_set_val < 0) {
             pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
+          my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
           my.vtarg_set = true;
           continue;
         }
@@ -1999,12 +1999,12 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
           double vtarg_set_val = 0;
           int sscanf_success = sscanf(extended_param, "vtarg=%lf", &vtarg_set_val);
 
-          my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
           if(sscanf_success < 1 || vtarg_set_val < 0) {
             pmsg_error("invalid value in -x %s\n", extended_param);
             rv = -1;
             break;
           }
+          my.vtarg_data = (double) ((int) (vtarg_set_val*100 + .5))/100;
           my.vtarg_set = true;
           continue;
         }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1743,11 +1743,18 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           my.vtarg_set = true;
           continue;
         }
+        pmsg_error("invalid setting in -x %s; use or -x vtarg=<dbl>\n", extended_param);
+        rv = -1;
+        break;
+      }
+      if(pgm->extra_features & HAS_VTARG_READ) {
         // Get target voltage
-        else if(str_eq(extended_param, "vtarg")) {
+        if(str_eq(extended_param, "vtarg")) {
           my.vtarg_get = true;
           continue;
         }
+        rv = -1;
+        break;
       }
     }
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1205,7 +1205,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       if(my.varef_get)
         msg_info("Analog reference voltage value read as %.2f V\n", (varef_read/10.0));
       // STK500: Write analog reference voltage
-      else {
+      if(my.varef_set) {
         msg_info("Changing analog reference voltage from %.2f V to %.2f V\n",
           varef_read/10.0, my.varef_data);
         if(pgm->set_varef(pgm, 0, my.varef_data) < 0)
@@ -1221,7 +1221,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
         msg_info("Analog reference channel %d voltage read as %.2f V\n",
           my.varef_channel, (varef_read/100.0));
       // STK600: Write target voltage value for channel n
-      else {
+      if(my.varef_set) {
         msg_info("Changing analog reference channel %d voltage from %.2f V to %.2f V\n",
           my.varef_channel, (varef_read/100.0), my.varef_data);
         if(pgm->set_varef(pgm, my.varef_channel, my.varef_data) < 0)
@@ -1241,7 +1241,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       if(my.fosc_get)
         msg_info("Oscillator currently set to %.3f %s\n", f_get, unit_get);
       // Write new osc freq
-      else {
+      if(my.fosc_set) {
         const char *unit_set;
         double f_set = f_to_kHz_MHz(my.fosc_data, &unit_set);
 
@@ -1340,10 +1340,10 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
       return -1;
     }
-    if(!my.suffer_set)
+    if(my.suffer_get)
       imsg_info("SUFFER register value read as 0x%02x\n", my.suffer_data[0]);
     // Write new SUFFER value
-    else {
+    if(my.suffer_set) {
       if(jtag3_setparm(pgmcp, SCOPE_EDBG, MEDBG_REG_SUFFER_BANK + 0x10,
         MEDBG_REG_SUFFER_OFFSET, my.suffer_data + 1, 1) < 0) {
 
@@ -1362,13 +1362,14 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
 
       return -1;
     }
-    if(!my.vtarg_switch_set) {
+    if(my.vtarg_switch_get) {
       pmsg_info("Vtarg switch setting read as %u: target power is switched %s\n",
         my.vtarg_switch_data[0], my.vtarg_switch_data[0]? "on": "off");
-    } else {                    // Write Vtarg switch value
+    } 
+    // Write Vtarg switch value
+    if(my.vtarg_switch_set) {
       if(jtag3_setparm(pgmcp, SCOPE_EDBG, EDBG_CTXT_CONTROL,
         EDBG_CONTROL_TARGET_POWER, my.vtarg_switch_data + 1, 1) < 0) {
-
         return -1;
       }
       pmsg_info("Vtarg switch setting changed from %u to %u\n", my.vtarg_switch_data[0],
@@ -1483,9 +1484,10 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
 
       if(stk500v2_getparm(pgm, PARAM_VADJUST, &varef_read) < 0)
         return -1;
-      if(my.varef_get) {
+      if(my.varef_get)
         msg_info("Analog reference voltage value read as %.2f V\n", varef_read/10.0);
-      } else {                  // STK500: Write analog reference voltage
+      // STK500: Write analog reference voltage
+      if(my.varef_set) {
         msg_info("Changing analog reference voltage from %.2f V to %.2f V\n",
           varef_read/10.0, my.varef_data);
         if(pgm->set_varef(pgm, 0, my.varef_data) < 0)
@@ -1500,7 +1502,9 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       if(my.varef_get) {
         msg_info("Analog reference channel %d voltage read as %.2f V\n",
           my.varef_channel, (varef_read/100.0));
-      } else {                  // STK600: Write target voltage value for channel n
+      }
+      // STK600: Write target voltage value for channel n
+      if(my.varef_set) {                  
         msg_info("Changing analog reference channel %d voltage from %.2f V to %.2f V\n",
           my.varef_channel, (varef_read/100.0), my.varef_data);
         if(pgm->set_varef(pgm, my.varef_channel, my.varef_data) < 0)
@@ -1553,7 +1557,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       }
       if(my.fosc_get)
         msg_info("Oscillator currently set to %.3f %s\n", f_get, unit_get);
-      else {
+      if(my.fosc_set) {
         const char *unit_set;
         double f_set = f_to_kHz_MHz(my.fosc_data, &unit_set);
 
@@ -1574,7 +1578,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       f_get = f_to_kHz_MHz(f_get, &unit_get);
       if(my.fosc_get)
         msg_info("Oscillator currently set to %.3f %s\n", f_get, unit_get);
-      else {
+      if(my.fosc_set) {
         const char *unit_set;
         double f_set = f_to_kHz_MHz(my.fosc_data, &unit_set);
 

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1187,7 +1187,7 @@ static int stk500v2_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if(my.vtarg_get)
       msg_info("Target voltage value read as %.2f V\n", (vtarg_read/10.0));
     // Write target voltage value
-    else {
+    if(my.vtarg_set) {
       msg_info("Changing target voltage from %.2f V to %.2f V\n", (vtarg_read/10.0), my.vtarg_data);
       if(pgm->set_vtarget(pgm, my.vtarg_data) < 0)
         return -1;
@@ -1393,7 +1393,7 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if(my.vtarg_get)
       msg_info("Target voltage value read as %.2f V\n", b2_to_u16(buf)/1000.0);
     // Write target voltage value
-    else {
+    if(my.vtarg_set) {
       u16_to_b2(buf, (unsigned) (my.vtarg_data*1000));
       msg_info("Changing target voltage from %.2f V to %.2f V\n", vtarg_read, my.vtarg_data);
       if(jtag3_setparm(pgmcp, SCOPE_GENERAL, 1, PARM3_VADJUST, buf, sizeof(buf)) < 0) {
@@ -1468,7 +1468,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
     if(my.vtarg_get)
       msg_info("Target voltage value read as %.2f V\n", (vtarg_read/10.0));
     // Write target voltage value
-    else {
+    if(my.vtarg_set) {
       msg_info("Changing target voltage from %.2f V to %.2f V\n", (vtarg_read/10.0), my.vtarg_data);
       if(pgm->set_vtarget(pgm, my.vtarg_data) < 0)
         return -1;
@@ -1553,7 +1553,6 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       }
       if(my.fosc_get)
         msg_info("Oscillator currently set to %.3f %s\n", f_get, unit_get);
-      // Write target voltage value
       else {
         const char *unit_set;
         double f_set = f_to_kHz_MHz(my.fosc_data, &unit_set);
@@ -1575,7 +1574,6 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
       f_get = f_to_kHz_MHz(f_get, &unit_get);
       if(my.fosc_get)
         msg_info("Oscillator currently set to %.3f %s\n", f_get, unit_get);
-      // Write target voltage value
       else {
         const char *unit_set;
         double f_set = f_to_kHz_MHz(my.fosc_data, &unit_set);
@@ -1755,8 +1753,6 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
         rv = -1;
         break;
       }
-      rv = -1;
-      break;
     }
 
     if(str_starts(extended_param, "varef")) {
@@ -2016,8 +2012,6 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
         rv = -1;
         break;
       }
-      rv = -1;
-      break;
     }
 
     if(str_starts(extended_param, "mode") && (str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))) {


### PR DESCRIPTION
Resolves issue #2082 and #2093

With this PR it is possible to read the target voltage with programmers that can only read but not supply target power. There was also a bug that prevented `-x vtarg` from working on (jtag3 compatible) programmers all together. 

It also resolves an issue first discovered in #2082 where the target voltage is printed twice, but the first readout value is read a zero. This is the same bug that prevented `-x vtarg` from working.

<details>
<summary>avrispmkii output</summary>

```
$ avrdude -cavrispmkii -pattiny1634 -v
Avrdude version 8.1-20260406 (475cf17a)
Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

System wide configuration file is /usr/local/etc/avrdude.conf
User configuration file /Users/hans/.avrduderc does not exist

Using port            : usb
Using programmer      : avrispmkII
Found AVRISP mkII with serno = 000200124552
AVR part              : ATtiny1634
Programming modes     : SPM, ISP, HVPP, debugWIRE
Programmer type       : STK500V2
Description           : USB Atmel AVR ISP mkII
Programmer model      : AVRISP mkII
HW version            : 1
Serial number         : 000200124552
FW Version Controller : 1.24
Vtarget               : 5.4 V
SCK period            : 32.1 us

AVR device initialized and ready to accept instructions
Device signature = 1E 94 12 (ATtiny1634, ATtiny1634R)

Avrdude done.  Thank you.


$ avrdude -cavrispmkii -pattiny1634 -xhelp
avrdude -c avrispmkII extended options:
  -x vtarg          Read on-board target supply voltage
  -x xtal=<n>[unit] Set programmer xtal frequency to <n> Hz (or kHz/MHz)
  -x help           Show this help menu and exit


$ avrdude -cavrispmkii -pattiny1634 -xvtarg
Target voltage value read as 5.40 V

Avrdude done.  Thank you.


$ avrdude -cavrispmkii -pattiny1634 -T 'parms'
Vtarget               : 5.4 V
SCK period            : 32.1 us

Avrdude done.  Thank you.
```
</details>


<details>
<summary>snap_isp output</summary>

```
$ avrdude -csnap_isp -pattiny1634 -v
Avrdude version 8.1-20260406 (475cf17a)
Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

System wide configuration file is /usr/local/etc/avrdude.conf
User configuration file /Users/hans/.avrduderc does not exist

Using port            : usb
Using programmer      : snap_isp
AVR part              : ATtiny1634
Programming modes     : SPM, ISP, HVPP, debugWIRE
Programmer type       : JTAG3_ISP
Description           : MPLAB(R) SNAP in ISP mode
ICE HW version        : 1
ICE FW version        : 1.11 (rel. 20)
Serial number         : BUR183076609
SCK period            : 8.0 us
Vtarget               : 5.24 V


AVR device initialized and ready to accept instructions
Device signature = 1E 94 12 (ATtiny1634, ATtiny1634R)

Avrdude done.  Thank you.


$ avrdude -csnap_isp -pattiny1634 -xhelp
avrdude -c snap_isp extended options:
  -x vtarg               Read on-board target supply voltage
  -x mode=avr|pic        Set programmer to AVR or PIC mode, then exit
  -x help                Show this help menu and exit


$ avrdude -csnap_isp -pattiny1634 -xvtarg
Target voltage value read as 5.25 V

Avrdude done.  Thank you.


$ avrdude -csnap_isp -pattiny1634 -T 'parms'
SCK period            : 8.0 us
Vtarget               : 5.24 V


Avrdude done.  Thank you.
```
</details>