### PR TITLE
Provide and utilise minm(), maxm() and cliptom() macros

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1862,7 +1862,7 @@ void trace_buffer(const char *funstr, const unsigned char *buf, size_t buflen) {
     char out[72];
 
     while(buflen) {
-      size_t len = buflen > 16? 16: buflen;
+      size_t len = minm(buflen, 16);
       str_hexdump16(out, buf, len);
       pmsg_trace("%s: %s\n", funstr, out);
       buf += len;

--- a/src/avrftdi.c
+++ b/src/avrftdi.c
@@ -39,14 +39,6 @@
 #include "avrftdi_private.h"
 #include "usbdevs.h"
 
-#ifndef MAX
-#define MAX(a, b) ((a)>(b)?(a):(b))
-#endif
-
-#ifndef MIN
-#define MIN(a, b) ((a)<(b)?(a):(b))
-#endif
-
 #ifdef DO_NOT_BUILD_AVRFTDI
 static int avrftdi_noftdi_open(PROGRAMMER *pgm, const char *name) {
   pmsg_error("no libftdi or libusb support; install\n");
@@ -308,10 +300,10 @@ static int avrftdi_transmit_bb(const PROGRAMMER *pgm, unsigned char mode, const 
   size_t blocksize = pdata->rx_buffer_size/2; // Reading 2 bytes per data byte
 
   // Determine a maximum size of data block
-  size_t max_size = MIN(pdata->ftdic->max_packet_size, (unsigned int) pdata->tx_buffer_size);
+  size_t max_size = minm(pdata->ftdic->max_packet_size, (unsigned int) pdata->tx_buffer_size);
 
   // Select block size so that resulting commands does not exceed max_size if possible
-  blocksize = MAX(1, (max_size - 7)/((8*2*6) + (8*1*2)));
+  blocksize = maxm(1, (max_size - 7)/((8*2*6) + (8*1*2)));
   // msg_notice("blocksize %d \n", blocksize);
 
   unsigned char *send_buffer = alloca(8*2*6*blocksize + 8*1*2*blocksize + 7);

--- a/src/config.c
+++ b/src/config.c
@@ -1118,7 +1118,7 @@ void cfg_update_mcuid(AVRPART *part) {
       if(flash) {
         size_t l1 = strlen(part->desc), l2 = strlen(uP_table[i].name);
 
-        if(strncasecmp(part->desc, uP_table[i].name, l1 < l2? l1: l2) ||
+        if(strncasecmp(part->desc, uP_table[i].name, minm(l1, l2)) ||
           flash->size != uP_table[i].flashsize ||
           flash->page_size != uP_table[i].pagesize || part->n_interrupts != (int8_t) uP_table[i].ninterrupts)
           yywarning("mcuid %d is reserved for %s, use a free number >= %d",

--- a/src/config_gram.y
+++ b/src/config_gram.y
@@ -997,7 +997,7 @@ part_parm :
         unsigned char cmd[4] = { 0, 0, 0, 0, };
         int bn;
 
-        for(int i=0; i<AVR_OP_MAX; i++)
+        for(int i = 0; i < AVR_OP_MAX; i++)
           if(current_mem && current_mem->op[i]) {
             if((bn = avr_set_addr_mem(current_mem, i, cmd, 0UL)) > 0)
               yywarning("%s's %s %s misses a necessary address bit a%d",

--- a/src/developer_opts.c
+++ b/src/developer_opts.c
@@ -1159,8 +1159,7 @@ void dev_output_part_defs(char *partdesc) {
         dev_info
           ("%s '%s' =>%*s [0x%02X, 0x%02X, 0x%02X, 0x%08x, 0x%05x, 0x%03x, "
            "0x%06x, 0x%04x, 0x%03x, %d, 0x%03x, 0x%04x, '%s'],",
-          tsv || all? ".desc": "   ",
-          p->desc, len > 0? len: 0, "",
+          tsv || all? ".desc": "   ", p->desc, maxm(len, 0), "",
           p->signature[0], p->signature[1], p->signature[2], flashoffset, flashsize, flashpagesize,
           eepromoffset, eepromsize, eeprompagesize, nfuses, ok, p->flags, dev_prog_modes(p->prog_modes));
         if(verbose > 0)
@@ -1592,8 +1591,7 @@ void dev_output_pgm_defs(char *pgmidcp) {
         int len = 19 - strlen(id);
 
         dev_info("%s '%s' =>%*s ['%s', '%s', '%s'], # %s %d\n",
-          tsv? ".desc": "   ",
-          id, len > 0? len: 0, "",
+          tsv? ".desc": "   ", id, maxm(len, 0), "",
           locate_programmer_type_id(pgm->initpgm), dev_prog_modes(pgm->prog_modes),
           pgm->desc, pgm->config_file, pgm->lineno);
       }

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -123,7 +123,7 @@ static int nmult(int type) {
 static int maxmult(Dis_symbol *s, int done) {
   int max = nmult(s->subtype);
 
-  return s->count-done < max? s->count-done: max;
+  return minm(s->count-done, max);
 }
 
 // Width of memory a subtype covers

--- a/src/dryrun.c
+++ b/src/dryrun.c
@@ -836,7 +836,7 @@ static void dryrun_enable(PROGRAMMER *pgm, const AVRPART *p) {
   if(fusesm) {
     size_t fusz = fusesm->size;
 
-    memcpy(fusesm->buf, inifuses, fusz < sizeof inifuses? fusz: sizeof inifuses);
+    memcpy(fusesm->buf, inifuses, minm(fusz, sizeof inifuses));
   }
 
   // Is the programmer a bootloader?
@@ -1006,7 +1006,7 @@ static int dryrun_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVR
         pgm->read_byte(pgm, p, dmem, i, m->buf+i);
 
     for(; addr < end; addr += chunk) {
-      chunk = end - addr < page_size? end - addr: page_size;
+      chunk = minm(end - addr, page_size);
 
       // Silently skip writing the chunk if that were to overwrite bootloader
       if(dry.bl && mchr == 'F' && !mem_is_apptable(m) && ur.blend > ur.blstart) {
@@ -1064,7 +1064,7 @@ static int dryrun_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
         addr, end - 1, dry.dp->desc, dmem->desc, dmem->size - 1);
 
     for(; addr < end; addr += chunk) {
-      chunk = end - addr < page_size? end - addr: page_size;
+      chunk = minm(end - addr, page_size);
       memcpy(m->buf + addr, dmem->buf + addr, chunk);
     }
   }

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -496,7 +496,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
 
     if(frag == 0) {
       // Only first fragment has TOKEN and seq#
-      this_len = (int) len < max_xfer - 8? (int) len: max_xfer - 8;
+      this_len = minm((int) len, max_xfer - 8);
       buf[2] = (this_len + 4) >> 8;
       buf[3] = (this_len + 4) & 0xff;
       buf[4] = TOKEN;
@@ -508,7 +508,7 @@ static int jtag3_edbg_send(const PROGRAMMER *pgm, unsigned char *data, size_t le
       }
       memcpy(buf + 8, data, this_len);
     } else {
-      this_len = (int) len < max_xfer - 4? (int) len: max_xfer - 4;
+      this_len = minm((int) len, max_xfer - 4);
       buf[2] = (this_len) >> 8;
       buf[3] = (this_len) & 0xff;
       if(this_len < 0) {
@@ -1999,7 +1999,7 @@ static int jtag3_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AVRM
   }
   serial_recv_timeout = 100;
   for(; addr < maxaddr; addr += page_size) {
-    unsigned int block_size = maxaddr - addr < page_size? maxaddr - addr: page_size;
+    unsigned int block_size = minm(maxaddr - addr, page_size);
     pmsg_debug("%s(): block_size at addr %d is %d\n", __func__, addr, block_size);
 
     if(dynamic_mtype)
@@ -2081,7 +2081,7 @@ static int jtag3_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   }
   serial_recv_timeout = 100;
   for(; addr < maxaddr; addr += page_size) {
-    unsigned int block_size = maxaddr - addr < page_size? maxaddr - addr: page_size;
+    unsigned int block_size = minm(maxaddr - addr, page_size);
     pmsg_debug("%s(): block_size at addr %d is %d\n", __func__, addr, block_size);
 
     if(dynamic_mtype)
@@ -2496,7 +2496,7 @@ int jtag3_getparm(const PROGRAMMER *pgm, unsigned char scope,
     return -1;
   }
   if(resp)
-    memcpy(value, resp + 3, (length < status? length: status));
+    memcpy(value, resp + 3, minm(length, status));
   mmt_free(resp);
 
   return 0;
@@ -3138,7 +3138,7 @@ static int jtag3_paged_load_tpi(const PROGRAMMER *pgm, const AVRPART *p,
 
   serial_recv_timeout = 100;
   for(; addr < maxaddr; addr += page_size) {
-    unsigned int block_size = maxaddr - addr < page_size? maxaddr - addr: page_size;
+    unsigned int block_size = minm(maxaddr - addr, page_size);
     pmsg_debug("%s(): block_size at addr 0x%x is %d\n", __func__, addr, block_size);
 
     u32_to_b4_big_endian((cmd + 2), addr + m->offset);  // Address
@@ -3185,7 +3185,7 @@ static int jtag3_paged_write_tpi(const PROGRAMMER *pgm, const AVRPART *p,
 
   serial_recv_timeout = 100;
   for(; addr < maxaddr; addr += page_size) {
-    unsigned int block_size = maxaddr - addr < page_size? maxaddr - addr: page_size;
+    unsigned int block_size = minm(maxaddr - addr, page_size);
     pmsg_debug("%s(): block_size at addr 0x%x is %d\n", __func__, addr, block_size);
 
     u32_to_b4_big_endian((cmd + 3), addr + m->offset);  // Address

--- a/src/jtagmkII.c
+++ b/src/jtagmkII.c
@@ -3387,7 +3387,7 @@ static int jtagmkII_paged_load32(const PROGRAMMER *pgm, const AVRPART *p_unused,
   cmd[2] = 0x05;
 
   for(; addr < maxaddr; addr += block_size) {
-    block_size = maxaddr - addr < (unsigned int) pgm->page_size? maxaddr - addr: (unsigned int) pgm->page_size;
+    block_size = minm(maxaddr - addr, (unsigned int) pgm->page_size);
     pmsg_debug("%s(): block_size at addr %d is %d\n", __func__, addr, block_size);
 
     u32_to_b4r(cmd + 3, m->offset + addr);
@@ -3489,7 +3489,7 @@ static int jtagmkII_paged_write32(const PROGRAMMER *pgm, const AVRPART *p_unused
       gotoerr;
 
     for(blocks = 0; blocks < 2; ++blocks) {
-      block_size = maxaddr - addr < (unsigned int) pgm->page_size? maxaddr - addr: (unsigned int) pgm->page_size;
+      block_size = minm(maxaddr - addr, (unsigned int) pgm->page_size);
       pmsg_debug("%s(): block_size at addr %d is %d\n", __func__, addr, block_size);
 
       u32_to_b4r(cmd + 6, m->offset + addr);

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -53,8 +53,6 @@
  * with the application.
  */
 
-typedef uint32_t Pinmask;
-
 /*
  * Values returned by library functions. Some library functions also return a
  * count, i.e. a positive number greater than 0.
@@ -690,6 +688,8 @@ extern "C" {
 
 // Formerly pindefs.h
 
+typedef uint32_t Pinmask;
+
 enum {
   PPI_AVR_VCC = 1,
   PPI_AVR_BUFF,
@@ -714,7 +714,6 @@ enum {
 #define PIN_MAX              31 // Largest allowed pin number
 
 #ifdef HAVE_LINUXGPIO
-
 // Embedded systems might have a lot more gpio than only 0-31
 #undef PIN_MAX
 #define PIN_MAX     1000        // Largest allowed pin number

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -1972,7 +1972,6 @@ extern libavrdude_context *cx;
 // Formerly confwin.h
 
 #if defined(WIN32)
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1983,6 +1982,11 @@ extern "C" {
 }
 #endif
 #endif                          // WIN32
+
+// Minimum, maximum and clip-to-interval macros
+#define minm(a, b) ((a) < (b)? (a): (b))
+#define maxm(a, b) ((a) > (b)? (a): (b))
+#define cliptom(v, min, max) ((v) < (min)? (min): (v) > (max)? (max): (v))
 
 #ifndef TO_BE_DEPRECATED_IN_2026
 

--- a/src/micronucleus.c
+++ b/src/micronucleus.c
@@ -759,7 +759,7 @@ static int micronucleus_paged_write(const PROGRAMMER *pgm, const AVRPART *p, con
     int result = 0;
 
     while(n_bytes > 0) {
-      size_t chunk_size = n_bytes < pdata->page_size? n_bytes: pdata->page_size;
+      size_t chunk_size = minm(n_bytes, pdata->page_size);
 
       memcpy(page_buffer, mem->buf + addr, chunk_size);
       memset(page_buffer + chunk_size, 0xFF, pdata->page_size - chunk_size);

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -105,10 +105,6 @@ static int usb_open_device(PROGRAMMER *pgm, struct usb_dev_handle **dev, int vid
 static int pickit2_write_report(const PROGRAMMER *pgm, const unsigned char report[65]);
 static int pickit2_read_report(const PROGRAMMER *pgm, unsigned char report[65]);
 
-#ifndef MIN
-#define MIN(X, Y) ((X) < (Y)? (X): (Y))
-#endif
-
 struct pdata {
 
 #ifdef WIN32
@@ -211,9 +207,9 @@ static int pickit2_open(PROGRAMMER *pgm, const char *port) {
     pmsg_warning("both -i delay and -B bitrate set; using -i\n");
 
   if(pgm->ispdelay > 0) {
-    my.clock_period = MIN(pgm->ispdelay, 255);
+    my.clock_period = minm(pgm->ispdelay, 255);
   } else if(pgm->bitclock > 0.0) {
-    my.clock_period = MIN(pgm->bitclock*1e6, 255);
+    my.clock_period = minm(pgm->bitclock*1e6, 255);
   }
 
   return 0;
@@ -456,7 +452,7 @@ static int pickit2_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
      * handles breaking up the data into packets -- but we need to keep
      * transfers frequent so that we can update the status indicator bar.
      */
-    uint32_t blockSize = MIN(65536 - (addr_base%65536), MIN(max_addr - addr_base, SPI_MAX_CHUNK/4));
+    uint32_t blockSize = minm(65536 - (addr_base%65536), minm(max_addr - addr_base, SPI_MAX_CHUNK/4));
 
     memset(cmd, 0, sizeof(cmd));
     memset(res, 0, sizeof(res));
@@ -572,8 +568,8 @@ static int pickit2_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     uint32_t blockSize;
 
     if(mem->paged) {
-      blockSize = MIN(page_size - (addr_base%page_size),
-        MIN(max_addr - addr_base, SPI_MAX_CHUNK/4)); // Bytes remaining in page
+      blockSize = minm(page_size - (addr_base%page_size),
+        minm(max_addr - addr_base, SPI_MAX_CHUNK/4)); // Bytes remaining in page
     } else {
       blockSize = 1;
     }
@@ -646,7 +642,7 @@ static int pickit2_spi(const PROGRAMMER *pgm, const unsigned char *cmd, unsigned
   int retval = 0, temp1 = 0, temp2 = 0, count = n_bytes;
 
   while(count > 0) {
-    uint8_t i, blockSize = MIN(count, SPI_MAX_CHUNK);
+    uint8_t i, blockSize = minm(count, SPI_MAX_CHUNK);
     uint8_t report[65] = { 0, CMD_DOWNLOAD_DATA_2(blockSize) };
     uint8_t *repptr = report + 3;
 
@@ -1016,7 +1012,7 @@ static int pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
         break;
       }
 
-      int clock_period = MIN(1000000/clock_rate, 255);        // Max period is 255
+      int clock_period = minm(1000000/clock_rate, 255);       // Max period is 255
 
       clock_rate = (int) (1000000/(clock_period + 5e-7));     // Assume highest speed is 2 MHz
 

--- a/src/pickit2.c
+++ b/src/pickit2.c
@@ -1012,9 +1012,9 @@ static int pickit2_parseextparams(const PROGRAMMER *pgm, const LISTID extparms) 
         break;
       }
 
-      int clock_period = minm(1000000/clock_rate, 255);       // Max period is 255
+      int clock_period = minm(1000000/clock_rate, 255);   // Max period is 255
 
-      clock_rate = (int) (1000000/(clock_period + 5e-7));     // Assume highest speed is 2 MHz
+      clock_rate = (int) (1000000/(clock_period + 5e-7)); // Assume highest speed is 2 MHz
 
       pmsg_notice2("%s(): effective clock rate set to 0x%02x\n", __func__, clock_rate);
       my.clock_period = clock_period;

--- a/src/pickit5.c
+++ b/src/pickit5.c
@@ -823,9 +823,9 @@ static void pickit5_enable(PROGRAMMER *pgm, const AVRPART *p) {
 
   if(is_updi(pgm)) {
     if((mem = avr_locate_sram(p)))
-      mem->page_size = mem->size < 256? mem->size : 256;
+      mem->page_size = minm(mem->size, 256);
     if((mem = avr_locate_eeprom(p)))
-      mem->page_size = mem->size < 32? mem->size : 32;
+      mem->page_size = minm(mem->size, 32);
     if((mem = avr_locate_sib(p))) { // This is mandatory as PICkit is reading all 32 bytes at once
       mem->page_size = 32;
       mem->readsize = 32;
@@ -833,15 +833,15 @@ static void pickit5_enable(PROGRAMMER *pgm, const AVRPART *p) {
   }
   if(is_debugwire(pgm)) {
     if((mem = avr_locate_flash(p))) {
-      mem->page_size = mem->size < 1024? mem->size : 1024; // The Flash Write function on DW needs 1600 bytes.
-      mem->readsize = mem->size < 1024? mem->size : 1024;  // This reduces overhead and speeds things up
+      mem->page_size = minm(mem->size, 1024); // The Flash Write function on DW needs 1600 bytes.
+      mem->readsize = minm(mem->size, 1024);  // This reduces overhead and speeds things up
     }
   }
   if(is_isp(pgm)) {
     if((mem = avr_locate_flash(p))) {
       if(mem->mode != 0x04) {   // Don't change default flash settings on old AVRs
-        mem->page_size = mem->size < 1024? mem->size : 1024;
-        mem->readsize = mem->size < 1024? mem->size : 1024;
+        mem->page_size = minm(mem->size, 1024);
+        mem->readsize = minm(mem->size, 1024);
       } else {
         mem->page_size = 256;
         mem->readsize = 256;
@@ -862,26 +862,26 @@ static void pickit5_enable(PROGRAMMER *pgm, const AVRPART *p) {
   }
   if(both_jtag(pgm, p)) {
     if((mem = avr_locate_flash(p))) {
-      mem->page_size = mem->size < 512? mem->size : 512;
-      mem->readsize = mem->size < 512? mem->size : 512;
+      mem->page_size = minm(mem->size, 512);
+      mem->readsize = minm(mem->size, 512);
     }
   }
   if(both_xmegajtag(pgm, p)) {    // True Page size is needed for a PDI fix, so don't increase them
     if((mem = avr_locate_flash(p))) {
-      mem->page_size = mem->size < 1024? mem->size : 1024;
-      mem->readsize = mem->size < 1024? mem->size : 1024;
+      mem->page_size = minm(mem->size, 1024);
+      mem->readsize = minm(mem->size, 1024);
     }
     if((mem = avr_locate_application(p))) {
-      mem->page_size = mem->size < 1024? mem->size : 1024;
-      mem->readsize = mem->size < 1024? mem->size : 1024;
+      mem->page_size = minm(mem->size, 1024);
+      mem->readsize = minm(mem->size, 1024);
     }
     if((mem = avr_locate_apptable(p))) {
-      mem->page_size = mem->size < 1024? mem->size : 1024;
-      mem->readsize = mem->size < 1024? mem->size : 1024;
+      mem->page_size = minm(mem->size, 1024);
+      mem->readsize = minm(mem->size, 1024);
     }
     if((mem = avr_locate_boot(p))) {
-      mem->page_size = mem->size < 1024? mem->size : 1024;
-      mem->readsize = mem->size < 1024? mem->size : 1024;
+      mem->page_size = minm(mem->size, 1024);
+      mem->readsize = minm(mem->size, 1024);
     }
   }
 }
@@ -1243,7 +1243,7 @@ static int pickit5_read_byte(const PROGRAMMER *pgm, const AVRPART *p,
   if(rc == 0)
     rc = pickit5_read_array(pgm, p, mem, addr, 1, value);
 
-  return rc < 0? rc: 0;
+  return minm(rc, 0);
 }
 
 // UPDI Specific function providing a reduced overhead when writing a single byte
@@ -2247,7 +2247,7 @@ static int usbdev_bulk_recv(const union filedescriptor *fd, unsigned char *buf, 
       cx->usb_bufptr = 0;
     }
 
-    amnt = cx->usb_buflen - cx->usb_bufptr > (int) nbytes? (int) nbytes: cx->usb_buflen - cx->usb_bufptr;
+    amnt = minm(cx->usb_buflen - cx->usb_bufptr, (int) nbytes);
     memcpy(buf + i, cx->usb_buf + cx->usb_bufptr, amnt);
     cx->usb_bufptr += amnt;
     nbytes -= amnt;

--- a/src/ser_avrdoper.c
+++ b/src/ser_avrdoper.c
@@ -231,7 +231,7 @@ static int avrdoper_send(const union filedescriptor *fdp, const unsigned char *b
   while(buflen > 0) {
     unsigned char buffer[256];
     int rval, lenIndex = chooseDataSize(buflen);
-    int thisLen = (int) buflen > reportDataSizes[lenIndex]? reportDataSizes[lenIndex]: (int) buflen;
+    int thisLen = minm((int) buflen, reportDataSizes[lenIndex]);
 
     buffer[0] = lenIndex + 1;   // Report ID
     buffer[1] = thisLen;
@@ -294,7 +294,7 @@ static int avrdoper_recv(const union filedescriptor *fdp, unsigned char *buf, si
         return -1;
       continue;
     }
-    len = remaining < available? remaining: available;
+    len = minm(remaining, available);
     memcpy(p, cx->sad_avrdoperRxBuffer + cx->sad_avrdoperRxPosition, len);
     p += len;
     remaining -= len;

--- a/src/ser_posix.c
+++ b/src/ser_posix.c
@@ -428,7 +428,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char *buf, si
   trace_buffer(__func__, buf, len);
 
   while(len) {
-    rc = write(fd->ifd, buf, len > 1024? 1024: len);
+    rc = write(fd->ifd, buf, minm(len, 1024));
     if(rc < 0) {
       pmsg_ext_error("unable to write: %s\n", strerror(errno));
       return -1;
@@ -471,7 +471,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
       }
     }
 
-    rc = read(fd->ifd, p, buflen - len > 1024? 1024: buflen - len);
+    rc = read(fd->ifd, p, minm(buflen - len, 1024));
     if(rc < 0) {
       pmsg_ext_error("unable to read: %s\n", strerror(errno));
       return -1;

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -317,7 +317,7 @@ static int net_send(const union filedescriptor *fd, const unsigned char *buf, si
   trace_buffer(__func__, buf, len);
 
   while(len) {
-    rc = send(fd->ifd, (const char *) buf, len > 1024? 1024: len, 0);
+    rc = send(fd->ifd, (const char *) buf, minm(len, 1024), 0);
     if(rc < 0) {
       FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
         FORMAT_MESSAGE_FROM_SYSTEM |

--- a/src/ser_win32.c
+++ b/src/ser_win32.c
@@ -353,7 +353,7 @@ static int ser_send(const union filedescriptor *fd, const unsigned char *buf, si
   trace_buffer(__func__, buf, len);
 
   // Set minimum r/w timeout to 2000 ms or higher to cater for 110 baud or faster
-  if(!serial_w32SetRWTimeOut(hComPort, (len > 20? len: 20)*100)) {
+  if(!serial_w32SetRWTimeOut(hComPort, maxm(len, 20)*100)) {
     pmsg_error("cannot set r/w timeout for serial port\n");
     return -1;
   }
@@ -445,7 +445,7 @@ static int ser_recv(const union filedescriptor *fd, unsigned char *buf, size_t b
   }
 
   // Ensure can receive buflen bytes at 8N1 at 110 baud or higher: one byte takes 91 ms at 110 baud
-  long timeout = (long) buflen*100 > serial_recv_timeout? (long) buflen*100: serial_recv_timeout;
+  long timeout = maxm((long) buflen*100, serial_recv_timeout);
   if(!serial_w32SetTimeOut(hComPort, timeout)) {
     pmsg_error("cannot set read timeout for serial port\n");
     return -1;

--- a/src/serialadapter.c
+++ b/src/serialadapter.c
@@ -68,7 +68,7 @@ static int sa_portcmp(const void *p, const void *q) {
   size_t la = null_len(a) - null_len(na), lb = null_len(b) - null_len(nb);
 
   // Compare string bases first
-  if(la && lb && (ret = strncasecmp(a, b, la < lb? la: lb)))
+  if(la && lb && (ret = strncasecmp(a, b, minm(la, lb))))
     return ret;
   if((ret = la - lb))
     return ret;

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -558,8 +558,8 @@ static int serialupdi_write_userrow(const PROGRAMMER *pgm, const AVRPART *p, con
       pmsg_error("writing USER ROW failed\n");
       return -1;
     }
-    addr_offset+=current_write_size;
-    remaining_bytes-=current_write_size;
+    addr_offset += current_write_size;
+    remaining_bytes -= current_write_size;
   }
 
   if(updi_write_cs(pgm, UPDI_ASI_SYS_CTRLA,

--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -812,7 +812,7 @@ static int serialupdi_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const 
 
     while(remaining_bytes > 0) {
       rc = updi_read_data(pgm, m->offset + read_offset, m->buf + read_offset,
-        remaining_bytes > m->readsize? m->readsize: remaining_bytes);
+        minm(remaining_bytes, m->readsize));
       if(rc < 0) {
         pmsg_error("paged load operation failed\n");
         return rc;
@@ -845,16 +845,16 @@ static int serialupdi_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const
 
       if(mem_is_eeprom(m)) {
         rc = updi_nvm_write_eeprom(pgm, p, m->offset + write_offset, m->buf + write_offset,
-          remaining_bytes > m->page_size? m->page_size: remaining_bytes);
+          minm(remaining_bytes, m->page_size));
       } else if(mem_is_flash(m)) {
         rc = updi_nvm_write_flash(pgm, p, m->offset + write_offset, m->buf + write_offset,
-          remaining_bytes > m->page_size? m->page_size: remaining_bytes);
+          minm(remaining_bytes, m->page_size));
       } else if(mem_is_userrow(m)) {
         rc = serialupdi_write_userrow(pgm, p, m, page_size, write_offset,
-          remaining_bytes > m->page_size? m->page_size: remaining_bytes);
+          minm(remaining_bytes, m->page_size));
       } else if(mem_is_bootrow(m)) {
         rc = updi_nvm_write_boot_row(pgm, p, m->offset + write_offset, m->buf + write_offset,
-          remaining_bytes > m->page_size? m->page_size: remaining_bytes);
+          minm(remaining_bytes, m->page_size));
       } else if(mem_is_fuses(m)) {
         pmsg_debug("page write operation requested for fuses, falling back to byte-level write\n");
         return -1;

--- a/src/strutil.c
+++ b/src/strutil.c
@@ -1508,7 +1508,7 @@ static size_t qwertydist(size_t w, unsigned char c1, unsigned char c2) {
 
   ret += sqrt((x1 - x2)*(x1 - x2) + (y1 - y2)*(y1 - y2))/2.5*w;
 
-  return ret > w? w: ret < 1? 1: ret;
+  return cliptom(ret, 1, w);
 }
 
 // Substitution cost considering qwerty keyboard typos and case

--- a/src/term.c
+++ b/src/term.c
@@ -375,7 +375,7 @@ static unsigned char *readbuf(const PROGRAMMER *pgm, const AVRPART *p, int argc,
       toread = maxsize - whence;
     int gap = maxsize - whence - toread;
 
-    after = gap > 16? 16: gap < 0? 0: gap;
+    after = cliptom(gap, 0, 16);
     toread += after;
     if(toread - before < 2)     // Cannot disassemble just one byte
       goto nocontent;
@@ -3064,7 +3064,7 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
     cx->term_header = mmt_strdup(hdr);
   }
 
-  percent = percent > 100? 100: percent < 0? 0: percent;
+  percent = cliptom(percent, 0, 100);
 
   if(cx->term_tty_todo) {
     if(!cx->term_header)
@@ -3095,7 +3095,7 @@ static void update_progress_tty(int percent, double etime, const char *hdr, int 
 static void update_progress_no_tty(int percent, double etime, const char *hdr, int finish) {
   setvbuf(stderr, (char *) NULL, _IONBF, 0);
 
-  percent = percent > 100? 100: percent < 0? 0: percent;
+  percent = cliptom(percent, 0, 100);
 
   if(hdr) {
     lmsg_info("%s | ", hdr);

--- a/src/term.c
+++ b/src/term.c
@@ -1580,7 +1580,7 @@ static void printproperty(Cnfg *cc, int ii, Cfg_opts o) {
         o.vmax = vt[j].value;
       llen = strlen(vt[j].label);
       lmin = minm(llen, lmin);
-      lmax = llen > lmax? llen: lmax;
+      lmax = maxm(llen, lmax);
     }
   }
   llen = lmax <= lmin + MAX_PAD? lmax: 1;     // Align label width if max and min length are similar
@@ -1865,8 +1865,8 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
         if(vj == -1 || (str_starts(vt[j].label, rhs) || str_match(rhs, vt[j].label))) {
           llen = strlen(vt[j].label);
           lmin = minm(llen, lmin);
-          lmax = llen > lmax? llen: lmax;
-          o.vmax = vt[j].value > o.vmax? vt[j].value: o.vmax;
+          lmax = maxm(llen, lmax);
+          o.vmax = maxm(vt[j].value, o.vmax);
         }
       }
       llen = lmax <= lmin + MAX_PAD? lmax: 1; // Align label width if max and min length are similar

--- a/src/term.c
+++ b/src/term.c
@@ -287,7 +287,7 @@ static unsigned char *readbuf(const PROGRAMMER *pgm, const AVRPART *p, int argc,
       cx->term_rmem[mi].mem = mem;
     if(cx->term_rmem[mi].mem == mem) {
       if(cx->term_rmem[mi].len <= 0)
-        cx->term_rmem[mi].len = maxsize > default_len? default_len: maxsize;
+        cx->term_rmem[mi].len = minm(maxsize, default_len);
       else if(cx->term_rmem[mi].len > maxsize)
         cx->term_rmem[mi].len = maxsize;
       if(cx->term_rmem[mi].addr < 0 || cx->term_rmem[mi].addr >= maxsize)
@@ -973,7 +973,7 @@ done:
   mmt_free(seglist);
   mmt_free(filename);
 
-  return ret < 0? ret: 0;
+  return minm(ret, 0);
 }
 
 static int cmd_backup(const PROGRAMMER *pgm, const AVRPART *p, int argc, const char *argv[]) {
@@ -1579,7 +1579,7 @@ static void printproperty(Cnfg *cc, int ii, Cfg_opts o) {
       if(vt[j].value > o.vmax)
         o.vmax = vt[j].value;
       llen = strlen(vt[j].label);
-      lmin = llen < lmin? llen: lmin;
+      lmin = minm(llen, lmin);
       lmax = llen > lmax? llen: lmax;
     }
   }
@@ -1864,7 +1864,7 @@ static int cmd_config(const PROGRAMMER *pgm, const AVRPART *p, int argc, const c
       for(int j = 0; j < nv; j++) {
         if(vj == -1 || (str_starts(vt[j].label, rhs) || str_match(rhs, vt[j].label))) {
           llen = strlen(vt[j].label);
-          lmin = llen < lmin? llen: lmin;
+          lmin = minm(llen, lmin);
           lmax = llen > lmax? llen: lmax;
           o.vmax = vt[j].value > o.vmax? vt[j].value: o.vmax;
         }

--- a/src/urbootautogen.c
+++ b/src/urbootautogen.c
@@ -425,7 +425,7 @@ static int rawuartbrr(const Avrintel *up, long f_cpu, long br, int nsamples) {
 static int uartbrr(const Avrintel *up, long f_cpu, long br, int nsamples) {
   int ret = rawuartbrr(up, f_cpu, br, nsamples), mxb = maxbrr(up);
 
-  return ret < 0? 0: ret > mxb? mxb: ret;
+  return cliptom(ret, 0, mxb);
 }
 
 // Actual baud rate given f_cpu, desired baud rated and number 8..63 of samples

--- a/src/urbootautogen.c
+++ b/src/urbootautogen.c
@@ -39,7 +39,7 @@
 } while (0)
 
 static int has_alt_spec(int nu, const Uart_conf *uap) {
-  for(int i=0; i<nu; i++)
+  for(int i = 0; i < nu; i++)
     if(uap[i].alt)
       return 1;
   return 0;
@@ -1396,7 +1396,7 @@ static int urbootautogen_parse(const AVRPART *part, char *urname, Urbootparams *
     int add[32] = { 0 }, maxd = 0, addone = 0, alldiff = 0;
     int sw=0, se=0, sU=0, sd=0, sj=0, sh=0, sP=0, sr=0, sa=0, sc=0, sp=0, sm=0;
 
-    for(int n=0; n<nut; n++) {
+    for(int n = 0; n < nut; n++) {
       char *t = ppp->vectorstr && !(urlist[n]->features & URFEATURE_HW)? "vector": urlist[n]->type;
       if(strlen(t) > maxtype)
         maxtype = strlen(t);
@@ -1433,7 +1433,7 @@ static int urbootautogen_parse(const AVRPART *part, char *urname, Urbootparams *
 
     term_out("%*.*s Size %*sUse Vers%s Features  Type%*s Canonical file name\n",
       maxd, maxd, "Selection", (int) maxuse-3, "", maxver < 15? "": "i", (int) maxtype-4, "");
-    for(int use=0, n=0; n<nut; n++) {
+    for(int use = 0, n = 0; n < nut; n++) {
       ppp->ut = urlist[n];
       char *p = urboot_filename(ppp, ".hex");
       char *t = ppp->vectorstr && !(urlist[n]->features & URFEATURE_HW)? "vector": urlist[n]->type;
@@ -1520,7 +1520,7 @@ static int urbootautogen_parse(const AVRPART *part, char *urname, Urbootparams *
         ppp->ut = urlist[n];
 
   // Deallocate urlist
-  for(int n=0; n<nut; n++) {
+  for(int n = 0; n < nut; n++) {
     if(urlist[n] && urlist[n] != ppp->ut) {
       mmt_free(urlist[n]->tofree);
       mmt_free(urlist[n]);

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1538,7 +1538,7 @@ vblvecfound:
                 rc = ur_readEF(pgm, p, spc, ur.pfend+1-nmeta(mcode, ur.uP.flashsize), mcode, 'F');
                 if(rc < 0)
                   return rc;
-                int len = mcode < sizeof ur.filename? mcode: sizeof ur.filename;
+                int len = minm(mcode, sizeof ur.filename);
                 memcpy(ur.filename, spc, len);
                 ur.filename[len-1] = 0;
               }
@@ -1790,7 +1790,7 @@ static int ur_readEF(const PROGRAMMER *pgm, const AVRPART *p, uint8_t *buf, uint
   // Read in chunks that the bootloader can send within 800 ms lest it triggers WDT
   int bd = pgm->baudrate <= 0? 115200: pgm->baudrate, rdchunk = maxm(4*bd/5/10 - 2, 2) & ~1;
   while(len > 0) {
-    int thislen = len < rdchunk? len: rdchunk;
+    int thislen = minm(len, rdchunk);
 
     if(urclock_paged_rdwr(pgm, p, Cmnd_STK_READ_PAGE, badd, thislen, mchr, NULL) < 0)
       return -1;
@@ -1988,7 +1988,7 @@ static int urclock_getsync(const PROGRAMMER *pgm) {
       } else
         break;
     } else {                    // Board not yet out of reset or bootloader twiddles lights
-      int slp = 32<<(attempt < 3? attempt: 3);
+      int slp = 32 << minm(attempt, 3);
       pmsg_debug("%4lld ms: sleeping for %d ms\n", (long long) avr_mstimestamp(), slp);
       usleep(slp*1000);
     }
@@ -2302,7 +2302,7 @@ static int urclock_paged_write(const PROGRAMMER *pgm, const AVRPART *p, const AV
     n = addr + n_bytes;
 
     for(; addr < n; addr += chunk) {
-      chunk = n-addr < page_size? n-addr: page_size;
+      chunk = minm(n-addr, page_size);
 
       if(urclock_paged_rdwr(pgm, p, Cmnd_STK_PROG_PAGE, addr, chunk, mchr, (char *) m->buf+addr)<0)
         return -3;
@@ -2341,7 +2341,7 @@ static int urclock_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
 
     n = addr + n_bytes;
     for(; addr < n; addr += chunk) {
-      chunk = n-addr < page_size? n-addr: page_size;
+      chunk = minm(n-addr, page_size);
 
       if(urclock_paged_rdwr(pgm, p, Cmnd_STK_READ_PAGE, addr, chunk, mchr, NULL) < 0)
         return -3;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -219,9 +219,6 @@
 #include "urclock.h"
 #include "urclock_private.h"
 
-#define urmax(a, b) ((a) > (b)? (a): (b))
-#define urmin(a, b) ((a) < (b)? (a): (b))
-
 static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p);
 static int ur_readEF(const PROGRAMMER *pgm, const AVRPART *p, uint8_t *buf, uint32_t addr, int len,
   char memchr);
@@ -1295,9 +1292,9 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
     if(ur.boothigh && ur.xbootsize % ur.uP.pagesize)
       Return("-x bootsize=%d size not a multiple of flash page size %d",
         ur.xbootsize, ur.uP.pagesize);
-    if(ur.xbootsize < 64 || ur.xbootsize > urmin(8192, ur.uP.flashsize/4))
+    if(ur.xbootsize < 64 || ur.xbootsize > minm(8192, ur.uP.flashsize/4))
       Return("implausible -x bootsize=%d, should be in [64, %d]",
-        ur.xbootsize, urmin(8192, ur.uP.flashsize/4));
+        ur.xbootsize, minm(8192, ur.uP.flashsize/4));
     if(ur.boothigh) {
       ur.blstart = flm->size - ur.xbootsize;
       ur.blend   = flm->size - 1;
@@ -1686,7 +1683,7 @@ static int urclock_paged_rdwr(const PROGRAMMER *pgm, const AVRPART *part, char r
       int resetsize = set_resetvector(ur.blstart, ur.uP.flashsize, jmptoboot, vecsz, ur.urprotocol);
 
       if(badd < (unsigned int) resetsize) { // Ensure reset vector points to bl
-        int n = urmin((unsigned int) resetsize - badd, (unsigned int) len);
+        int n = minm((unsigned int) resetsize - badd, (unsigned int) len);
         int resetdest;
 
         if(badd == 0 && len >= vecsz) {
@@ -1778,20 +1775,20 @@ static int ur_readEF(const PROGRAMMER *pgm, const AVRPART *p, uint8_t *buf, uint
     Return("bootloader %s not have EEPROM access%s", ur.blurversion? "does": "might",
       ur.blurversion? " capability": "; try -x eepromrw if it has");
 
-  if(len < 1 || len > urmax(ur.uP.pagesize, 256))
-    Return("len %d exceeds range [1, %d]", len, urmax(ur.uP.pagesize, 256));
+  if(len < 1 || len > maxm(ur.uP.pagesize, 256))
+    Return("len %d exceeds range [1, %d]", len, maxm(ur.uP.pagesize, 256));
 
   // Odd byte address under word-address protocol for "classic" parts (optiboot, avrisp etc)
   int odd = !ur.urprotocol && classic && (badd&1);
   if(odd) {                     // Need to read one extra byte
     len++;
     badd--;
-    if(len > urmax(ur.uP.pagesize, 256))
-      Return("len+1 = %d odd address exceeds range [1, %d]", len, urmax(ur.uP.pagesize, 256));
+    if(len > maxm(ur.uP.pagesize, 256))
+      Return("len+1 = %d odd address exceeds range [1, %d]", len, maxm(ur.uP.pagesize, 256));
   }
 
   // Read in chunks that the bootloader can send within 800 ms lest it triggers WDT
-  int bd = pgm->baudrate <= 0? 115200: pgm->baudrate, rdchunk = urmax(4*bd/5/10 - 2, 2) & ~1;
+  int bd = pgm->baudrate <= 0? 115200: pgm->baudrate, rdchunk = maxm(4*bd/5/10 - 2, 2) & ~1;
   while(len > 0) {
     int thislen = len < rdchunk? len: rdchunk;
 
@@ -2325,7 +2322,7 @@ static int urclock_paged_load(const PROGRAMMER *pgm, const AVRPART *p, const AVR
   unsigned int n;
 
   // Read in chunks that the bootloader can send within 800 ms lest it triggers WDT
-  int bd = pgm->baudrate <= 0? 115200: pgm->baudrate, rdchunk = urmax(4*bd/5/10 - 2, 2) & ~1;
+  int bd = pgm->baudrate <= 0? 115200: pgm->baudrate, rdchunk = maxm(4*bd/5/10 - 2, 2) & ~1;
   if((unsigned) rdchunk < page_size)
     page_size = rdchunk;
 
@@ -2539,7 +2536,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
     for(size_t i = 0; i < sizeof options/sizeof*options; i++) {
       msg_error("  -x %s%s%*s%s\n", options[i].name,
         options[i].assign && options[i].strbuf? "=<str>": options[i].assign? "=<n>  ": "",
-        urmax(0, 16-(int) strlen(options[i].name)-(options[i].assign? 6: 0)), "", options[i].help);
+        maxm(0, 16-(int) strlen(options[i].name)-(options[i].assign? 6: 0)), "", options[i].help);
     }
     if(rc == 0)
       return LIBAVRDUDE_EXIT_OK;

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -609,7 +609,7 @@ static int urclock_flash_readhook(const PROGRAMMER *pgm, const AVRPART *p, const
 
   bool llcode = firstbeg == 0 && firstlen > ur.uP.ninterrupts*vecsz; // Looks like code
   bool llvectors = firstbeg == 0 && firstlen >= ur.uP.ninterrupts*vecsz; // Looks like vector table
-  for(int i=0; llvectors && i<ur.uP.ninterrupts*vecsz; i+=vecsz) {
+  for(int i = 0; llvectors && i < ur.uP.ninterrupts*vecsz; i += vecsz) {
     uint16_t op16 = buf2uint16(flm->buf+i);
     if(!isop(op16, rjmp) && !(vecsz == 4 && isop(op16, jmp)))
       llvectors = 0;
@@ -1440,11 +1440,11 @@ static int ur_initstruct(const PROGRAMMER *pgm, const AVRPART *p) {
         op16 = wasjmp = wasop32 = 0;
         toend = flm->size-ur.blstart; // Number of bytes to FLASHEND
         npages = toend/flm->page_size;
-        for(i=0; i<npages; i++) {
+        for(i = 0; i < npages; i++) {
           // Read bootloader page by page
           if((rc = ur_readEF(pgm, p, spc, ur.blstart+i*flm->page_size, flm->page_size, 'F')))
             return rc;
-          for(n=flm->page_size/2, q=spc, j=0; j<n; j++, q+=2, toend-=2) { // Check 16-bit opcodes
+          for(n = flm->page_size/2, q = spc, j = 0; j < n; j++, q += 2, toend -= 2) { // Check 16-bit opcodes
             opcode = buf2uint16(q);
             if(wasjmp) {        // Opcode is the word address of the destination
               wasjmp=0;
@@ -1541,7 +1541,7 @@ vblvecfound:
                 rc = ur_readEF(pgm, p, spc, ur.pfend+1-nmeta(mcode, ur.uP.flashsize), mcode, 'F');
                 if(rc < 0)
                   return rc;
-                int len = mcode<sizeof ur.filename? mcode: sizeof ur.filename;
+                int len = mcode < sizeof ur.filename? mcode: sizeof ur.filename;
                 memcpy(ur.filename, spc, len);
                 ur.filename[len-1] = 0;
               }
@@ -1588,7 +1588,7 @@ vblvecfound:
     first=0;
   }
   if(ur.showboot || ur.showall) {
-    term_out(&" %s%d"[first], single? "": "boot ", ur.blend>ur.blstart? ur.blend-ur.blstart+1: 0);
+    term_out(&" %s%d"[first], single? "": "boot ", ur.blend > ur.blstart? ur.blend - ur.blstart+1: 0);
     first=0;
   }
   if(ur.showversion || ur.showall) {
@@ -1991,7 +1991,7 @@ static int urclock_getsync(const PROGRAMMER *pgm) {
       } else
         break;
     } else {                    // Board not yet out of reset or bootloader twiddles lights
-      int slp = 32<<(attempt<3? attempt: 3);
+      int slp = 32<<(attempt < 3? attempt: 3);
       pmsg_debug("%4lld ms: sleeping for %d ms\n", (long long) avr_mstimestamp(), slp);
       usleep(slp*1000);
     }
@@ -2489,7 +2489,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
     const char *extended_param = ldata(ln);
     size_t i, olen, plen = strlen(extended_param);
 
-    for(i=0; i<sizeof options/sizeof*options; i++) {
+    for(i = 0; i < sizeof options/sizeof*options; i++) {
       olen = strlen(options[i].name);
       if(strncmp(extended_param, options[i].name, olen) == 0) {
         if(!options[i].nstrbuf) {
@@ -2536,7 +2536,7 @@ static int urclock_parseextparms(const PROGRAMMER *pgm, LISTID extparms) {
 
   if(help || rc < 0) {
     msg_error("%s -c %s extended options:\n", progname, pgmid);
-    for(size_t i=0; i<sizeof options/sizeof*options; i++) {
+    for(size_t i = 0; i < sizeof options/sizeof*options; i++) {
       msg_error("  -x %s%s%*s%s\n", options[i].name,
         options[i].assign && options[i].strbuf? "=<str>": options[i].assign? "=<n>  ": "",
         urmax(0, 16-(int) strlen(options[i].name)-(options[i].assign? 6: 0)), "", options[i].help);

--- a/src/urclock.c
+++ b/src/urclock.c
@@ -1723,7 +1723,7 @@ static int urclock_paged_rdwr(const PROGRAMMER *pgm, const AVRPART *part, char r
         Return("urprotocol paged r/w len %d cannot exceed 256", len);
       *q++ = len;               // len==256 is sent as 0
     } else {
-      int max = ur.uP.pagesize > 256? ur.uP.pagesize: 256;
+      int max = maxm(ur.uP.pagesize, 256);
       if(len > max)
         Return("urprotocol paged r/w len %d cannot exceed %d for %s", len, max, ur.uP.name);
       *q++ = len>>8;            // Big endian length when needed
@@ -1732,7 +1732,7 @@ static int urclock_paged_rdwr(const PROGRAMMER *pgm, const AVRPART *part, char r
     i = q-buf;
 
   } else {
-    int max = ur.uP.pagesize > 256? ur.uP.pagesize: 256;
+    int max = maxm(ur.uP.pagesize, 256);
     if(len > max)
       Return("stk500 paged r/w len %d cannot exceed %d for %s", len, max, ur.uP.name);
 

--- a/src/usb_libusb.c
+++ b/src/usb_libusb.c
@@ -327,7 +327,7 @@ static int usbdev_recv(const union filedescriptor *fd, unsigned char *buf, size_
     if(cx->usb_bufptr >= cx->usb_buflen)
       if(usb_fill_buf(udev, fd->usb.max_xfer, fd->usb.rep, fd->usb.use_interrupt_xfer) < 0)
         return -1;
-    int amnt = cx->usb_buflen - cx->usb_bufptr > n? n: cx->usb_buflen - cx->usb_bufptr;
+    int amnt = minm(cx->usb_buflen - cx->usb_bufptr, n);
     memcpy(buf + i, cx->usb_buf + cx->usb_bufptr, amnt);
     cx->usb_bufptr += amnt;
     n -= amnt;


### PR DESCRIPTION
Various contributions define their own minimum and maximum macros. This PR standardises these under one name `minm()` and `maxm()`, respectively, and adds a macro for clipping a number into an interval
```
#define cliptom(v, min, max) ((v) < (min)? (min): (v) > (max)? (max): (v))
```

The trailing `m` in the name stands for `macro`. Standardising the name should help improve readability.

The PR also converts matching `? :` expressions to the corresponding macros, eg, converts `buflen > 16? 16: buflen` to `minm(buflen, 16)`. An `sed` script produced these rewrites, each of which was checked by hand.

All in all this PR somewhat enhances readability and compactness of the code.

Safe to merge.