### PR TITLE
Refrain from generating label for fill disassembly

### DIFF
--- a/src/disasm.c
+++ b/src/disasm.c
@@ -548,7 +548,6 @@ static void lineout(const char *code, const char *comment,
 
   if(cx->dis_opts.labels && showlabel) {
     int match = 0, first = -1;
-    const char *comment = NULL, *name;
     Dis_symbol *s;
 
     for(int i = 0; i < cx->dis_jumpcallN; i++)
@@ -573,24 +572,26 @@ static void lineout(const char *code, const char *comment,
         strcpy(r, str_ccprintf(&", L%0*x"[2*(r == reflist)], cx->dis_addrwidth, jc[i].from));
         r += strlen(r);
       }
-      name = get_label_name(here, &comment);
-      if(!comment && strlen(reflist) + commentcol() < 70 && one_mne) {  // Refs line with label
-        const char *mnestr = avr_opcodes[mne].opcode;
+      const char *comment = NULL, *name;
+      if((name = get_label_name(here, &comment))) {
+        if(!comment && strlen(reflist) + commentcol() < 70 && one_mne) { // Refs line with label
+          const char *mnestr = avr_opcodes[mne].opcode;
 
-        if(cx->dis_opts.comments)
-          disasm_out("%-*s ; %s\n", commentcol(), str_ccprintf("%s:", name),
-            str_ccprintf("%c%s from %s", toupper(*mnestr & 0xff), mnestr + 1, reflist));
-        else
-          disasm_out("%s:\n", name);
-      } else {
-        if(cx->dis_opts.comments)
-          output_references(avr_opcodes[mne].opcode, reflist);
-        if(!comment || !*comment || !cx->dis_opts.comments)
-          disasm_out("%s:\n", name);
-        else
-          disasm_out("%-*s ; %s\n", commentcol(), str_ccprintf("%s:", name), comment);
+          if(cx->dis_opts.comments)
+            disasm_out("%-*s ; %s\n", commentcol(), str_ccprintf("%s:", name),
+              str_ccprintf("%c%s from %s", toupper(*mnestr & 0xff), mnestr + 1, reflist));
+          else
+            disasm_out("%s:\n", name);
+        } else {
+          if(cx->dis_opts.comments)
+            output_references(avr_opcodes[mne].opcode, reflist);
+          if(!comment || !*comment || !cx->dis_opts.comments)
+            disasm_out("%s:\n", name);
+          else
+            disasm_out("%-*s ; %s\n", commentcol(), str_ccprintf("%s:", name), comment);
+        }
+        cx->dis_para = -1;
       }
-      cx->dis_para = -1;
       mmt_free(reflist);
     } else if(match) {          // Register potential L label in pass 1 as to be printed
       (void) get_label_name(here, &comment);


### PR DESCRIPTION
When disassembling an `rjmp` to the start of a memory hole a `(null)` label is wrongly printed:

```
$ avrdude -qq -cdryrun -pt13 -T "wr fl 0 0xc001 0x0000; di fl 0 -1"

L000: 01 c0        rjmp    .+2                  ; L004
L002: 00 00        nop

(null):                                         ; Rjmp from L000
L004: ff ff ff ff  .fill   510, 2, 0xffff
```


With this PR no corresponding label is printed:

```
$ avrdude -qq -cdryrun -pt13 -T "wr fl 0 0xc001 0x0000; di fl 0 -1"

L000: 01 c0        rjmp    .+2                  ; L004
L002: 00 00        nop

L004: ff ff ff ff  .fill   510, 2, 0xffff
```
