### PR TITLE
jtagmkII: treat leave-progmode refusal as benign when target reset succeeds

### DIFF
--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -1093,6 +1093,20 @@ static int jtagmkII_program_disable(const PROGRAMMER *pgm) {
   c = resp[0];
   mmt_free(resp);
   if(c != RSP_OK) {
+    my.recently_written = 0;
+    my.prog_enabled = 0;
+    /*
+     * The JTAG ICE mkII couples leaving progmode with re-attaching the
+     * on-chip debug system; on a part with the OCDEN fuse unprogrammed that
+     * attach cannot succeed and the ICE answers RSP_FAILED even though the
+     * memory operations all completed. A reset releases the target, so this
+     * is only an error if the reset fails too.
+     */
+    if(jtagmkII_reset(pgm, 0x01) >= 0) {
+      pmsg_notice("leave progmode declined by ICE (%s), target reset and running; "
+        "this is expected when the OCDEN fuse is unprogrammed\n", jtagmkII_get_rc(pgm, c));
+      return 0;
+    }
     pmsg_error("bad response to leave progmode command: %s\n", jtagmkII_get_rc(pgm, c));
     return -1;
   }


### PR DESCRIPTION
The JTAG ICE mkII couples `CMND_LEAVE_PROGMODE` with re-attaching the on-chip debug system. On a part whose OCDEN fuse is unprogrammed — the required state of every shipped product per the AVR datasheets ("Never ship a product with the OCDEN Fuse programmed") — that attach cannot succeed and the ICE answers `RSP_FAILED`, although every memory operation completed. avrdude then prints

```
Error: bad response to leave progmode command: RSP_FAILED
```

and `jtagmkII_program_disable()` returns -1, leaving the target parked even though nothing actually failed.

This was isolated on an AT90CAN128 with a JTAGICE mkII: byte-identical `CMND_LEAVE_PROGMODE` frames get `RSP_OK` with OCDEN programmed and `RSP_FAILED` with it unprogrammed; lock-bit settings were ruled out (OCDEN off with lock bits fully open still fails). The ICE keys on the stored fuse value, not the reset-latched one. A subsequent `CMND_RESET` with flag 0x01 returns `RSP_OK` and the target runs normally.

The fix issues the recovery reset first and reports a notice when it succeeds:

```
Leave progmode declined by ICE (RSP_FAILED), target reset and running; this is expected when the OCDEN fuse is unprogrammed
```

keeping the error and failure return only for the case where the reset fails too, which is the only outcome that actually leaves the target dead.

Bench-tested on the AT90CAN128 in both OCDEN states: fuse/flash/EEPROM operations complete with exit 0 and the target running afterwards (verified over the target's serial bootloader); the OCDEN-programmed path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Mh2GBGBjSKBTr3Lrxo2fa
