### PR TITLE
Future-proof programmer identification

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -861,7 +861,7 @@ int jtag3_getsync(const PROGRAMMER *pgm, int mode) {
   pmsg_debug("jtag3_getsync()\n");
 
   // XplainedMini boards do not need this, and early revisions had a FW bug that complained about it
-  if((pgm->flag & PGM_FL_IS_EDBG) && !str_starts(pgmid, "xplainedmini")) {
+  if((pgm->flag & PGM_FL_IS_EDBG) && !pgmid_is("xplainedmini")) {
     if(jtag3_edbg_prepare(pgm) < 0) {
       return -1;
     }
@@ -1074,7 +1074,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     if(!pgm->bitclock) {
       // PICkit 4 and SNAP requires the bitclock to be explicitly set when programming Xmegas using JTAG
       // However, we will not set a new bit clock value if it already has a valid clock speed
-      if(my.set_sck == jtag3_set_sck_xmega_jtag && (str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))) {
+      if(my.set_sck == jtag3_set_sck_xmega_jtag && (pgmid_is("pickit4") || pgmid_is("snap"))) {
         double bclk = 0;
         if(pgm->get_sck_period)
           if(pgm->get_sck_period(pgm, &bclk) < 0)
@@ -1601,7 +1601,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       }
     }
 
-    if(str_starts(extended_param, "mode") && (str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))) {
+    if(str_starts(extended_param, "mode") && (pgmid_is("pickit4") || pgmid_is("snap"))) {
       // Flag a switch to AVR mode
       if(str_caseeq(extended_param, "mode=avr")) {
         my.pk4_snap_mode = PK4_SNAP_MODE_AVR;
@@ -1645,7 +1645,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       msg_error("  -x vtarg               Read on-board target supply voltage\n");
     if(pgm->extra_features & HAS_VTARG_ADJ)
       msg_error("  -x vtarg=<dbl>         Set on-board target supply voltage to <dbl> V\n");
-    if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap")) {
+    if(pgmid_is("pickit4") || pgmid_is("snap")) {
       msg_error("  -x mode=avr            Set programmer to AVR mode and exit if it was not\n");
       msg_error("  -x mode=<mplab|pic>    Set programmer to MPLAB aka PIC mode and exit\n");
     }
@@ -1913,7 +1913,7 @@ void jtag3_close(PROGRAMMER *pgm) {
     mmt_free(resp);
 
   // XplainedMini boards do not need this, and early revisions had a FW bug that complained about it
-  if((pgm->flag & PGM_FL_IS_EDBG) && !str_starts(pgmid, "xplainedmini")) {
+  if((pgm->flag & PGM_FL_IS_EDBG) && !pgmid_is("xplainedmini")) {
     jtag3_edbg_signoff(pgm);
   }
 

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1161,8 +1161,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   // Abort and print error if programmer does not support the target microcontroller
-  if((str_starts(pgm->type, "JTAGMKII_UPDI") && !is_updi(p)) ||
-    (str_starts(pgmid, "jtagmkII") && is_updi(p))) {
+  if((str_eq(pgm->type, "JTAGMKII_UPDI") && !is_updi(p)) || (pgmid_is("jtagmkII") && is_updi(p))) {
     msg_error("programmer %s does not support target %s\n\n", pgmid, p->desc);
     return -1;
   }
@@ -1235,7 +1234,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
     AVRMEM *flashmem = avr_locate_flash(p);
 
     if(bootmem == NULL || flashmem == NULL) {
-      if(str_starts(pgmid, "jtagmkII"))
+      if(pgmid_is("jtagmkII"))
         pmsg_error("cannot locate flash or boot memories in description\n");
     } else {
       if(my.fwver < 0x700) {
@@ -1745,9 +1744,9 @@ void jtagmkII_close(PROGRAMMER *pgm) {
    * after a programming session has ended before Avrdude can
    * communicate with the programmer again.
    */
-  if(str_casestarts(pgmid, "dragon"))
+  if(pgmid_is("dragon"))
     usleep(1000*1000*1.5);
-  else if(str_caseeq(pgmid, "nanoevery"))
+  else if(pgmid_is("nanoevery"))
     usleep(1000*1000*0.5);
 }
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1750,6 +1750,7 @@ extern "C" {
   char *str_quote_bash(const char *s);
   const char *str_ccsharg(const char *str);
   char *str_vectorname(const Avrintel *up, int vn);
+  int pgmid_is(const char *str);
 
   int led_set(const PROGRAMMER *pgm, int led);
   int led_clr(const PROGRAMMER *pgm, int led);

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -323,6 +323,7 @@ PROGRAMMER *locate_programmer_starts_set(const LISTID programmers, const char *p
           }
           if(id[l] == 0) {      // Exact match; return straight away
             matches = 1;
+            matchid = id;
             goto done;
           }
         }

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -376,7 +376,7 @@ static int stk500_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   // MIB510 does not need extparams
-  if(str_eq(pgmid, "mib510"))
+  if(pgmid_is("mib510"))
     n_extparms = 0;
   else if((maj > 1) || ((maj == 1) && (min > 10)))
     n_extparms = 4;
@@ -862,7 +862,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
   stk500_drain(pgm, 0);
 
   // MIB510 init
-  if(str_eq(pgmid, "mib510") && mib510_isp(pgm, 1) != 0)
+  if(pgmid_is("mib510") && mib510_isp(pgm, 1) != 0)
     return -1;
 
   if(stk500_getsync(pgm) < 0)
@@ -881,7 +881,7 @@ static int stk500_open(PROGRAMMER *pgm, const char *port) {
 
 static void stk500_close(PROGRAMMER *pgm) {
   // MIB510 close
-  if(str_eq(pgmid, "mib510"))
+  if(pgmid_is("mib510"))
     (void) mib510_isp(pgm, 0);
 
   serial_close(&pgm->fd);
@@ -991,7 +991,7 @@ static int set_memchr_a_div(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   if(mem_is_eeprom(m)) {
     *memchrp = 'E';
     // Word addr for bootloaders or Arduino as ISP if part is a classic part; byte addr otherwise
-    *a_divp = (is_spm(pgm) || str_caseeq(pgmid, "arduino_as_isp"))
+    *a_divp = (is_spm(pgm) || pgmid_is("arduino_as_isp"))
       && is_classic(p)? 2: 1;
     return 0;
   }
@@ -1020,7 +1020,7 @@ static int stk500_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
   for(; addr < n; addr += block_size) {
     // MIB510 uses fixed blocks size of 256 bytes
-    if(str_eq(pgmid, "mib510")) {
+    if(pgmid_is("mib510")) {
       block_size = 256;
     } else {
       if(n - addr < page_size)
@@ -1089,7 +1089,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   n = addr + n_bytes;
   for(; addr < n; addr += block_size) {
     // MIB510 uses fixed blocks size of 256 bytes
-    if(str_eq(pgmid, "mib510")) {
+    if(pgmid_is("mib510")) {
       block_size = 256;
     } else {
       if(n - addr < page_size)
@@ -1132,7 +1132,7 @@ static int stk500_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
     if(stk500_recv(pgm, buf, 1) < 0)
       return -1;
 
-    if(str_eq(pgmid, "mib510")) {
+    if(pgmid_is("mib510")) {
       if(buf[0] != Resp_STK_INSYNC) {
         msg_error("\n");
         pmsg_error("protocol expects sync byte 0x%02x but got 0x%02x\n", Resp_STK_INSYNC, buf[0]);
@@ -1540,7 +1540,7 @@ static void stk500_setup(PROGRAMMER *pgm) {
   my.ext_addr_byte = 0xff;
   my.xbeeResetPin = XBEE_DEFAULT_RESET_PIN;
   // nanoSTK (Arduino Nano HW) uses 16 MHz
-  if(str_starts(pgmid, "nanoSTK"))
+  if(pgmid_is("nanoSTK"))
     my.xtal = 16000000U;
   else
     my.xtal = STK500_XTAL;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -284,7 +284,7 @@ void stk500v2_setup(PROGRAMMER *pgm) {
   pgm->cookie = mmt_malloc(sizeof(struct pdata));
   my.command_sequence = 1;
   my.boot_start = ULONG_MAX;
-  my.xtal = str_starts(pgmid, "scratchmonkey")? SCRATCHMONKEY_XTAL: STK500V2_XTAL;
+  my.xtal = pgmid_is("scratchmonkey")? SCRATCHMONKEY_XTAL: STK500V2_XTAL;
 }
 
 static void stk500v2_jtagmkII_setup(PROGRAMMER *pgm) {
@@ -2018,7 +2018,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
       }
     }
 
-    if(str_starts(extended_param, "mode") && (str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))) {
+    if(str_starts(extended_param, "mode") && (pgmid_is("pickit4") || pgmid_is("snap"))) {
       // Flag a switch to AVR mode
       if(str_caseeq(extended_param, "mode=avr")) {
         my.pk4_snap_mode = PK4_SNAP_MODE_AVR;
@@ -2056,7 +2056,7 @@ static int stk500v2_jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extp
       msg_error("  -x vtarg               Read on-board target supply voltage\n");
     if(pgm->extra_features & HAS_VTARG_ADJ)
       msg_error("  -x vtarg=<dbl>         Set on-board target supply voltage to <dbl> V\n");
-    if(str_starts(pgmid, "pickit4") || str_starts(pgmid, "snap"))
+    if(pgmid_is("pickit4") || pgmid_is("snap"))
       msg_error("  -x mode=avr|pic        Set programmer to AVR or PIC mode, then exit\n");
     msg_error("  -x help                Show this help menu and exit\n");
     return rv;

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1693,3 +1693,29 @@ char *str_vectorname(const Avrintel *up, int vn) {
 
   return ret;
 }
+
+// Return whether pgmid matches str or any of str's programming mode variants
+int pgmid_is(const char *str) {
+  const char *sufx[] = {"_tpi", "_isp", "_hvsp", "_pp", "_dw", "_jtag", "_pdi", "_updi", "_avr32"};
+
+  if(!str_starts(pgmid, str))   // Pgmid doesn't start with str: no match
+    return 0;
+
+  // Now that pgmid starts with str, is its remainder one of known suffixes?
+  const char *pend = pgmid + strlen(str);
+  if(!*pend)                    // Yes (empty suffix): str is same as pgmid
+    return 1;
+
+  // Lex arduino_as_isp (misleading suffix): arduino_as is not the programmer
+  if(str_eq(str, "arduino_as") && str_eq(pgmid, "arduino_as_isp"))
+    return 0;
+
+  // Lex jtag2isp/stk500pp: if the programmer name ends in a digit also skip the _
+  int digitend = pend > pgmid && pend[-1] >= '0' && pend[-1] <= '9';
+
+  for(size_t i = 0; i < sizeof sufx/sizeof*sufx; i++)
+    if(str_eq(pend, sufx[i]) || (digitend && str_eq(pend, sufx[i] + 1)))
+      return 1;
+
+  return 0;
+}

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -638,7 +638,7 @@ static int usbasp_open(PROGRAMMER *pgm, const char *port) {
   }
   vid = pgm->usbvid? pgm->usbvid: USBASP_SHARED_VID;
   if(usbOpenDevice(pgm, &my.usbhandle, vid, pgm->usbvendor, pid, pgm->usbproduct, port) != 0) {
-    if(str_eq(pgmid, "usbasp")) {
+    if(pgmid_is("usbasp")) {
       // Check if device with old VID/PID is available
       if(usbOpenDevice(pgm, &my.usbhandle, USBASP_OLD_VID, "www.fischl.de",
         USBASP_OLD_PID, "USBasp", port) == 0) {


### PR DESCRIPTION
For details see #2140 

Although the current code base works without this PR, subtle and difficult to debug problems might arise once a user adds programmers with ids that are similar to existing ones, e.g. "snappy".

I am pretty happy with this PR and suggest merging it tomorrow before releasing v8.2 unless I hear objections, bug reports etc.