### PR TITLE
Alias `hvmoncfg `to `hwmoncfg`

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1599,6 +1599,7 @@ Memtable avr_mem_order[100] = {
   {"fuse4", MEM_FUSE4 | MEM_IS_A_FUSE},
   {"tcd0cfg", MEM_FUSE4 | MEM_IS_A_FUSE},
   {"hwmoncfg", MEM_FUSE4 | MEM_IS_A_FUSE},
+  {"hvmoncfg", MEM_FUSE4 | MEM_IS_A_FUSE},
   {"fuse5", MEM_FUSE5 | MEM_IS_A_FUSE},
   {"syscfg0", MEM_FUSE5 | MEM_IS_A_FUSE},
   {"fuse6", MEM_FUSE6 | MEM_IS_A_FUSE},

--- a/src/avrdude.conf.in
+++ b/src/avrdude.conf.in
@@ -24608,7 +24608,11 @@ part # .avr-lx
         readsize           = 1;
     ;
 
-    memory "hwmoncfg"
+    memory "hwmoncfg"           # datasheet name for this fuse
+        alias "fuse4";
+    ;
+
+    memory "hvmoncfg"           # .atdf name for this fuse
         alias "fuse4";
     ;
 

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -424,7 +424,7 @@ typedef struct {
 #define MEM_FUSE1             1 // hfuse fuse1 bodcfg
 #define MEM_FUSE2             2 // efuse fuse2 osccfg
 #define MEM_FUSE3             3 // fuse3 pincfg
-#define MEM_FUSE4             4 // fuse4 tcd0cfg hwmoncfg
+#define MEM_FUSE4             4 // fuse4 tcd0cfg hwmoncfg hvmoncfg
 #define MEM_FUSE5             5 // fuse5 syscfg0
 #define MEM_FUSE6             6 // fuse6 syscfg1
 #define MEM_FUSE7             7 // fuse7 append codesize


### PR DESCRIPTION
Fixes #2142 

For example, it is now possible to do this:
```
$ avrdude -qq -p16la32 -cdryrun -U hw:r:-:d -U hv:w:1:m -U hw:r:-:d
0
1
```
Note the reading of h**w**moncfg, writing to h**v**moncfg and reading from  h**w**moncfg.