### PR TITLE
Fix programmer type usage

### DIFF
--- a/src/arduino.c
+++ b/src/arduino.c
@@ -165,7 +165,7 @@ void arduino_initpgm(PROGRAMMER *pgm) {
      and the DTR signal is set when opening the serial port
      for the Auto-Reset feature */
   stk500_initpgm(pgm);
-  strcpy(pgm->type, "Arduino");
+  pgm->type = "Arduino";
   pgm->read_sig_bytes = arduino_read_sig_bytes;
   pgm->open = arduino_open;
   pgm->close = arduino_close;

--- a/src/arduino.c
+++ b/src/arduino.c
@@ -165,7 +165,7 @@ void arduino_initpgm(PROGRAMMER *pgm) {
      and the DTR signal is set when opening the serial port
      for the Auto-Reset feature */
   stk500_initpgm(pgm);
-  pgm->type = "Arduino";
+  pgm->ptyp = "Arduino";
   pgm->read_sig_bytes = arduino_read_sig_bytes;
   pgm->open = arduino_open;
   pgm->close = arduino_close;

--- a/src/avr.c
+++ b/src/avr.c
@@ -239,7 +239,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
     str_ccaddress(addr, mem->size));
 
   if(pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->type, __func__);
+    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->ptyp, __func__);
     return -1;
   }
 
@@ -248,7 +248,7 @@ int avr_read_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM 
 
   if(is_tpi(p)) {
     if(pgm->cmd_tpi == NULL) {
-      pmsg_error("%s programmer does not support TPI\n", pgm->type);
+      pmsg_error("%s programmer does not support TPI\n", pgm->ptyp);
       goto error;
     }
 
@@ -519,7 +519,7 @@ int avr_write_page(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem, u
   led_set(pgm, LED_PGM);
 
   if(pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->type, __func__);
+    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->ptyp, __func__);
     goto error;
   }
 
@@ -702,7 +702,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
   led_set(pgm, LED_PGM);
 
   if(pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->type, __func__);
+    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->ptyp, __func__);
     goto error;
   }
 
@@ -720,7 +720,7 @@ int avr_write_byte_default(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
 
   if(is_tpi(p)) {
     if(pgm->cmd_tpi == NULL) {
-      pmsg_error("%s programmer does not support TPI\n", pgm->type);
+      pmsg_error("%s programmer does not support TPI\n", pgm->ptyp);
       goto error;
     }
 

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -647,7 +647,7 @@ static int avr910_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
 const char avr910_desc[] = "Serial programmer using protocol from appnote AVR910";
 
 void avr910_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "avr910");
+  pgm->type = "avr910";
 
   // Mandatory functions
   pgm->initialize = avr910_initialize;

--- a/src/avr910.c
+++ b/src/avr910.c
@@ -647,7 +647,7 @@ static int avr910_read_sig_bytes(const PROGRAMMER *pgm, const AVRPART *p, const 
 const char avr910_desc[] = "Serial programmer using protocol from appnote AVR910";
 
 void avr910_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "avr910";
+  pgm->ptyp = "avr910";
 
   // Mandatory functions
   pgm->initialize = avr910_initialize;

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -55,12 +55,12 @@ static int avrftdi_noftdi_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void avrftdi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "avrftdi");
+  pgm->type = "avrftdi";
   pgm->open = avrftdi_noftdi_open;
 }
 
 void avrftdi_jtag_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "avrftdi_jtag");
+  pgm->type = "avrftdi_jtag";
   pgm->open = avrftdi_noftdi_open;
 }
 
@@ -1686,7 +1686,7 @@ static int avrftdi_jtag_paged_read(const PROGRAMMER *pgm, const AVRPART *p,
 }
 
 void avrftdi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "avrftdi");
+  pgm->type = "avrftdi";
 
   // Mandatory functions
   pgm->initialize = avrftdi_initialize;
@@ -1716,7 +1716,7 @@ void avrftdi_initpgm(PROGRAMMER *pgm) {
 }
 
 void avrftdi_jtag_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "avrftdi_jtag");
+  pgm->type = "avrftdi_jtag";
 
   // Mandatory functions
   pgm->initialize = avrftdi_jtag_initialize;

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -55,12 +55,12 @@ static int avrftdi_noftdi_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void avrftdi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "avrftdi";
+  pgm->ptyp = "avrftdi";
   pgm->open = avrftdi_noftdi_open;
 }
 
 void avrftdi_jtag_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "avrftdi_jtag";
+  pgm->ptyp = "avrftdi_jtag";
   pgm->open = avrftdi_noftdi_open;
 }
 
@@ -1343,7 +1343,7 @@ static int avrftdi_jtag_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
       str_eq(p->id, "m32a") || str_eq(p->id, "m32") ||
       str_eq(p->id, "m16a") || str_eq(p->id, "m16") || str_eq(p->id, "m162")) {
 
-      pmsg_error("programmer type %s is known not to work for %s\n", pgm->type, p->desc);
+      pmsg_error("programmer type %s is known not to work for %s\n", pgm->ptyp, p->desc);
       pmsg_error("exiting, use -F to carry on regardless\n");
       return LIBAVRDUDE_EXIT_FAIL;
     }
@@ -1686,7 +1686,7 @@ static int avrftdi_jtag_paged_read(const PROGRAMMER *pgm, const AVRPART *p,
 }
 
 void avrftdi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "avrftdi";
+  pgm->ptyp = "avrftdi";
 
   // Mandatory functions
   pgm->initialize = avrftdi_initialize;
@@ -1716,7 +1716,7 @@ void avrftdi_initpgm(PROGRAMMER *pgm) {
 }
 
 void avrftdi_jtag_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "avrftdi_jtag";
+  pgm->ptyp = "avrftdi_jtag";
 
   // Mandatory functions
   pgm->initialize = avrftdi_jtag_initialize;

