### PR TITLE
Improve readability of `trace_buffer()`

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1856,32 +1856,17 @@ void report_progress(int completed, int total, const char *hdr) {
   }
 }
 
-// Output comms buffer
-void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen) {
-  pmsg_trace("%s: ", funstr);
-  while(buflen--) {
-    unsigned char c = *buf++;
-
-    msg_trace("%c [%02x]%s", isascii(c) && isprint(c)? c: '.', c, buflen? " ": "");
-  }
-  msg_trace("\n");
-}
-
 // Output comms buffer like memory dump
-void trace_dump(const char *funstr, const unsigned char *buf, size_t buflen) {
+void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen) {
   if(verblevel >= MSG_TRACE) {
     char out[72];
-    int nspaces = (int) strlen(funstr) + 2;
 
-    pmsg_trace("%s: ", funstr);
     while(buflen) {
       size_t len = buflen > 16? 16: buflen;
-
       str_hexdump16(out, buf, len);
-      msg_trace("%s\n", out);
+      pmsg_trace("%s: %s\n", funstr, out);
       buf += len;
-      if(buflen -= len)
-        pmsg_trace("%*s", nspaces, "");
+      buflen -= len;
     }
   }
 }

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -604,9 +604,7 @@ int jtagmkII_recv(const PROGRAMMER *pgm, unsigned char **msg) {
        */
       memmove(*msg, *msg + 8, rv);
 
-      if(verblevel >= MSG_TRACE)
-        trace_buffer(__func__, *msg, rv);
-
+      trace_buffer(__func__, *msg, rv);
       return rv;
     }
     if(r_seqno == 0xffff) {

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1234,7 +1234,6 @@ extern "C" {
   int avr_unlock(const PROGRAMMER *pgm, const AVRPART *p);
   void report_progress(int completed, int total, const char *hdr);
   void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen);
-  void trace_dump(const char *funstr, const unsigned char *buf, size_t buflen);
   int avr_has_paged_access(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);
   int avr_has_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);
   int avr_has_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *m);

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -2254,9 +2254,7 @@ static int usbdev_bulk_recv(const union filedescriptor *fd, unsigned char *buf, 
     i += amnt;
   }
 
-  if(verblevel >= MSG_TRACE2)
-    trace_buffer(__func__, p, i);
-
+  trace_buffer(__func__, p, i);
   return 0;
 }
 
@@ -2287,8 +2285,7 @@ static int usbdev_bulk_send(const union filedescriptor *fd, const unsigned char 
     i += tx_size;
   } while(mlen > 0);
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, p, i);
+  trace_buffer(__func__, p, i);
   return 0;
 }
 

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -425,8 +425,7 @@ static void ser_rawclose(union filedescriptor *fd) {
 static int ser_send(const union filedescriptor *fd, const unsigned char *buf, size_t len) {
   int rc;
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, buf, len);
+  trace_buffer(__func__, buf, len);
 
   while(len) {
     rc = write(fd->ifd, buf, len > 1024? 1024: len);
@@ -481,9 +480,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
     len += rc;
   }
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, buf, len);
-
+  trace_buffer(__func__, buf, len);
   return 0;
 }
 

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -314,8 +314,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char *buf, si
   if(!len)
     return 0;
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, buf, len);
+  trace_buffer(__func__, buf, len);
 
   while(len) {
     rc = send(fd->ifd, (const char *) buf, len > 1024? 1024: len, 0);
@@ -351,8 +350,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char *buf, si
   if(!len)
     return 0;
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, buf, len);
+  trace_buffer(__func__, buf, len);
 
   // Set minimum r/w timeout to 2000 ms or higher to cater for 110 baud or faster
   if(!serial_w32SetRWTimeOut(hComPort, (len > 20? len: 20)*100)) {
@@ -429,9 +427,7 @@ static int net_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
     len += rc;
   }
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, buf, len);
-
+  trace_buffer(__func__, buf, len);
   return 0;
 }
 
@@ -473,9 +469,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
     return -1;
   }
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, buf, read);
-
+  trace_buffer(__func__, buf, read);
   return 0;
 }
 

--- a/src/usb_hidapi.c
+++ b/src/usb_hidapi.c
@@ -250,9 +250,7 @@ static int usbhid_send(const union filedescriptor *fd, const unsigned char *bp, 
   if(rv != tx_size + 1)
     pmsg_error("short write to USB: %d bytes out of %d written\n", rv, tx_size + 1);
 
-  if(verblevel >= MSG_TRACE2)
-    trace_buffer(__func__, bp, tx_size);
-
+  trace_buffer(__func__, bp, tx_size);
   return 0;
 }
 
@@ -270,9 +268,7 @@ static int usbhid_recv(const union filedescriptor *fd, unsigned char *buf, size_
   else if((size_t) i != nbytes)
     pmsg_error("short read, read only %d out of %lu bytes\n", i, (unsigned long) nbytes);
 
-  if(verblevel >= MSG_TRACE2 && i > 0)
-    trace_buffer(__func__, p, i);
-
+  trace_buffer(__func__, p, i);
   return rv;
 }
 

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -283,8 +283,7 @@ static int usbdev_send(const union filedescriptor *fd, const unsigned char *bp, 
     mlen -= tx_size;
   } while(mlen > 0);
 
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, p, i);
+  trace_buffer(__func__, p, i);
   return 0;
 }
 
@@ -333,9 +332,7 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
     i += amnt;
   }
 
-  if(verblevel >= MSG_TRACE2)
-    trace_buffer(__func__, p, i);
-
+  trace_buffer(__func__, p, i);
   return 0;
 }
 
@@ -408,9 +405,7 @@ static int usbdev_recv_frame(const union filedescriptor *fd, unsigned char *buf,
  *
  */
 printout:
-  if(verblevel >= MSG_TRACE)
-    trace_buffer(__func__, p, n & USB_RECV_LENGTH_MASK);
-
+  trace_buffer(__func__, p, n & USB_RECV_LENGTH_MASK);
   return n;
 }
 


### PR DESCRIPTION
Without this PR debug output for tracing low-level communication looks like this:

```
Ser_send: T [54] h [68] e [65]   [20] q [71] u [75] i [69] c [63] k [6b]   [20] b [62] r [72] o [6f] w [77] n [6e]   [20] f [66] o [6f] x [78]   [20] j [6a] u [75] m [6d] p [70] s [73]   [20] o [6f] v [76] e [65] r [72]   [20] t [74] h [68] e [65]   [20] l [6c] a [61] z [7a] y [79]   [20] d [64] o [6f] g [67] . [0a] . [00]
```

With this PR as per [popular demand](https://github.com/avrdudes/avrdude/issues/2136#issuecomment-5037672980):

```
Ser_send: 54 68 65 20 71 75 69 63  6b 20 62 72 6f 77 6e 20  |The quick brown |
Ser_send: 66 6f 78 20 6a 75 6d 70  73 20 6f 76 65 72 20 74  |fox jumps over t|
Ser_send: 68 65 20 6c 61 7a 79 20  64 6f 67 0a 00           |he lazy dog .   |
```