### PR TITLE
Terminal mode: re-add "d" as alias for "dump"

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -95,6 +95,7 @@ static int cmd_quell(const PROGRAMMER *pgm, const AVRPART *p, int argc, const ch
 // List of commands; don't add a command starting with e: main.c relies on e expanding to erase
 static const struct command cmd[] = {
   {"dump", cmd_dump, _fo(read_byte_cached), "display a memory section as hex dump"},
+  {"d", cmd_dump, _fo(read_byte_cached), "abbreviation for dump"},
   {"read", cmd_dump, _fo(read_byte_cached), "alias for dump"},
   {"disasm", cmd_disasm, _fo(read_byte_cached), "disassemble a memory section"},
   {"write", cmd_write, _fo(write_byte_cached), "write data to memory; flash and EEPROM are cached"},


### PR DESCRIPTION
"d" has been a valid alias for "dump" for a long time.  This was disturbed by adding the "disasm" command, as a single "d" was no longer unambiguous then.

Thus, restore "d" as an alias for "dump" now.