### PR TITLE
Remove `-Uall:v:file.hex` test in `test8`

### DIFF
--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -160,7 +160,7 @@ static int parse_cmdbits(OPCODE *op, int opnum);
 
 %%
 
-number_real : 
+number_real :
  numexpr {
     $$ = $1;
     /* convert value to real */
@@ -317,8 +317,8 @@ prog_decl :
 
 
 part_def :
-  part_decl part_parms 
-    { 
+  part_decl part_parms
+    {
       LNODEID ln;
       AVRMEM *m;
       AVRPART *existing_part;
@@ -392,8 +392,8 @@ part_def :
       }
 
       current_part->comments = cfg_move_comments();
-      LISTADD(part_list, current_part); 
-      current_part = NULL; 
+      LISTADD(part_list, current_part);
+      current_part = NULL;
       current_strct = COMP_CONFIG_MAIN;
     }
 ;
@@ -405,7 +405,7 @@ part_decl :
       current_part->config_file = cache_string(cfg_infile);
       current_part->lineno = cfg_lineno;
     } |
-  K_PART K_PARENT TKN_STRING 
+  K_PART K_PARENT TKN_STRING
     {
       AVRPART *parent_part = locate_part(part_list, $3->value.string);
       if(parent_part == NULL) {
@@ -474,11 +474,11 @@ prog_parm_type_id:
   const PROGRAMMER_TYPE *pgm_type = locate_programmer_type($1->value.string);
     if(pgm_type == NULL) {
         yyerror("programmer type %s not found", $1->value.string);
-        free_token($1); 
+        free_token($1);
         YYABORT;
     }
     current_prog->initpgm = pgm_type->initpgm;
-    free_token($1); 
+    free_token($1);
 }
   | error
 {
@@ -642,7 +642,7 @@ part_parm :
     cfg_assign((char *) current_part, COMP_AVRPART, $1->value.comp, &$3->value);
     free_token($1);
   } |
-  K_ID TKN_EQUAL TKN_STRING 
+  K_ID TKN_EQUAL TKN_STRING
     {
       current_part->id = cache_string($3->value.string);
       free_token($3);
@@ -928,7 +928,7 @@ part_parm :
     } |
 
 
-  K_MEMORY TKN_STRING 
+  K_MEMORY TKN_STRING
     { /* select memory for extension or create if not there */
       AVRMEM *mem = avr_locate_mem_noalias(current_part, $2->value.string);
       if(!mem) {
@@ -940,7 +940,7 @@ part_parm :
       current_mem = mem;
       free_token($2);
     }
-    mem_specs 
+    mem_specs
     {
       if(is_alias) {            // alias mem has been already entered
         lrmv_d(current_part->mem, current_mem);
@@ -959,7 +959,7 @@ part_parm :
         current_mem->comments = cfg_move_comments();
       }
       cfg_pop_comms();
-      current_mem = NULL; 
+      current_mem = NULL;
       current_strct = COMP_AVRPART;
     } |
   K_MEMORY TKN_STRING TKN_EQUAL K_NULL
@@ -975,7 +975,7 @@ part_parm :
       current_strct = COMP_AVRPART;
     } |
   opcode TKN_EQUAL string_list {
-    { 
+    {
       int opnum;
       OPCODE *op;
 
@@ -1042,7 +1042,7 @@ mem_spec :
     } |
 
   opcode TKN_EQUAL string_list {
-    { 
+    {
       int opnum;
       OPCODE *op;
 
@@ -1190,7 +1190,7 @@ static int which_opcode(TOKEN *opcode) {
   case K_WRITEPAGE:     return AVR_OP_WRITEPAGE;
   case K_CHIP_ERASE:    return AVR_OP_CHIP_ERASE;
   case K_PGM_ENABLE:    return AVR_OP_PGM_ENABLE;
-  default: 
+  default:
     yyerror("invalid opcode");
     return -1;
   }

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -133,7 +133,7 @@ static int dryrun_init_ur(const PROGRAMMER *pgm, const AVRPART *p) {
   if(ur.urversion) {
     char buf[20];
     urbootPutVersion(buf, (uint16_t *) top);
-    pmsg_info("detected urboot bootloader %s in [0x%04x, 0x%04x] with vector=%d\n", 
+    pmsg_info("detected urboot bootloader %s in [0x%04x, 0x%04x] with vector=%d\n",
       buf, ur.blstart, ur.blend, ur.vectornum);
   }
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -122,7 +122,7 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
 "/*" {  /* The following eats multiline C style comments, they are not captured */
         int c;
         int comment_start;
-        
+
         comment_start = cfg_lineno;
         while (1) {
           while (((c = input()) != '*') && (c != EOF)) {
@@ -130,14 +130,14 @@ INF  [Ii][Nn][Ff]([Ii][Nn][Ii][Tt][Yy])?
             if (c == '\n')
               cfg_lineno++;
           }
-          
+
           if (c == '*') {
             while ((c = input()) == '*')
               ;
             if (c == '/')
               break;    /* found the end */
           }
-          
+
           if (c == EOF) {
             yyerror("EOF in comment (started on line %d)", comment_start);
             return YYERRCODE;
@@ -268,7 +268,7 @@ writepage        { yylval=new_token(K_WRITEPAGE); ccap(); return K_WRITEPAGE; }
 [ \r\t]+  { /* ignore whitespace */ }
 
 c: { yyerror("possible old-style config file entry\n"
-             "  Update your config file (see " CONFIG_DIR 
+             "  Update your config file (see " CONFIG_DIR
                "/avrdude.conf.sample for a sample)");
      return YYERRCODE; }
 

--- a/src/msvc/getopt.h
+++ b/src/msvc/getopt.h
@@ -4,9 +4,9 @@
  * This file has no copyright assigned and is placed in the Public Domain.
  * This file is part of the mingw-w64 runtime package.
  *
- * The mingw-w64 runtime package and its code is distributed in the hope that it 
- * will be useful but WITHOUT ANY WARRANTY.  ALL WARRANTIES, EXPRESSED OR 
- * IMPLIED ARE HEREBY DISCLAIMED.  This includes but is not limited to 
+ * The mingw-w64 runtime package and its code is distributed in the hope that it
+ * will be useful but WITHOUT ANY WARRANTY.  ALL WARRANTIES, EXPRESSED OR
+ * IMPLIED ARE HEREBY DISCLAIMED.  This includes but is not limited to
  * warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 

--- a/src/msvc/msvc_compat.h
+++ b/src/msvc/msvc_compat.h
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <io.h>
-#include <malloc.h> 
+#include <malloc.h>
 
 #define strerror_r(errno,buf,len) strerror_s(buf,len,errno)
 

--- a/src/msvc/readline/history.h
+++ b/src/msvc/readline/history.h
@@ -9,7 +9,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
+
 void add_history(const char* string);
 
 #ifdef __cplusplus

--- a/tools/test8
+++ b/tools/test8
@@ -18,9 +18,9 @@ Function: test AVRDUDE v 8.0 or later with -c programmer -p part;
 Options:
   -i <n>     Write human-readable contents seeded by <n> to part and exit
   -r <n>     Write random contents seeded by <n> to part and exit
-  -e <exe>   path of the avrdude executable
-  -a <opt>   pass option <opt> to avrdude; no space in <opt>, eg, -Pch340
-  -m <mlist> use memory list <mlist> instead of ALL
+  -e <exe>   Path of the avrdude executable
+  -a <opt>   Pass option <opt> to avrdude; no space in <opt>, eg, -Pch340
+  -m <mlist> Use memory list <mlist> instead of ALL
 
 Examples:
   - Prepare a part with non-trivial random content
@@ -84,7 +84,7 @@ fi
 ######
 # Actual test
 
-if ! $avrdude_bin "${adopts[@]}" -c $1 -p $2 -D -U$mem:r:$f -T "fact reset" -U$mem:w:$f -U$mem:v:$f; then
+if ! $avrdude_bin "${adopts[@]}" -c $1 -p $2 -D -U$mem:r:$f -T "fact reset" -U$mem:w:$f; then
   echo -------------------------------
   echo Re-running to create error logs
   $avrdude_bin "${adopts[@]}" -vvv -c $1 -p $2 -D -U$mem:r:$f -T "fact reset" -U$mem:w:$f -U$mem:v:$f -llog-$1-$2.txt


### PR DESCRIPTION
This PR makes `test8` faster by removing the explicit verification of the part contents with file contents. This `-U all:v:file.hex` test was designed to test the (explicit) verification code for `v` when multi-memory `.hex` files and the terminal commands `backup` and `restore` were introduced. Now that this code has been tested thoroughly, it is sufficient to run only the `-U all:v:file.hex` operation that entails an implicit running verification as memories are written.