### PR TITLE
Upgrade github action to be compatibel with node.js 24

### DIFF
--- a/.github/workflows/arduino_packing.yml
+++ b/.github/workflows/arduino_packing.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
 
     - name: Checkout avrdude repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         repository: avrdudes/avrdude
         path: ${{ env.PROJECT_NAME }}
@@ -85,7 +85,7 @@ jobs:
         tar -czv ${{ env.PROJECT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF##*/}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         if-no-files-found: error
         name: ${{ env.ARTIFACT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }}

--- a/.github/workflows/arduino_packing_release.yml
+++ b/.github/workflows/arduino_packing_release.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
 
     - name: Checkout avrdude repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: replace system ranlib with darwin one
       # for some reason is not possible to override ranlib with env vars, so this is ugly but it's the only way I found
@@ -77,7 +77,7 @@ jobs:
         tar -czv ${{ env.PROJECT_NAME }}_${{ matrix.config.os }}_${{ matrix.config.arch }} -f ${{ env.PROJECT_NAME }}_${GITHUB_REF##*/}_${{ matrix.config.os }}_${{ matrix.config.arch }}.tar.gz
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         if-no-files-found: error
         name: ${{ env.ARTIFACT_NAME }}-${{ matrix.config.os }}-${{ matrix.config.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         run: printf "\n\n" | ./tools/test-avrdude -v -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-linux-x86_64
           path: |
@@ -203,7 +203,7 @@ jobs:
         run: build/src/avrdude -?
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-linux-${{matrix.processor}}
           path: |
@@ -271,7 +271,7 @@ jobs:
             !**/*.d
             !**/*.o
       - name: Archive executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: avrdude-macos-arm64
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
   linux-x86_64-autotools:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install prerequisites
         run: >-
           sudo apt-get update
@@ -88,7 +88,7 @@ jobs:
   linux-x86_64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install prerequisites
         run: >-
           sudo apt-get update
@@ -140,7 +140,7 @@ jobs:
             !**/*.d
             !**/*.o
       - name: Archive executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: avrdude-linux-x86_64
           path: |
@@ -157,7 +157,7 @@ jobs:
           - { arch: armhf, processor: armhf, prefix: arm-linux-gnueabihf, inc-lib: arm-linux-gnueabihf }
           - { arch: arm64, processor: aarch64, prefix: aarch64-linux-gnu, inc-lib: aarch64-linux-gnu }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Add architecture
         run: |
           dpkg --add-architecture ${{matrix.arch}}
@@ -211,7 +211,7 @@ jobs:
             !**/*.d
             !**/*.o
       - name: Archive executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: avrdude-linux-${{matrix.processor}}
           path: |
@@ -221,7 +221,7 @@ jobs:
   macos-arm64:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Original PATH and build tools
         run: |
           echo "PATH=$PATH"
@@ -263,7 +263,7 @@ jobs:
         run: printf "\n\n" | ./tools/test-avrdude -v -e build/src/avrdude -c '-C build/src/avrdude.conf' -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-macos-arm64
           path: |
@@ -281,7 +281,7 @@ jobs:
   macos-arm64-autotools:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Original PATH and build tools
         run: |
           echo "PATH=$PATH"
@@ -335,7 +335,7 @@ jobs:
           - { arch: x64, platform: x64 }
           - { arch: arm64, platform: ARM64 }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install prerequisites
         # As Chocolatey is notoriously unreliable, install winflexbison3 directly from GitHub.
         # run: choco install winflexbison3
@@ -372,7 +372,7 @@ jobs:
           Write-Host "`n`n" -NoNewline | bash tools/test-avrdude -v -t "$tmp_slash" -e build/src/${{env.BUILD_TYPE}}/avrdude.exe -c "-C build/src/avrdude.conf" -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-msvc-${{matrix.arch}}
           path: |
@@ -384,7 +384,7 @@ jobs:
           mv build/src/${{env.BUILD_TYPE}}/avrdude.exe build/src
           mv build/src/${{env.BUILD_TYPE}}/avrdude.pdb build/src
       - name: Archive executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: avrdude-msvc-${{matrix.arch}}
           path: |
@@ -397,7 +397,7 @@ jobs:
           mv build/src/${{env.BUILD_TYPE}}/_swig_avrdude.pyd build/src
       - name: Archive Python related files for x64
         if: matrix.arch == 'x64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: avrdude-msvc-python_x64
           path: |        
@@ -419,7 +419,7 @@ jobs:
           - { sys: ucrt64, env: ucrt-x86_64 }
           - { sys: clang64, env: clang-x86_64 }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.sys}}
@@ -456,13 +456,13 @@ jobs:
       #   run: printf "\n\n" | ./tools/test-avrdude -v -e build/src/avrdude.exe -c "-C build/src/avrdude.conf" -d0 -p"-cdryrun -pm2560" -p"-cdryrun -pavr64du28"
       - name: Archive build artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-mingw-${{matrix.env}}
           path: |
             build/
       - name: Archive executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: avrdude-mingw-${{matrix.env}}
           path: |

--- a/.github/workflows/check-sourcecode.yml
+++ b/.github/workflows/check-sourcecode.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # - name: Install prerequisites
 
@@ -29,7 +29,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install prerequisites
         run: >-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           - { arch: arm64 }
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: avrdude-msvc-${{matrix.arch}}
 


### PR DESCRIPTION
This will address the warnings generated with the current github actions.