### PR TITLE
Add tinyAVR 1-series automotive parts

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -19786,8 +19786,10 @@ part parent "t416" # t416auto
     desc                   = "ATtiny416auto";
     id                     = "t416auto";
     variants               =
-        "ATtiny416-MBT: VQFN20, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
-        "ATtiny416-MZT: VQFN20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+        "ATtiny416-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny416-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny416-SBT: SOIC, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny416-SZT: SOIC, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
     mcuid                  = 290;
     signature              = 0x1e 0x92 0x28;
     factory_fcpu           = 16000000;
@@ -19850,6 +19852,24 @@ part parent ".avr8x_tiny" # t417
 ;
 
 #------------------------------------------------------------
+# ATtiny417auto
+#------------------------------------------------------------
+
+part parent "t417" # t417auto
+    desc                   = "ATtiny417auto";
+    id                     = "t417auto";
+    variants               =
+        "ATtiny417-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny417-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 422;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
+    ;
+;
+
+#------------------------------------------------------------
 # ATtiny814
 #------------------------------------------------------------
 
@@ -19899,6 +19919,24 @@ part parent ".avr8x_tiny" # t814
     memory "sram"
         size               = 512;
         offset             = 0x3e00;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny814auto
+#------------------------------------------------------------
+
+part parent "t814" # t814auto
+    desc                   = "ATtiny814auto";
+    id                     = "t814auto";
+    variants               =
+        "ATtiny814-SSBT: SOIC, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny814-SSZT: SOIC, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 423;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
     ;
 ;
 
@@ -19960,6 +19998,26 @@ part parent ".avr8x_tiny" # t816
 ;
 
 #------------------------------------------------------------
+# ATtiny816auto
+#------------------------------------------------------------
+
+part parent "t816" # t816auto
+    desc                   = "ATtiny816auto";
+    id                     = "t816auto";
+    variants               =
+        "ATtiny816-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny816-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny816-SBT: SOIC, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny816-SZT: SOIC, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 424;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
+    ;
+;
+
+#------------------------------------------------------------
 # ATtiny817
 #------------------------------------------------------------
 
@@ -20013,6 +20071,25 @@ part parent ".avr8x_tiny" # t817
 ;
 
 #------------------------------------------------------------
+# ATtiny817auto
+#------------------------------------------------------------
+
+part parent "t817" # t817auto
+    desc                   = "ATtiny817auto";
+    id                     = "t817auto";
+    variants               =
+        "ATtiny817-MB:  VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny817-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny817-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 425;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
+    ;
+;
+
+#------------------------------------------------------------
 # ATtiny1614
 #------------------------------------------------------------
 
@@ -20061,6 +20138,24 @@ part parent ".avr8x_tiny" # t1614
     memory "sram"
         size               = 2048;
         offset             = 0x3800;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny1614auto
+#------------------------------------------------------------
+
+part parent "t1614" # t1614auto
+    desc                   = "ATtiny1614auto";
+    id                     = "t1614auto";
+    variants               =
+        "ATtiny1614-SSBT: SOIC, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny1614-SSZT: SOIC, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 426;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
     ;
 ;
 
@@ -20119,6 +20214,26 @@ part parent ".avr8x_tiny" # t1616
 ;
 
 #------------------------------------------------------------
+# ATtiny1616auto
+#------------------------------------------------------------
+
+part parent "t1616" # t1616auto
+    desc                   = "ATtiny1616auto";
+    id                     = "t1616auto";
+    variants               =
+        "ATtiny1616-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny1616-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny1616-SBT: SOIC, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny1616-SZT: SOIC, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 427;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
+    ;
+;
+
+#------------------------------------------------------------
 # ATtiny1617
 #------------------------------------------------------------
 
@@ -20167,6 +20282,24 @@ part parent ".avr8x_tiny" # t1617
     memory "sram"
         size               = 2048;
         offset             = 0x3800;
+    ;
+;
+
+#------------------------------------------------------------
+# ATtiny1617auto
+#------------------------------------------------------------
+
+part parent "t1617" # t1617auto
+    desc                   = "ATtiny1617auto";
+    id                     = "t1617auto";
+    variants               =
+        "ATtiny1617-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny1617-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 428;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
     ;
 ;
 
