### PR TITLE
AVR dragon does not support TPI programming

### DIFF
--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -2450,7 +2450,7 @@ programmer # dragon_isp
     id                     = "dragon_isp";
     desc                   = "Atmel AVR Dragon in ISP mode";
     type                   = "dragon_isp";
-    prog_modes             = PM_TPI | PM_ISP;
+    prog_modes             = PM_ISP;
     extra_features         = HAS_VTARG_READ | HAS_BITCLOCK_ADJ;
     connection_type        = usb;
     baudrate               = 115200;


### PR DESCRIPTION
The AVR dragon user guide can be found here, and there's no mention of TPI programming anywhere.
https://ww1.microchip.com/downloads/en/devicedoc/atmel-42723-avr-dragon_userguide.pdf

Testing also shows that TPI programming does not work.