### PR TITLE
Fix issue #2149

### DIFF
--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -378,6 +378,10 @@ part_def :
           yywarning("revise fileio_mem_offset(), avrdude.conf entry or memory type assignment");
       }
 
+      // Sort memories in canonical order
+      if(current_part->mem)
+        lsort(current_part->mem, avr_mem_cmp);
+
       existing_part = locate_part(part_list, current_part->id);
       if(existing_part) {
         { /* temporarily set lineno to lineno of part start */

--- a/src/libavrdude.i
+++ b/src/libavrdude.i
@@ -627,6 +627,7 @@ AVRMEM * avr_locate_mem(const AVRPART *p, const char *desc);
 AVRPART * locate_part(const LISTID parts, const char *partdesc);
 AVRMEM_ALIAS * avr_locate_memalias(const AVRPART *p, const char *desc);
 AVRMEM_ALIAS * avr_find_memalias(const AVRPART *p, const AVRMEM *m_orig);
+const char *avr_mem_name(const AVRPART *p, const AVRMEM *mem);
 
 // Programming modes for parts and programmers: ensure it's copied from libavrdude.h
 #define PM_SPM                1 // Bootloaders, self-programming with SPM opcodes or NVM Controllers

--- a/src/main.c
+++ b/src/main.c
@@ -1184,11 +1184,6 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  // Sort memories of all parts in canonical order
-  for(LNODEID ln1 = lfirst(part_list); ln1; ln1 = lnext(ln1))
-    if((p = ldata(ln1))->mem)
-      lsort(p->mem, avr_mem_cmp);
-
   // Set bitclock from configuration files unless changed by command line
   if(default_bitclock > 0 && bitclock == 0.0) {
     bitclock = default_bitclock;

--- a/src/python/adgui.py
+++ b/src/python/adgui.py
@@ -877,7 +877,8 @@ class adgui(QObject):
         mm = avrpart_to_mem(p)
         row = 0
         for m in mm:
-            model.setItem(row, 0, QStandardItem(m.desc))
+            name = ad.avr_mem_name(p, m)
+            model.setItem(row, 0, QStandardItem(name))
             sz = QStandardItem(size_to_str(m.size))
             sz.setTextAlignment(Qt.Alignment(int(Qt.AlignRight) | int(Qt.AlignVCenter)))
             model.setItem(row, 1, sz)


### PR DESCRIPTION
Split the AVR-DD and AVR-DU common values into two separate config sections.,

That maintains "fusea" in the order right behind "fuse9" where it was expected to be.

Fixes #2149 