### PR TITLE
Exit with error on missing sys config file

### DIFF
--- a/src/avrdude.h
+++ b/src/avrdude.h
@@ -26,9 +26,11 @@
 
 #if defined(WIN32)
 #define USER_CONF_FILE "avrdude.rc"
+#define LAST_RESORT_SYS_CONF_DESCRIPTION "First " SYSTEM_CONF_FILE " in PATH"
 #else
 #define USER_CONF_FILE ".avrduderc"
 #define XDG_USER_CONF_FILE "avrdude/avrdude.rc"
+#define LAST_RESORT_SYS_CONF_DESCRIPTION  CONFIG_DIR "/" SYSTEM_CONF_FILE
 #endif
 
 extern char *progname;          // Name of program, for messages

--- a/src/main.c
+++ b/src/main.c
@@ -969,10 +969,9 @@ int main(int argc, char *argv[]) {
     mmt_free(usrconfig);
   }
 
-  if(!str_eq(avrdude_conf_version, AVRDUDE_FULL_VERSION)) {
-    pmsg_warning("system wide configuration file version (%s)\n", avrdude_conf_version);
-    imsg_warning("does not match Avrdude build version (%s)\n", AVRDUDE_FULL_VERSION);
-  }
+  if(!str_eq(avrdude_conf_version, AVRDUDE_FULL_VERSION))
+    pmsg_warning("config file version %s does not match %s's %s\n",
+      avrdude_conf_version, progname, AVRDUDE_FULL_VERSION);
 
   if(lsize(additional_config_files) > 0) {
     for(LNODEID ln1 = lfirst(additional_config_files); ln1; ln1 = lnext(ln1)) {

--- a/src/main.c
+++ b/src/main.c
@@ -933,24 +933,30 @@ int main(int argc, char *argv[]) {
   if(1 != sscanf("42", "%zi", &ztest) || ztest != 42)
     pmsg_warning("linked C library does not conform to C99; %s may not work as expected\n", progname);
 
-  // Set system configuration file unless -C conffile was given
-  if(!sysconfig)
-    sysconfig = str_sysconfig();
-  msg_trace2("sysconfig = %s\n", sysconfig? sysconfig: "not set");
-
   if(quell_progress == 0)
     terminal_setup_update_progress();
 
   pmsg_notice("%s version %s\n", progname, AVRDUDE_FULL_VERSION);
   pmsg_notice("Copyright see https://github.com/avrdudes/avrdude/blob/main/AUTHORS\n\n");
 
-  if(sysconfig) {
-    if(read_config(sysconfig)) {
-      pmsg_error("unable to process system wide configuration file %s\n", sysconfig);
-      exit(1);
-    }
-    mmt_free(sysconfig);
+  // Set system configuration file unless -C conffile was given
+  if(!sysconfig)
+    sysconfig = str_sysconfig();
+  if(!sysconfig || !*sysconfig) {
+    pmsg_error("cannot locate a readable system configuration file in:\n"
+      "  - <dirpath of %s>/../etc/avrdude.conf\n"
+      "  - <dirpath of %s>/avrdude.conf\n"
+      "  - First avrdude.conf in PATH (Windows) or " CONFIG_DIR "/" SYSTEM_CONF_FILE " (otherwise)\n",
+      progname, progname);
+    exit(1);
   }
+  msg_trace2("sysconfig = %s\n", sysconfig);
+
+  if(read_config(sysconfig)) {
+    pmsg_error("unable to process system wide configuration file %s\n", sysconfig);
+    exit(1);
+  }
+  mmt_free(sysconfig);
 
   if(!no_avrduderc) {
     char *usrconfig = str_usrconfig();

--- a/src/main.c
+++ b/src/main.c
@@ -943,10 +943,10 @@ int main(int argc, char *argv[]) {
   if(!sysconfig)
     sysconfig = str_sysconfig();
   if(!sysconfig || !*sysconfig) {
-    pmsg_error("cannot locate a readable system configuration file in:\n"
-      "  - <dirpath of %s>/../etc/avrdude.conf\n"
-      "  - <dirpath of %s>/avrdude.conf\n"
-      "  - First avrdude.conf in PATH (Windows) or " CONFIG_DIR "/" SYSTEM_CONF_FILE " (otherwise)\n",
+    pmsg_error("cannot locate a readable system configuration file in either:\n"
+      "  - <dirpath of %s>/../etc/" SYSTEM_CONF_FILE "\n"
+      "  - <dirpath of %s>/" SYSTEM_CONF_FILE "\n"
+      "  - " LAST_RESORT_SYS_CONF_DESCRIPTION "\n",
       progname, progname);
     exit(1);
   }

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -59,7 +59,7 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
   struct usb_device *dev;
   usb_dev_handle *udev;
   char serno[64] = { 0 };
-  int i, iface, rc;
+  int i, iface;
 
   if(fd->usb.max_xfer == 0)
     fd->usb.max_xfer = USBDEV_MAX_XFER_MKII;
@@ -160,7 +160,8 @@ static int usbdev_open(const char *port, union pinfo pinfo, union filedescriptor
              * HID-class device.  On those, the driver needs to be detached
              * before we can claim the interface.
              */
-            if((rc = usb_detach_kernel_driver_np(udev, cx->usb_interface)))
+            int rc = usb_detach_kernel_driver_np(udev, cx->usb_interface);
+            if(rc)
               pmsg_notice("usb_detach_kernel_driver_np() unexpectedly returns %d: %s\n", rc, usb_strerror());
 #endif
 


### PR DESCRIPTION
AVRDUDE cannot do much without a readable configuration file. The current version silently continues, if the system config file cannot be located:

```
$ avrdude -cdryrun
Warning: system wide configuration file version ()
does not match Avrdude build version (8.2-20260817 (ff7fb67d))
Error: cannot find programmer id dryrun
use -c? to see all possible programmers
```

This PR is very clear about the cause of the problem:
```
$ avrdude -cdryrun
Error: cannot locate a readable system configuration file in:
  - <dirpath of avrdude>/../etc/avrdude.conf
  - <dirpath of avrdude>/avrdude.conf
  - /usr/local/etc/avrdude.conf
```
Under Windows the last line should read
```
  - First avrdude.conf in PATH
```