--- a/src/bitbang.c
+++ b/src/bitbang.c
@@ -463,7 +463,7 @@ int bitbang_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if(is_tpi(p)) {
     // Make sure cmd_tpi() is defined
     if(pgm->cmd_tpi == NULL) {
-      pmsg_error("%s programmer does not support TPI\n", pgm->type);
+      pmsg_error("%s programmer does not support TPI\n", pgm->ptyp);
       return -1;
     }
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -1120,7 +1120,7 @@ static void buspirate_teardown(PROGRAMMER *pgm) {
 const char buspirate_desc[] = "Bus Pirate's SPI interface";
 
 void buspirate_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "BusPirate");
+  pgm->type = "BusPirate";
 
   pgm->display = buspirate_dummy_6;
 
@@ -1307,7 +1307,7 @@ static void buspirate_bb_powerdown(const PROGRAMMER *pgm) {
 const char buspirate_bb_desc[] = "Bus Pirate's bitbang interface";
 
 void buspirate_bb_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "BusPirate_BB");
+  pgm->type = "BusPirate_BB";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/buspirate.c
+++ b/src/buspirate.c
@@ -436,7 +436,7 @@ static int buspirate_verifyconfig(const PROGRAMMER *pgm) {
 // ====== Programmer methods =======
 static int buspirate_open(PROGRAMMER *pgm, const char *port) {
   if(pgm->bitclock) {
-    if(str_caseeq(pgm->type, "BusPirate_BB"))
+    if(str_caseeq(pgm->ptyp, "BusPirate_BB"))
       pmsg_warning("-c %s does not support adjustable bitclock speed using -B; use -i instead\n", pgmid);
     else {
       pmsg_warning("-c %s does not support adjustable bitclock speed; ignoring -B\n", pgmid);
@@ -1120,7 +1120,7 @@ static void buspirate_teardown(PROGRAMMER *pgm) {
 const char buspirate_desc[] = "Bus Pirate's SPI interface";
 
 void buspirate_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "BusPirate";
+  pgm->ptyp = "BusPirate";
 
   pgm->display = buspirate_dummy_6;
 
@@ -1307,7 +1307,7 @@ static void buspirate_bb_powerdown(const PROGRAMMER *pgm) {
 const char buspirate_bb_desc[] = "Bus Pirate's bitbang interface";
 
 void buspirate_bb_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "BusPirate_BB";
+  pgm->ptyp = "BusPirate_BB";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -660,7 +660,7 @@ static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 const char butterfly_desc[] = "Atmel Butterfly evaluation board (AVR109, AVR911)";
 
 void butterfly_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "butterfly");
+  pgm->type = "butterfly";
 
   // Mandatory functions
   pgm->rdy_led = butterfly_default_led;
@@ -695,6 +695,6 @@ const char butterfly_mk_desc[] = "Mikrokopter.de Butterfly";
 
 void butterfly_mk_initpgm(PROGRAMMER *pgm) {
   butterfly_initpgm(pgm);
-  strcpy(pgm->type, "butterfly_mk");
+  pgm->type = "butterfly_mk";
   pgm->flag = IS_BUTTERFLY_MK;
 }

--- a/src/butterfly.c
+++ b/src/butterfly.c
@@ -660,7 +660,7 @@ static int butterfly_parseextparms(const PROGRAMMER *pgm, const LISTID extparms)
 const char butterfly_desc[] = "Atmel Butterfly evaluation board (AVR109, AVR911)";
 
 void butterfly_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "butterfly";
+  pgm->ptyp = "butterfly";
 
   // Mandatory functions
   pgm->rdy_led = butterfly_default_led;
@@ -695,6 +695,6 @@ const char butterfly_mk_desc[] = "Mikrokopter.de Butterfly";
 
 void butterfly_mk_initpgm(PROGRAMMER *pgm) {
   butterfly_initpgm(pgm);
-  pgm->type = "butterfly_mk";
+  pgm->ptyp = "butterfly_mk";
   pgm->flag = IS_BUTTERFLY_MK;
 }

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -450,7 +450,7 @@ static void ch341a_display(const PROGRAMMER *pgm, const char *p) {
 }
 
 void ch341a_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "ch341a";
+  pgm->ptyp = "ch341a";
 
   // Mandatory functions
   pgm->initialize = ch341a_initialize;
@@ -482,7 +482,7 @@ static int ch341a_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void ch341a_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "ch341a";
+  pgm->ptyp = "ch341a";
   pgm->open = ch341a_nousb_open;
 }
 #endif                          // !defined(HAVE_LIBUSB_1_0)

--- a/src/ch341a.c
+++ b/src/ch341a.c
@@ -450,7 +450,7 @@ static void ch341a_display(const PROGRAMMER *pgm, const char *p) {
 }
 
 void ch341a_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "ch341a");
+  pgm->type = "ch341a";
 
   // Mandatory functions
   pgm->initialize = ch341a_initialize;
@@ -482,7 +482,7 @@ static int ch341a_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void ch341a_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "ch341a");
+  pgm->type = "ch341a";
   pgm->open = ch341a_nousb_open;
 }
 #endif                          // !defined(HAVE_LIBUSB_1_0)

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1231,7 +1231,7 @@ void dev_output_part_defs(char *partdesc) {
 
 static void dev_pgm_raw(const PROGRAMMER *pgm) {
   PROGRAMMER dp;
-  int len, idx;
+  int idx;
   char *id = ldata(lfirst(pgm->id));
   LNODEID ln;
 
@@ -1256,10 +1256,6 @@ static void dev_pgm_raw(const PROGRAMMER *pgm) {
     dev_raw_dump(dp.usbvendor, strlen(dp.usbvendor) + 1, id, "usbvend", 0);
   if(dp.usbproduct && *dp.usbproduct)
     dev_raw_dump(dp.usbproduct, strlen(dp.usbproduct) + 1, id, "usbprod", 0);
-
-  // Zap all bytes beyond terminating nul of type array
-  if((len = (int) strlen(dp.type) + 1) < (int) sizeof dp.type)
-    memset(dp.type + len, 0, sizeof dp.type - len);
 
   // Zap address values
   dp.desc = NULL;

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -1304,7 +1304,7 @@ const char dryrun_desc[] = "Dryrun programmer for testing avrdude";
 void dryrun_initpgm(PROGRAMMER *pgm) {
   pmsg_debug("%s()\n", __func__);
 
-  strcpy(pgm->type, "Dryrun");
+  pgm->type = "Dryrun";
 
   pgm->read_sig_bytes = dryrun_read_sig_bytes;
 

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -1304,7 +1304,7 @@ const char dryrun_desc[] = "Dryrun programmer for testing avrdude";
 void dryrun_initpgm(PROGRAMMER *pgm) {
   pmsg_debug("%s()\n", __func__);
 
-  pgm->type = "Dryrun";
+  pgm->ptyp = "Dryrun";
 
   pgm->read_sig_bytes = dryrun_read_sig_bytes;
 

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -157,7 +157,7 @@ static enum flip1_mem_unit flip1_mem_unit(const char *name);
 #endif                          // HAVE_LIBUSB
 
 void flip1_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "flip1";
+  pgm->ptyp = "flip1";
 
   // Mandatory functions
   pgm->initialize = flip1_initialize;

--- a/src/flip1.c
+++ b/src/flip1.c
@@ -157,7 +157,7 @@ static enum flip1_mem_unit flip1_mem_unit(const char *name);
 #endif                          // HAVE_LIBUSB
 
 void flip1_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "flip1");
+  pgm->type = "flip1";
 
   // Mandatory functions
   pgm->initialize = flip1_initialize;

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -156,7 +156,7 @@ static const char *flip2_mem_unit_str(enum flip2_mem_unit mem_unit);
 static enum flip2_mem_unit flip2_mem_unit(const char *name);
 
 void flip2_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "flip2";
+  pgm->ptyp = "flip2";
 
   // Mandatory functions
   pgm->initialize = flip2_initialize;
@@ -912,7 +912,7 @@ static int flip2_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void flip2_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "flip2";
+  pgm->ptyp = "flip2";
   pgm->open = flip2_nousb_open;
 }
 #endif                          // HAVE_LIBUSB

--- a/src/flip2.c
+++ b/src/flip2.c
@@ -156,7 +156,7 @@ static const char *flip2_mem_unit_str(enum flip2_mem_unit mem_unit);
 static enum flip2_mem_unit flip2_mem_unit(const char *name);
 
 void flip2_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "flip2");
+  pgm->type = "flip2";
 
   // Mandatory functions
   pgm->initialize = flip2_initialize;
@@ -912,7 +912,7 @@ static int flip2_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void flip2_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "flip2");
+  pgm->type = "flip2";
   pgm->open = flip2_nousb_open;
 }
 #endif                          // HAVE_LIBUSB

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -98,7 +98,7 @@ static int ft245r_noftdi_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void ft245r_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "ftdi_syncbb");
+  pgm->type = "ftdi_syncbb";
   pgm->open = ft245r_noftdi_open;
 }
 
@@ -1208,7 +1208,7 @@ void ft245r_teardown(PROGRAMMER *pgm) {
 }
 
 void ft245r_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "ftdi_syncbb");
+  pgm->type = "ftdi_syncbb";
 
   // Mandatory functions
   pgm->initialize = ft245r_initialize;

--- a/src/ft245r.c
+++ b/src/ft245r.c
@@ -98,7 +98,7 @@ static int ft245r_noftdi_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void ft245r_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "ftdi_syncbb";
+  pgm->ptyp = "ftdi_syncbb";
   pgm->open = ft245r_noftdi_open;
 }
 
