### PR TITLE
Add more AVR-LA support

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24718,6 +24718,18 @@ part # .avr-lx
         readsize           = 1;
     ;
 
+    memory "osccal20"
+        size               = 1;
+        offset             = 0x108c;
+        readsize           = 1;
+    ;
+
+    memory "osccal16"
+        size               = 1;
+        offset             = 0x108d;
+        readsize           = 1;
+    ;
+
     memory "sernum"
         size               = 16;
         offset             = 0x1090;

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24542,6 +24542,7 @@ part # .avr-lx
     id                     = ".avr-lx";
     family_id              = "AVR    ";
     prog_modes             = PM_SPM | PM_UPDI;
+    n_interrupts           = 29;
     n_boot_sections        = 1;
     boot_section_size      = 256;
     # Shared UPDI pin, HV on _RESET
@@ -24718,9 +24719,9 @@ part # .avr-lx
         readsize           = 1;
     ;
 
-    memory "osccal20"
-        size               = 1;
-        offset             = 0x108c;
+    memory "sernum"
+        size               = 16;
+        offset             = 0x1090;
         readsize           = 1;
     ;
 
@@ -24730,9 +24731,9 @@ part # .avr-lx
         readsize           = 1;
     ;
 
-    memory "sernum"
-        size               = 16;
-        offset             = 0x1090;
+    memory "osccal20"
+        size               = 1;
+        offset             = 0x108c;
         readsize           = 1;
     ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24749,7 +24749,7 @@ part parent ".avr-lx" # 16la14
     variants               =
         "AVR16LA14-SOIC/TSSOP: DIP14, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 414;
-    signature              = 0x1e 0x95 0x54;
+    signature              = 0x1e 0x94 0x54;
 
     memory "eeprom"
         size               = 512;
@@ -24781,7 +24781,7 @@ part parent "16la14" # 16la20
     variants               =
         "AVR16LA20-SOIC/TSSOP: DIP20, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 415;
-    signature              = 0x1e 0x95 0x53;
+    signature              = 0x1e 0x94 0x53;
 ;
 
 #------------------------------------------------------------
@@ -24794,7 +24794,7 @@ part parent "16la14" # 16la28
     variants               =
         "AVR16LA28-SSOP/SPDIP: DIP28, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 416;
-    signature              = 0x1e 0x95 0x52;
+    signature              = 0x1e 0x94 0x52;
 ;
 
 #------------------------------------------------------------
@@ -24807,7 +24807,7 @@ part parent "16la14" # 16la32
     variants               =
         "AVR16LA32-VQFN/TQFP: QFP32, Fmax=20 MHz, T=[-40 C, 125 C], Vcc=[1.8 V, 5.5 V]";
     mcuid                  = 417;
-    signature              = 0x1e 0x95 0x51;
+    signature              = 0x1e 0x94 0x51;
 ;
 
 #------------------------------------------------------------

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24551,6 +24551,13 @@ part # .avr-lx
     syscfg_base            = 0x0f00;
     factory_fcpu           = 20000000;
 
+    memory "eeprom"
+        size               = 512;
+        page_size          = 8;
+        offset             = 0x1400;
+        readsize           = 256;
+    ;
+
     memory "fuses"
         size               = 16;
         offset             = 0x1050;
@@ -24733,6 +24740,11 @@ part # .avr-lx
         readsize           = 1;
     ;
 
+    memory "sram"
+        size               = 2048;
+        offset             = 0x7800;
+    ;
+
     memory "sib"
         size               = 32;
         readsize           = 1;
@@ -24751,23 +24763,11 @@ part parent ".avr-lx" # 16la14
     mcuid                  = 414;
     signature              = 0x1e 0x94 0x54;
 
-    memory "eeprom"
-        size               = 512;
-        page_size          = 8;
-        offset             = 0x1400;
-        readsize           = 256;
-    ;
-
     memory "flash"
         size               = 0x4000;
         page_size          = 64;
         offset             = 0x800000;
         readsize           = 256;
