### PR TITLE
Provide `trace_dump()`

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1869,15 +1869,17 @@ void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen) {
 
 // Output comms buffer like memory dump
 void trace_dump(const char *funstr, const unsigned char *buf, size_t buflen) {
+  char out[72];
+  int nspaces = (int) strlen(funstr) + 2;
+
   pmsg_trace("%s: ", funstr);
   while(buflen) {
-    char out[69];
     size_t len = buflen > 16? 16: buflen;
 
     str_hexdump16(out, buf, len);
     msg_trace("%s\n", out);
     buf += len;
     if(buflen -= len)
-      pmsg_trace("%*s", (int) strlen(funstr)+2, "");
+      pmsg_trace("%*s", nspaces, "");
   }
 }

--- a/src/avr.c
+++ b/src/avr.c
@@ -1869,17 +1869,19 @@ void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen) {
 
 // Output comms buffer like memory dump
 void trace_dump(const char *funstr, const unsigned char *buf, size_t buflen) {
-  char out[72];
-  int nspaces = (int) strlen(funstr) + 2;
+  if(verblevel >= MSG_TRACE) {
+    char out[72];
+    int nspaces = (int) strlen(funstr) + 2;
 
-  pmsg_trace("%s: ", funstr);
-  while(buflen) {
-    size_t len = buflen > 16? 16: buflen;
+    pmsg_trace("%s: ", funstr);
+    while(buflen) {
+      size_t len = buflen > 16? 16: buflen;
 
-    str_hexdump16(out, buf, len);
-    msg_trace("%s\n", out);
-    buf += len;
-    if(buflen -= len)
-      pmsg_trace("%*s", nspaces, "");
+      str_hexdump16(out, buf, len);
+      msg_trace("%s\n", out);
+      buf += len;
+      if(buflen -= len)
+        pmsg_trace("%*s", nspaces, "");
+    }
   }
 }

--- a/src/avr.c
+++ b/src/avr.c
@@ -1866,3 +1866,18 @@ void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen) {
   }
   msg_trace("\n");
 }
+
+// Output comms buffer like memory dump
+void trace_dump(const char *funstr, const unsigned char *buf, size_t buflen) {
+  pmsg_trace("%s: ", funstr);
+  while(buflen) {
+    char out[69];
+    size_t len = buflen > 16? 16: buflen;
+
+    str_hexdump16(out, buf, len);
+    msg_trace("%s\n", out);
+    buf += len;
+    if(buflen -= len)
+      pmsg_trace("%*s", (int) strlen(funstr)+2, "");
+  }
+}

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1233,6 +1233,7 @@ extern "C" {
   int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p);
   void report_progress(int completed, int total, const char *hdr);
   void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen);
