### PR TITLE
Fix subtle usb issues including inconsistent parsing

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -119,9 +119,9 @@ static int arduino_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   if(my.autoreset) {
     // This code assumes a negative-logic USB to TTL serial adapter

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -328,8 +328,9 @@ static int avr910_open(PROGRAMMER *pgm, const char *port) {
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 19200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  if(serial_open(port, pinfo, &pgm->fd) < 0)
-    return -1;
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   (void) avr910_drain(pgm, 0);
 

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -613,7 +613,7 @@ they are automatically identified via their vendor and product IDs from
 avrdude.conf or .avrduderc. Only when there are multiple programmers of
 the same type plugged into the host computer is the -P option needed, see
 below. Some -c programmers, however, ignore the -P option altogether, eg,
-pickit2, teensy, ch341a or avrftdi; these cannot distinguish multiple plugged-in
+pickit2, teensy or ch341a; these cannot distinguish multiple plugged-in
 programmers.
 .Pp
 Most USB programmers, however, support the command-line syntax  -P
@@ -623,8 +623,8 @@ request a match of the desired device's serial number with <serialno>. The
 match is done after stripping any existing colons from the given serial
 number on the command line, and right-to-left, so only the least
 significant bytes from the serial number need to be given. The JTAG ICE
-mkII, JTAGICE3, SNAP, and PICKit5 programmers are examples for this -P
-port syntax.
+mkII, JTAGICE3, SNAP, PICKit5 and avrftdi programmers are examples for
+this -P port syntax.
 .Pp
 If
 .Nm

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -612,9 +612,8 @@ USB-only programmers normally do not need the port option be specified as
 they are automatically identified via their vendor and product IDs from
 avrdude.conf or .avrduderc. Only when there are multiple programmers of
 the same type plugged into the host computer is the -P option needed, see
-below. Some -c programmers, however, ignore the -P option altogether, eg,
-pickit2 or teensy; these cannot distinguish multiple plugged-in
-programmers.
+below. Some -c programmers, eg, pickit2, ignore the -P option altogether;
+these cannot distinguish multiple plugged-in programmers.
 .Pp
 Most USB programmers, however, support the command-line syntax -P
 usb[:<vid>:<pid>][:<serialno>] which allows the user to override the
@@ -623,9 +622,9 @@ request a match of the desired device's serial number with <serialno>. The
 match is done after stripping any existing colons from the given serial
 number on the command line, and right-to-left, so only the least
 significant bytes from the serial number need to be given. The JTAG ICE
-mkII, JTAGICE3, SNAP, PICKit5, CH341A and avrftdi programmers are examples
-for this -P port syntax. Some of these in turn, e.g. the CH341A, are not
-capable of matching serial numbers.
+mkII, JTAGICE3, SNAP, PICKit5, CH341A, teensy and avrftdi programmers are
+examples for this -P port syntax. Some of these in turn, e.g. the CH341A
+and teensy are not capable of matching serial numbers.
 .Pp
 If
 .Nm

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -613,8 +613,18 @@ they are automatically identified via their vendor and product IDs from
 avrdude.conf or .avrduderc. Only when there are multiple programmers of
 the same type plugged into the host computer is the -P option needed, see
 below. Some -c programmers, however, ignore the -P option altogether, eg,
-teensy, ch341a or avrftdi; these cannot distinguish multiple plugged-in
+pickit2, teensy, ch341a or avrftdi; these cannot distinguish multiple plugged-in
 programmers.
+.Pp
+Most USB programmers, however, support the command-line syntax  -P
+usb[:<vid>:<pid>][:<serialno>] which allows the user to override the
+vendor and product IDs with hexadecimal numbers <vid> and <pid> and/or
+request a match of the desired device's serial number with <serialno>. The
+match is done after stripping any existing colons from the given serial
+number on the command line, and right-to-left, so only the least
+significant bytes from the serial number need to be given. The JTAG ICE
+mkII, JTAGICE3, SNAP, and PICKit5 programmers are examples for this -P
+port syntax.
 .Pp
 If
 .Nm
@@ -626,10 +636,10 @@ or
 If more than one serial adapter of the same type is connected, they can be
 distinguished by appending a serial number, e.g.,
 .Ar ft232r:12345678 .
-Note that the USB to serial chip has to have a serial number for this to work.
-.Nm Avrdude
-can check for leading and trailing serial number matches as well.
-In the above example,
+The USB to serial chip has to have a serial number for this to work. Note
+that serial number matches for serial adapters (in contrast to matches for
+USB programmers above) ist from left-to-right. For matches from
+right-to-left, serial adapters can use the ellipses. In the above example,
 .Ar ft232r:1234
 would also result in a match, and so would
 .Ar ft232r:...5678 .
@@ -697,13 +707,6 @@ usb:<busdir>:<devicefile> or using the serial number -P usb:<serialno>.
 For examples, see the respective
 .Em Troubleshooting
 entry in the detailed pdf documentation.
-.Pp
-The -c pickit5 programmer allows overriding the vendor and product IDs
-with hexadecimal numbers <vid> and <pid> using -P usb:<vid>:<pid>. The
-form -P usb:<serialno> requests AVRDUDE select the PICkit5 programmer with
-a serial number that ends in <serialno> and with vid/pid from the
-configuration files. It is also possible to override vid/pid and require a
-serialno match via -P usb:<vid>:<pid>:<serialno>.
 .Pp
 For the XBee programmer the target MCU is to be programmed wirelessly over a
 ZigBee mesh using the XBeeBoot bootloader.  The ZigBee 64-bit address for the

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -698,12 +698,12 @@ For examples, see the respective
 .Em Troubleshooting
 entry in the detailed pdf documentation.
 .Pp
-The -c pickit5 programmer allows overriding the product ID with a
-hexadecimal number <pid> using -P usb::<pid> and the vendor and product
-IDs with hexadecimal numbers <vid> and <pid> using -P usb:<vid>:<pid>. The
+The -c pickit5 programmer allows overriding the vendor and product IDs
+with hexadecimal numbers <vid> and <pid> using -P usb:<vid>:<pid>. The
 form -P usb:<serialno> requests AVRDUDE select the PICkit5 programmer with
-a serial number that ends in <serialno> (and with vid/pid from the
-configuration files).
+a serial number that ends in <serialno> and with vid/pid from the
+configuration files. It is also possible to override vid/pid and require a
+serialno match via -P usb:<vid>:<pid>:<serialno>.
 .Pp
 For the XBee programmer the target MCU is to be programmed wirelessly over a
 ZigBee mesh using the XBeeBoot bootloader.  The ZigBee 64-bit address for the

--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -613,18 +613,19 @@ they are automatically identified via their vendor and product IDs from
 avrdude.conf or .avrduderc. Only when there are multiple programmers of
 the same type plugged into the host computer is the -P option needed, see
 below. Some -c programmers, however, ignore the -P option altogether, eg,
-pickit2, teensy or ch341a; these cannot distinguish multiple plugged-in
+pickit2 or teensy; these cannot distinguish multiple plugged-in
 programmers.
 .Pp
-Most USB programmers, however, support the command-line syntax  -P
+Most USB programmers, however, support the command-line syntax -P
 usb[:<vid>:<pid>][:<serialno>] which allows the user to override the
 vendor and product IDs with hexadecimal numbers <vid> and <pid> and/or
 request a match of the desired device's serial number with <serialno>. The
 match is done after stripping any existing colons from the given serial
 number on the command line, and right-to-left, so only the least
 significant bytes from the serial number need to be given. The JTAG ICE
-mkII, JTAGICE3, SNAP, PICKit5 and avrftdi programmers are examples for
-this -P port syntax.
+mkII, JTAGICE3, SNAP, PICKit5, CH341A and avrftdi programmers are examples
+for this -P port syntax. Some of these in turn, e.g. the CH341A, are not
+capable of matching serial numbers.
 .Pp
 If
 .Nm

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -637,31 +637,30 @@ static int avrftdi_pin_setup(const PROGRAMMER *pgm) {
 }
 
 static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
-  int vid, pid, interface, err;
+  int vid, pid, interface, err, numids;
+  char serno[64] = {0};
+  unsigned short new_vid = 0, new_pid = 0;
 
   Avrftdi_data *pdata = to_pdata(pgm);
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(!str_caseeq(port, "usb"))
-    pmsg_warning("option -P %s ignored\n", port);
+
+  // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
+  if((numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, serno, sizeof serno)) < 0) {
+    pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
+    return LIBAVRDUDE_EXIT_FAIL;
+  }
 
   // Parameter validation
 
-  // Use vid/pid in following priority: config, defaults cmd-line is currently not supported
-
-  if(pgm->usbvid)
-    vid = pgm->usbvid;
-  else
-    vid = USB_VENDOR_FTDI;
-
+  // Set vid/pid in following priority: command-line, config, default
+  vid = numids >= 2? new_vid: pgm->usbvid? pgm->usbvid: USB_VENDOR_FTDI;
   LNODEID usbpid = lfirst(pgm->usbpid);
+  pid = numids >= 2? new_pid: usbpid? *(int *) ldata(usbpid): USB_DEVICE_FT2232;
+  if(numids < 2 && usbpid && lnext(usbpid))
+    pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
 
-  if(usbpid) {
-    pid = *(int *) ldata(usbpid);
-    if(lnext(usbpid))
-      pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
-  } else
-    pid = USB_DEVICE_FT2232;
+  const char *serial = *serno? serno: *pgm->usbsn? pgm->usbsn: NULL; // No SN means use first available
 
   if(pgm->usbdev[0] == 'a' || pgm->usbdev[0] == 'A')
     interface = INTERFACE_A;
@@ -675,8 +674,6 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
   // Device setup
 
   E(ftdi_set_interface(pdata->ftdic, interface) < 0, pdata->ftdic);
-
-  const char *serial = *pgm->usbsn? pgm->usbsn: NULL; // No SN means use first available
 
   // Todo: use desc and index argument, currently set to NULL and 0
   err = ftdi_usb_open_desc_index(pdata->ftdic, vid, pid, NULL, serial, 0);

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -645,7 +645,7 @@ static int avrftdi_open(PROGRAMMER *pgm, const char *port) {
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
 
-  // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
+  // Set new_vid, new_pid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
   if((numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, serno, sizeof serno)) < 0) {
     pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
     return LIBAVRDUDE_EXIT_FAIL;

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -448,9 +448,9 @@ static int buspirate_open(PROGRAMMER *pgm, const char *port) {
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   serial_drain(&pgm->fd, 0);

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -329,8 +329,9 @@ static int butterfly_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 19200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  if(serial_open(port, pinfo, &pgm->fd) == -1)
-    return -1;
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   if(my.autoreset) {
     // This code assumes a negative-logic USB to TTL serial adapter

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -196,29 +196,33 @@ bool CH341ChipSelect(const PROGRAMMER *pgm, unsigned int cs, bool enable) {
 }
 
 static int ch341a_open(PROGRAMMER *pgm, const char *port) {
-  LNODEID usbpid = lfirst(pgm->usbpid);
-  int pid, vid, j, r;
+  int pid, vid, j, r, numids;
   int errorCode = USB_ERROR_NOTFOUND;
   libusb_device_handle *handle = NULL;
+  char serno[64] = {0};
+  unsigned short new_vid = 0, new_pid = 0;
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(!str_caseeq(port, "usb"))
-    pmsg_warning("option -P %s ignored\n", port);
+
+  // Set new_vid, new_pid and/or serno from -P usb[:<vid>:<pid>]
+  if((numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, serno, sizeof serno)) < 0) {
+    pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>]\n", port);
+    return LIBAVRDUDE_EXIT_FAIL;
+  }
+  if(*serno)
+    pmsg_warning("ignoring serial number %s given in -P %s\n", serno, port);
+
+  // Set vid/pid in following priority: command-line, config, default
+  vid = numids >= 2? new_vid: pgm->usbvid? pgm->usbvid: CH341A_VID;
+  LNODEID usbpid = lfirst(pgm->usbpid);
+  pid = numids >= 2? new_pid: usbpid? *(int *) ldata(usbpid): CH341A_PID;
+  if(numids < 2 && usbpid && lnext(usbpid))
+    pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
 
   if(!my.USB_init) {
     my.USB_init = 1;
     libusb_init(&my.ctx);
   }
-
-  if(usbpid) {
-    pid = *(int *) ldata(usbpid);
-    if(lnext(usbpid))
-      pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
-  } else {
-    pid = CH341A_PID;
-  }
-  vid = pgm->usbvid? pgm->usbvid: CH341A_VID;
-
   libusb_device **dev_list;
   int dev_list_len = libusb_get_device_list(my.ctx, &dev_list);
 

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -839,9 +839,9 @@ USB-only programmers normally do not need the port option be specified as
 they are automatically identified via their vendor and product IDs from
 @code{avrdude.conf} or @code{.avrduderc}. Only when there are multiple
 programmers of the same type plugged into the host computer is the
-@code{-P} option needed, see below. Some @code{-c} programmers, however,
-ignore the @code{-P} option altogether, eg, pickit5 or teensy;
-these cannot distinguish multiple plugged-in programmers.
+@code{-P} option needed, see below. Some @code{-c} programmers, e.g.,
+pickit5, ignore the @code{-P} option altogether; these cannot distinguish
+multiple plugged-in programmers.
 
 Most USB programmers, however, support the command-line syntax  @code{-P
 usb[:@var{vid}:@var{pid}][:@var{serialno}]} which allows the user to
@@ -850,9 +850,10 @@ override the vendor and product IDs with hexadecimal numbers @var{vid} and
 with @var{serialno}. The match is done after stripping any existing colons
 from the given serial number on the command line, and right-to-left, so
 only the least significant bytes from the serial number need to be given.
-The JTAG ICE mkII, JTAGICE3, SNAP, PICKit5, CH341A and avrftdi programmers
-are examples for this @code{-P} port syntax. Some of these in turn, e.g.
-the CH341A, are not capable of matching serial numbers.
+The JTAG ICE mkII, JTAGICE3, SNAP, PICKit5, CH341A, teensy and avrftdi
+programmers are examples for this @code{-P} port syntax. Some of these in
+turn, e.g. the CH341A and teensy, are not capable of matching serial
+numbers.
 
 If avrdude has been configured with libserialport support, a serial port
 can be specified using a predefined serial adapter type in

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -889,13 +889,13 @@ usb:@var{serialno}}. The USBasp serial number is matched from the end, so
 only the unique least significant bytes are needed. For examples, see the
 respective entry in @ref{Troubleshooting}.
 
-The @code{-c pickit5} programmer allows overriding the product ID with a
-hexadecimal number @var{pid} using @code{-P usb::@var{pid}} and the vendor
-and product IDs with hexadecimal numbers @var{vid} and @var{pid} using
-@code{-P usb:@var{vid}:@var{pid}}. The form @code{-P usb:@var{serialno}}
-requests AVRDUDE select the PICkit5 programmer with a serial number that
-ends in @var{serialno} (and with @var{vid}/@var{pid} from the
-configuration files).
+The @code{-c pickit5} programmer allows overriding the vendor and product
+IDs with hexadecimal numbers @var{vid} and @var{pid} using @code{-P
+usb:@var{vid}:@var{pid}}. The form @code{-P usb:@var{serialno}} requests
+AVRDUDE select the PICkit5 programmer with a serial number that ends in
+@var{serialno} and with @var{vid}/@var{pid} from the configuration files.
+It is also possible to override @var{vid}/@var{pid} and require a
+@var{serialno} match via @code{-P usb:@var{vid}:@var{pid}:@var{serialno}}.
 
 For the XBee programmer the target MCU is to be programmed wirelessly
 over a ZigBee mesh using the XBeeBoot bootloader.  The ZigBee 64-bit

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -840,18 +840,18 @@ they are automatically identified via their vendor and product IDs from
 @code{avrdude.conf} or @code{.avrduderc}. Only when there are multiple
 programmers of the same type plugged into the host computer is the
 @code{-P} option needed, see below. Some @code{-c} programmers, however,
-ignore the @code{-P} option altogether, eg, pickit5, teensy, ch341a or avrftdi;
+ignore the @code{-P} option altogether, eg, pickit5, teensy or ch341a;
 these cannot distinguish multiple plugged-in programmers.
 
 Most USB programmers, however, support the command-line syntax  @code{-P
 usb[:@var{vid}:@var{pid}][:@var{serialno}]} which allows the user to
 override the vendor and product IDs with hexadecimal numbers @var{vid} and
-@var{pid} and/or request a match of the desired device's serial number with
-@var{serialno}. The match is done after stripping any existing colons from the
-given serial number on the command line, and right-to-left, so only the
-least significant bytes from the serial number need to be given. The JTAG
-ICE mkII, JTAGICE3, SNAP, and PICKit5 programmers are examples for this
-@code{-P} port syntax.
+@var{pid} and/or request a match of the desired device's serial number
+with @var{serialno}. The match is done after stripping any existing colons
+from the given serial number on the command line, and right-to-left, so
+only the least significant bytes from the serial number need to be given.
+The JTAG ICE mkII, JTAGICE3, SNAP, PICKit5 and avrftdi programmers are
+examples for this @code{-P} port syntax.
 
 If avrdude has been configured with libserialport support, a serial port
 can be specified using a predefined serial adapter type in

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -840,7 +840,7 @@ they are automatically identified via their vendor and product IDs from
 @code{avrdude.conf} or @code{.avrduderc}. Only when there are multiple
 programmers of the same type plugged into the host computer is the
 @code{-P} option needed, see below. Some @code{-c} programmers, however,
-ignore the @code{-P} option altogether, eg, pickit5, teensy or ch341a;
+ignore the @code{-P} option altogether, eg, pickit5 or teensy;
 these cannot distinguish multiple plugged-in programmers.
 
 Most USB programmers, however, support the command-line syntax  @code{-P
@@ -850,8 +850,9 @@ override the vendor and product IDs with hexadecimal numbers @var{vid} and
 with @var{serialno}. The match is done after stripping any existing colons
 from the given serial number on the command line, and right-to-left, so
 only the least significant bytes from the serial number need to be given.
-The JTAG ICE mkII, JTAGICE3, SNAP, PICKit5 and avrftdi programmers are
-examples for this @code{-P} port syntax.
+The JTAG ICE mkII, JTAGICE3, SNAP, PICKit5, CH341A and avrftdi programmers
+are examples for this @code{-P} port syntax. Some of these in turn, e.g.
+the CH341A, are not capable of matching serial numbers.
 
 If avrdude has been configured with libserialport support, a serial port
 can be specified using a predefined serial adapter type in

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -840,26 +840,37 @@ they are automatically identified via their vendor and product IDs from
 @code{avrdude.conf} or @code{.avrduderc}. Only when there are multiple
 programmers of the same type plugged into the host computer is the
 @code{-P} option needed, see below. Some @code{-c} programmers, however,
-ignore the @code{-P} option altogether, eg, teensy, ch341a or avrftdi;
+ignore the @code{-P} option altogether, eg, pickit5, teensy, ch341a or avrftdi;
 these cannot distinguish multiple plugged-in programmers.
+
+Most USB programmers, however, support the command-line syntax  @code{-P
+usb[:@var{vid}:@var{pid}][:@var{serialno}]} which allows the user to
+override the vendor and product IDs with hexadecimal numbers @var{vid} and
+@var{pid} and/or request a match of the desired device's serial number with
+@var{serialno}. The match is done after stripping any existing colons from the
+given serial number on the command line, and right-to-left, so only the
+least significant bytes from the serial number need to be given. The JTAG
+ICE mkII, JTAGICE3, SNAP, and PICKit5 programmers are examples for this
+@code{-P} port syntax.
 
 If avrdude has been configured with libserialport support, a serial port
 can be specified using a predefined serial adapter type in
 @code{avrdude.conf} or @code{.avrduderc}, e.g., @code{ch340} or
 @code{ft232r}. If more than one serial adapter of the same type is
 connected, they can be distinguished by appending a serial number, e.g.,
-@code{ft232r:12345678}. Note that the USB to serial chip has to have a
-serial number for this to work. Avrdude can check for leading and trailing
-serial number matches as well. In the above example, @code{ft232r:1234}
-would also result in a match, and so would @code{ft232r:...5678}. If the
-USB to serial chip is not known to avrdude, it can be specified using the
-hexadecimal USB vendor ID, hexadecimal product ID and an optional serial
-number, following the serial number matching rules described above, e.g.,
-@code{usb:0x2341:0x0043} or @code{usb:2341:0043:12345678}. To see a list
-of currently plugged-in serial ports use @code{-P ?s}. In order to see a
-list of all possible serial adapters known to avrdude use @code{-P ?sa}.
-Depending on the used shell, @code{?} may need to be quoted as in
-@code{"?"} or @code{\?}.
+@code{ft232r:12345678}. The USB to serial chip has to have a serial number
+for this to work. Note that serial number matches for serial adapters (in
+contrast to matches for USB programmers above) ist from left-to-right. For
+matches from right-to-left, serial adapters can use the ellipses. In the
+above example, @code{ft232r:1234} would also result in a match, and so
+would @code{ft232r:...5678}. If the USB to serial chip is not known to
+avrdude, it can be specified using the hexadecimal USB vendor ID,
+hexadecimal product ID and an optional serial number, following the serial
+number matching rules described above, e.g., @code{usb:0x2341:0x0043} or
+@code{usb:2341:0043:12345678}. To see a list of currently plugged-in
+serial ports use @code{-P ?s}. In order to see a list of all possible
+serial adapters known to avrdude use @code{-P ?sa}. Depending on the used
+shell, @code{?} may need to be quoted as in @code{"?"} or @code{\?}.
 
 For the JTAG ICE mkII, if AVRDUDE has been built with libusb support, the
 port can be specified as @code{usb}[:@var{serialno}].  In that case, the
@@ -888,14 +899,6 @@ usb:@var{busdir}:@var{devicefile}} or using the serial number @code{-P
 usb:@var{serialno}}. The USBasp serial number is matched from the end, so
 only the unique least significant bytes are needed. For examples, see the
 respective entry in @ref{Troubleshooting}.
-
-The @code{-c pickit5} programmer allows overriding the vendor and product
-IDs with hexadecimal numbers @var{vid} and @var{pid} using @code{-P
-usb:@var{vid}:@var{pid}}. The form @code{-P usb:@var{serialno}} requests
-AVRDUDE select the PICkit5 programmer with a serial number that ends in
-@var{serialno} and with @var{vid}/@var{pid} from the configuration files.
-It is also possible to override @var{vid}/@var{pid} and require a
-@var{serialno} match via @code{-P usb:@var{vid}:@var{pid}:@var{serialno}}.
 
 For the XBee programmer the target MCU is to be programmed wirelessly
 over a ZigBee mesh using the XBeeBoot bootloader.  The ZigBee 64-bit

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1775,7 +1775,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
       notfirst = 1;
     }
     char serno[64] = {0};
-    if(str_set_vid_pid_serno(port, NULL, NULL, 0, serno, sizeof serno) >= 0 && *serno)
+    if(str_set_vid_pid_serno(port, NULL, NULL, serno, sizeof serno) >= 0 && *serno)
       msg_error(" with SN %s", serno);
     msg_error("\n");
 

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1698,6 +1698,7 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
 
   if(rv < 0) {
     // Check if SNAP or PICkit4 are in PIC mode
+    unsigned short vidbak = pinfo.usbinfo.vid; // Save vid
     for(LNODEID ln = lfirst(pgm->id); ln; ln = lnext(ln)) {
       if(str_starts(ldata(ln), "snap") || str_starts(ldata(ln), "pickit4")) {
         bool is_snap_pgm = str_starts(ldata(ln), "snap");
@@ -1763,20 +1764,19 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
         }
       }
     }
+    pinfo.usbinfo.vid = vidbak; // Restore vid
+
     pmsg_error("no device found matching VID 0x%04x and PID list: ", (unsigned) pinfo.usbinfo.vid);
     int notfirst = 0;
-
     for(usbpid = lfirst(pgm->usbpid); usbpid; usbpid = lnext(usbpid)) {
       if(notfirst)
         msg_error(", ");
       msg_error("0x%04x", (unsigned int) *(int *) ldata(usbpid));
       notfirst = 1;
     }
-
-    char *serno;
-
-    if((serno = strchr(port, ':')))
-      msg_error(" with SN %s", ++serno);
+    char serno[64] = {0};
+    if(str_set_vid_pid_serno(port, NULL, NULL, 0, serno, sizeof serno) >= 0 && *serno)
+      msg_error(" with SN %s", serno);
     msg_error("\n");
 
     return -1;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1673,6 +1673,8 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
 
     pgm->port = port;
     rv = serial_open(port, pinfo, &pgm->fd);
+    if(rv == LIBAVRDUDE_EXIT_FAIL || rv == LIBAVRDUDE_EXIT_OK)
+      return rv;
   }
   if(rv < 0) {
 #endif                          // HAVE_LIBHIDAPI
@@ -1689,6 +1691,8 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
 
       pgm->port = port;
       rv = serial_open(port, pinfo, &pgm->fd);
+      if(rv == LIBAVRDUDE_EXIT_FAIL || rv == LIBAVRDUDE_EXIT_OK)
+        return rv;
     }
 #endif                          // HAVE_LIBUSB
 
