### PR TITLE
Suppress gcc compiler warning

### DIFF
--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -54,7 +54,8 @@ static int sa_setport(char **portp, const char *sp_port) {
 
 // Is the actual serial number sn matched by the query q?
 static int sa_snmatch(const char *sn, const char *q) {
-  return sn && (str_starts(sn, q) || (str_starts(q, "...") && str_ends(sn, q + 3)));
+  return sn && (str_starts(sn, q) ||
+    (str_starts(q, "...") && strlen(q) >= 3 /* suppress gcc warning */ && str_ends(sn, q + 3)));
 }
 
 #define null_len(s) ((s)? strlen(s): 0)


### PR DESCRIPTION
For some reason gcc thinks q+3 might be out of bounds in `serialadapter.c` below. It isn't, but adding the `strlen(q) >= 3` condition suppresses the warning.

```
In function ‘sa_snmatch’,
    inlined from ‘sa_snmatch’ at /home/srueger/etc/clock/avrdude/gcc-warning/src/serialadapter.c:56:12,
    inlined from ‘sa_num_matches_by_ids’ at /home/srueger/etc/clock/avrdude/gcc-warning/src/serialadapter.c:190:48,
    inlined from ‘sa_unique_by_ids’ at /home/srueger/etc/clock/avrdude/gcc-warning/src/serialadapter.c:203:61,
    inlined from ‘sa_list_specs’ at /home/srueger/etc/clock/avrdude/gcc-warning/src/serialadapter.c:239:8,
    inlined from ‘sa_print_specs’ at /home/srueger/etc/clock/avrdude/gcc-warning/src/serialadapter.c:253:19:
/home/srueger/etc/clock/avrdude/gcc-warning/src/serialadapter.c:57:63: warning: array subscript 3 is outside array bounds of ‘char[1]’ [-Warray-bounds=]
   57 |   return sn && (str_starts(sn, q) || (str_starts(q, "...") && str_ends(sn, q + 3)));
      |                                                               ^~~~~~~~~~~~~~~~~~~
```