-    ;
-
-    memory "sram"
-        size               = 2048;
-        offset             = 0x7800;
     ;
 ;
 

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24826,7 +24826,7 @@ part parent "16la14" # 16la32
 # AVR32LA14
 #------------------------------------------------------------
 
-part parent "16la14" # 32la14
+part parent ".avr-lx" # 32la14
     desc                   = "AVR32LA14";
     id                     = "32la14";
     variants               =
@@ -24836,6 +24836,9 @@ part parent "16la14" # 32la14
 
     memory "flash"
         size               = 0x8000;
+        page_size          = 64;
+        offset             = 0x800000;
+        readsize           = 256;
     ;
 ;
 

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1158,12 +1158,14 @@ void dev_output_part_defs(char *partdesc) {
 
         dev_info
           ("%s '%s' =>%*s [0x%02X, 0x%02X, 0x%02X, 0x%08x, 0x%05x, 0x%03x, "
-           "0x%06x, 0x%04x, 0x%03x, %d, 0x%03x, 0x%04x, '%s'], # %s %d\n",
+           "0x%06x, 0x%04x, 0x%03x, %d, 0x%03x, 0x%04x, '%s'],",
           tsv || all? ".desc": "   ",
           p->desc, len > 0? len: 0, "",
-          p->signature[0], p->signature[1], p->signature[2],
-          flashoffset, flashsize, flashpagesize, eepromoffset, eepromsize, eeprompagesize, nfuses, ok, p->flags,
-          dev_prog_modes(p->prog_modes), p->config_file, p->lineno);
+          p->signature[0], p->signature[1], p->signature[2], flashoffset, flashsize, flashpagesize,
+          eepromoffset, eepromsize, eeprompagesize, nfuses, ok, p->flags, dev_prog_modes(p->prog_modes));
+        if(verbose > 0)
+          dev_info(" # %s %d", p->config_file, p->lineno);
+        dev_info("\n");
       }
 
       if(vtabs && (up = silent_locate_uP(p)) && up->isrtable)

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -5946,18 +5946,18 @@ A.k.a. @code{pdicfg}: configures/locks updi access; it is the only fuse that con
 A logical memory of up to 16 bytes containing all fuseX of a part, which can be used to program all fuses at the same time
 @cindex @code{osc16err}
 @item osc16err
-Two bytes typically describing the 16 MHz oscillator frequency error at 3 V and 5 V, respectively
+Two bytes typically describing the 16 MHz oscillator frequency error at 3 V and 5 V, respectively (not all devices)
 @cindex @code{osc20err}
 @item osc20err
-Two bytes typically describing the 20 MHz oscillator frequency error at 3 V and 5 V, respectively
+Two bytes typically describing the 20 MHz oscillator frequency error at 3 V and 5 V, respectively (not all devices)
 @cindex @code{osccal16}
 @item osccal16
 @cindex @code{calibration}
-Two oscillator calibration bytes for 16 MHz
+One or two oscillator calibration bytes for 16 MHz (not all devices)
 @cindex @code{osccal20}
 @item osccal20
 @cindex @code{calibration}
-Two oscillator calibration bytes for 20 MHz
+One or two oscillator calibration bytes for 20 MHz (not all devices)
 @cindex @code{prodsig}
 @item prodsig
 @cindex @code{signature}

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -5915,10 +5915,10 @@ A.k.a. @code{wdtcfg}: watchdog configuration
 A.k.a. @code{bodcfg}: brownout detection configuration
 @cindex @code{osccfg}
 @item fuse2
-A.k.a. @code{pincfg}: (not all devices): UPDI and reset pin configuration
+A.k.a. @code{osccfg}: oscillator configuration
 @cindex @code{pincfg}
 @item fuse3
-A.k.a. @code{osccfg}: oscillator configuration
+A.k.a. @code{pincfg} (not all devices): UPDI and reset pin configuration
 @cindex @code{tcd0cfg}
 @cindex @code{hwmoncfg}
 @item fuse4


### PR DESCRIPTION
This PR extends PR #2105: fixing documentation, signatures and adding `osccal16`/`osccal20` memories.