@@ -1714,9 +1718,13 @@ int jtag3_open_common(PROGRAMMER *pgm, const char *port, int mode_switch) {
         int pic_mode = serial_open(port, pinfo, &pgm->fd);
 
         if(pic_mode < 0) {
+          if(pic_mode == LIBAVRDUDE_EXIT_FAIL || pic_mode == LIBAVRDUDE_EXIT_OK)
+            return pic_mode;
           // Retry with bootloader USB PID
           pinfo.usbinfo.pid = bl_pid;
           pic_mode = serial_open(port, pinfo, &pgm->fd);
+          if(pic_mode == LIBAVRDUDE_EXIT_FAIL || pic_mode == LIBAVRDUDE_EXIT_OK)
+            return pic_mode;
         }
         if(pic_mode >= 0) {
           const char *partsdesc_flag = partdesc? " -p ": "";

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -522,9 +522,9 @@ static int jtagmkI_open(PROGRAMMER *pgm, const char *port) {
     pinfo.serialinfo.baud = baudtab[i].baud;
     pinfo.serialinfo.cflags = SERIAL_8N1;
     pmsg_notice2("%s(): trying to sync at baud rate %ld:\n", __func__, pinfo.serialinfo.baud);
-    if(serial_open(port, pinfo, &pgm->fd) == -1) {
-      return -1;
-    }
+    int rc;
+    if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+      return rc;
 
     // Drain any extraneous input
     jtagmkI_drain(pgm, 0);

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1417,9 +1417,9 @@ static int jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   jtagmkII_drain(pgm, 0);
@@ -1467,9 +1467,9 @@ static int jtagmkII_open_dw(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   jtagmkII_drain(pgm, 0);
@@ -1517,9 +1517,9 @@ static int jtagmkII_open_pdi(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   jtagmkII_drain(pgm, 0);
@@ -1573,9 +1573,9 @@ static int jtagmkII_dragon_open(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   jtagmkII_drain(pgm, 0);
@@ -1623,9 +1623,9 @@ static int jtagmkII_dragon_open_dw(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   jtagmkII_drain(pgm, 0);
@@ -1650,11 +1650,7 @@ static int jtagmkII_dragon_open_pdi(PROGRAMMER *pgm, const char *port) {
   pinfo.serialinfo.baud = 19200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
 
-  /*
-   * If the port name starts with "usb", divert the serial routines to the USB
-   * ones.  The serial_open() function for USB overrides the meaning of the
-   * "baud" parameter to be the USB device ID to search for.
-   */
+  // If the port name starts with "usb", divert the serial routines to the USB ones
   if(str_casestarts(port, "usb")) {
 
 #if defined(HAVE_LIBUSB)
@@ -1673,9 +1669,9 @@ static int jtagmkII_dragon_open_pdi(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   jtagmkII_drain(pgm, 0);
@@ -3255,9 +3251,9 @@ static int jtagmkII_open32(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   jtagmkII_drain(pgm, 0);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1737,7 +1737,7 @@ extern "C" {
   unsigned long long int str_int(const char *str, int type, const char **errpp);
   int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
   int str_set_vid_pid_serno(const char *port, unsigned short *vidp, unsigned short *pidp,
-    int defvid, char *serno, size_t n);
+    char *serno, size_t n);
   char *str_nexttok(char *buf, const char *delim, char **next);
   const char *str_ccfrq(double f, int n);
   const char *str_cchex(const void *buf, size_t len, int add_space);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1736,6 +1736,8 @@ extern "C" {
   void str_freedata(Str2data *sd);
   unsigned long long int str_int(const char *str, int type, const char **errpp);
   int str_membuf(const char *str, int type, unsigned char *buf, int size, const char **errpp);
+  int str_set_vid_pid_serno(const char *port, unsigned short *vidp, unsigned short *pidp,
+    int defvid, char *serno, size_t n);
   char *str_nexttok(char *buf, const char *delim, char **next);
   const char *str_ccfrq(double f, int n);
   const char *str_cchex(const void *buf, size_t len, int add_space);

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -650,93 +650,47 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
   union pinfo pinfo;
   LNODEID usbpid;
   int rv = LIBAVRDUDE_GENERAL_FAILURE;
-  size_t serial_num_len = 0;
 
 #if !defined(HAVE_LIBUSB)
   pmsg_error("need to be compiled with USB or HIDAPI support\n");
   return LIBAVRDUDE_GENERAL_FAILURE;
 #endif
 
-  if(!str_casestarts(port, "usb:") && !str_caseeq(port, "usb")) {
-    pmsg_error("invalid -P %s; drop -P option or else use -P usb:<vid>:<pid> or -P usb:<serialno>\n", port);
+  unsigned short new_vid = 0, new_pid = 0;
+  char serno[64] = { 0 };
+  int numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, USB_VENDOR_MICROCHIP, serno, sizeof serno);
+  if(numids < 0) {
+    pmsg_error("invalid -P %s; drop -P option or else use -P usb[:[<vid>]:<pid>][:<serno>]\n", port);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
-  unsigned int new_vid = 0, new_pid = 0, setids = 0;
-  const char *vidp, *pidp;
-
-  /*
-   * The syntax for usb devices is defined as:
-   *
-   * -P usb:vid:pid
-   * -P usb::pid
-   * -P usb:serialnumber
-   * -P usb
-   *
-   * First we check if we have two colons.
-   * Then check the filed between the two colons is empty
-   * Parse VID as hex number
-   * If it is empty, assume Microchip VID
-   * The PID is handled similary but can not be empty
-   *
-   * If there are fewer than two colons nothing is changed
-   */
-
-  vidp = strchr(port, ':');
-  if(vidp != NULL) {
-    vidp += 1;
-    pidp = strchr(vidp, ':');
-    if(pidp != NULL) {
-      setids = 1;
-      if(vidp != pidp) {        // User specified an VID
-        // First: Handle VID input
-        if(sscanf(vidp, "%x", &new_vid) != 1) {
-          pmsg_error("failed to parse -P VID input %s: expected hexadecimal number\n", vidp);
-          return LIBAVRDUDE_GENERAL_FAILURE;
-        }
-      } else {                  // VID space empty: default to Microchip
-        new_vid = USB_VENDOR_MICROCHIP;
-      }
-
-      // Now handle PID input
-      if(sscanf(pidp + 1, "%x", &new_pid) != 1) {
-        pmsg_error("failed to parse -P PID input %s: expected hexadecimal number\n", pidp+1);
-        return LIBAVRDUDE_GENERAL_FAILURE;
-      }
-
-      pmsg_notice("overwriting VID:PID to %04x:%04x\n", new_vid, new_pid);
-      port = "usb";             // Overwrite the string to avoid confusing the libusb
-    } else {                    // pidp == NULL means vidp points to serial number
-      serial_num_len = strlen(vidp);
-    }
-  }                             // vidp == NULL means dropped -P option or -P usb
 
   // If the config entry did not specify a USB PID, insert the default one
   if(lfirst(pgm->usbpid) == NULL)
     ladd(pgm->usbpid, (void *) USB_DEVICE_PICKIT5);
 
-  pinfo.usbinfo.vid = pgm->usbvid? pgm->usbvid: USB_VENDOR_MICROCHIP;
-
   // PICkit 5 does not have support for HID, so no need to support it
   serdev = &usb_serdev;
-  if(setids) {                  // In case a specific VID/PID was specified
+  pinfo.usbinfo.vid = pgm->usbvid? pgm->usbvid: USB_VENDOR_MICROCHIP;
+  pinfo.usbinfo.flags = PINFO_FL_SILENT;
+  if(numids >= 2) {             // Valid VID:PID was specified in -P port
+    if(pinfo.usbinfo.vid != new_vid || pinfo.usbinfo.pid != new_pid)
+      pmsg_notice("overwriting VID:PID to %04x:%04x\n", new_vid, new_pid);
     pinfo.usbinfo.vid = new_vid;
     pinfo.usbinfo.pid = new_pid;
-    pinfo.usbinfo.flags = PINFO_FL_SILENT;
     pgm->fd.usb.max_xfer = USB_PK5_MAX_XFER;
     pgm->fd.usb.rep = USB_PK5_CMD_READ_EP;  // Command read
     pgm->fd.usb.wep = USB_PK5_CMD_WRITE_EP; // Command write
     pgm->fd.usb.eep = 0x00;
+    port = str_sprintf("usb:%s", serno); // Avoids passing on usb::<pid>:<serno>
     pgm->port = port;
     rv = serial_open(port, pinfo, &pgm->fd);
   } else {                      // Otherwise walk the list of config file PIDs
     for(usbpid = lfirst(pgm->usbpid); rv < 0 && usbpid != NULL; usbpid = lnext(usbpid)) {
-      pinfo.usbinfo.flags = PINFO_FL_SILENT;
       pinfo.usbinfo.pid = *(int *) ldata(usbpid);
       pgm->fd.usb.max_xfer = USB_PK5_MAX_XFER;
       pgm->fd.usb.rep = USB_PK5_CMD_READ_EP;  // Command read
       pgm->fd.usb.wep = USB_PK5_CMD_WRITE_EP; // Command write
       pgm->fd.usb.eep = 0x00;
-
       pgm->port = port;
       rv = serial_open(port, pinfo, &pgm->fd);
     }
@@ -808,8 +762,8 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
       serial_close(&pgm->fd);
       return LIBAVRDUDE_EXIT_FAIL;
     }
-    if(serial_num_len) {
-      pmsg_error("no device found matching the specified serial number %s", vidp);
+    if(*serno) {
+      pmsg_error("no device found matching the specified serial number %s", serno);
       return LIBAVRDUDE_GENERAL_FAILURE;
     }
 

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -681,7 +681,6 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
     pgm->fd.usb.rep = USB_PK5_CMD_READ_EP;  // Command read
     pgm->fd.usb.wep = USB_PK5_CMD_WRITE_EP; // Command write
     pgm->fd.usb.eep = 0x00;
-    port = str_sprintf("usb:%s", serno); // Avoids passing on usb::<pid>:<serno>
     pgm->port = port;
     rv = serial_open(port, pinfo, &pgm->fd);
   } else {                      // Otherwise walk the list of config file PIDs

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -658,9 +658,9 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
 
   unsigned short new_vid = 0, new_pid = 0;
   char serno[64] = { 0 };
-  int numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, USB_VENDOR_MICROCHIP, serno, sizeof serno);
+  int numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, serno, sizeof serno);
   if(numids < 0) {
-    pmsg_error("invalid -P %s; drop -P option or else use -P usb[:[<vid>]:<pid>][:<serno>]\n", port);
+    pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
     return LIBAVRDUDE_GENERAL_FAILURE;
   }
 

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -661,7 +661,7 @@ static int pickit5_open(PROGRAMMER *pgm, const char *port) {
   int numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, serno, sizeof serno);
   if(numids < 0) {
     pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
-    return LIBAVRDUDE_GENERAL_FAILURE;
+    return LIBAVRDUDE_EXIT_FAIL;
   }
 
   // If the config entry did not specify a USB PID, insert the default one

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -331,9 +331,10 @@ int touch_serialport(char **portp, int baudrate, int nwaits) {
 
   pinfo.serialinfo.baud = baudrate;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  if(serial_open(*portp, pinfo, &fd) == -1) {
+  int rc;
+  if((rc = serial_open(*portp, pinfo, &fd)) < 0) {
     pmsg_error("%s() failed to open port %s at %d baud\n", __func__, *portp, baudrate);
-    return -1;
+    return rc;
   }
   serial_set_dtr_rts(&fd, 1);
   usleep(100);

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -169,8 +169,9 @@ static int serprog_open(PROGRAMMER *pgm, const char *port) {
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  if(serial_open(port, pinfo, &pgm->fd) == -1)
-    return -1;
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   unsigned char buf[32];
 

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -854,9 +854,9 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   stk500_drain(pgm, 0);

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1365,7 +1365,7 @@ static int stk500v2_jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if(my.vtarg_switch_get) {
       pmsg_info("Vtarg switch setting read as %u: target power is switched %s\n",
         my.vtarg_switch_data[0], my.vtarg_switch_data[0]? "on": "off");
-    } 
+    }
     // Write Vtarg switch value
     if(my.vtarg_switch_set) {
       if(jtag3_setparm(pgmcp, SCOPE_EDBG, EDBG_CTXT_CONTROL,
@@ -1504,7 +1504,7 @@ static int stk500hv_initialize(const PROGRAMMER *pgm, const AVRPART *p, enum hvm
           my.varef_channel, (varef_read/100.0));
       }
       // STK600: Write target voltage value for channel n
-      if(my.varef_set) {                  
+      if(my.varef_set) {
         msg_info("Changing analog reference channel %d voltage from %.2f V to %.2f V\n",
           my.varef_channel, (varef_read/100.0), my.varef_data);
         if(pgm->set_varef(pgm, my.varef_channel, my.varef_data) < 0)
@@ -2148,9 +2148,9 @@ static int stk500v2_open(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Make USB serial number and USB product name available to programmer
   if(serdev) {
@@ -2216,9 +2216,9 @@ static int stk600_open(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input, synchronise and drain again
   if(stk500v2_drain(pgm, 0) < 0 || stk500v2_getsync(pgm) < 0 || stk500v2_drain(pgm, 0) < 0)
@@ -3927,9 +3927,9 @@ static int stk500v2_jtagmkII_open(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   stk500v2_drain(pgm, 0);
@@ -4025,9 +4025,9 @@ static int stk500v2_dragon_isp_open(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   stk500v2_drain(pgm, 0);
@@ -4098,9 +4098,9 @@ static int stk500v2_dragon_hv_open(PROGRAMMER *pgm, const char *port) {
   }
 
   pgm->port = port;
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // Drain any extraneous input
   stk500v2_drain(pgm, 0);

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1231,6 +1231,94 @@ finished:
 }
 
 /*
+ * The syntax of the -P port string is -P usb[[:[<vid>]:<pid>]:<serno>]
+ *
+ * Set *vidp and *pidp if <vid> and <pid> are hex strings in [0, 0xffff];
+ * an empty <vid> string is allowed if defvid is given as non-negative
+ * number, in which case *vidp is set to defvid. In case there is no valid
+ * <vid>/<pid> pair, the full string after usb: is treated as serial
+ * number, as is any trailing string a after a valid usb:<vid>:<pid>:
+ * sequence. Serial numbers, if detected in the port string, are stripped
+ * of colon characters, while a maximum of n-1 serial number characters
+ * are stored in the space pointed to by serno, followed by a terminating
+ * nul character.
+ *
+ * Returns
+ *  -1 on failed parsing
+ *   0 if no paramters could be set
+ *   1 if only serno could be set
+ *   2 if only vid and pid could be set
+ *   3 if vid, pid and serno could be set
+ *
+ * *vidp and *pidp are unchanged for return values smaller than 2. The
+ * buffer serno may be set with the initial serial number if n turned out
+ * to be too small to hold the full serial number: in this case the return
+ * value is 0 or 2 indicating the serial number could not be completely
+ * copied over from the port string. On a failed parsing or on -P usb,
+ * serno is not set, otherwise it will contain a nul-terminated string
+ * within the n bytes size associated with serno.
+ */
+
+int str_set_vid_pid_serno(const char *port, unsigned short *vidp, unsigned short *pidp,
+  int defvid, char *serno, size_t n) {
+
+  unsigned long vid, pid;
+  const char *pidstr, *sn = port + 4;
+  char *endhex;
+  int ret = 0;
+
+  if(!str_casestarts(port, "usb"))
+    return -1;
+
+  if(port[3] != ':')            // -P usb returns 0, wrong character after -p usb returns -1
+    return port[3] == 0? 0: -1;
+
+  if(port[4] == ':' && defvid >= 0) { // -P usb::<pid> <vid> sets vid to defvid if given
+    vid = defvid;
+    pidstr = port + 5;
+  } else {                      // Scan hex vid and ensure it's terminated by :
+    errno = 0;
+    vid = strtoul(port + 4, &endhex, 16);
+    if(endhex == port + 4 || *endhex != ':' || errno || vid > 0xffff)
+      goto setserno;
+    pidstr = endhex + 1;
+  }
+
+  errno = 0;                    // Scan hex pid and ensure it's terminated by nul or :
+  pid = strtoul(pidstr, &endhex, 16);
+  if(endhex == pidstr || (*endhex != 0 && *endhex != ':') || errno || pid > 0xffff)
+    goto setserno;
+
+  if(vidp)
+    *vidp = (int) vid;
+  if(pidp)
+    *pidp = (int) pid;
+
+  if(*endhex == 0)              // No :<serno> after <pid>? Finished
+    return 2;
+
+  sn = endhex + 1;
+  ret = 2;
+setserno:
+
+  if(serno && !n)
+    return ret;
+
+  // Copy the serial number into given buffer but without colons
+  for(; *sn; sn++)
+    if(*sn != ':') {
+      if(!--n)
+        break;
+      if(serno)
+        *serno++ = *sn;
+     }
+  if(serno)
+    *serno = 0;
+
+  return ret + !*sn;            // Return 0 iff serno buffer was too short
+}
+
+/*
  * Returns the next space separated token in buf (terminating it) and places
  * start of next token into pointer pointed to by next. Keeps single or double
  * quoted strings together and changes backslash-space sequences to space

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1231,41 +1231,34 @@ finished:
 }
 
 /*
- * The syntax of the -P port string is -P usb[[:[<vid>]:<pid>]:<serno>]
+ * The syntax of the -P port string is -P usb[:<vid>:<pid>]:[<serno>]
  *
- * Set *vidp and *pidp if <vid> and <pid> are hex strings in [0, 0xffff];
- * an empty <vid> string is allowed if defvid is given as non-negative
- * number, in which case *vidp is set to defvid. In case there is no valid
- * <vid>/<pid> pair, the full string after usb: is treated as serial
- * number, as is any trailing string a after a valid usb:<vid>:<pid>:
- * sequence. Serial numbers, if detected in the port string, are stripped
- * of colon characters, while a maximum of n-1 serial number characters
- * are stored in the space pointed to by serno, followed by a terminating
- * nul character.
+ * Set *vidp and *pidp iff <vid> and <pid> are hex strings in [0, 0xffff]. If
+ * there is no valid :<vid>:<pid> pair the full string after usb: is treated as
+ * serial number, as is any trailing string after a valid usb:<vid>:<pid>:
+ * sequence. Serial numbers, if detected in port, are stripped of colons, while
+ * a maximum of n-1 serial-number characters are stored in the serno buffer
+ * followed by a terminating nul character. If the serno buffer is too small
+ * serno remains unset and the port argument is considered invalid.
  *
  * Returns
- *  -1 on failed parsing
- *   0 if no paramters could be set
- *   1 if only serno could be set
- *   2 if only vid and pid could be set
- *   3 if vid, pid and serno could be set
+ *  -1 on failed parsing (-P string does not start with usb[:], n too small)
+ *   0 if no paramters was set (-P usb)
+ *   1 if only serno was set or serno could have been set but was NULL
+ *   2 if only vid and pid were or could have been set
+ *   3 if vid, pid and serno were or could have been set
  *
- * *vidp and *pidp are unchanged for return values smaller than 2. The
- * buffer serno may be set with the initial serial number if n turned out
- * to be too small to hold the full serial number: in this case the return
- * value is 0 or 2 indicating the serial number could not be completely
- * copied over from the port string. On a failed parsing or on -P usb,
- * serno is not set, otherwise it will contain a nul-terminated string
- * within the n bytes size associated with serno.
+ * *vidp and *pidp remain unchanged for return values smaller than 2. The serno
+ * buffer remains unchanged on return values other than 1 or 3.
  */
 
 int str_set_vid_pid_serno(const char *port, unsigned short *vidp, unsigned short *pidp,
-  int defvid, char *serno, size_t n) {
+  char *serno, const size_t n) {
 
   unsigned long vid, pid;
-  const char *pidstr, *sn = port + 4;
-  char *endhex;
+  const char *sn = port + 4;
   int ret = 0;
+  char *pidstr, *endhex;
 
   if(!str_casestarts(port, "usb"))
     return -1;
@@ -1273,26 +1266,21 @@ int str_set_vid_pid_serno(const char *port, unsigned short *vidp, unsigned short
   if(port[3] != ':')            // -P usb returns 0, wrong character after -p usb returns -1
     return port[3] == 0? 0: -1;
 
-  if(port[4] == ':' && defvid >= 0) { // -P usb::<pid> <vid> sets vid to defvid if given
-    vid = defvid;
-    pidstr = port + 5;
-  } else {                      // Scan hex vid and ensure it's terminated by :
-    errno = 0;
-    vid = strtoul(port + 4, &endhex, 16);
-    if(endhex == port + 4 || *endhex != ':' || errno || vid > 0xffff)
-      goto setserno;
-    pidstr = endhex + 1;
-  }
+  errno = 0;                    // Read hex vid and assert it is followed by a colon
+  vid = strtoul(port + 4, &endhex, 16);
+  if(endhex == port + 4 || *endhex != ':' || errno || vid > 0xffff)
+    goto setserno;
 
-  errno = 0;                    // Scan hex pid and ensure it's terminated by nul or :
+  errno = 0;                    // Read hex pid and assert it is followed by nul or colon
+  pidstr = endhex + 1;
   pid = strtoul(pidstr, &endhex, 16);
   if(endhex == pidstr || (*endhex != 0 && *endhex != ':') || errno || pid > 0xffff)
     goto setserno;
 
   if(vidp)
-    *vidp = (int) vid;
+    *vidp = vid;
   if(pidp)
-    *pidp = (int) pid;
+    *pidp = pid;
 
   if(*endhex == 0)              // No :<serno> after <pid>? Finished
     return 2;
@@ -1301,21 +1289,24 @@ int str_set_vid_pid_serno(const char *port, unsigned short *vidp, unsigned short
   ret = 2;
 setserno:
 
-  if(serno && !n)
-    return ret;
+  if(!n)
+    return -1;
 
+  char *serbuf = mmt_malloc(n), *bp;
   // Copy the serial number into given buffer but without colons
-  for(; *sn; sn++)
+  for(bp = serbuf; *sn; sn++)
     if(*sn != ':') {
-      if(!--n)
+      if(bp >= serbuf + n-1)
         break;
-      if(serno)
-        *serno++ = *sn;
-     }
-  if(serno)
-    *serno = 0;
+      *bp++ = *sn;
+    }
+  *bp = 0;
 
-  return ret + !*sn;            // Return 0 iff serno buffer was too short
+  if(serno && !*sn)
+    memcpy(serno, serbuf, n);
+  mmt_free(serbuf);
+
+  return *sn? -1: ret+1;
 }
 
 /*

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -305,27 +305,31 @@ static int teensy_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 static int teensy_open(PROGRAMMER *pgm, const char *port) {
+  char serno[64] = {0};
+  unsigned short new_vid = 0, new_pid = 0;
+  int vid, pid, numids;
+
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(!str_caseeq(port, "usb"))
-    pmsg_warning("option -P %s ignored\n", port);
+
+  // Set new_vid, new_pid and/or serno from -P usb[:<vid>:<pid>]
+  if((numids = str_set_vid_pid_serno(port, &new_vid, &new_pid, serno, sizeof serno)) < 0) {
+    pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>]\n", port);
+    return LIBAVRDUDE_EXIT_FAIL;
+  }
+  if(*serno)
+    pmsg_warning("ignoring serial number %s given in -P %s\n", serno, port);
+
+  // Set vid/pid in following priority: command-line, config, default
+  vid = numids >= 2? new_vid: pgm->usbvid? pgm->usbvid: TEENSY_VID;
+  LNODEID usbpid = lfirst(pgm->usbpid);
+  pid = numids >= 2? new_pid: usbpid? *(int *) ldata(usbpid): TEENSY_PID;
+  if(numids < 2 && usbpid && lnext(usbpid))
+    pmsg_warning("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
 
   if(pgm->bitclock)
     pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
 
   struct pdata *pdata = &my;
-
-  // Determine VID/PID
-  int vid = pgm->usbvid? pgm->usbvid: TEENSY_VID;
-  int pid = TEENSY_PID;
-
-  LNODEID usbpid = lfirst(pgm->usbpid);
-
-  if(usbpid != NULL) {
-    pid = *(int *) ldata(usbpid);
-    if(lnext(usbpid)) {
-      pmsg_error("using PID 0x%04x, ignoring remaining PIDs in list\n", pid);
-    }
-  }
 
   bool show_retry_message = true;
 

--- a/src/updi_link.c
+++ b/src/updi_link.c
@@ -57,10 +57,10 @@ static int updi_physical_open(PROGRAMMER *pgm, int baudrate, unsigned long cflag
 
   pmsg_debug("opening serial port ...\n");
 
-  if(serial_open(pgm->port, pinfo, &pgm->fd) == -1) {
-
+  int rc;
+  if((rc = serial_open(pgm->port, pinfo, &pgm->fd)) < 0) {
     pmsg_debug("serial port open failed!\n");
-    return -1;
+    return rc;
   }
 
   // Drain any extraneous input

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2249,8 +2249,9 @@ static int urclock_open(PROGRAMMER *pgm, const char *port) {
   pinfo.serialinfo.cflags = SERIAL_8N1;
 
   pmsg_debug("%s(\"%s\")\n", __func__, port);
-  if(serial_open(port, pinfo, &pgm->fd) == -1)
-    return -1;
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   if(!ur.noautoreset) {
     // This code assumes a negative-logic USB to TTL serial adapter

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -64,7 +64,8 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
 
     list = hid_enumerate(pinfo.usbinfo.vid, pinfo.usbinfo.pid);
     if(list == NULL) {
-      pmsg_error("no USB HID devices found\n");
+      if(!(pinfo.usbinfo.flags & PINFO_FL_SILENT))
+        pmsg_error("no USB HID devices found\n");
       return -1;
     }
 
@@ -82,7 +83,8 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       walk = walk->next;
     }
     if(walk == NULL) {
-      pmsg_error("no matching device found\n");
+      if(!(pinfo.usbinfo.flags & PINFO_FL_SILENT))
+        pmsg_error("no matching device found\n");
       hid_free_enumeration(list);
       return -1;
     }

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -48,7 +48,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
   // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
   if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, serno, sizeof serno) < 0) {
     pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
-    return -1;
+    return LIBAVRDUDE_EXIT_FAIL;
   }
 
   if(*serno) {
@@ -151,7 +151,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
         // The JTAGICE3 running CMSIS-DAP doesn't use a separate endpoint for event reception
         fd->usb.eep = 0;
         fd->usb.max_xfer = 64;
-        pmsg_debug("usbhid_open(): product string: %s\n", cn);
+        pmsg_debug("%s(): product string: %s\n", __func__, cn);
       }
     }
   }

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -45,9 +45,9 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
   if(fd->usb.max_xfer == 0)
     fd->usb.max_xfer = USBDEV_MAX_XFER_3;
 
-  // Override/set pid, vid and/or serno from -P usb[[:[<vid>]:<pid>]:<serno>]
+  // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
   if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, -1, serno, sizeof serno) < 0) {
-    pmsg_error("parsing error in -P %s\n", port);
+    pmsg_error("invalid -P %s; drop -P option or else use -P usb[:<vid>:<pid>][:<serno>]\n", port);
     return -1;
   }
 

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -46,8 +46,8 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
     fd->usb.max_xfer = USBDEV_MAX_XFER_3;
 
   // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
-  if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, -1, serno, sizeof serno) < 0) {
-    pmsg_error("invalid -P %s; drop -P option or else use -P usb[:<vid>:<pid>][:<serno>]\n", port);
+  if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, serno, sizeof serno) < 0) {
+    pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
     return -1;
   }
 

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -37,54 +37,24 @@
 
 #include "usbdevs.h"
 
-/*
- * The "baud" parameter is meaningless for USB devices, so we reuse it to pass
- * the desired USB device ID.
- */
 static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor *fd) {
   hid_device *dev = NULL;
-  char serno[64], *s;
-  const char *serp, *vidp, *pidp;
+  char serno[64] = {0};
   unsigned char usbbuf[USBDEV_MAX_XFER_3 + 1];
 
   if(fd->usb.max_xfer == 0)
     fd->usb.max_xfer = USBDEV_MAX_XFER_3;
 
-  /*
-   * The syntax for usb devices is defined as:
-   *
-   * -P usb:vid:pid
-   * -P usb:serialnumber
-   * -P usb
-   *
-   * First check for a valid vid:pid pair, then see if there is a serial number
-   * passed here. The serial number might contain colons which are removed;
-   * comparison is right-to-left, so only the least significant nibbles need to
-   * be specified.
-   */
-
-  if((vidp = strchr(port, ':')) && (pidp = strchr(vidp + 1, ':'))) {
-    int vid, pid;
-
-    if(sscanf(vidp + 1, "%x", &vid) == 1 && sscanf(pidp + 1, "%x", &pid) == 1) {
-      if((dev = hid_open(vid, pid, NULL))) {
-        pmsg_notice2("USB device with VID: 0x%04x and PID: 0x%04x\n", vid, pid);
-        pinfo.usbinfo.vid = vid;
-        pinfo.usbinfo.pid = pid;
-      }
-    }
+  // Override/set pid, vid and/or serno from -P usb[[:[<vid>]:<pid>]:<serno>]
+  if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, -1, serno, sizeof serno) < 0) {
+    pmsg_error("parsing error in -P %s\n", port);
+    return -1;
   }
 
-  if(!dev && (serp = vidp) && *++serp) {
-    // First, get a copy of the serial number w/out colons
-    for(s = serno; *serp && s < serno + sizeof serno - 1; serp++)
-      if(*serp != ':')
-        *s++ = *serp;
-    *s = 0;
-
+  if(*serno) {
     wchar_t wserno[sizeof serno] = { 0 };
     mbstowcs(wserno, serno, sizeof serno);
-    size_t serlen = s - serno;
+    size_t serlen = strlen(serno);
 
     /*
      * Now, try finding all devices matching VID:PID, and compare their serial
@@ -123,7 +93,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
       pmsg_error("found device, but hid_open_path() failed\n");
       return -1;
     }
-  } else if(!dev) {
+  } else {
     dev = hid_open(pinfo.usbinfo.vid, pinfo.usbinfo.pid, NULL);
     if(dev == NULL) {
       pmsg_notice2("USB device with VID: 0x%04x and PID: 0x%04x not found\n", pinfo.usbinfo.vid, pinfo.usbinfo.pid);

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -213,7 +213,7 @@ static int usbhid_open(const char *port, union pinfo pinfo, union filedescriptor
     }
   }
   if(fd->usb.max_xfer > USBDEV_MAX_XFER_3) {
-    pmsg_error("unexpected max size %d, reducing to %d\n", fd->usb.max_xfer, USBDEV_MAX_XFER_3);
+    pmsg_error("reducing too big max packet size %d to %d\n", fd->usb.max_xfer, USBDEV_MAX_XFER_3);
     fd->usb.max_xfer = USBDEV_MAX_XFER_3;
   }
 

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -145,11 +145,6 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
             goto trynext;
           }
 
-          if(usb_set_configuration(udev, dev->config[0].bConfigurationValue)) {
-            pmsg_notice("(config %d) %s\n", dev->config[0].bConfigurationValue, usb_strerror());
-            // goto trynext;    // Let's hope it has already been configured
-          }
-
           int usehid = !!(pinfo.usbinfo.flags & PINFO_FL_USEHID);
           for(iface = 0; iface < dev->config[0].bNumInterfaces; iface++) {
             cx->usb_interface = dev->config[0].interface[iface].altsetting[0].bInterfaceNumber;

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -67,7 +67,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
   // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
   if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, serno, sizeof serno) < 0) {
     pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
-    return -1;
+    return LIBAVRDUDE_EXIT_FAIL;
   }
 
   usb_init();

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -64,9 +64,9 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
   if(fd->usb.max_xfer == 0)
     fd->usb.max_xfer = USBDEV_MAX_XFER_MKII;
 
-  // Override/set pid, vid and/or serno from -P usb[[:[<vid>]:<pid>]:<serno>]
+  // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
   if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, -1, serno, sizeof serno) < 0) {
-    pmsg_error("parsing error in -P %s\n", port);
+    pmsg_error("invalid -P %s; drop -P option or else use -P usb[:<vid>:<pid>][:<serno>]\n", port);
     return -1;
   }
 

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -207,7 +207,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
             // (usehid && (mps == 64 || mps == 512)) suggested by Claude free chatbot (Sonnet 4.6 Low)
             if((usehid && (mps == 64 || mps == 512)) || mps < fd->usb.max_xfer) {
               if(mps != fd->usb.max_xfer) {
-                pmsg_notice("CMSIS-DAP max_xfer adjusted %d -> %d owing to EP 0x%02x's wMaxPacketSize\n",
+                pmsg_notice("max packet size adjusted %d -> %d owing to EP 0x%02x's wMaxPacketSize\n",
                   fd->usb.max_xfer, mps, epa);
                 fd->usb.max_xfer = mps;
               }
@@ -215,7 +215,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
           }
           if(fd->usb.max_xfer > USBDEV_MAX_XFER_3) {
             pmsg_error("reducing too big max packet size %d to %d\n", fd->usb.max_xfer, USBDEV_MAX_XFER_3);
-           fd->usb.max_xfer = USBDEV_MAX_XFER_3;
+            fd->usb.max_xfer = USBDEV_MAX_XFER_3;
           }
           if(usehid && usb_control_msg(udev, 0x21, 0x0a /* SET_IDLE */ , 0, 0, NULL, 0, 100) < 0)
             pmsg_warning("SET_IDLE failed\n");

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -213,6 +213,10 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
               }
             }
           }
+          if(fd->usb.max_xfer > USBDEV_MAX_XFER_3) {
+            pmsg_error("reducing too big max packet size %d to %d\n", fd->usb.max_xfer, USBDEV_MAX_XFER_3);
+           fd->usb.max_xfer = USBDEV_MAX_XFER_3;
+          }
           if(usehid && usb_control_msg(udev, 0x21, 0x0a /* SET_IDLE */ , 0, 0, NULL, 0, 100) < 0)
             pmsg_warning("SET_IDLE failed\n");
           return 0;

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -54,34 +54,21 @@
  * the desired USB device ID.
  */
 static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor *fd) {
-  char string[256];
-  char product[256];
+  char string[256], product[256];
   struct usb_bus *bus;
   struct usb_device *dev;
   usb_dev_handle *udev;
-  char *s, serno[64] = { 0 };
-  const char *serp;
+  char serno[64] = { 0 };
   int i, iface;
-
-  /*
-   * The syntax for usb devices is defined as:
-   *
-   * -P usb[:serialnumber]
-   *
-   * See if we've got a serial number passed here.  The serial number might
-   * contain colons which we remove below, and we compare it right-to-left, so
-   * only the least significant nibbles need to be specified.
-   */
-  if((serp = strchr(port, ':')) && *++serp) {
-    // First, get a copy of the serial number w/out colons
-    for(s = serno; *serp && s < serno + sizeof serno - 1; serp++)
-      if(*serp != ':')
-        *s++ = *serp;
-    *s = 0;
-  }
 
   if(fd->usb.max_xfer == 0)
     fd->usb.max_xfer = USBDEV_MAX_XFER_MKII;
+
+  // Override/set pid, vid and/or serno from -P usb[[:[<vid>]:<pid>]:<serno>]
+  if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, -1, serno, sizeof serno) < 0) {
+    pmsg_error("parsing error in -P %s\n", port);
+    return -1;
+  }
 
   usb_init();
 
@@ -103,7 +90,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
              */
             cx->usb_access_error = 1;
             if(*serno)
-              goto none_matching;       // No chance of serno matches
+              goto none_matching;       // Unable to match serno
             strcpy(string, "[unknown]");
           }
           if(serdev)
@@ -115,14 +102,13 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
           if(serdev)
             serdev->usbproduct = cache_string(product);
 
-          /* We need to write to endpoint 2 to switch the PICkit4 and SNAP
-           * from PIC to AVR mode
-           */
+          // Need to write to endpoint 2 to switch the PICkit4/SNAP from PIC to AVR mode
           if(str_casestarts(product, "MPLAB") && (str_caseends(product, "Snap ICD")
               || str_caseends(product, "PICkit 4"))) {
             pinfo.usbinfo.flags = 0;
             fd->usb.wep = 2;
           }
+
           /*
            * The CMSIS-DAP specification mandates the string "CMSIS-DAP" must
            * be present somewhere in the product name string for a device
@@ -142,12 +128,9 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
             fd->usb.wep = 0x02;
           }
 
-          pmsg_notice("found %s with serno = %s\n", product, string);
+          pmsg_notice2("found %s with serno = %s\n", product, string);
           if(*serno) {
-            /*
-             * See if the serial number requested by the user matches what we
-             * found, matching right-to-left.
-             */
+            // See if the serial number requested by the user matches right-to-left
             int x = strlen(string) - strlen(serno);
 
             if(x < 0 || !str_caseeq(string + x, serno)) {

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -65,8 +65,8 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
     fd->usb.max_xfer = USBDEV_MAX_XFER_MKII;
 
   // Override/set pid, vid and/or serno from -P usb[:<vid>:<pid>][:<serno>]
-  if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, -1, serno, sizeof serno) < 0) {
-    pmsg_error("invalid -P %s; drop -P option or else use -P usb[:<vid>:<pid>][:<serno>]\n", port);
+  if(str_set_vid_pid_serno(port, &pinfo.usbinfo.vid, &pinfo.usbinfo.pid, serno, sizeof serno) < 0) {
+    pmsg_error("invalid -P %s; drop -P option or use -P usb[:<vid>:<pid>][:<serno>]\n", port);
     return -1;
   }
 

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -110,16 +110,16 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
           }
 
           /*
-           * The CMSIS-DAP specification mandates the string "CMSIS-DAP" must
-           * be present somewhere in the product name string for a device
-           * compliant to that protocol.  Use this for the decisision whether
-           * we have to search for a HID interface below.
+           * If the product name contains the string "CMSIS-DAP" it claims to
+           * be a CMSIS-DAP spec HID device. HID interrupt packets can only be
+           * 64 byte (Full-Speed) or 512 byte (High-Speed) not any other value.
+           * Standard-Speed (8 bytes) will not work.
            */
           if(str_contains(product, "CMSIS-DAP")) {
             pinfo.usbinfo.flags |= PINFO_FL_USEHID;
-            /* The JTAGICE3 running the CMSIS-DAP firmware doesn't
-             * use a separate endpoint for event reception */
+            // JTAGICE3 doesn't use a separate endpoint for event reception
             fd->usb.eep = 0;
+            fd->usb.max_xfer = 64;
           }
 
           if(str_contains(product, "mEDBG")) {
@@ -150,6 +150,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
             // goto trynext;    // Let's hope it has already been configured
           }
 
+          int usehid = !!(pinfo.usbinfo.flags & PINFO_FL_USEHID);
           for(iface = 0; iface < dev->config[0].bNumInterfaces; iface++) {
             cx->usb_interface = dev->config[0].interface[iface].altsetting[0].bInterfaceNumber;
 
@@ -166,8 +167,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
               pmsg_warning("(i/face %d) %s\n", cx->usb_interface, usb_strerror());
               cx->usb_access_error = 1;
             } else {
-              if(pinfo.usbinfo.flags & PINFO_FL_USEHID) {
-                // Only consider an interface that is of class HID
+              if(usehid) {      // Only consider an interface that is of class HID
                 if(dev->config[0].interface[iface].altsetting[0].bInterfaceClass != USB_CLASS_HID)
                   continue;
                 fd->usb.use_interrupt_xfer = 1;
@@ -198,20 +198,23 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
             }
           }
           for(i = 0; i < dev->config[0].interface[iface].altsetting[0].bNumEndpoints; i++) {
-            if((dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress == fd->usb.rep ||
-                dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress == fd->usb.wep) &&
-              dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize < fd->usb.max_xfer) {
-              pmsg_notice("max packet size expected %d, but found %d due to EP 0x%02x's wMaxPacketSize\n",
-                fd->usb.max_xfer,
-                dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize,
-                dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress);
-              fd->usb.max_xfer = dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize;
+            int mps = dev->config[0].interface[iface].altsetting[0].endpoint[i].wMaxPacketSize,
+                epa = dev->config[0].interface[iface].altsetting[0].endpoint[i].bEndpointAddress;
+
+            if(epa != fd->usb.rep && epa != fd->usb.wep)
+              continue;
+
+            // (usehid && (mps == 64 || mps == 512)) suggested by Claude free chatbot (Sonnet 4.6 Low)
+            if((usehid && (mps == 64 || mps == 512)) || mps < fd->usb.max_xfer) {
+              if(mps != fd->usb.max_xfer) {
+                pmsg_notice("CMSIS-DAP max_xfer adjusted %d -> %d owing to EP 0x%02x's wMaxPacketSize\n",
+                  fd->usb.max_xfer, mps, epa);
+                fd->usb.max_xfer = mps;
+              }
             }
           }
-          if(pinfo.usbinfo.flags & PINFO_FL_USEHID) {
-            if(usb_control_msg(udev, 0x21, 0x0a /* SET_IDLE */ , 0, 0, NULL, 0, 100) < 0)
-              pmsg_warning("SET_IDLE failed\n");
-          }
+          if(usehid && usb_control_msg(udev, 0x21, 0x0a /* SET_IDLE */ , 0, 0, NULL, 0, 100) < 0)
+            pmsg_warning("SET_IDLE failed\n");
           return 0;
 
         trynext:

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -621,7 +621,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
     pmsg_warning("setting bitclock despite HAS_BITCLOCK_ADJ missing in pgm->extra_features\n");
 
   if(!str_casestarts(port, "usb:") && !str_caseeq(port, "usb")) {
-    pmsg_error("invalid -P %s; drop -P option or else use -P usb:<busdir>:<devicefile> or -P usb:<serialno>\n", port);
+    pmsg_error("invalid -P %s; drop -P option or use -P usb:<busdir>:<devicefile> or -P usb:<serialno>\n", port);
     return -1;
   }
 

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -144,7 +144,9 @@ static int wiring_open(PROGRAMMER *pgm, const char *port) {
   pgm->port = port;
   pinfo.serialinfo.baud = pgm->baudrate? pgm->baudrate: 115200;
   pinfo.serialinfo.cflags = SERIAL_8N1;
-  serial_open(port, pinfo, &pgm->fd);
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   // If we have a snoozetime, then we wait and do NOT toggle DTR/RTS
   if(mywiring.snoozetime > 0) {

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1438,9 +1438,9 @@ static int xbee_open(PROGRAMMER *pgm, const char *port) {
   serdev->set_dtr_rts = xbeedev_set_dtr_rts;
   serdev->flags = SERDEV_FL_NONE;
 
-  if(serial_open(port, pinfo, &pgm->fd) == -1) {
-    return -1;
-  }
+  int rc;
+  if((rc = serial_open(port, pinfo, &pgm->fd)) < 0)
+    return rc;
 
   xbeedev_setresetpin(&pgm->fd, my.xbeeResetPin);
 


### PR DESCRIPTION
Fixes #2127 and #1221 

This is also an attempt to standardise `-P usb[:<vid>:<pid>][:<serno>]` parsing to a better degree for those programmers that allow  vid, pid and serno specification. (There are some that use the `-P usb[:<busdir>:<devicefile]` logic; these won't be affected).

Novelty: for the first time I've used a code fragment suggested by an AI program following @mcuee's enthusiastic use:
https://github.com/stefanrueger/avrdude/blob/68b970e2456083566cb8be1d2d935780b052bcad/src/usb_libusb.c#L207-L208
I might delete that attribution to Claude, as the used code fragment is only a small sub-expression, and I wonder how much that differs from using a tip that Ms Google had given. It's certainly been some work trying to make sense of the verbose AI review.

What is needed now is good testing, a) whether #2127 and #1221 are really gone and b) whether there are regressions. 

@MX682X This PR replaces pickit5.c's `-P usb[:<vid>:<pid>]` parsing with the more general (and stricter) parsing through `str_set_vid_pid_serno()`. Could you please test/try/review the changed parsing? How attached are you to the variant `-P usb::<pid>` where vid defaults to Microchip's vid? This element turns out to be a slight pain for the attempt to standardise `-P usb:...` parsing across different programmers in AVRDUDE, as it's not clear to me whether defaulting to Microchip's vid makes generally sense (I suspect, not). Dropping that otherwise neat `-P usb::<pid>` syntax would also make documentation easier.

I intend to use `-P usb:...` parsing for more programmers, eg, avrftdi, ch341a, pickit2, teensy, ... where `-P ...` is currently ignored.That's why this PR is a draft for now (though one that can be tested).