@@ -20228,6 +20361,24 @@ part parent ".avr8x_tiny" # t3216
 ;
 
 #------------------------------------------------------------
+# ATtiny3216auto
+#------------------------------------------------------------
+
+part parent "t3216" # t3216auto
+    desc                   = "ATtiny3216auto";
+    id                     = "t3216auto";
+    variants               =
+        "ATtiny3216-SBT: SOIC, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny3216-SZT: SOIC, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 429;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
+    ;
+;
+
+#------------------------------------------------------------
 # ATtiny3217
 #------------------------------------------------------------
 
@@ -20241,6 +20392,24 @@ part parent "t3216" # t3217
         "ATtiny3217-MNR: VQFN24, Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 315;
     signature              = 0x1e 0x95 0x22;
+;
+
+#------------------------------------------------------------
+# ATtiny3217auto
+#------------------------------------------------------------
+
+part parent "t3217" # t3217auto
+    desc                   = "ATtiny3217auto";
+    id                     = "t3217auto";
+    variants               =
+        "ATtiny3217-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
+        "ATtiny3217-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
+    mcuid                  = 430;
+    factory_fcpu           = 16000000;
+
+    memory "fuse2"
+        initval            = 0x7d;
+    ;
 ;
 
 #------------------------------------------------------------

--- a/src/libavrdude-avrintel.h
+++ b/src/libavrdude-avrintel.h
@@ -11,8 +11,8 @@
  * Published under GNU General Public License, version 3 (GPL-3.0)
  * Meta-author Stefan Rueger <stefan.rueger@urclocks.com>
  *
- * v 1.50
- * 17.04.2026
+ * v 1.51
+ * 20.04.2026
  *
  */
 
