### PR TITLE
Add consistent support for `-P USB`

### DIFF
--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -642,7 +642,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
   Avrftdi_data *pdata = to_pdata(pgm);
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(!str_eq(port, "usb"))
+  if(!str_caseeq(port, "usb"))
     pmsg_warning("option -P %s ignored\n", port);
 
   // Parameter validation

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -202,7 +202,7 @@ static int ch341a_open(PROGRAMMER *pgm, const char *port) {
   libusb_device_handle *handle = NULL;
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(!str_eq(port, "usb"))
+  if(!str_caseeq(port, "usb"))
     pmsg_warning("option -P %s ignored\n", port);
 
   if(!my.USB_init) {

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -103,7 +103,7 @@ struct dfu_dev *dfu_open(const char *port_spec) {
 
   pmsg_debug("%s(\"%s\")\n", __func__, port_spec);
 
-  if(!str_starts(port_spec, "usb:") && !str_eq(port_spec, "usb")) {
+  if(!str_casestarts(port_spec, "usb:") && !str_caseeq(port_spec, "usb")) {
     pmsg_error("invalid -P %s; drop this option or use -P usb:<busdir>:<devicefile>\n", port_spec);
     return NULL;
   }

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -823,7 +823,7 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
   pgm->port = port;
 
   // Read device string cut after 8 chars (max. length of serial number)
-  if(!str_casestarts(port, "usb:") || (port+4, "%8s", device) != 1) {
+  if(!str_casestarts(port, "usb:") || sscanf(port+4, "%8s", device) != 1) {
     pmsg_notice("%s(): no device identifier in portname, using default\n", __func__);
     pgm->usbsn = cache_string("");
     devnum = 0;

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -823,7 +823,7 @@ static int ft245r_open(PROGRAMMER *pgm, const char *port) {
   pgm->port = port;
 
   // Read device string cut after 8 chars (max. length of serial number)
-  if((sscanf(port, "usb:%8s", device) != 1)) {
+  if(!str_casestarts(port, "usb:") || (port+4, "%8s", device) != 1) {
     pmsg_notice("%s(): no device identifier in portname, using default\n", __func__);
     pgm->usbsn = cache_string("");
     devnum = 0;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1646,7 +1646,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
   return -1;
 #endif
 
-  if(!str_starts(port, "usb")) {
+  if(!str_casestarts(port, "usb")) {
     pmsg_error("JTAGICE3/EDBG port names must start with usb\n");
     return -1;
   }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1399,7 +1399,7 @@ static int jtagmkII_open(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -1449,7 +1449,7 @@ static int jtagmkII_open_dw(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -1499,7 +1499,7 @@ static int jtagmkII_open_pdi(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -1555,7 +1555,7 @@ static int jtagmkII_dragon_open(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -1605,7 +1605,7 @@ static int jtagmkII_dragon_open_dw(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -1655,7 +1655,7 @@ static int jtagmkII_dragon_open_pdi(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -3237,7 +3237,7 @@ static int jtagmkII_open32(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -585,13 +585,13 @@ static int micronucleus_open(PROGRAMMER *pgm, const char *port) {
   struct pdata *pdata = &my;
   const char *bus_name = NULL, *dev_name = NULL;
 
-  if(!str_starts(port, "usb:") && !str_eq(port, "usb")) {
+  if(!str_casestarts(port, "usb:") && !str_caseeq(port, "usb")) {
     pmsg_error("invalid -P %s; drop this option or use -P usb:<busdir>:<devicefile>\n", port);
     return -1;
   }
 
   // Calculate bus and device names from -P usb:<busdir>:<devicefile> option if present
-  if(str_starts(port, "usb:")) {
+  if(str_casestarts(port, "usb:")) {
     bus_name = port + 4;
     if((dev_name = strchr(bus_name, ':')))
       dev_name++;

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -173,7 +173,7 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(!str_eq(port, "usb"))
+  if(!str_caseeq(port, "usb"))
     pmsg_warning("option -P %s ignored\n", port);
 
 #ifdef WIN32

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -657,7 +657,7 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
   return LIBAVRDUDE_GENERAL_FAILURE;
 #endif
 
-  if(!str_starts(port, "usb:") && !str_eq(port, "usb")) {
+  if(!str_casestarts(port, "usb:") && !str_caseeq(port, "usb")) {
     pmsg_error("invalid -P %s; drop -P option or else use -P usb:<vid>:<pid> or -P usb:<serialno>\n", port);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -2128,7 +2128,7 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev_frame;
@@ -2196,7 +2196,7 @@ static int stk600_open(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev_frame;
@@ -3909,7 +3909,7 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -4007,7 +4007,7 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;
@@ -4080,7 +4080,7 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
    * ones.  The serial_open() function for USB overrides the meaning of the
    * "baud" parameter to be the USB device ID to search for.
    */
-  if(str_starts(port, "usb")) {
+  if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
     serdev = &usb_serdev;

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -306,7 +306,7 @@ static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 
 static int teensy_open(PROGRAMMER *pgm, const char *port) {
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(!str_eq(port, "usb"))
+  if(!str_caseeq(port, "usb"))
     pmsg_warning("option -P %s ignored\n", port);
 
   if(pgm->bitclock)

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -423,7 +423,7 @@ static int check_for_port_argument_match(const char *port, const char *bus,
 
   pmsg_notice("found USBasp with busdir:devicefile = %s:%s, serial_number = %s\n", bus, device, serial_num);
 
-  if(str_starts(port, "usb:")) {
+  if(str_casestarts(port, "usb:")) {
     port += 4;
     char *dev_name = strchr(port, ':');
 
@@ -589,7 +589,7 @@ static int usbOpenDevice(const PROGRAMMER *pgm, usb_dev_handle **device, int ven
             errorCode = USB_ERROR_NOTFOUND;
         }
         if(errorCode == 0) {
-          if(!str_eq(port, "usb")) {
+          if(!str_caseeq(port, "usb")) {
             // -P option given
             usb_get_string_simple(handle, dev->descriptor.iSerialNumber, string, sizeof(string));
             if(!check_for_port_argument_match(port, bus->dirname, dev->filename, string))
@@ -620,7 +620,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock && !(pgm->extra_features & HAS_BITCLOCK_ADJ))
     pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
-  if(!str_starts(port, "usb:") && !str_eq(port, "usb")) {
+  if(!str_casestarts(port, "usb:") && !str_caseeq(port, "usb")) {
     pmsg_error("invalid -P %s; drop -P option or else use -P usb:<busdir>:<devicefile> or -P usb:<serialno>\n", port);
     return -1;
   }

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -287,13 +287,13 @@ static int usbtiny_open(PROGRAMMER *pgm, const char *port) {
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
 
-  if(!str_starts(port, "usb:") && !str_eq(port, "usb")) {
+  if(!str_casestarts(port, "usb:") && !str_caseeq(port, "usb")) {
     pmsg_error("invalid -P %s; drop this option or use -P usb:<busdir>:<devicefile>\n", port);
     return -1;
   }
 
   // Calculate bus and device names from -P usb:<busdir>:<devicefile> option if present
-  if(str_starts(port, "usb:")) {
+  if(str_casestarts(port, "usb:")) {
     bus_name = port + 4;
     if((dev_name = strchr(bus_name, ':')))
       dev_name++;


### PR DESCRIPTION
It seems like support for upper case `USB` could vary from programmer implementation to programmer implementation in earlier versions of Avrdude.

Resolves #2103