### PR TITLE
Improve verification reports

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1387,25 +1387,18 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
 
       if(ro || (pgm->readonly && pgm->readonly(pgm, p, a, i))) {
         if(quell_progress < 2) {
-          if(vroerror < 10) {
-            if(!(verror + vroerror))
-              pmsg_warning("%s verification mismatch%s\n", a->desc,
-                mem_is_in_flash(a)? " in r/o areas, expected for vectors and/or bootloader": "");
-            imsg_warning("  device 0x%02x != input 0x%02x at addr 0x%04x "
-              "(read only location: ignored)\n", buf1[i], buf2[i], i);
-          } else if(vroerror == 10)
+          if(vroerror < 10)
+            imsg_warning("  device 0x%02x != input 0x%02x at addr 0x%04x (read-only location: ignored)\n", buf1[i], buf2[i], i);
+          else if(vroerror == 10)
             imsg_warning("  suppressing further mismatches in read-only areas\n");
         }
         vroerror++;
       } else if((buf1[i] & bitmask) != (buf2[i] & bitmask)) {
         // Mismatch is not just in unused bits
-        if(verror < maxerrs) {
-          if(!(verror + vroerror))
-            pmsg_warning("%s verification mismatch\n", a->desc);
+        if(verror < maxerrs)
           imsg_error("  device 0x%02x != input 0x%02x at addr 0x%04x (error)\n", buf1[i], buf2[i], i);
-        } else if(verror == maxerrs) {
+        else if(verror == maxerrs)
           imsg_warning("  suppressing further verification errors\n");
-        }
         verror++;
       } else {
         // Mismatch is only in unused bits

--- a/src/avr.c
+++ b/src/avr.c
@@ -1386,19 +1386,17 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
       uint8_t bitmask = is_isp(p)? get_fuse_bitmask(a): avr_mem_bitmask(p, a, i);
 
       if(ro || (pgm->readonly && pgm->readonly(pgm, p, a, i))) {
-        if(quell_progress < 2) {
-          if(vroerror < 10)
-            imsg_warning("  device 0x%02x != input 0x%02x at addr 0x%04x (read-only location: ignored)\n", buf1[i], buf2[i], i);
-          else if(vroerror == 10)
-            imsg_warning("  suppressing further mismatches in read-only areas\n");
-        }
+        if(vroerror < 10)
+          imsg_info("  device 0x%02x != input 0x%02x at addr 0x%04x (read-only location: ignored)\n", buf1[i], buf2[i], i);
+        else if(vroerror == 10)
+          imsg_info("  suppressing further mismatches in read-only areas\n");
         vroerror++;
       } else if((buf1[i] & bitmask) != (buf2[i] & bitmask)) {
         // Mismatch is not just in unused bits
         if(verror < maxerrs)
-          imsg_error("  device 0x%02x != input 0x%02x at addr 0x%04x (error)\n", buf1[i], buf2[i], i);
+          imsg_info("  device 0x%02x != input 0x%02x at addr 0x%04x (error)\n", buf1[i], buf2[i], i);
         else if(verror == maxerrs)
-          imsg_warning("  suppressing further verification errors\n");
+          imsg_info("  suppressing further verification errors\n");
         verror++;
       } else {
         // Mismatch is only in unused bits

--- a/src/avr.c
+++ b/src/avr.c
@@ -1389,14 +1389,14 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
         if(vroerror < 10)
           imsg_info("  device 0x%02x != input 0x%02x at addr 0x%04x (read-only location: ignored)\n", buf1[i], buf2[i], i);
         else if(vroerror == 10)
-          imsg_info("  suppressing further mismatches in read-only areas\n");
+          imsg_info("  showing no further mismatches in read-only areas\n");
         vroerror++;
       } else if((buf1[i] & bitmask) != (buf2[i] & bitmask)) {
         // Mismatch is not just in unused bits
         if(verror < maxerrs)
           imsg_info("  device 0x%02x != input 0x%02x at addr 0x%04x (error)\n", buf1[i], buf2[i], i);
         else if(verror == maxerrs)
-          imsg_info("  suppressing further verification errors\n");
+          imsg_info("  showing no further verification errors (increase verbosity for more)\n");
         verror++;
       } else {
         // Mismatch is only in unused bits

--- a/src/avr.c
+++ b/src/avr.c
@@ -1421,6 +1421,11 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
       }
     }
   }
+  if(verror)
+    imsg_info("  %d byte%s do not match caused by %d bit error%s of which %d set and %d cleared on device\n",
+      verror, str_plural(verror), biterrs, str_plural(biterrs), bitsset, biterrs-bitsset);
+  if(verror && bitsset == 0 && mem_is_in_flash(a))
+    imsg_info("  maybe flash was not erased beforehand or flash programming sections overlap?\n");
 
   return verror? -1: size;
 }

--- a/src/avr.c
+++ b/src/avr.c
@@ -1378,7 +1378,7 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
     size = vsize;
   }
 