@@ -148,7 +148,7 @@ typedef enum {
 
 #define UB_N_MCU           2040 // mcuid is in 0..2039
 
-extern const Avrintel uP_table[422];
+extern const Avrintel uP_table[431];
 
 
 // MCU id: running number in arbitrary order; once assigned never change for backward compatibility
@@ -461,15 +461,24 @@ extern const Avrintel uP_table[422];
 #define id_attiny416       289u
 #define id_attiny416auto   290u
 #define id_attiny417       291u
+#define id_attiny417auto   422u
 #define id_attiny814       298u
+#define id_attiny814auto   423u
 #define id_attiny816       299u
+#define id_attiny816auto   424u
 #define id_attiny817       300u
+#define id_attiny817auto   425u
 #define id_attiny1614      307u
+#define id_attiny1614auto  426u
 #define id_attiny1616      308u
+#define id_attiny1616auto  427u
 #define id_attiny1617      309u
+#define id_attiny1617auto  428u
 #define id_attiny3214      313u
 #define id_attiny3216      314u
+#define id_attiny3216auto  429u
 #define id_attiny3217      315u
+#define id_attiny3217auto  430u
 #define id_attiny424       292u
 #define id_attiny426       293u
 #define id_attiny427       294u
@@ -871,15 +880,24 @@ extern const Avrintel uP_table[422];
 #define vts_attiny416        26
 #define vts_attiny416auto    26
 #define vts_attiny417        26
+#define vts_attiny417auto    26
 #define vts_attiny814        26
+#define vts_attiny814auto    26
 #define vts_attiny816        26
+#define vts_attiny816auto    26
 #define vts_attiny817        26
+#define vts_attiny817auto    26
 #define vts_attiny1614       31
+#define vts_attiny1614auto   31
 #define vts_attiny1616       31
+#define vts_attiny1616auto   31
 #define vts_attiny1617       31
+#define vts_attiny1617auto   31
 #define vts_attiny3214       31
 #define vts_attiny3216       31
+#define vts_attiny3216auto   31
 #define vts_attiny3217       31
+#define vts_attiny3217auto   31
 #define vts_attiny424        30
 #define vts_attiny426        30
 #define vts_attiny427        30
@@ -1279,15 +1297,24 @@ extern const Avrintel uP_table[422];
 #define vbu_attiny416        26
 #define vbu_attiny416auto    26
 #define vbu_attiny417        26
+#define vbu_attiny417auto    26
 #define vbu_attiny814         5
+#define vbu_attiny814auto     5
 #define vbu_attiny816        26
+#define vbu_attiny816auto    26
 #define vbu_attiny817        26
+#define vbu_attiny817auto    26
 #define vbu_attiny1614        5
+#define vbu_attiny1614auto    5
 #define vbu_attiny1616       31
+#define vbu_attiny1616auto   31
 #define vbu_attiny1617       31
+#define vbu_attiny1617auto   31
 #define vbu_attiny3214       31
 #define vbu_attiny3216       31
+#define vbu_attiny3216auto   31
 #define vbu_attiny3217       31
+#define vbu_attiny3217auto   31
 #define vbu_attiny424        30
 #define vbu_attiny426        30
 #define vbu_attiny427        30
@@ -1786,19 +1813,28 @@ extern const char * const    vtab_attiny212[26];
 extern const char * const    vtab_attiny214[26];
 #define vtab_attiny414       vtab_attiny214
 #define vtab_attiny814       vtab_attiny214
+#define vtab_attiny814auto   vtab_attiny214
 
 extern const char * const    vtab_attiny416[26];
 #define vtab_attiny416auto   vtab_attiny416
 #define vtab_attiny417       vtab_attiny416
+#define vtab_attiny417auto   vtab_attiny416
 #define vtab_attiny816       vtab_attiny416
+#define vtab_attiny816auto   vtab_attiny416
 #define vtab_attiny817       vtab_attiny416
+#define vtab_attiny817auto   vtab_attiny416
 
 extern const char * const    vtab_attiny1614[31];
+#define vtab_attiny1614auto  vtab_attiny1614
 
 extern const char * const    vtab_attiny1616[31];
+#define vtab_attiny1616auto  vtab_attiny1616
 #define vtab_attiny1617      vtab_attiny1616
+#define vtab_attiny1617auto  vtab_attiny1616
 #define vtab_attiny3216      vtab_attiny1616
+#define vtab_attiny3216auto  vtab_attiny1616
 #define vtab_attiny3217      vtab_attiny1616
+#define vtab_attiny3217auto  vtab_attiny1616
 
 extern const char * const    vtab_attiny3214[31];
 
@@ -2350,6 +2386,15 @@ extern const Configitem      cfgtab_attiny804[15];
 #define cfgtab_attiny1607    cfgtab_attiny804
 
 extern const Configitem      cfgtab_attiny416auto[23];
+#define cfgtab_attiny417auto cfgtab_attiny416auto
+#define cfgtab_attiny814auto cfgtab_attiny416auto
+#define cfgtab_attiny816auto cfgtab_attiny416auto
+#define cfgtab_attiny817auto cfgtab_attiny416auto
+#define cfgtab_attiny1614auto cfgtab_attiny416auto
+#define cfgtab_attiny1616auto cfgtab_attiny416auto
+#define cfgtab_attiny1617auto cfgtab_attiny416auto
+#define cfgtab_attiny3216auto cfgtab_attiny416auto
+#define cfgtab_attiny3217auto cfgtab_attiny416auto
 
 extern const Configitem      cfgtab_attiny424[16];
 #define cfgtab_attiny426     cfgtab_attiny424
@@ -3741,14 +3786,23 @@ extern const Uart_conf       uarts_attiny204[2];
 #define uarts_attiny416      uarts_attiny204
 #define uarts_attiny416auto  uarts_attiny204
 #define uarts_attiny417      uarts_attiny204
+#define uarts_attiny417auto  uarts_attiny204
 #define uarts_attiny814      uarts_attiny204
+#define uarts_attiny814auto  uarts_attiny204
 #define uarts_attiny816      uarts_attiny204
+#define uarts_attiny816auto  uarts_attiny204
 #define uarts_attiny817      uarts_attiny204
+#define uarts_attiny817auto  uarts_attiny204
 #define uarts_attiny1614     uarts_attiny204
+#define uarts_attiny1614auto uarts_attiny204
 #define uarts_attiny1616     uarts_attiny204
+#define uarts_attiny1616auto uarts_attiny204
 #define uarts_attiny1617     uarts_attiny204
+#define uarts_attiny1617auto uarts_attiny204
 #define uarts_attiny3216     uarts_attiny204
+#define uarts_attiny3216auto uarts_attiny204
 #define uarts_attiny3217     uarts_attiny204
+#define uarts_attiny3217auto uarts_attiny204
 
 extern const Uart_conf       uarts_attiny424[3];
 #define uarts_attiny824      uarts_attiny424


### PR DESCRIPTION
This PR adds 
 - `ATtiny417auto`
 - `ATtiny814auto` `ATtiny816auto` `ATtiny817auto`
 - `ATtiny1614auto` `ATtiny1616auto` `ATtiny1617auto`
 - `ATtiny3216auto` `ATtiny3217auto`

Of the 10 tinyAVR 1-series automotive parts only `ATtiny416auto` has an .atdf file. Possibly, because it's the only one where the signature differs from the sibling part without auto designation. That meant that the `ATtiny416auto` was so far the only one that AVRDUDE knew about.

The differences for programming are subtle but there are some: Automotive grade means max F_CPU is limited to 16 MHz as opposed to 20 MHz, and the minimum Vcc is 2.7 V as opposed to 1.8 V. Therefore the default fuse configuration is different (16 MHz at startup) and there are fewer choices for fuse settings (no 1.8 V BOD either).

Here the differences for the `ATtiny167auto`:
``` diff
$ avrdude -qq -pt1617auto/S >/tmp/t1617auto
$ avrdude -qq -pt1617/S >/tmp/t1617
$ diff /tmp/t1617*
2c2
< # ATtiny1617
---
> # ATtiny1617auto
5,7c5,7
< part parent ".avr8x_tiny" # t1617
<     desc                   = "ATtiny1617";
<     id                     = "t1617";
---
> part parent "t1617" # t1617auto
>     desc                   = "ATtiny1617auto";
>     id                     = "t1617auto";
9,12c9,10
<         "ATtiny1617-MF:  VQFN24, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
<         "ATtiny1617-MFR: VQFN24, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]",
<         "ATtiny1617-MN:  QFN24,  Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]",
<         "ATtiny1617-MNR: QFN24,  Fmax=20 MHz, T=[-40 C, 105 C], Vcc=[1.8 V, 5.5 V]";
---
>         "ATtiny1617-MBT: VQFN, Fmax=16 MHz, T=[-40 C, 105 C], Vcc=[2.7 V, 5.5 V]",
>         "ATtiny1617-MZT: VQFN, Fmax=16 MHz, T=[-40 C, 125 C], Vcc=[2.7 V, 5.5 V]";
15c13
<     mcuid                  = 309;
---
>     mcuid                  = 428;
25c23
<     factory_fcpu           = 20000000;
---
>     factory_fcpu           = 16000000;
71c69
<         initval            = 0x7e;
---
>         initval            = 0x7d;
```

And here the differences in the fuse configuration:
``` diff
$ avrdude -qq -pt1617auto -cdryrun -T "config -a" >/tmp/t1617auto
$ avrdude -qq -pt1617 -cdryrun -T "config -a" >/tmp/t1617
$ diff /tmp/t1617*
51d50
< config bodlevel=bod_1v8 # 0 = 0b000 = 0x00>>5 (factory)
53a53
> config bodlevel=0       # reserved = 0b000 = 0x00>>5 (factory)
56c56
< # Fuse osccfg/fuse2 value 0x7e (factory 0x7e) mask 0x83
---
> # Fuse osccfg/fuse2 value 0x7d (factory 0x7d) mask 0x83
59,60c59
< # conf freqsel=fcpu_16mhz # 1 = 0b01 = 0x01>>0
< config freqsel=fcpu_20mhz # 2 = 0b10 = 0x02>>0 (factory)
---
> config freqsel=fcpu_16mhz # 1 = 0b01 = 0x01>>0 (factory)
```