### PR TITLE
Improve Micronucleus info/warning/error messages

### DIFF
--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -669,12 +669,12 @@ static int micronucleus_open(PROGRAMMER *pgm, const char *port) {
     if(pdata->usb_handle == NULL && pdata->wait_until_device_present) {
       if(show_retry_message) {
         if(pdata->wait_timout < 0) {
-          msg_info("No device found, waiting for device to be plugged in ...\n");
+          pmsg_info("no device found, waiting for device to be plugged in ...\n");
         } else {
-          msg_info("No device found, waiting %d seconds for device to be plugged in ...\n", pdata->wait_timout);
+          pmsg_info("no device found, waiting %d seconds for device to be plugged in ...\n", pdata->wait_timout);
         }
 
-        msg_info("Press CTRL-C to terminate\n\n");
+        pmsg_info("press CTRL-C to terminate\n\n");
         show_retry_message = false;
       }
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -272,14 +272,14 @@ static int micronucleus_get_bootloader_info(struct pdata *pdata) {
 }
 
 static void micronucleus_dump_device_info(struct pdata *pdata) {
-  pmsg_notice("Bootloader version: %d.%d\n", pdata->major_version, pdata->minor_version);
-  imsg_notice("Available flash size: %u\n", pdata->flash_size);
-  imsg_notice("Page size: %u\n", pdata->page_size);
-  imsg_notice("Bootloader start: 0x%04X\n", pdata->bootloader_start);
-  imsg_notice("Write sleep: %ums\n", pdata->write_sleep);
-  imsg_notice("Erase sleep: %ums\n", pdata->erase_sleep);
-  imsg_notice("Signature1: 0x%02X\n", pdata->signature1);
-  imsg_notice("Signature2: 0x%02X\n", pdata->signature2);
+  pmsg_notice("Bootloader version    : %d.%d\n", pdata->major_version, pdata->minor_version);
+  imsg_notice("Available flash size  : %u\n", pdata->flash_size);
+  imsg_notice("Page size             : %u\n", pdata->page_size);
+  imsg_notice("Bootloader start addr : 0x%04X\n", pdata->bootloader_start);
+  imsg_notice("Write sleep           : %ums\n", pdata->write_sleep);
+  imsg_notice("Erase sleep           : %ums\n", pdata->erase_sleep);
+  imsg_notice("Signature1            : 0x%02X\n", pdata->signature1);
+  imsg_notice("Signature2            : 0x%02X\n", pdata->signature2);
 }
 
 static int micronucleus_erase_device(struct pdata *pdata) {
@@ -636,7 +636,7 @@ static int micronucleus_open(PROGRAMMER *pgm, const char *port) {
 
           if(!micronucleus_is_device_responsive(pdata, device)) {
             if(show_unresponsive_device_message) {
-              pmsg_warning("unresponsive Micronucleus device detected, please reconnect ...\n");
+              msg_warning("\nUnresponsive Micronucleus device detected, please reconnect ...\n");
 
               show_unresponsive_device_message = false;
             }
@@ -669,12 +669,12 @@ static int micronucleus_open(PROGRAMMER *pgm, const char *port) {
     if(pdata->usb_handle == NULL && pdata->wait_until_device_present) {
       if(show_retry_message) {
         if(pdata->wait_timout < 0) {
-          pmsg_error("no device found, waiting for device to be plugged in ...\n");
+          msg_info("No device found, waiting for device to be plugged in ...\n");
         } else {
-          pmsg_error("no device found, waiting %d seconds for device to be plugged in ...\n", pdata->wait_timout);
+          msg_info("No device found, waiting %d seconds for device to be plugged in ...\n", pdata->wait_timout);
         }
 
-        pmsg_error("press CTRL-C to terminate\n");
+        msg_info("Press CTRL-C to terminate\n\n");
         show_retry_message = false;
       }
 
@@ -719,7 +719,7 @@ static int micronucleus_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const
     *value = 0xFF;
     return 0;
   } else {
-    pmsg_notice("reading not supported for %s memory\n", mem->desc);
+    pmsg_notice2("reading not supported for %s memory\n", mem->desc);
     return -1;
   }
 }


### PR DESCRIPTION
To see the Micronucleus output Without this PR, see the first post in #2109. Not sure what the USB errors is all about. I am not experiencing any USB related issues with Avrdude and the Micronucleus bootloader on my mac.

With this PR:

<details>
<summary>$ avrdude -V -pattiny85 -cmicronucleus -xwait=60 -Uflash:w:Blink.ino.hex:i</summary>

```
$ avrdude -V -pattiny85 -cmicronucleus -xwait=60 -Uflash:w:/var/folders/zb/v12zftvj4dv7mw0_1c6x8lwc0000gn/T/arduino_build_219152/Blink.ino.hex:i

Unresponsive Micronucleus device detected, please reconnect ...
No device found, waiting 60 seconds for device to be plugged in ...
Press CTRL-C to terminate

Reading 126 bytes for flash from input file Blink.ino.hex
Writing 126 bytes to flash
Writing | ################################################## | 100% 0.08 s 
126 bytes of flash written

USB access errors detected; this could have many reasons; if it is
USB permission problems, avrdude is likely to work when run as root
but this is not good practice; instead you might want to
check out USB port permissions on your OS and set them correctly

Avrdude done.  Thank you.
```

</details>

<details>
<summary>$ avrdude -v -V -pattiny85 -cmicronucleus -xwait=60 -Uflash:w:Blink.ino.hex:i</summary>

```
$ avrdude -v -V -pattiny85 -cmicronucleus -xwait=60 -Uflash:w:/var/folders/zb/v12zftvj4dv7mw0_1c6x8lwc0000gn/T/arduino_build_219152/Blink.ino.hex:i
Avrdude version 8.1-20260526 (c81badaa)
Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

System wide configuration file is /usr/local/etc/avrdude.conf
User configuration file /Users/hans/.avrduderc does not exist

Using port            : usb
Using programmer      : micronucleus

Unresponsive Micronucleus device detected, please reconnect ...
No device found, waiting 60 seconds for device to be plugged in ...
Press CTRL-C to terminate

Found device with Micronucleus V2.6, busdir:devicefile = 001:001
AVR part              : ATtiny85
Programming modes     : SPM, ISP, HVSP, debugWIRE
Programmer type       : Micronucleus V2.0
Description           : Micronucleus bootloader
Bootloader version    : 2.6
Available flash size  : 6778
Page size             : 64
Bootloader start addr : 0x1A80
Write sleep           : 7ms
Erase sleep           : 742ms
Signature1            : 0x93
Signature2            : 0x0B

AVR device initialized and ready to accept instructions
Device signature = 1E 93 0B (ATtiny85)
Auto-erasing chip as flash memory needs programming (-U flash:w:...)
specify the -D option to disable this feature
Erased chip
Reading 126 bytes for flash from input file Blink.ino.hex
in 1 section [0, 0x7d]: 2 pages and 2 pad bytes
Writing 126 bytes to flash
Writing | ################################################## | 100% 0.08 s 
126 bytes of flash written

USB access errors detected; this could have many reasons; if it is
USB permission problems, avrdude is likely to work when run as root
but this is not good practice; instead you might want to
check out USB port permissions on your OS and set them correctly

Avrdude done.  Thank you.
```

</details>