-  int verror = 0, vroerror = 0, maxerrs = verbose >= MSG_DEBUG? size + 1: 10;
+  int verror = 0, vroerror = 0, maxerrs = verbose >= MSG_DEBUG? size: verbose >= MSG_NOTICE? 10: 1;
   int ro = mem_is_readonly(a);  // Other memories can have known protected zones such as bootloaders
 
   for(int i = 0; i < size; i++) {
@@ -1407,8 +1407,6 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
           imsg_warning("  suppressing further verification errors\n");
         }
         verror++;
-        if(verbose < MSG_NOTICE)
-          return -1;
       } else {
         // Mismatch is only in unused bits
         if((buf1[i] | bitmask) != 0xff) {

--- a/src/avr.c
+++ b/src/avr.c
@@ -1422,8 +1422,8 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
     }
   }
   if(verror)
-    imsg_info("  %d byte%s do not match caused by %d bit error%s of which %d set and %d cleared on device\n",
-      verror, str_plural(verror), biterrs, str_plural(biterrs), bitsset, biterrs-bitsset);
+    imsg_info("  %d byte%s do%s not match caused by %d bit error%s of which %d set and %d cleared on device\n",
+      verror, str_plural(verror), verror > 1? "": "es", biterrs, str_plural(biterrs), bitsset, biterrs-bitsset);
   if(verror && bitsset == 0 && mem_is_in_flash(a))
     imsg_info("  maybe flash was not erased beforehand or flash programming sections overlap?\n");
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -1355,7 +1355,6 @@ int avr_verify(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, const 
 }
 
 int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, const AVRMEM *a, int size) {
-  int i;
   unsigned char *buf1, *buf2;
   int vsize;
   AVRMEM *b;
@@ -1382,7 +1381,7 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
   int verror = 0, vroerror = 0, maxerrs = verbose >= MSG_DEBUG? size + 1: 10;
   int ro = mem_is_readonly(a);  // Other memories can have known protected zones such as bootloaders
 
-  for(i = 0; i < size; i++) {
+  for(int i = 0; i < size; i++) {
     if((b->tags[i] & TAG_ALLOCATED) != 0 && buf1[i] != buf2[i]) {
       uint8_t bitmask = is_isp(p)? get_fuse_bitmask(a): avr_mem_bitmask(p, a, i);
 

--- a/src/avr.c
+++ b/src/avr.c
@@ -1380,6 +1380,8 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
 
   int verror = 0, vroerror = 0, maxerrs = verbose >= MSG_DEBUG? size: verbose >= MSG_NOTICE? 10: 1;
   int ro = mem_is_readonly(a);  // Other memories can have known protected zones such as bootloaders
+  int biterrs = 0, bitsset = 0;
+  unsigned int bdiff;
 
   for(int i = 0; i < size; i++) {
     if((b->tags[i] & TAG_ALLOCATED) != 0 && buf1[i] != buf2[i]) {
@@ -1391,8 +1393,13 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
         else if(vroerror == 10)
           imsg_info("  showing no further mismatches in read-only areas\n");
         vroerror++;
-      } else if((buf1[i] & bitmask) != (buf2[i] & bitmask)) {
-        // Mismatch is not just in unused bits
+      } else if((bdiff = (buf1[i] & bitmask) ^ (buf2[i] & bitmask))) {
+        // Mismatch is not just in unused bits, loop over bit positions that differ
+        for(unsigned int lbit; bdiff; bdiff ^= lbit) {
+           lbit = bdiff & -bdiff; // Lowest bit that differs
+           biterrs++;             // Number of bit mismatches
+           bitsset += !!(lbit & buf1[i]); // The mismatched bit was set on device
+        }
         if(verror < maxerrs)
           imsg_info("  device 0x%02x != input 0x%02x at addr 0x%04x (error)\n", buf1[i], buf2[i], i);
         else if(verror == maxerrs)


### PR DESCRIPTION
This PR improves the verification report on errors.

For example, if two overlapping hex files are programmed in flash, chances are there will be verification errors owing to NOR flash memory's inability to set bits that had been cleared. This PR diagnoses those situations.

Without this PR:

```
$ avrdude -q -cdryrun -pm328p -U urboot:autobaud_ee -U urboot:autobaud

[...]
Writing 260 bytes to flash, 260 bytes written
Warning: flash verification mismatch
  device 0x3f != input 0x7f at addr 0x0000 (error)
Error: flash verification mismatch
```

With this PR:

```
$ avrdude -q -cdryrun -pm328p -U urboot:autobaud_ee -U urboot:autobaud

[...]
Writing 260 bytes to flash, 260 bytes written
  device 0x3f != input 0x7f at addr 0x0000 (error)
  showing no further verification errors (increase verbosity for more)
  200 bytes do not match caused by 461 bit errors of which 0 set and 461 cleared on device
  maybe flash was not erased beforehand or flash programming sections overlap?
Error: flash verification mismatch
```