@@ -1208,7 +1208,7 @@ void ft245r_teardown(PROGRAMMER *pgm) {
 }
 
 void ft245r_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "ftdi_syncbb";
+  pgm->ptyp = "ftdi_syncbb";
 
   // Mandatory functions
   pgm->initialize = ft245r_initialize;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -3275,7 +3275,7 @@ static int jtag3_paged_write_tpi(const PROGRAMMER *pgm, const AVRPART *p,
 const char jtag3_desc[] = "Atmel JTAGICE3";
 
 void jtag3_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGICE3");
+  pgm->type = "JTAGICE3";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3313,7 +3313,7 @@ void jtag3_initpgm(PROGRAMMER *pgm) {
 const char jtag3_dw_desc[] = "Atmel JTAGICE3 in debugWire mode";
 
 void jtag3_dw_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGICE3_DW");
+  pgm->type = "JTAGICE3_DW";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3348,7 +3348,7 @@ void jtag3_dw_initpgm(PROGRAMMER *pgm) {
 const char jtag3_pdi_desc[] = "Atmel JTAGICE3 in PDI mode";
 
 void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGICE3_PDI");
+  pgm->type = "JTAGICE3_PDI";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3386,7 +3386,7 @@ void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
 const char jtag3_updi_desc[] = "Atmel JTAGICE3 in UPDI mode";
 
 void jtag3_updi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGICE3_UPDI");
+  pgm->type = "JTAGICE3_UPDI";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3426,7 +3426,7 @@ void jtag3_updi_initpgm(PROGRAMMER *pgm) {
 const char jtag3_tpi_desc[] = "Atmel JTAGICE3 in TPI mode";
 
 void jtag3_tpi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGICE3_TPI");
+  pgm->type = "JTAGICE3_TPI";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize_tpi;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -1390,7 +1390,7 @@ static int jtag3_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   if(use_ext_reset > 1) {
-    if(str_eq(pgm->type, "JTAGICE3") && (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG)))
+    if(str_eq(pgm->ptyp, "JTAGICE3") && (p->prog_modes & (PM_JTAG | PM_JTAGmkI | PM_XMEGAJTAG | PM_AVR32JTAG)))
       pmsg_error("JTAGEN fuse disabled?\n");
     return -1;
   }
@@ -1627,7 +1627,7 @@ static int jtag3_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) {
       rv = -1;
     }
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    if(str_eq(pgm->type, "JTAGICE3")) {
+    if(str_eq(pgm->ptyp, "JTAGICE3")) {
       msg_error("  -x jtagchain=UB,UA,BB,BA Setup the JTAG scan chain order\n");
       msg_error("                         UB/UA = units before/after, BB/BA = bits before/after\n");
     }
@@ -2712,7 +2712,7 @@ void jtag3_print_parms1(const PROGRAMMER *pgm, const char *p, FILE *fp) {
   }
 
   // Print clocks if programmer type is not TPI
-  if(!str_eq(pgm->type, "JTAGICE3_TPI")) {
+  if(!str_eq(pgm->ptyp, "JTAGICE3_TPI")) {
     // Get current programming mode and target type from to determine what data to print
     if(jtag3_getparm(pgm, SCOPE_AVR, 1, PARM3_CONNECTION, prog_mode, 1) < 0)
       return;
@@ -3275,7 +3275,7 @@ static int jtag3_paged_write_tpi(const PROGRAMMER *pgm, const AVRPART *p,
 const char jtag3_desc[] = "Atmel JTAGICE3";
 
 void jtag3_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGICE3";
+  pgm->ptyp = "JTAGICE3";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3313,7 +3313,7 @@ void jtag3_initpgm(PROGRAMMER *pgm) {
 const char jtag3_dw_desc[] = "Atmel JTAGICE3 in debugWire mode";
 
 void jtag3_dw_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGICE3_DW";
+  pgm->ptyp = "JTAGICE3_DW";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3348,7 +3348,7 @@ void jtag3_dw_initpgm(PROGRAMMER *pgm) {
 const char jtag3_pdi_desc[] = "Atmel JTAGICE3 in PDI mode";
 
 void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGICE3_PDI";
+  pgm->ptyp = "JTAGICE3_PDI";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3386,7 +3386,7 @@ void jtag3_pdi_initpgm(PROGRAMMER *pgm) {
 const char jtag3_updi_desc[] = "Atmel JTAGICE3 in UPDI mode";
 
 void jtag3_updi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGICE3_UPDI";
+  pgm->ptyp = "JTAGICE3_UPDI";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize;
@@ -3426,7 +3426,7 @@ void jtag3_updi_initpgm(PROGRAMMER *pgm) {
 const char jtag3_tpi_desc[] = "Atmel JTAGICE3 in TPI mode";
 
 void jtag3_tpi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGICE3_TPI";
+  pgm->ptyp = "JTAGICE3_TPI";
 
   // Mandatory functions
   pgm->initialize = jtag3_initialize_tpi;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -1162,7 +1162,7 @@ static void jtagmkI_print_parms(const PROGRAMMER *pgm, FILE *fp) {
 const char jtagmkI_desc[] = "Atmel JTAG ICE mkI";
 
 void jtagmkI_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGMKI");
+  pgm->type = "JTAGMKI";
 
   // Mandatory functions
   pgm->initialize = jtagmkI_initialize;

--- a/src/jtagmkI.c
+++ b/src/jtagmkI.c
@@ -1162,7 +1162,7 @@ static void jtagmkI_print_parms(const PROGRAMMER *pgm, FILE *fp) {
 const char jtagmkI_desc[] = "Atmel JTAG ICE mkI";
 
 void jtagmkI_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGMKI";
+  pgm->ptyp = "JTAGMKI";
 
   // Mandatory functions
   pgm->initialize = jtagmkI_initialize;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -629,9 +629,9 @@ int jtagmkII_getsync(const PROGRAMMER *pgm, int mode) {
 
   pmsg_debug("jtagmkII_getsync()\n");
 
-  if(str_starts(pgm->type, "JTAG")) {
+  if(str_starts(pgm->ptyp, "JTAG")) {
     is_dragon = 0;
-  } else if(str_starts(pgm->type, "DRAGON")) {
+  } else if(str_starts(pgm->ptyp, "DRAGON")) {
     is_dragon = 1;
   } else {
     pmsg_error("programmer is neither JTAG ICE mkII nor AVR Dragon\n");
@@ -1161,7 +1161,7 @@ static int jtagmkII_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   }
 
   // Abort and print error if programmer does not support the target microcontroller
-  if((str_eq(pgm->type, "JTAGMKII_UPDI") && !is_updi(p)) || (pgmid_is("jtagmkII") && is_updi(p))) {
+  if((str_eq(pgm->ptyp, "JTAGMKII_UPDI") && !is_updi(p)) || (pgmid_is("jtagmkII") && is_updi(p))) {
     msg_error("programmer %s does not support target %s\n\n", pgmid, p->desc);
     return -1;
   }
@@ -3705,7 +3705,7 @@ static int jtagmkII_updi_end_programming(const PROGRAMMER *pgm, const AVRPART *p
 const char jtagmkII_desc[] = "Atmel JTAG ICE mkII";
 
 void jtagmkII_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGMKII";
+  pgm->ptyp = "JTAGMKII";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3737,7 +3737,7 @@ void jtagmkII_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dw_desc[] = "Atmel JTAG ICE mkII in debugWire mode";
 
 void jtagmkII_dw_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGMKII_DW";
+  pgm->ptyp = "JTAGMKII_DW";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3764,7 +3764,7 @@ void jtagmkII_dw_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_pdi_desc[] = "Atmel JTAG ICE mkII in PDI mode";
 
 void jtagmkII_pdi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGMKII_PDI";
+  pgm->ptyp = "JTAGMKII_PDI";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3793,7 +3793,7 @@ void jtagmkII_pdi_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_updi_desc[] = "Atmel JTAG ICE mkII in UPDI mode";
 
 void jtagmkII_updi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGMKII_UPDI";
+  pgm->ptyp = "JTAGMKII_UPDI";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3825,7 +3825,7 @@ void jtagmkII_updi_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dragon_desc[] = "Atmel AVR Dragon in JTAG mode";
 
 void jtagmkII_dragon_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "DRAGON_JTAG";
+  pgm->ptyp = "DRAGON_JTAG";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3857,7 +3857,7 @@ void jtagmkII_dragon_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dragon_dw_desc[] = "Atmel AVR Dragon in debugWire mode";
 
 void jtagmkII_dragon_dw_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "DRAGON_DW";
+  pgm->ptyp = "DRAGON_DW";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3884,7 +3884,7 @@ void jtagmkII_dragon_dw_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_avr32_desc[] = "Atmel JTAG ICE mkII in AVR32 mode";
 
 void jtagmkII_avr32_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGMKII_AVR32";
+  pgm->ptyp = "JTAGMKII_AVR32";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize32;
@@ -3913,7 +3913,7 @@ void jtagmkII_avr32_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dragon_pdi_desc[] = "Atmel AVR Dragon in PDI mode";
 
 void jtagmkII_dragon_pdi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "DRAGON_PDI";
+  pgm->ptyp = "DRAGON_PDI";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -3705,7 +3705,7 @@ static int jtagmkII_updi_end_programming(const PROGRAMMER *pgm, const AVRPART *p
 const char jtagmkII_desc[] = "Atmel JTAG ICE mkII";
 
 void jtagmkII_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGMKII");
+  pgm->type = "JTAGMKII";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3737,7 +3737,7 @@ void jtagmkII_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dw_desc[] = "Atmel JTAG ICE mkII in debugWire mode";
 
 void jtagmkII_dw_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGMKII_DW");
+  pgm->type = "JTAGMKII_DW";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3764,7 +3764,7 @@ void jtagmkII_dw_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_pdi_desc[] = "Atmel JTAG ICE mkII in PDI mode";
 
 void jtagmkII_pdi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGMKII_PDI");
+  pgm->type = "JTAGMKII_PDI";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3793,7 +3793,7 @@ void jtagmkII_pdi_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_updi_desc[] = "Atmel JTAG ICE mkII in UPDI mode";
 
 void jtagmkII_updi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGMKII_UPDI");
+  pgm->type = "JTAGMKII_UPDI";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3825,7 +3825,7 @@ void jtagmkII_updi_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dragon_desc[] = "Atmel AVR Dragon in JTAG mode";
 
 void jtagmkII_dragon_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "DRAGON_JTAG");
+  pgm->type = "DRAGON_JTAG";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3857,7 +3857,7 @@ void jtagmkII_dragon_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dragon_dw_desc[] = "Atmel AVR Dragon in debugWire mode";
 
 void jtagmkII_dragon_dw_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "DRAGON_DW");
+  pgm->type = "DRAGON_DW";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;
@@ -3884,7 +3884,7 @@ void jtagmkII_dragon_dw_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_avr32_desc[] = "Atmel JTAG ICE mkII in AVR32 mode";
 
 void jtagmkII_avr32_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGMKII_AVR32");
+  pgm->type = "JTAGMKII_AVR32";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize32;
@@ -3913,7 +3913,7 @@ void jtagmkII_avr32_initpgm(PROGRAMMER *pgm) {
 const char jtagmkII_dragon_pdi_desc[] = "Atmel AVR Dragon in PDI mode";
 
 void jtagmkII_dragon_pdi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "DRAGON_PDI");
+  pgm->type = "DRAGON_PDI";
 
   // Mandatory functions
   pgm->initialize = jtagmkII_initialize;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1011,7 +1011,7 @@ typedef struct programmer {
 
   // Values below are not set by config_gram.y; ensure fd is first for dev_pgm_raw()
   union filedescriptor fd;
-  const char *type;
+  const char *ptyp;
   const char *port;
   unsigned int pinno[N_PINS];   // TODO: to be removed if old pin data no longer needed
   Exit_vcc exit_vcc;            // Should these be set in avrdude.conf?

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -936,8 +936,6 @@ typedef struct {                // Memory cache for a subset of cached pages
 #define OFF                   0 // Many contexts: reset, power, LEDs, ...
 #define ON                    1 // Many contexts
 
-#define PGM_TYPELEN 32
-
 typedef enum {
   EXIT_VCC_UNSPEC,
   EXIT_VCC_ENABLED,
@@ -1013,7 +1011,7 @@ typedef struct programmer {
 
   // Values below are not set by config_gram.y; ensure fd is first for dev_pgm_raw()
   union filedescriptor fd;
-  char type[PGM_TYPELEN];
+  const char *type;
   const char *port;
   unsigned int pinno[N_PINS];   // TODO: to be removed if old pin data no longer needed
   Exit_vcc exit_vcc;            // Should these be set in avrdude.conf?

--- a/src/libavrdude.i
+++ b/src/libavrdude.i
@@ -538,7 +538,7 @@ typedef struct programmer {
   LISTID usbpid;
   int ispdelay;                 // ISP clock delay
   double bitclock;              // JTAG ICE clock period in microseconds
-  const char *type;
+  const char *ptyp;
 
   // methods; they must *not* be declares as pointers
   void initpgm        (struct programmer *pgm); // Sets up the AVRDUDE programmer

--- a/src/libavrdude.i
+++ b/src/libavrdude.i
@@ -538,7 +538,7 @@ typedef struct programmer {
   LISTID usbpid;
   int ispdelay;                 // ISP clock delay
   double bitclock;              // JTAG ICE clock period in microseconds
-  char type[PGM_TYPELEN];
+  const char *type;
 
   // methods; they must *not* be declares as pointers
   void initpgm        (struct programmer *pgm); // Sets up the AVRDUDE programmer

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -729,7 +729,7 @@ static int linuxgpio_libgpiod_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
 #endif                          // HAVE_LIBGPIOD
 
 void linuxgpio_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "linuxgpio");
+  pgm->type = "linuxgpio";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/linuxgpio.c
+++ b/src/linuxgpio.c
@@ -729,7 +729,7 @@ static int linuxgpio_libgpiod_highpulsepin(const PROGRAMMER *pgm, int pinfunc) {
 #endif                          // HAVE_LIBGPIOD
 
 void linuxgpio_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "linuxgpio";
+  pgm->ptyp = "linuxgpio";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -455,7 +455,7 @@ static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
 }
 
 void linuxspi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = LINUXSPI;
+  pgm->ptyp = LINUXSPI;
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/linuxspi.c
+++ b/src/linuxspi.c
@@ -455,7 +455,7 @@ static int linuxspi_parseextparams(const PROGRAMMER *pgm, const LISTID extparms)
 }
 
 void linuxspi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, LINUXSPI);
+  pgm->type = LINUXSPI;
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/main.c
+++ b/src/main.c
@@ -1378,7 +1378,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  int is_dryrun = str_eq(pgm->type, "Dryrun") || (dry && pgm->initpgm == dry->initpgm);
+  int is_dryrun = str_eq(pgm->ptyp, "Dryrun") || (dry && pgm->initpgm == dry->initpgm);
 
   if((port[0] == 0 || str_eq(port, "unknown")) && !is_dryrun) {
     msg_error("\n");
@@ -1544,7 +1544,7 @@ int main(int argc, char *argv[]) {
   }
 
   if(verbose > 0) {
-    if((str_eq(pgm->type, "avr910"))) {
+    if((str_eq(pgm->ptyp, "avr910"))) {
       imsg_notice("avr910_devcode (avrdude.conf) : ");
       if(p->avr910_devcode)
         msg_notice("0x%02x\n", (uint8_t) p->avr910_devcode);
@@ -1651,17 +1651,17 @@ init_again:
     else
       imsg_error(" - double check the connections and try again\n");
 
-    if(str_eq(pgm->type, "serialupdi"))
+    if(str_eq(pgm->ptyp, "serialupdi"))
       imsg_error(" - use -b to set lower baud rate, e.g. -b %d\n", baudrate? baudrate/2: 57600);
-    else if(str_eq(pgm->type, "BusPirate_BB") || str_eq(pgm->type, "linuxgpio") ||
-      str_eq(pgm->type, "PPI") || str_eq(pgm->type, "SERBB")) {
+    else if(str_eq(pgm->ptyp, "BusPirate_BB") || str_eq(pgm->ptyp, "linuxgpio") ||
+      str_eq(pgm->ptyp, "PPI") || str_eq(pgm->ptyp, "SERBB")) {
       imsg_error(" - use -i %sto set a longer delay (in microseconds) between each bit state change, e.g. -i 50\n",
         bitclock? "instead of -B ": "");
     }
     else
       imsg_error(" - use -B to set lower the bit clock frequency, e.g. -B 125kHz\n");
 
-    if(str_starts(pgm->type, "pickit5"))
+    if(str_starts(pgm->ptyp, "pickit5"))
       imsg_error(" - reset the programmer by unplugging it");
 
     if(!ovsigck) {

--- a/src/main.c
+++ b/src/main.c
@@ -1378,7 +1378,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  int is_dryrun = str_eq(pgm->type, "dryrun") || (dry && pgm->initpgm == dry->initpgm);
+  int is_dryrun = str_eq(pgm->type, "Dryrun") || (dry && pgm->initpgm == dry->initpgm);
 
   if((port[0] == 0 || str_eq(port, "unknown")) && !is_dryrun) {
     msg_error("\n");
@@ -1653,8 +1653,8 @@ init_again:
 
     if(str_eq(pgm->type, "serialupdi"))
       imsg_error(" - use -b to set lower baud rate, e.g. -b %d\n", baudrate? baudrate/2: 57600);
-    else if(str_eq(pgm->type, "buspirate_bb") || str_eq(pgm->type, "linuxgpio") ||
-      str_eq(pgm->type, "par") || str_eq(pgm->type, "SERBB")) {
+    else if(str_eq(pgm->type, "BusPirate_BB") || str_eq(pgm->type, "linuxgpio") ||
+      str_eq(pgm->type, "PPI") || str_eq(pgm->type, "SERBB")) {
       imsg_error(" - use -i %sto set a longer delay (in microseconds) between each bit state change, e.g. -i 50\n",
         bitclock? "instead of -B ": "");
     }

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -824,7 +824,7 @@ static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xpara
 }
 
 void micronucleus_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "Micronucleus V2.0");
+  pgm->type = "Micronucleus V2.0";
 
   pgm->setup = micronucleus_setup;
   pgm->teardown = micronucleus_teardown;
@@ -856,7 +856,7 @@ static int micronucleus_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void micronucleus_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "micronucleus");
+  pgm->type = "micronucleus";
   pgm->open = micronucleus_nousb_open;
 }
 #endif                          // HAVE_LIBUSB

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -824,7 +824,7 @@ static int micronucleus_parseextparams(const PROGRAMMER *pgm, const LISTID xpara
 }
 
 void micronucleus_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "Micronucleus V2.0";
+  pgm->ptyp = "Micronucleus V2.0";
 
   pgm->setup = micronucleus_setup;
   pgm->teardown = micronucleus_teardown;
@@ -856,7 +856,7 @@ static int micronucleus_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void micronucleus_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "micronucleus";
+  pgm->ptyp = "micronucleus";
   pgm->open = micronucleus_nousb_open;
 }
 #endif                          // HAVE_LIBUSB

--- a/src/par.c
+++ b/src/par.c
@@ -370,7 +370,7 @@ static int par_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
 }
 
 void par_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "PPI");
+  pgm->type = "PPI";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/par.c
+++ b/src/par.c
@@ -370,7 +370,7 @@ static int par_parseexitspecs(PROGRAMMER *pgm, const char *sp) {
 }
 
 void par_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "PPI";
+  pgm->ptyp = "PPI";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -132,7 +132,7 @@ PROGRAMMER *pgm_new(void) {
   pgm->usbpid = lcreat(NULL, 0);
   pgm->hvupdi_support = lcreat(NULL, 0);
   pgm->desc = nulp;
-  pgm->type = "not set";
+  pgm->ptyp = "not set";
   pgm->parent_id = nulp;
   pgm->usbdev = nulp;
   pgm->usbsn = nulp;
@@ -273,7 +273,7 @@ static void pgm_default_setup_teardown(PROGRAMMER *pgm) {
 }
 
 void programmer_display(PROGRAMMER *pgm, const char *p) {
-  msg_info("%sProgrammer type       : %s\n", p, pgm->type);
+  msg_info("%sProgrammer type       : %s\n", p, pgm->ptyp);
   msg_info("%sDescription           : %s\n", p, pgm->desc);
 
   pgm->display(pgm, p);

--- a/src/pgm.c
+++ b/src/pgm.c
@@ -132,6 +132,7 @@ PROGRAMMER *pgm_new(void) {
   pgm->usbpid = lcreat(NULL, 0);
   pgm->hvupdi_support = lcreat(NULL, 0);
   pgm->desc = nulp;
+  pgm->type = "not set";
   pgm->parent_id = nulp;
   pgm->usbdev = nulp;
   pgm->usbsn = nulp;

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1098,7 +1098,7 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
   pgm->teardown = pickit2_teardown;
   // pgm->page_size = 256;      // Not sure what this does ... maybe the max page size that paged read/write can handle
 
-  pgm->type = "pickit2";
+  pgm->ptyp = "pickit2";
 }
 #else
 static int pickit2_nousb_open(PROGRAMMER *pgm, const char *name) {
@@ -1117,7 +1117,7 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
   // Mandatory function
   pgm->open = pickit2_nousb_open;
 
-  pgm->type = "pickit2";
+  pgm->ptyp = "pickit2";
 }
 #endif                          // defined(HAVE_LIBUSB) || defined(WIN32)
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1098,7 +1098,7 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
   pgm->teardown = pickit2_teardown;
   // pgm->page_size = 256;      // Not sure what this does ... maybe the max page size that paged read/write can handle
 
-  strncpy(pgm->type, "pickit2", sizeof(pgm->type));
+  pgm->type = "pickit2";
 }
 #else
 static int pickit2_nousb_open(PROGRAMMER *pgm, const char *name) {
@@ -1117,7 +1117,7 @@ void pickit2_initpgm(PROGRAMMER *pgm) {
   // Mandatory function
   pgm->open = pickit2_nousb_open;
 
-  strncpy(pgm->type, "pickit2", sizeof(pgm->type));
+  pgm->type = "pickit2";
 }
 #endif                          // defined(HAVE_LIBUSB) || defined(WIN32)
 

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -2157,7 +2157,7 @@ static int pickit5_software_reset(const PROGRAMMER *pgm) {
 */
 
 void pickit5_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "pickit5";
+  pgm->ptyp = "pickit5";
 
   // Mandatory functions
   pgm->initialize = pickit5_initialize;
@@ -2317,7 +2317,7 @@ static int pickit5_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void pickit5_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "pickit5";
+  pgm->ptyp = "pickit5";
 
   pgm->open = pickit5_nousb_open;
 }

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -2157,7 +2157,7 @@ static int pickit5_software_reset(const PROGRAMMER *pgm) {
 */
 
 void pickit5_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "pickit5");
+  pgm->type = "pickit5";
 
   // Mandatory functions
   pgm->initialize = pickit5_initialize;
@@ -2317,7 +2317,7 @@ static int pickit5_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void pickit5_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "pickit5");
+  pgm->type = "pickit5";
 
   pgm->open = pickit5_nousb_open;
 }

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -290,7 +290,7 @@ static void serbb_teardown(PROGRAMMER *pgm) {
 const char serbb_desc[] = "Serial port bitbanging";
 
 void serbb_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "SERBB");
+  pgm->type = "SERBB";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/serbb_posix.c
+++ b/src/serbb_posix.c
@@ -290,7 +290,7 @@ static void serbb_teardown(PROGRAMMER *pgm) {
 const char serbb_desc[] = "Serial port bitbanging";
 
 void serbb_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "SERBB";
+  pgm->ptyp = "SERBB";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -301,7 +301,7 @@ static void serbb_teardown(PROGRAMMER *pgm) {
 const char serbb_desc[] = "Serial port bitbanging";
 
 void serbb_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "SERBB");
+  pgm->type = "SERBB";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/serbb_win32.c
+++ b/src/serbb_win32.c
@@ -301,7 +301,7 @@ static void serbb_teardown(PROGRAMMER *pgm) {
 const char serbb_desc[] = "Serial port bitbanging";
 
 void serbb_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "SERBB";
+  pgm->ptyp = "SERBB";
 
   pgm_fill_old_pins(pgm);       // TODO to be removed if old pin data no longer needed
 

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -1057,7 +1057,7 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
 }
 
 void serialupdi_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "serialupdi";
+  pgm->ptyp = "serialupdi";
 
   // Mandatory functions
   pgm->initialize = serialupdi_initialize;

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -1057,7 +1057,7 @@ static int serialupdi_parseextparms(const PROGRAMMER *pgm, const LISTID extparms
 }
 
 void serialupdi_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "serialupdi");
+  pgm->type = "serialupdi";
 
   // Mandatory functions
   pgm->initialize = serialupdi_initialize;

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -497,7 +497,7 @@ static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
 }
 
 void serprog_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "serprog";
+  pgm->ptyp = "serprog";
 
   // Required fields
   pgm->initialize = serprog_initialize;

--- a/src/serprog.c
+++ b/src/serprog.c
@@ -497,7 +497,7 @@ static int serprog_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
 }
 
 void serprog_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "serprog");
+  pgm->type = "serprog";
 
   // Required fields
   pgm->initialize = serprog_initialize;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -107,7 +107,7 @@ int stk500_getsync(const PROGRAMMER *pgm) {
 
   for(attempt = 0; attempt < max_sync_attempts; attempt++) {
     // Restart Arduino bootloader for every sync attempt
-    if(str_eq(pgm->type, "Arduino") && my.autoreset && attempt > 0) {
+    if(str_eq(pgm->ptyp, "Arduino") && my.autoreset && attempt > 0) {
       // This code assumes a negative-logic USB to TTL serial adapter
       // Pull the RTS/DTR line low to reset AVR: it is still high from open()/last attempt
       serial_set_dtr_rts(&pgm->fd, 1);
@@ -186,7 +186,7 @@ static int stk500_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
   unsigned char res[4];
 
   if(pgm->cmd == NULL) {
-    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->type, __func__);
+    pmsg_error("%s programmer uses %s() without providing a cmd() method\n", pgm->ptyp, __func__);
     return -1;
   }
 
@@ -1461,7 +1461,7 @@ static void stk500_display(const PROGRAMMER *pgm, const char *p) {
     }
     msg_info("%sTopcard               : %s\n", p, n);
   }
-  if(!str_eq(pgm->type, "Arduino"))
+  if(!str_eq(pgm->ptyp, "Arduino"))
     stk500_print_parms1(pgm, p, stderr);
 
   return;
@@ -1545,7 +1545,7 @@ static void stk500_setup(PROGRAMMER *pgm) {
   else
     my.xtal = STK500_XTAL;
   // The -c arduino programmer has auto-reset enabled be default
-  if(str_eq(pgm->type, "Arduino"))
+  if(str_eq(pgm->ptyp, "Arduino"))
     my.autoreset = true;
 }
 
@@ -1557,7 +1557,7 @@ static void stk500_teardown(PROGRAMMER *pgm) {
 const char stk500_desc[] = "Atmel STK500 Version 1.x firmware";
 
 void stk500_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK500";
+  pgm->ptyp = "STK500";
 
   // Mandatory functions
   pgm->initialize = stk500_initialize;

--- a/src/stk500.c
+++ b/src/stk500.c
@@ -1557,7 +1557,7 @@ static void stk500_teardown(PROGRAMMER *pgm) {
 const char stk500_desc[] = "Atmel STK500 Version 1.x firmware";
 
 void stk500_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK500");
+  pgm->type = "STK500";
 
   // Mandatory functions
   pgm->initialize = stk500_initialize;

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -69,7 +69,7 @@ static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
 const char stk500generic_desc[] = "Atmel STK500, autodetect firmware version";
 
 void stk500generic_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK500GENERIC";
+  pgm->ptyp = "STK500GENERIC";
 
   pgm->open = stk500generic_open;
 }

--- a/src/stk500generic.c
+++ b/src/stk500generic.c
@@ -69,7 +69,7 @@ static int stk500generic_open(PROGRAMMER *pgm, const char *port) {
 const char stk500generic_desc[] = "Atmel STK500, autodetect firmware version";
 
 void stk500generic_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK500GENERIC");
+  pgm->type = "STK500GENERIC";
 
   pgm->open = stk500generic_open;
 }

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -1777,7 +1777,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           my.varef_set = true;
         }
         // Get new analog reference voltage for channel 1
-        else if(str_starts(extended_param, "varef1=") && str_contains(pgm->type, "STK600")) {
+        else if(str_starts(extended_param, "varef1=") && str_contains(pgm->ptyp, "STK600")) {
           sscanf_success = sscanf(extended_param, "varef1=%lf", &varef_set_val);
           my.varef_channel = 1;
           my.varef_set = true;
@@ -1789,7 +1789,7 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
           continue;
         }
         // Get current analog reference voltage for channel 1
-        else if(str_eq(extended_param, "varef1") && str_contains(pgm->type, "STK600")) {
+        else if(str_eq(extended_param, "varef1") && str_contains(pgm->ptyp, "STK600")) {
           my.varef_get = true;
           my.varef_channel = 1;
           continue;
@@ -1899,10 +1899,10 @@ static int stk500v2_parseextparms(const PROGRAMMER *pgm, const LISTID extparms) 
     if(pgm->extra_features & HAS_VTARG_ADJ)
       msg_error("  -x vtarg=<dbl>    Set on-board target supply voltage to <dbl> V\n");
     if(pgm->extra_features & HAS_VAREF_ADJ) {
-      if(str_contains(pgm->type, "STK500")) {
+      if(str_contains(pgm->ptyp, "STK500")) {
         msg_error("  -x varef          Read analog reference voltage\n");
         msg_error("  -x varef=<dbl>    Set analog reference voltage to <dbl> V\n");
-      } else if(str_contains(pgm->type, "STK600")) {
+      } else if(str_contains(pgm->ptyp, "STK600")) {
         msg_error("  -x varef          Read channel 0 analog reference voltage\n");
         msg_error("  -x varef0         Alias for -x varef\n");
         msg_error("  -x varef1         Read channel 1 analog reference voltage\n");
@@ -4760,7 +4760,7 @@ static void stk600_setup_isp(PROGRAMMER *pgm) {
 const char stk500v2_desc[] = "Atmel STK500 Version 2.x firmware";
 
 void stk500v2_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK500V2";
+  pgm->ptyp = "STK500V2";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -4806,7 +4806,7 @@ void stk500v2_initpgm(PROGRAMMER *pgm) {
 const char stk500pp_desc[] = "Atmel STK500 V2 in parallel programming mode";
 
 void stk500pp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK500PP";
+  pgm->ptyp = "STK500PP";
 
   // Mandatory functions
   pgm->initialize = stk500pp_initialize;
@@ -4842,7 +4842,7 @@ void stk500pp_initpgm(PROGRAMMER *pgm) {
 const char stk500hvsp_desc[] = "Atmel STK500 V2 in high-voltage serial programming mode";
 
 void stk500hvsp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK500HVSP";
+  pgm->ptyp = "STK500HVSP";
 
   // Mandatory functions
   pgm->initialize = stk500hvsp_initialize;
@@ -4878,7 +4878,7 @@ void stk500hvsp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_jtagmkII_desc[] = "Atmel JTAG ICE mkII in ISP mode";
 
 void stk500v2_jtagmkII_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAGMKII_ISP";
+  pgm->ptyp = "JTAGMKII_ISP";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -4909,7 +4909,7 @@ void stk500v2_jtagmkII_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_dragon_isp_desc[] = "Atmel AVR Dragon in ISP mode";
 
 void stk500v2_dragon_isp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "DRAGON_ISP";
+  pgm->ptyp = "DRAGON_ISP";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -4940,7 +4940,7 @@ void stk500v2_dragon_isp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_dragon_pp_desc[] = "Atmel AVR Dragon in PP mode";
 
 void stk500v2_dragon_pp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "DRAGON_PP";
+  pgm->ptyp = "DRAGON_PP";
 
   // Mandatory functions
   pgm->initialize = stk500pp_initialize;
@@ -4968,7 +4968,7 @@ void stk500v2_dragon_pp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_dragon_hvsp_desc[] = "Atmel AVR Dragon in HVSP mode";
 
 void stk500v2_dragon_hvsp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "DRAGON_HVSP";
+  pgm->ptyp = "DRAGON_HVSP";
 
   // Mandatory functions
   pgm->initialize = stk500hvsp_initialize;
@@ -4996,7 +4996,7 @@ void stk500v2_dragon_hvsp_initpgm(PROGRAMMER *pgm) {
 const char stk600_desc[] = "Atmel STK600";
 
 void stk600_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK600";
+  pgm->ptyp = "STK600";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -5034,7 +5034,7 @@ void stk600_initpgm(PROGRAMMER *pgm) {
 const char stk600pp_desc[] = "Atmel STK600 in parallel programming mode";
 
 void stk600pp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK600PP";
+  pgm->ptyp = "STK600PP";
 
   // Mandatory functions
   pgm->initialize = stk500pp_initialize;
@@ -5069,7 +5069,7 @@ void stk600pp_initpgm(PROGRAMMER *pgm) {
 const char stk600hvsp_desc[] = "Atmel STK600 in high-voltage serial programming mode";
 
 void stk600hvsp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "STK600HVSP";
+  pgm->ptyp = "STK600HVSP";
 
   // Mandatory functions
   pgm->initialize = stk500hvsp_initialize;
@@ -5104,7 +5104,7 @@ void stk600hvsp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_jtag3_desc[] = "Atmel JTAGICE3 in ISP mode";
 
 void stk500v2_jtag3_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "JTAG3_ISP";
+  pgm->ptyp = "JTAG3_ISP";
 
   // Mandatory functions
   pgm->initialize = stk500v2_jtag3_initialize;

--- a/src/stk500v2.c
+++ b/src/stk500v2.c
@@ -4760,7 +4760,7 @@ static void stk600_setup_isp(PROGRAMMER *pgm) {
 const char stk500v2_desc[] = "Atmel STK500 Version 2.x firmware";
 
 void stk500v2_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK500V2");
+  pgm->type = "STK500V2";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -4806,7 +4806,7 @@ void stk500v2_initpgm(PROGRAMMER *pgm) {
 const char stk500pp_desc[] = "Atmel STK500 V2 in parallel programming mode";
 
 void stk500pp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK500PP");
+  pgm->type = "STK500PP";
 
   // Mandatory functions
   pgm->initialize = stk500pp_initialize;
@@ -4842,7 +4842,7 @@ void stk500pp_initpgm(PROGRAMMER *pgm) {
 const char stk500hvsp_desc[] = "Atmel STK500 V2 in high-voltage serial programming mode";
 
 void stk500hvsp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK500HVSP");
+  pgm->type = "STK500HVSP";
 
   // Mandatory functions
   pgm->initialize = stk500hvsp_initialize;
@@ -4878,7 +4878,7 @@ void stk500hvsp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_jtagmkII_desc[] = "Atmel JTAG ICE mkII in ISP mode";
 
 void stk500v2_jtagmkII_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAGMKII_ISP");
+  pgm->type = "JTAGMKII_ISP";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -4909,7 +4909,7 @@ void stk500v2_jtagmkII_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_dragon_isp_desc[] = "Atmel AVR Dragon in ISP mode";
 
 void stk500v2_dragon_isp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "DRAGON_ISP");
+  pgm->type = "DRAGON_ISP";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -4940,7 +4940,7 @@ void stk500v2_dragon_isp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_dragon_pp_desc[] = "Atmel AVR Dragon in PP mode";
 
 void stk500v2_dragon_pp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "DRAGON_PP");
+  pgm->type = "DRAGON_PP";
 
   // Mandatory functions
   pgm->initialize = stk500pp_initialize;
@@ -4968,7 +4968,7 @@ void stk500v2_dragon_pp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_dragon_hvsp_desc[] = "Atmel AVR Dragon in HVSP mode";
 
 void stk500v2_dragon_hvsp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "DRAGON_HVSP");
+  pgm->type = "DRAGON_HVSP";
 
   // Mandatory functions
   pgm->initialize = stk500hvsp_initialize;
@@ -4996,7 +4996,7 @@ void stk500v2_dragon_hvsp_initpgm(PROGRAMMER *pgm) {
 const char stk600_desc[] = "Atmel STK600";
 
 void stk600_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK600");
+  pgm->type = "STK600";
 
   // Mandatory functions
   pgm->initialize = stk500v2_initialize;
@@ -5034,7 +5034,7 @@ void stk600_initpgm(PROGRAMMER *pgm) {
 const char stk600pp_desc[] = "Atmel STK600 in parallel programming mode";
 
 void stk600pp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK600PP");
+  pgm->type = "STK600PP";
 
   // Mandatory functions
   pgm->initialize = stk500pp_initialize;
@@ -5069,7 +5069,7 @@ void stk600pp_initpgm(PROGRAMMER *pgm) {
 const char stk600hvsp_desc[] = "Atmel STK600 in high-voltage serial programming mode";
 
 void stk600hvsp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "STK600HVSP");
+  pgm->type = "STK600HVSP";
 
   // Mandatory functions
   pgm->initialize = stk500hvsp_initialize;
@@ -5104,7 +5104,7 @@ void stk600hvsp_initpgm(PROGRAMMER *pgm) {
 const char stk500v2_jtag3_desc[] = "Atmel JTAGICE3 in ISP mode";
 
 void stk500v2_jtag3_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "JTAG3_ISP");
+  pgm->type = "JTAG3_ISP";
 
   // Mandatory functions
   pgm->initialize = stk500v2_jtag3_initialize;

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -510,7 +510,7 @@ static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
 }
 
 void teensy_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "teensy");
+  pgm->type = "teensy";
 
   pgm->setup = teensy_setup;
   pgm->teardown = teensy_teardown;
@@ -542,7 +542,7 @@ static int teensy_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void teensy_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "teensy");
+  pgm->type = "teensy";
   pgm->open = teensy_nousb_open;
 }
 #endif                          // HAVE_LIBHIDAPI

--- a/src/teensy.c
+++ b/src/teensy.c
@@ -510,7 +510,7 @@ static int teensy_parseextparams(const PROGRAMMER *pgm, const LISTID xparams) {
 }
 
 void teensy_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "teensy";
+  pgm->ptyp = "teensy";
 
   pgm->setup = teensy_setup;
   pgm->teardown = teensy_teardown;
@@ -542,7 +542,7 @@ static int teensy_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void teensy_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "teensy";
+  pgm->ptyp = "teensy";
   pgm->open = teensy_nousb_open;
 }
 #endif                          // HAVE_LIBHIDAPI

--- a/src/term.c
+++ b/src/term.c
@@ -1182,7 +1182,7 @@ static int cmd_send(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
   }
 
   if(spi_mode && (pgm->spi == NULL)) {
-    pmsg_error("(send) the %s programmer does not support direct SPI transfers\n", pgm->type);
+    pmsg_error("(send) the %s programmer does not support direct SPI transfers\n", pgm->ptyp);
     return -1;
   }
 

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -2140,7 +2140,7 @@ static int urclock_chip_erase(const PROGRAMMER *pgm, const AVRPART *p) {
     pmsg_notice2("chip erase via universal STK500v1 command\n");
 
     if(pgm->cmd == NULL) {      // Should not happen
-      pmsg_error("%s programmer does not provide a cmd() method\n", pgm->type);
+      pmsg_error("%s programmer does not provide a cmd() method\n", pgm->ptyp);
       serial_recv_timeout = bak_timeout;
       return -1;
     }
@@ -2572,7 +2572,7 @@ static void urclock_teardown(PROGRAMMER *pgm) {
 const char urclock_desc[] = "Urclock programmer for urboot bootloaders (arduino compatible)";
 
 void urclock_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "Urclock";
+  pgm->ptyp = "Urclock";
 
   pgm->read_sig_bytes = urclock_read_sig_bytes;
 

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -940,7 +940,7 @@ void urbootPutVersion(char *buf, uint16_t *top6table) {
 static const char *vblvecname(const PROGRAMMER *pgm, int num) {
   // This should never happen
   if(num < -1 || num > ur.uP.ninterrupts || !ur.uP.isrtable)
-    return("unknown");
+    return "unknown";
   if(num == -1)
     return "none";
   if(num == ur.uP.ninterrupts)
@@ -2572,7 +2572,7 @@ static void urclock_teardown(PROGRAMMER *pgm) {
 const char urclock_desc[] = "Urclock programmer for urboot bootloaders (arduino compatible)";
 
 void urclock_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "Urclock");
+  pgm->type = "Urclock";
 
   pgm->read_sig_bytes = urclock_read_sig_bytes;
 

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -1344,7 +1344,7 @@ static int usbasp_tpi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
 }
 
 void usbasp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "usbasp");
+  pgm->type = "usbasp";
 
   // Mandatory functions
   pgm->initialize = usbasp_initialize;
@@ -1378,7 +1378,7 @@ static int usbasp_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void usbasp_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "usbasp");
+  pgm->type = "usbasp";
 
   pgm->open = usbasp_nousb_open;
 }

--- a/src/usbasp.c
+++ b/src/usbasp.c
@@ -1344,7 +1344,7 @@ static int usbasp_tpi_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const 
 }
 
 void usbasp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "usbasp";
+  pgm->ptyp = "usbasp";
 
   // Mandatory functions
   pgm->initialize = usbasp_initialize;
@@ -1378,7 +1378,7 @@ static int usbasp_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void usbasp_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "usbasp";
+  pgm->ptyp = "usbasp";
 
   pgm->open = usbasp_nousb_open;
 }

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -544,7 +544,7 @@ static int usbtiny_spi(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned
   memset(res, 0, count);
 
   if(count%4) {
-    pmsg_error("direct SPI write must be a multiple of 4 bytes for %s\n", pgm->type);
+    pmsg_error("direct SPI write must be a multiple of 4 bytes for %s\n", pgm->ptyp);
     return -1;
   }
 
@@ -730,7 +730,7 @@ static int usbtiny_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 void usbtiny_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "USBtiny";
+  pgm->ptyp = "USBtiny";
 
   // Mandatory Functions
   pgm->initialize = usbtiny_initialize;
@@ -769,7 +769,7 @@ static int usbtiny_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void usbtiny_initpgm(PROGRAMMER *pgm) {
-  pgm->type = "usbtiny";
+  pgm->ptyp = "usbtiny";
 
   pgm->open = usbtiny_nousb_open;
 }

--- a/src/usbtiny.c
+++ b/src/usbtiny.c
@@ -730,7 +730,7 @@ static int usbtiny_program_enable(const PROGRAMMER *pgm, const AVRPART *p) {
 }
 
 void usbtiny_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "USBtiny");
+  pgm->type = "USBtiny";
 
   // Mandatory Functions
   pgm->initialize = usbtiny_initialize;
@@ -769,7 +769,7 @@ static int usbtiny_nousb_open(PROGRAMMER *pgm, const char *name) {
 }
 
 void usbtiny_initpgm(PROGRAMMER *pgm) {
-  strcpy(pgm->type, "usbtiny");
+  pgm->type = "usbtiny";
 
   pgm->open = usbtiny_nousb_open;
 }

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -199,7 +199,7 @@ void wiring_initpgm(PROGRAMMER *pgm) {
   // The Wiring bootloader uses a near-complete STK500v2 protocol
   stk500v2_initpgm(pgm);
 
-  strcpy(pgm->type, "Wiring");
+  pgm->type = "Wiring";
 
   pgm->open = wiring_open;
   pgm->close = wiring_close;

--- a/src/wiring.c
+++ b/src/wiring.c
@@ -199,7 +199,7 @@ void wiring_initpgm(PROGRAMMER *pgm) {
   // The Wiring bootloader uses a near-complete STK500v2 protocol
   stk500v2_initpgm(pgm);
 
-  pgm->type = "Wiring";
+  pgm->ptyp = "Wiring";
 
   pgm->open = wiring_open;
   pgm->close = wiring_close;

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1550,7 +1550,7 @@ void xbee_initpgm(PROGRAMMER *pgm) {
    */
   stk500_initpgm(pgm);
 
-  strncpy(pgm->type, "XBee", sizeof(pgm->type));
+  pgm->type = "XBee";
   pgm->read_sig_bytes = xbee_read_sig_bytes;
   pgm->open = xbee_open;
   pgm->close = xbee_close;

--- a/src/xbee.c
+++ b/src/xbee.c
@@ -1550,7 +1550,7 @@ void xbee_initpgm(PROGRAMMER *pgm) {
    */
   stk500_initpgm(pgm);
 
-  pgm->type = "XBee";
+  pgm->ptyp = "XBee";
   pgm->read_sig_bytes = xbee_read_sig_bytes;
   pgm->open = xbee_open;
   pgm->close = xbee_close;


### PR DESCRIPTION
See #2146 for details.

@dl8dtl You might want to check whether your example GUI *still* works. This PR (and potentially many others since v8.1) has changed `libavrdude.h` and that might have had an effect on how the python bindings and python code interfaces with `libavrdude`.

I *think* it's still OK, but I haven't tried.

@mcuee @MCUdude Have either of you tested Jörg's GUI for v8.2?