### PR TITLE
Only print the entire list of valid parts if the user requests this

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -644,13 +644,9 @@ static void programmer_not_found(const char *programmer, const PROGRAMMER *pgm, 
 static void part_not_found(const char *partdesc) {
   msg_error("\n");
   if(partdesc && *partdesc)
-    pmsg_error("AVR part %s not found\n", partdesc);
+    pmsg_error("AVR part %s not found. Use -p? to see all valid parts\n", partdesc);
   else
     pmsg_error("no AVR part has been specified; use -p part\n");
-
-  msg_error("\nValid parts are:\n");
-  list_parts(stderr, "  ", part_list, ~0);
-  msg_error("\n");
 }
 
 #if !defined(WIN32)

--- a/src/main.c
+++ b/src/main.c
@@ -646,7 +646,7 @@ static void part_not_found(const char *partdesc) {
   if(partdesc && *partdesc)
     pmsg_error("AVR part %s not found. Use -p? to see all valid parts\n", partdesc);
   else
-    pmsg_error("no AVR part has been specified; use -p part\n");
+    pmsg_error("no AVR part has been specified; use -p part or -p? to see all valid parts\n");
 }
 
 #if !defined(WIN32)


### PR DESCRIPTION
I find it quite annoying that the entire list of supported parts are printed if you forget to add `-p` or have a typo. And the list is so long I have to scroll way up there to see what my error really was. This PR makes it so that the user has to use `-p?` to get a list of all valid parts.

### With this PR:
```
$ avrdude -c dryrun -patmega327p

Error: AVR part atmega327p not found. Use -p? to see all valid parts

Avrdude done.  Thank you.
```

### Without this PR:
```
$ avrdude -c dryrun -patmega327p

Error: AVR part atmega327p not found

Valid parts are:
  uc3a0512   = AT32UC3A0512, AT32UC3A0512AU (AVR32JTAG, aWire)
  89S51      = AT89S51 (ISP, HVPP)
  89S52      = AT89S52 (ISP, HVPP)
  c128       = AT90CAN128 (SPM, ISP, HVPP, JTAG, JTAGmkI)
  c32        = AT90CAN32 (SPM, ISP, HVPP, JTAG)
  c64        = AT90CAN64 (SPM, ISP, HVPP, JTAG)
  pwm1       = AT90PWM1 (SPM, ISP, HVPP, debugWIRE)
  pwm161     = AT90PWM161 (SPM, ISP, HVPP, debugWIRE)
  pwm2       = AT90PWM2 (SPM, ISP, HVPP, debugWIRE)
  pwm216     = AT90PWM216 (SPM, ISP, HVPP, debugWIRE)
  pwm2b      = AT90PWM2B (SPM, ISP, HVPP, debugWIRE)
  pwm3       = AT90PWM3 (SPM, ISP, HVPP, debugWIRE)
  pwm316     = AT90PWM316 (SPM, ISP, HVPP, debugWIRE)
  pwm3b      = AT90PWM3B (SPM, ISP, HVPP, debugWIRE)
  pwm81      = AT90PWM81, AT90PWM81EP (SPM, ISP, HVPP, debugWIRE)
  1200       = AT90S1200, AT90S1200A (SPM, ISP, HVPP)
  2313       = AT90S2313 (SPM, ISP, HVPP)
  2323       = AT90S2323 (SPM, ISP, HVSP)
  2333       = AT90S2333 (SPM, ISP, HVPP)
  2343       = AT90S2343 (SPM, ISP, HVSP)
  4414       = AT90S4414 (SPM, ISP, HVPP)
  4433       = AT90S4433 (SPM, ISP, HVPP)
  4434       = AT90S4434 (SPM, ISP, HVPP)
  8515       = AT90S8515 (SPM, ISP, HVPP)
  8535       = AT90S8535 (SPM, ISP, HVPP)
  usb1286    = AT90USB1286 (SPM, ISP, HVPP, JTAG)
  usb1287    = AT90USB1287 (SPM, ISP, HVPP, JTAG)
  usb162     = AT90USB162 (SPM, ISP, HVPP, debugWIRE)
  usb646     = AT90USB646 (SPM, ISP, HVPP, JTAG)
  usb647     = AT90USB647 (SPM, ISP, HVPP, JTAG)
  usb82      = AT90USB82 (SPM, ISP, HVPP, debugWIRE)
  a5505      = ATA5505 (SPM, ISP, HVPP, debugWIRE)
  a6612c     = ATA6612C (SPM, ISP, HVPP, debugWIRE)
  a6613c     = ATA6613C (SPM, ISP, HVPP, debugWIRE)
  a6614q     = ATA6614Q (SPM, ISP, HVPP, debugWIRE)
  a6616c     = ATA6616C (SPM, ISP, HVPP, debugWIRE)
  a6617c     = ATA6617C (SPM, ISP, HVPP, debugWIRE)
  a664251    = ATA664251 (SPM, ISP, HVPP, debugWIRE)
  m103       = ATmega103, ATmega103L (SPM, ISP, HVPP)
  m128       = ATmega128, ATmega128L (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m1280      = ATmega1280, ATmega1280V (SPM, ISP, HVPP, JTAG)
  m1281      = ATmega1281, ATmega1281V (SPM, ISP, HVPP, JTAG)
  m1284      = ATmega1284 (SPM, ISP, HVPP, JTAG)
  m1284p     = ATmega1284P (SPM, ISP, HVPP, JTAG)
  m1284rfr2  = ATmega1284RFR2 (SPM, ISP, HVPP, JTAG)
  m128a      = ATmega128A (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m128rfa1   = ATmega128RFA1 (SPM, ISP, HVPP, JTAG)
  m128rfr2   = ATmega128RFR2 (SPM, ISP, HVPP, JTAG)
  m16        = ATmega16, ATmega16L (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m1608      = ATmega1608 (SPM, UPDI)
  m1609      = ATmega1609 (SPM, UPDI)
  m161       = ATmega161, ATmega161L (SPM, ISP, HVPP)
  m162       = ATmega162, ATmega162L, ATmega162V (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m163       = ATmega163, ATmega163L (SPM, ISP, HVPP)
  m164a      = ATmega164A (SPM, ISP, HVPP, JTAG)
  m164p      = ATmega164P, ATmega164PV (SPM, ISP, HVPP, JTAG)
  m164pa     = ATmega164PA (SPM, ISP, HVPP, JTAG)
  m165       = ATmega165, ATmega165V (SPM, ISP, HVPP, JTAG)
  m165a      = ATmega165A (SPM, ISP, HVPP, JTAG)
  m165p      = ATmega165P, ATmega165PV (SPM, ISP, HVPP, JTAG)
  m165pa     = ATmega165PA (SPM, ISP, HVPP, JTAG)
  m168       = ATmega168, ATmega168V (SPM, ISP, HVPP, debugWIRE)
  m168a      = ATmega168A (SPM, ISP, HVPP, debugWIRE)
  m168p      = ATmega168P, ATmega168PV (SPM, ISP, HVPP, debugWIRE)
  m168pa     = ATmega168PA (SPM, ISP, HVPP, debugWIRE)
  m168pb     = ATmega168PB (SPM, ISP, HVPP, debugWIRE)
  m169       = ATmega169, ATmega169L, ATmega169V (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m169a      = ATmega169A (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m169p      = ATmega169P, ATmega169PV (SPM, ISP, HVPP, JTAG)
  m169pa     = ATmega169PA (SPM, ISP, HVPP, JTAG)
  m16a       = ATmega16A (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m16hva     = ATmega16HVA (SPM, ISP, HVSP, debugWIRE)
  m16hvb     = ATmega16HVB (SPM, ISP, HVPP, debugWIRE)
  m16hvbrevb = ATmega16HVBrevB, ATMEGA16HVB (SPM, ISP, HVPP, debugWIRE)
  m16m1      = ATmega16M1 (SPM, ISP, HVPP, debugWIRE)
  m16u2      = ATmega16U2 (SPM, ISP, HVPP, debugWIRE)
  m16u4      = ATmega16U4, ATmega16U4RC (SPM, ISP, HVPP, JTAG)
  m2560      = ATmega2560, ATmega2560V (SPM, ISP, HVPP, JTAG)
  m2561      = ATmega2561, ATmega2561V (SPM, ISP, HVPP, JTAG)
  m2564rfr2  = ATmega2564RFR2 (SPM, ISP, HVPP, JTAG)
  m256rfr2   = ATmega256RFR2 (SPM, ISP, HVPP, JTAG)
  m32        = ATmega32, ATmega32L (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m3208      = ATmega3208 (SPM, UPDI)
  m3209      = ATmega3209 (SPM, UPDI)
  m324a      = ATmega324A (SPM, ISP, HVPP, JTAG)
  m324p      = ATmega324P, ATmega324PV (SPM, ISP, HVPP, JTAG)
  m324pa     = ATmega324PA (SPM, ISP, HVPP, JTAG)
  m324pb     = ATmega324PB (SPM, ISP, HVPP, JTAG)
  m325       = ATmega325, ATmega325V (SPM, ISP, HVPP, JTAG)
  m3250      = ATmega3250, ATmega3250V (SPM, ISP, HVPP, JTAG)
  m3250a     = ATmega3250A (SPM, ISP, HVPP, JTAG)
  m3250p     = ATmega3250P, ATmega3250PV (SPM, ISP, HVPP, JTAG)
  m3250pa    = ATmega3250PA (SPM, ISP, HVPP, JTAG)
  m325a      = ATmega325A (SPM, ISP, HVPP, JTAG)
  m325p      = ATmega325P, ATmega325PV (SPM, ISP, HVPP, JTAG)
  m325pa     = ATmega325PA (SPM, ISP, HVPP, JTAG)
  m328       = ATmega328 (SPM, ISP, HVPP, debugWIRE)
  m328p      = ATmega328P (SPM, ISP, HVPP, debugWIRE)
  m328pb     = ATmega328PB (SPM, ISP, HVPP, debugWIRE)
  m329       = ATmega329, ATmega329V (SPM, ISP, HVPP, JTAG)
  m3290      = ATmega3290, ATmega3290V (SPM, ISP, HVPP, JTAG)
  m3290a     = ATmega3290A (SPM, ISP, HVPP, JTAG)
  m3290p     = ATmega3290P, ATmega3290PV (SPM, ISP, HVPP, JTAG)
  m3290pa    = ATmega3290PA (SPM, ISP, HVPP, JTAG)
  m329a      = ATmega329A (SPM, ISP, HVPP, JTAG)
  m329p      = ATmega329P, ATmega329PV (SPM, ISP, HVPP, JTAG)
  m329pa     = ATmega329PA (SPM, ISP, HVPP, JTAG)
  m32a       = ATmega32A (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m32c1      = ATmega32C1 (SPM, ISP, HVPP, debugWIRE)
  m32hvb     = ATmega32HVB (SPM, ISP, HVPP, debugWIRE)
  m32hvbrevb = ATmega32HVBrevB, ATMEGA32HVB (SPM, ISP, HVPP, debugWIRE)
  m32hve2    = ATmega32HVE2 (SPM, ISP, HVSP, debugWIRE)
  m32m1      = ATmega32M1 (SPM, ISP, HVPP, debugWIRE)
  m32u2      = ATmega32U2 (SPM, ISP, HVPP, debugWIRE)
  m32u4      = ATmega32U4, ATmega32U4RC (SPM, ISP, HVPP, JTAG)
  m406       = ATmega406 (SPM, HVPP, JTAG)
  m48        = ATmega48, ATmega48V (SPM, ISP, HVPP, debugWIRE)
  m4808      = ATmega4808 (SPM, UPDI)
  m4809      = ATmega4809 (SPM, UPDI)
  m48a       = ATmega48A (SPM, ISP, HVPP, debugWIRE)
  m48p       = ATmega48P, ATmega48PV (SPM, ISP, HVPP, debugWIRE)
  m48pa      = ATmega48PA (SPM, ISP, HVPP, debugWIRE)
  m48pb      = ATmega48PB (SPM, ISP, HVPP, debugWIRE)
  m64        = ATmega64, ATmega64L (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m640       = ATmega640, ATmega640V (SPM, ISP, HVPP, JTAG)
  m644       = ATmega644, ATmega644V (SPM, ISP, HVPP, JTAG)
  m644a      = ATmega644A (SPM, ISP, HVPP, JTAG)
  m644p      = ATmega644P, ATmega644PV (SPM, ISP, HVPP, JTAG)
  m644pa     = ATmega644PA (SPM, ISP, HVPP, JTAG)
  m644rfr2   = ATmega644RFR2 (SPM, ISP, HVPP, JTAG)
  m645       = ATmega645, ATmega645V (SPM, ISP, HVPP, JTAG)
  m6450      = ATmega6450, ATmega6450V (SPM, ISP, HVPP, JTAG)
  m6450a     = ATmega6450A (SPM, ISP, HVPP, JTAG)
  m6450p     = ATmega6450P (SPM, ISP, HVPP, JTAG)
  m645a      = ATmega645A (SPM, ISP, HVPP, JTAG)
  m645p      = ATmega645P (SPM, ISP, HVPP, JTAG)
  m649       = ATmega649, ATmega649V (SPM, ISP, HVPP, JTAG)
  m6490      = ATmega6490, ATmega6490V (SPM, ISP, HVPP, JTAG)
  m6490a     = ATmega6490A (SPM, ISP, HVPP, JTAG)
  m6490p     = ATmega6490P (SPM, ISP, HVPP, JTAG)
  m649a      = ATmega649A (SPM, ISP, HVPP, JTAG)
  m649p      = ATmega649P (SPM, ISP, HVPP, JTAG)
  m64a       = ATmega64A (SPM, ISP, HVPP, JTAG, JTAGmkI)
  m64c1      = ATmega64C1 (SPM, ISP, HVPP, debugWIRE)
  m64hve2    = ATmega64HVE2 (SPM, ISP, HVSP, debugWIRE)
  m64m1      = ATmega64M1 (SPM, ISP, HVPP, debugWIRE)
  m64rfr2    = ATmega64RFR2 (SPM, ISP, HVPP, JTAG)
  m8         = ATmega8, ATmega8L (SPM, ISP, HVPP)
  m808       = ATmega808 (SPM, UPDI)
  m809       = ATmega809 (SPM, UPDI)
  m8515      = ATmega8515, ATmega8515L (SPM, ISP, HVPP)
  m8535      = ATmega8535, ATmega8535L (SPM, ISP, HVPP)
  m88        = ATmega88, ATmega88V (SPM, ISP, HVPP, debugWIRE)
  m88a       = ATmega88A (SPM, ISP, HVPP, debugWIRE)
  m88p       = ATmega88P, ATmega88PV (SPM, ISP, HVPP, debugWIRE)
  m88pa      = ATmega88PA (SPM, ISP, HVPP, debugWIRE)
  m88pb      = ATmega88PB (SPM, ISP, HVPP, debugWIRE)
  m8a        = ATmega8A (SPM, ISP, HVPP)
  m8hva      = ATmega8HVA (SPM, ISP, HVSP, debugWIRE)
  m8u2       = ATmega8U2 (SPM, ISP, HVPP, debugWIRE)
  ms128      = ATmegaS128 (SPM, ISP, HVPP, JTAG, JTAGmkI)
  ms64m1     = ATmegaS64M1 (SPM, ISP, HVPP, debugWIRE)
  t10        = ATtiny10 (TPI)
  t102       = ATtiny102, ATtiny102F (TPI)
  t104       = ATtiny104, ATtiny104F (TPI)
  t11        = ATtiny11, ATtiny11L (HVSP)
  t12        = ATtiny12, ATtiny12L, ATtiny12V (ISP, HVSP)
  t13        = ATtiny13, ATtiny13V (SPM, ISP, HVSP, debugWIRE)
  t13a       = ATtiny13A (SPM, ISP, HVSP, debugWIRE)
  t15        = ATtiny15, ATtiny15L (ISP, HVSP)
  t1604      = ATtiny1604 (SPM, UPDI)
  t1606      = ATtiny1606 (SPM, UPDI)
  t1607      = ATtiny1607 (SPM, UPDI)
  t1614      = ATtiny1614 (SPM, UPDI)
  t1616      = ATtiny1616 (SPM, UPDI)
  t1617      = ATtiny1617 (SPM, UPDI)
  t1624      = ATtiny1624 (SPM, UPDI)
  t1626      = ATtiny1626 (SPM, UPDI)
  t1627      = ATtiny1627 (SPM, UPDI)
  t1634      = ATtiny1634, ATtiny1634R (SPM, ISP, HVPP, debugWIRE)
  t1634r     = ATtiny1634R (SPM, ISP, HVPP, debugWIRE)
  t167       = ATtiny167 (SPM, ISP, HVPP, debugWIRE)
  t20        = ATtiny20 (TPI)
  t202       = ATtiny202 (SPM, UPDI)
  t204       = ATtiny204 (SPM, UPDI)
  t212       = ATtiny212 (SPM, UPDI)
  t214       = ATtiny214 (SPM, UPDI)
  t22        = ATtiny22, ATtiny22L (SPM, ISP, HVSP)
  t2313      = ATtiny2313, ATtiny2313V (SPM, ISP, HVPP, debugWIRE)
  t2313a     = ATtiny2313A (SPM, ISP, HVPP, debugWIRE)
  t24        = ATtiny24, ATtiny24V (SPM, ISP, HVSP, debugWIRE)
  t24a       = ATtiny24A (SPM, ISP, HVSP, debugWIRE)
  t25        = ATtiny25, ATtiny25V (SPM, ISP, HVSP, debugWIRE)
  t26        = ATtiny26, ATtiny26L (ISP, HVPP)
  t261       = ATtiny261, ATtiny261V (SPM, ISP, HVPP, debugWIRE)
  t261a      = ATtiny261A (SPM, ISP, HVPP, debugWIRE)
  t28        = ATtiny28, ATtiny28L, ATtiny28V (HVPP)
  t3216      = ATtiny3216 (SPM, UPDI)
  t3217      = ATtiny3217 (SPM, UPDI)
  t3224      = ATtiny3224 (SPM, UPDI)
  t3226      = ATtiny3226 (SPM, UPDI)
  t3227      = ATtiny3227 (SPM, UPDI)
  t4         = ATtiny4 (TPI)
  t40        = ATtiny40 (TPI)
  t402       = ATtiny402 (SPM, UPDI)
  t404       = ATtiny404 (SPM, UPDI)
  t406       = ATtiny406 (SPM, UPDI)
  t412       = ATtiny412 (SPM, UPDI)
  t414       = ATtiny414 (SPM, UPDI)
  t416       = ATtiny416 (SPM, UPDI)
  t416auto   = ATtiny416auto, ATtiny416 (SPM, UPDI)
  t417       = ATtiny417 (SPM, UPDI)
  t424       = ATtiny424 (SPM, UPDI)
  t426       = ATtiny426 (SPM, UPDI)
  t427       = ATtiny427 (SPM, UPDI)
  t4313      = ATtiny4313 (SPM, ISP, HVPP, debugWIRE)
  t43u       = ATtiny43U (SPM, ISP, HVPP, debugWIRE)
  t44        = ATtiny44, ATtiny44V (SPM, ISP, HVSP, debugWIRE)
  t441       = ATtiny441 (SPM, ISP, HVSP, debugWIRE)
  t44a       = ATtiny44A (SPM, ISP, HVSP, debugWIRE)
  t45        = ATtiny45, ATtiny45V (SPM, ISP, HVSP, debugWIRE)
  t461       = ATtiny461, ATtiny461V (SPM, ISP, HVPP, debugWIRE)
  t461a      = ATtiny461A (SPM, ISP, HVPP, debugWIRE)
  t48        = ATtiny48 (SPM, ISP, HVPP, debugWIRE)
  t5         = ATtiny5 (TPI)
  t804       = ATtiny804 (SPM, UPDI)
  t806       = ATtiny806 (SPM, UPDI)
  t807       = ATtiny807 (SPM, UPDI)
  t814       = ATtiny814 (SPM, UPDI)
  t816       = ATtiny816 (SPM, UPDI)
  t817       = ATtiny817 (SPM, UPDI)
  t824       = ATtiny824 (SPM, UPDI)
  t826       = ATtiny826 (SPM, UPDI)
  t827       = ATtiny827 (SPM, UPDI)
  t828       = ATtiny828, ATtiny828R (SPM, ISP, HVPP, debugWIRE)
  t828r      = ATtiny828R (SPM, ISP, HVPP, debugWIRE)
  t84        = ATtiny84, ATtiny84V (SPM, ISP, HVSP, debugWIRE)
  t841       = ATtiny841 (SPM, ISP, HVSP, debugWIRE)
  t84a       = ATtiny84A (SPM, ISP, HVSP, debugWIRE)
  t85        = ATtiny85, ATtiny85V (SPM, ISP, HVSP, debugWIRE)
  t861       = ATtiny861, ATtiny861V (SPM, ISP, HVPP, debugWIRE)
  t861a      = ATtiny861A (SPM, ISP, HVPP, debugWIRE)
  t87        = ATtiny87 (SPM, ISP, HVPP, debugWIRE)
  t88        = ATtiny88 (SPM, ISP, HVPP, debugWIRE)
  t9         = ATtiny9 (TPI)
  x128a1     = ATxmega128A1 (SPM, PDI, XMEGAJTAG)
  x128a1d    = ATxmega128A1revD (SPM, PDI, XMEGAJTAG)
  x128a1u    = ATxmega128A1U (SPM, PDI, XMEGAJTAG)
  x128a3     = ATxmega128A3 (SPM, PDI, XMEGAJTAG)
  x128a3u    = ATxmega128A3U (SPM, PDI, XMEGAJTAG)
  x128a4     = ATxmega128A4 (SPM, PDI, XMEGAJTAG)
  x128a4u    = ATxmega128A4U (SPM, PDI)
  x128b1     = ATxmega128B1 (SPM, PDI, XMEGAJTAG)
  x128b3     = ATxmega128B3 (SPM, PDI, XMEGAJTAG)
  x128c3     = ATxmega128C3 (SPM, PDI)
  x128d3     = ATxmega128D3 (SPM, PDI)
  x128d4     = ATxmega128D4 (SPM, PDI)
  x16a4      = ATxmega16A4 (SPM, PDI)
  x16a4u     = ATxmega16A4U (SPM, PDI)
  x16c4      = ATxmega16C4 (SPM, PDI)
  x16d4      = ATxmega16D4 (SPM, PDI)
  x16e5      = ATxmega16E5 (SPM, PDI)
  x192a1     = ATxmega192A1 (SPM, PDI, XMEGAJTAG)
  x192a3     = ATxmega192A3 (SPM, PDI, XMEGAJTAG)
  x192a3u    = ATxmega192A3U (SPM, PDI, XMEGAJTAG)
  x192c3     = ATxmega192C3 (SPM, PDI)
  x192d3     = ATxmega192D3 (SPM, PDI)
  x256a1     = ATxmega256A1 (SPM, PDI, XMEGAJTAG)
  x256a3     = ATxmega256A3 (SPM, PDI, XMEGAJTAG)
  x256a3b    = ATxmega256A3B (SPM, PDI, XMEGAJTAG)
  x256a3bu   = ATxmega256A3BU (SPM, PDI, XMEGAJTAG)
  x256a3u    = ATxmega256A3U (SPM, PDI, XMEGAJTAG)
  x256c3     = ATxmega256C3 (SPM, PDI)
  x256d3     = ATxmega256D3 (SPM, PDI)
  x32a4      = ATxmega32A4 (SPM, PDI)
  x32a4u     = ATxmega32A4U (SPM, PDI)
  x32c3      = ATxmega32C3 (SPM, PDI)
  x32c4      = ATxmega32C4 (SPM, PDI)
  x32d3      = ATxmega32D3 (SPM, PDI)
  x32d4      = ATxmega32D4 (SPM, PDI)
  x32e5      = ATxmega32E5 (SPM, PDI)
  x384c3     = ATxmega384C3 (SPM, PDI)
  x384d3     = ATxmega384D3 (SPM, PDI)
  x64a1      = ATxmega64A1 (SPM, PDI, XMEGAJTAG)
  x64a1u     = ATxmega64A1U (SPM, PDI, XMEGAJTAG)
  x64a3      = ATxmega64A3 (SPM, PDI, XMEGAJTAG)
  x64a3u     = ATxmega64A3U (SPM, PDI, XMEGAJTAG)
  x64a4      = ATxmega64A4 (SPM, PDI, XMEGAJTAG)
  x64a4u     = ATxmega64A4U (SPM, PDI)
  x64b1      = ATxmega64B1 (SPM, PDI, XMEGAJTAG)
  x64b3      = ATxmega64B3 (SPM, PDI, XMEGAJTAG)
  x64c3      = ATxmega64C3 (SPM, PDI)
  x64d3      = ATxmega64D3 (SPM, PDI)
  x64d4      = ATxmega64D4 (SPM, PDI)
  x8e5       = ATxmega8E5 (SPM, PDI)
  128da28    = AVR128DA28, AVR128DA28T (SPM, UPDI)
  128da28s   = AVR128DA28S (SPM, UPDI)
  128da32    = AVR128DA32, AVR128DA32T (SPM, UPDI)
  128da32s   = AVR128DA32S (SPM, UPDI)
  128da48    = AVR128DA48, AVR128DA48T (SPM, UPDI)
  128da48s   = AVR128DA48S (SPM, UPDI)
  128da64    = AVR128DA64, AVR128DA64T (SPM, UPDI)
  128da64s   = AVR128DA64S (SPM, UPDI)
  128db28    = AVR128DB28, AVR128DB28T (SPM, UPDI)
  128db32    = AVR128DB32, AVR128DB32T (SPM, UPDI)
  128db48    = AVR128DB48, AVR128DB48T (SPM, UPDI)
  128db64    = AVR128DB64, AVR128DB64T (SPM, UPDI)
  16dd14     = AVR16DD14 (SPM, UPDI)
  16dd20     = AVR16DD20 (SPM, UPDI)
  16dd28     = AVR16DD28 (SPM, UPDI)
  16dd32     = AVR16DD32 (SPM, UPDI)
  16du14     = AVR16DU14 (SPM, UPDI)
  16du20     = AVR16DU20 (SPM, UPDI)
  16du28     = AVR16DU28 (SPM, UPDI)
  16du32     = AVR16DU32 (SPM, UPDI)
  16ea28     = AVR16EA28 (SPM, UPDI)
  16ea32     = AVR16EA32 (SPM, UPDI)
  16ea48     = AVR16EA48 (SPM, UPDI)
  16eb14     = AVR16EB14 (SPM, UPDI)
  16eb20     = AVR16EB20 (SPM, UPDI)
  16eb28     = AVR16EB28 (SPM, UPDI)
  16eb32     = AVR16EB32 (SPM, UPDI)
  32da28     = AVR32DA28, AVR32DA28T (SPM, UPDI)
  32da28s    = AVR32DA28S (SPM, UPDI)
  32da32     = AVR32DA32, AVR32DA32T (SPM, UPDI)
  32da32s    = AVR32DA32S (SPM, UPDI)
  32da48     = AVR32DA48, AVR32DA48T (SPM, UPDI)
  32da48s    = AVR32DA48S (SPM, UPDI)
  32db28     = AVR32DB28, AVR32DB28T (SPM, UPDI)
  32db32     = AVR32DB32, AVR32DB32T (SPM, UPDI)
  32db48     = AVR32DB48, AVR32DB48T (SPM, UPDI)
  32dd14     = AVR32DD14 (SPM, UPDI)
  32dd20     = AVR32DD20 (SPM, UPDI)
  32dd28     = AVR32DD28 (SPM, UPDI)
  32dd32     = AVR32DD32 (SPM, UPDI)
  32du14     = AVR32DU14 (SPM, UPDI)
  32du20     = AVR32DU20 (SPM, UPDI)
  32du28     = AVR32DU28 (SPM, UPDI)
  32du32     = AVR32DU32 (SPM, UPDI)
  32ea28     = AVR32EA28 (SPM, UPDI)
  32ea32     = AVR32EA32 (SPM, UPDI)
  32ea48     = AVR32EA48 (SPM, UPDI)
  32eb14     = AVR32EB14 (SPM, UPDI)
  32eb20     = AVR32EB20 (SPM, UPDI)
  32eb28     = AVR32EB28 (SPM, UPDI)
  32eb32     = AVR32EB32 (SPM, UPDI)
  32sd20     = AVR32SD20 (SPM, UPDI)
  32sd28     = AVR32SD28 (SPM, UPDI)
  32sd32     = AVR32SD32 (SPM, UPDI)
  64da28     = AVR64DA28, AVR64DA28T (SPM, UPDI)
  64da28s    = AVR64DA28S (SPM, UPDI)
  64da32     = AVR64DA32, AVR64DA32T (SPM, UPDI)
  64da32s    = AVR64DA32S (SPM, UPDI)
  64da48     = AVR64DA48, AVR64DA48T (SPM, UPDI)
  64da48s    = AVR64DA48S (SPM, UPDI)
  64da64     = AVR64DA64, AVR64DA64T (SPM, UPDI)
  64da64s    = AVR64DA64S (SPM, UPDI)
  64db28     = AVR64DB28, AVR64DB28T (SPM, UPDI)
  64db32     = AVR64DB32, AVR64DB32T (SPM, UPDI)
  64db48     = AVR64DB48, AVR64DB48T (SPM, UPDI)
  64db64     = AVR64DB64, AVR64DB64T (SPM, UPDI)
  64dd14     = AVR64DD14 (SPM, UPDI)
  64dd20     = AVR64DD20 (SPM, UPDI)
  64dd28     = AVR64DD28 (SPM, UPDI)
  64dd32     = AVR64DD32 (SPM, UPDI)
  64du28     = AVR64DU28 (SPM, UPDI)
  64du32     = AVR64DU32 (SPM, UPDI)
  64ea28     = AVR64EA28 (SPM, UPDI)
  64ea32     = AVR64EA32 (SPM, UPDI)
  64ea48     = AVR64EA48 (SPM, UPDI)
  8ea28      = AVR8EA28 (SPM, UPDI)
  8ea32      = AVR8EA32 (SPM, UPDI)
  lgt168p    = LGT8F168P (SPM, ISP, HVPP, debugWIRE)
  lgt328p    = LGT8F328P (SPM, ISP, HVPP, debugWIRE)
  lgt88p     = LGT8F88P (SPM, ISP, HVPP, debugWIRE)


Avrdude done.  Thank you.
```