+  void trace_dump(const char *funstr, const unsigned char *buf, size_t buflen);
   int avr_has_paged_access(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);
   int avr_has_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);
   int avr_has_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1749,6 +1749,7 @@ extern "C" {
   const char *str_infilename(const char *fn);
   const char *str_outname(const char *fn);
   const char *str_outfilename(const char *fn);
+  void str_hexdump16(char *buf69, const unsigned char *p, int n);
   const char *str_ccinterval(int a, int b);
   bool is_bigendian(void);
   void change_endian(void *p, int size);

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -626,6 +626,22 @@ const char *str_ccinterval(int a, int b) {
   return ret;
 }
 
+// Dump n bytes (max 16) as hex line with adjacent character field into buffer of size 69
+void str_hexdump16(char *buf, const unsigned char *p, int n) {
+  const char *hexdata = "0123456789abcdef";
+
+  memset(buf, ' ', 67);
+  buf[50] = buf[67] = '|';
+  buf[68] = 0;
+
+  for(int j = 0, i = 0; i < n && i < 16; i++, j += i==8? 2: 1) {
+    unsigned char c = p[i];
+    buf[j++] = hexdata[(c & 0xf0) >> 4];
+    buf[j++] = hexdata[c & 0x0f];
+    buf[51 + i] = isascii(c) && isspace(c)? ' ': isascii(c) && isgraph(c)? c: '.';
+  }
+}
+
 bool is_bigendian() {
   union {
     char a[2];

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -634,10 +634,10 @@ void str_hexdump16(char *buf, const unsigned char *p, int n) {
   buf[50] = buf[67] = '|';
   buf[68] = 0;
 
-  for(int j = 0, i = 0; i < n && i < 16; i++, j += i==8? 2: 1) {
-    unsigned char c = p[i];
-    buf[j++] = hexdata[(c & 0xf0) >> 4];
-    buf[j++] = hexdata[c & 0x0f];
+  for(int j = 0, i = 0; i < n && i < 16; i++, j += i==8? 4: 3) {
+    int c = p[i];
+    buf[j] = hexdata[(c & 0xf0) >> 4];
+    buf[j + 1] = hexdata[c & 0x0f];
     buf[51 + i] = isascii(c) && isspace(c)? ' ': isascii(c) && isgraph(c)? c: '.';
   }
 }

--- a/src/term.c
+++ b/src/term.c
@@ -135,56 +135,24 @@ static const struct command cmd[] = {
 
 #define spi_mode (cx->term_spi_mode)
 
-static int hexdump_line(char *buffer, unsigned char *p, int n, int pad) {
-  char *hexdata = "0123456789abcdef";
-  char *b = buffer;
-  int i = 0;
-  int j = 0;
+// Dump n bytes (max 16) as hex line with adjacent character field into buffer of size 69
+static void hexdump16(char *buf, const unsigned char *p, int n) {
+  const char *hexdata = "0123456789abcdef";
 
-  for(i = 0; i < n; i++) {
-    if(i && ((i%8) == 0))
-      b[j++] = ' ';
-    b[j++] = hexdata[(p[i] & 0xf0) >> 4];
-    b[j++] = hexdata[(p[i] & 0x0f)];
-    if(i < 15)
-      b[j++] = ' ';
+  memset(buf, ' ', 67);
+  buf[50] = buf[67] = '|';
+  buf[68] = 0;
+
+  for(int j = 0, i = 0; i < n && i < 16; i++, j += i==8? 2: 1) {
+    unsigned char c = p[i];
+    buf[j++] = hexdata[(c & 0xf0) >> 4];
+    buf[j++] = hexdata[c & 0x0f];
+    buf[51 + i] = isascii(c) && isspace(c)? ' ': isascii(c) && isgraph(c)? c: '.';
   }
-
-  for(i = j; i < pad; i++)
-    b[i] = ' ';
-
-  b[i] = 0;
-
-  for(i = 0; i < pad; i++) {
-    if(!((b[i] == '0') || (b[i] == ' ')))
-      return 0;
-  }
-
-  return 1;
 }
 
-static int chardump_line(char *buffer, unsigned char *p, int n, int pad) {
-  int i;
-  unsigned char b[128];
-
-  // Sanity check
-  n = n < 1? 1: n > (int) sizeof b? (int) sizeof b: n;
-
-  memcpy(b, p, n);
-  for(int i = 0; i < n; i++)
-    buffer[i] = isascii(b[i]) && isspace(b[i])? ' ': isascii(b[i]) && isgraph(b[i])? b[i]: '.';
-
-  for(i = n; i < pad; i++)
-    buffer[i] = ' ';
-
-  buffer[i] = 0;
-
-  return 0;
-}
-
-static int hexdump_buf(const FILE *f, const AVRMEM *m, int startaddr, const unsigned char *buf, int len) {
-  char dst1[80];
-  char dst2[80];
+static int hexdump_buf(const AVRMEM *m, int startaddr, const unsigned char *buf, int len) {
+  char dst[80];
 
   int addr = startaddr;
   unsigned char *p = (unsigned char *) buf;
@@ -197,9 +165,8 @@ static int hexdump_buf(const FILE *f, const AVRMEM *m, int startaddr, const unsi
     if(addr + n > m->size)
       n = m->size - addr;
 
-    hexdump_line(dst1, p, n, 48);
-    chardump_line(dst2, p, n, 16);
-    term_out("%0*x  %s  |%s|\n", m->size > 0x10000? 5: 4, addr, dst1, dst2);
+    hexdump16(dst, p, n);
+    term_out("%0*x  %s\n", m->size > 0x10000? 5: 4, addr, dst);
     len -= n;
     addr += n;
     if(addr >= m->size)
@@ -499,7 +466,7 @@ static int cmd_dump(const PROGRAMMER *pgm, const AVRPART *p, int argc, const cha
   if(!buf)
     return -1;
 
-  hexdump_buf(stdout, mem, addr, buf, len);
+  hexdump_buf(mem, addr, buf, len);
   lterm_out("");
   mmt_free(buf);
 

--- a/src/term.c
+++ b/src/term.c
@@ -136,7 +136,7 @@ static const struct command cmd[] = {
 #define spi_mode (cx->term_spi_mode)
 
 static int hexdump_buf(const AVRMEM *m, int startaddr, const unsigned char *buf, int len) {
-  char dst[80];
+  char dst[72];
 
   int addr = startaddr;
   unsigned char *p = (unsigned char *) buf;

--- a/src/term.c
+++ b/src/term.c
@@ -135,22 +135,6 @@ static const struct command cmd[] = {
 
 #define spi_mode (cx->term_spi_mode)
 
-// Dump n bytes (max 16) as hex line with adjacent character field into buffer of size 69
-static void hexdump16(char *buf, const unsigned char *p, int n) {
-  const char *hexdata = "0123456789abcdef";
-
-  memset(buf, ' ', 67);
-  buf[50] = buf[67] = '|';
-  buf[68] = 0;
-
-  for(int j = 0, i = 0; i < n && i < 16; i++, j += i==8? 2: 1) {
-    unsigned char c = p[i];
-    buf[j++] = hexdata[(c & 0xf0) >> 4];
-    buf[j++] = hexdata[c & 0x0f];
-    buf[51 + i] = isascii(c) && isspace(c)? ' ': isascii(c) && isgraph(c)? c: '.';
-  }
-}
-
 static int hexdump_buf(const AVRMEM *m, int startaddr, const unsigned char *buf, int len) {
   char dst[80];
 
@@ -165,7 +149,7 @@ static int hexdump_buf(const AVRMEM *m, int startaddr, const unsigned char *buf,
     if(addr + n > m->size)
       n = m->size - addr;
 
-    hexdump16(dst, p, n);
+    str_hexdump16(dst, p, n);
     term_out("%0*x  %s\n", m->size > 0x10000? 5: 4, addr, dst);
     len -= n;
     addr += n;


### PR DESCRIPTION
This PR provides the function `trace_dump()`, which can be used as a drop-in for `trace_buffer()` and that displays the communication in the same way as terminal memory dumps.