### PR TITLE
Enforce modify cannot be used in system config file

### DIFF
--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -48,6 +48,7 @@ static int assign_pin(int pinfunc, TOKEN *v, int invert);
 static int assign_pin_list(int invert);
 static int which_opcode(TOKEN *opcode);
 static int parse_cmdbits(OPCODE *op, int opnum);
+static int in_systemconfig(void);
 
 #define pin_name (cx->cfgy_pin_name)
 %}
@@ -323,6 +324,10 @@ prog_decl :
 
 prog_modify:
   K_MODIFY K_PROGRAMMER TKN_STRING {
+    if(in_systemconfig()) {
+      free_token($3);
+      YYABORT;
+    }
     current_prog = locate_programmer(programmers, $3->value.string);
     if(!current_prog) {
       yyerror("to be modified programmer %s not found", $3->value.string);
@@ -452,6 +457,10 @@ part_decl :
 
 part_modify:
   K_MODIFY K_PART TKN_STRING {
+    if(in_systemconfig()) {
+      free_token($3);
+      YYABORT;
+    }
     current_part = locate_part(part_list, $3->value.string);
     if(!current_part) {
       yyerror("to be modified part %s not found", $3->value.string);
@@ -1375,4 +1384,14 @@ static int parse_cmdbits(OPCODE *op, int opnum) {
     yywarning("too few opcode bits in instruction");
 
   return rv;
+}
+
+static int in_systemconfig(void) {
+  char *sysconfig = str_sysconfig();
+  int ret = !cfg_infile || str_eq(cfg_infile, sysconfig);
+  mmt_free(sysconfig);
+
+  if(ret)
+    yyerror("modify operation %s configuration file", !cfg_infile? "without obvious": "not allowd in system");
+  return ret;
 }

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -3843,7 +3843,7 @@ modify programmer <id>
 The @code{modify} keyword makes most sense in the per-user configuration
 file, where users may want to add specific properties of their programmer.
 This could be its USB serial number or default port, eg, a serialadapter
-such as @code{"ch340"}. This technique should not be used for the main
+such as @code{"ch340"}. This technique must not be used in the system
 @code{avrdude.conf} file, as the developer option @code{-c <programmer>/S}
 that prints the programmer definition as AVRDUDE understands it will only
 consider the final definition; it will not print @code{modify} statements.
@@ -4130,7 +4130,7 @@ modify part <id>
 @noindent
 The @code{modify} keyword makes most sense in the per-user configuration
 file, where users may want to modify specific properties of a part for
-debugging. This technique should not be used within the main
+debugging. This technique must not be used in the system
 @code{avrdude.conf} file, as the developer option @code{-p <part>/S} that
 prints the part definition as AVRDUDE understands it will only consider
 the final definition; it will not print @code{modify} statements.


### PR DESCRIPTION
The developer option `-p*/s` is routinely used for canonicalisation of the system configuration file, as are the options `-p*/si` and `-p*/s` that are used for programmatically injecting .atdf properties into the `avrdude.conf` file.  These techniques interfere with the `modify` operation that is only meant for last-resort changes of parts or programmers in the per-user configuration file.