### PR TITLE
Provide special `test` memory

### DIFF
--- a/src/avrdude.1
+++ b/src/avrdude.1
@@ -788,21 +788,31 @@ multiple memories. The special memory
 expands to all memories that a part has while
 .Ar all
 expands to all memories with exception of sub-memories.
+.Ar test
+expands to a list of writable memories plus signature; this is
+particularly useful for testing AVRDUDE and its -c programmers.
 .Ar etc
 is the same as
 .Ar all ;
 this can be used to change the order in which memories are written to
 or read from file, eg,
 .Ar signature,etc
-is a list of all memories such that the
+expands to a list of all memories such that the
 .Ar signature
 memory comes first. It is possible to remove a memory from the list so far
 by preceding a minus or backslash, eg,
 .Ar all,-calibration .
-The available memory types are device-dependent, the actual configuration
+The available memories are device-dependent; the actual memory configuration
 can be viewed with the
 .Cm part
-command in terminal mode.
+command in terminal mode. The expansion of memory lists depends in subtle
+ways on the actually used -c programmer or on the chosen programming mode:
+for example, the
+.Ar usersig
+memories of classic parts cannot be handled by ISP programming, so in
+those cases above lists would not include the
+.Ar usersig
+memory, while it would be included in other programming constellations.
 .Pp
 Typically, a device's memory configuration at least contains
 the memories

--- a/src/doc/avrdude.texi
+++ b/src/doc/avrdude.texi
@@ -234,7 +234,7 @@ A typical programming cable would then look like:
 @item @tab @code{25}     @tab @code{6}   @tab @code{GND}
 @end multitable
 
-The @code{-P @var{port}} option for this programmer typically has the
+The @option{-P @var{port}} option for this programmer typically has the
 format @code{/dev/spidev0.0:/dev/gpiochip0}. And, mind the 3.3@w{ }V
 voltage level of the Raspberry Pi!
 
@@ -331,7 +331,7 @@ When used in ISP and PDI mode, the AVR Dragon behaves similar to an
 AVRISP mkII (or JTAG ICE mkII in ISP mode), so all device-specific
 comments will apply there.
 In particular, the Dragon starts out with a rather fast ISP clock
-frequency, so the @code{-B @var{bitclock}}
+frequency, so the @option{-B @var{bitclock}}
 option might be required to achieve a stable ISP communication.
 For ATxmega devices, the AVR Dragon is supported in PDI mode, provided it
 has a firmware version of at least 6.11 (decimal).
@@ -340,7 +340,7 @@ has a firmware version of at least 6.11 (decimal).
 Wiring boards (e.g. Arduino Mega 2560 Rev3) are supported, utilizing
 STK500 V2.x protocol, but a simple DTR/RTS toggle to set the boards
 into programming mode.  The programmer type is ``wiring''. Note that
-the @code{-D} option will likely be required in this case, because the
+the @option{-D} option will likely be required in this case, because the
 bootloader will rewrite the program memory, but no true chip erase can
 be performed.
 
@@ -363,10 +363,10 @@ much smaller, e.g., as implemented in the urboot project
 caters for these urboot bootloaders. Owing to its backward compatibility,
 bootloaders that can be served by the arduino programmer can normally also
 be served by the urclock programmer. This may require specifying the size
-of (to AVRDUDE) @emph{unknown} bootloaders in bytes using the @code{-x
+of (to AVRDUDE) @emph{unknown} bootloaders in bytes using the @option{-x
 bootsize=@var{n}} option, which is necessary for the urclock programmer to
 enable it to protect the bootloader from being overwritten. If an unknown
-bootloader has EEPROM read/write capability then the option @code{-x eepromrw}
+bootloader has EEPROM read/write capability then the option @option{-x eepromrw}
 informs @code{avrdude -c urclock} of that capability.
 
 @cindex The Bus Pirate
@@ -385,7 +385,7 @@ CH341A programmers connect directly to the AVR target. Their SPI bit clock
 is approximately 1.7@w{ }MHz and cannot be changed. As a consequence, the
 AVR target must have a CPU frequency of 6.8@w{ }MHz or more: factory-set
 AVR parts, which typically run on an internal oscillator between 1 MHz and
-1.6 MHz, cannot be programmed using @code{-c ch341a}.
+1.6 MHz, cannot be programmed using @option{-c ch341a}.
 
 @cindex FLIP bootloader
 The Atmel DFU bootloader is supported in both, FLIP protocol version 1
@@ -424,7 +424,7 @@ via a serial link (@url{https://github.com/ElTangas/jtag2updi}).
 @cindex @code{flash}
 The Micronucleus bootloader is supported for both protocol version V1 and
 V2. As the bootloader does not support reading from flash memory, use the
-@code{-V} option to prevent AVRDUDE from verifying the flash memory. See
+@option{-V} option to prevent AVRDUDE from verifying the flash memory. See
 the section on @emph{extended parameters} below for Micronucleus specific
 options.
 
@@ -432,7 +432,7 @@ options.
 @cindex @code{flash}
 The Teensy bootloader is supported for all AVR boards.
 As the bootloader does not support reading from flash memory,
-use the @code{-V} option to prevent AVRDUDE from verifying the flash memory.
+use the @option{-V} option to prevent AVRDUDE from verifying the flash memory.
 See the section on @emph{extended parameters}
 below for Teensy specific options.
 
@@ -509,10 +509,10 @@ following options are recognized:
 @table @code
 @item -p @var{partname}
 @item --part @var{partname}
-@cindex Option @code{-p} @var{partname}
-@cindex Option @code{--part} @var{partname}
-@cindex @code{-p} @var{partname}
-@cindex @code{--part} @var{partname}
+@cindex Option @option{-p} @var{partname}
+@cindex Option @option{--part} @var{partname}
+@cindex @option{-p} @var{partname}
+@cindex @option{--part} @var{partname}
 @cindex Part specification
 This option tells AVRDUDE what part (MCU) is connected to the programmer.
 The @var{partname} parameter is the part's id listed in the configuration
@@ -520,15 +520,15 @@ file. To see a list of currently supported MCUs use @code{?} as partname,
 which will, for each part, print its id; its official part name;
 alternative names, if any; and the list of available programming
 interfaces. Depending on the used shell, @code{?} may need to be quoted
-as in @code{"?"} or @code{\?}. In connection with @code{-v}, this will
+as in @code{"?"} or @code{\?}. In connection with @option{-v}, this will
 also print a table of variant part names with the package code and some
 absolute maximum ratings. The part id, their official part name, the
 listed alternative names or any of the full variant part names can be used
-to specify a part with the @code{-p} option. If a part is unknown to
+to specify a part with the @option{-p} option. If a part is unknown to
 AVRDUDE, it means that there is no config file entry for that part, but it
 can be added to the configuration file if you have the Atmel datasheet so
-that you can enter the programming specifications. If @code{-p ?} is
-specified with a specific programmer, see @code{-c} below, then only those
+that you can enter the programming specifications. If @option{-p ?} is
+specified with a specific programmer, see @option{-c} below, then only those
 parts are output that the programmer expects to be able to handle,
 together with the programming interface(s) that can be used in that
 combination. In reality there can be deviations from this list,
@@ -537,10 +537,10 @@ Parts} for a full and detailed listing of supported parts.
 
 @item -p @var{wildcard/flags}
 @item --part @var{wildcard/flags}
-@cindex Option @code{-p} @var{wildcard/flags}
-@cindex Option @code{--part} @var{wildcard/flags}
-@cindex @code{-p} @var{wildcard/flags}
-@cindex @code{--part} @var{wildcard/flags}
+@cindex Option @option{-p} @var{wildcard/flags}
+@cindex Option @option{--part} @var{wildcard/flags}
+@cindex @option{-p} @var{wildcard/flags}
+@cindex @option{--part} @var{wildcard/flags}
 Run developer options for MCUs that are matched by @var{wildcard}. Whilst
 their main use is for developers some @var{flags} can be of utility for
 users, e.g.,  @code{avrdude -p m328p/S} outputs AVRDUDE's understanding of
@@ -548,10 +548,10 @@ ATmega328P MCU properties; for more information run @code{avrdude -p x/h}.
 
 @item -b @var{baudrate}
 @item --baud @var{baudrate}
-@cindex Option @code{-b} @var{baudrate}
-@cindex Option @code{--baud} @var{baudrate}
-@cindex @code{-b} @var{baudrate}
-@cindex @code{--baud} @var{baudrate}
+@cindex Option @option{-b} @var{baudrate}
+@cindex Option @option{--baud} @var{baudrate}
+@cindex @option{-b} @var{baudrate}
+@cindex @option{--baud} @var{baudrate}
 Override the RS-232 connection baud rate specified in the respective
 programmer's @code{baudrate} entry of the configuration file
 or defined by the @code{default_baudrate} entry in your
@@ -560,10 +560,10 @@ file if no @code{baudrate} entry was provided for this programmer.
 
 @item -B @var{bitclock}
 @item --bitclock @var{bitclock}
-@cindex Option @code{-B} @var{bitclock}
-@cindex Option @code{--bitclock} @var{bitclock}
-@cindex @code{-B} @var{bitclock}
-@cindex @code{--bitclock} @var{bitclock}
+@cindex Option @option{-B} @var{bitclock}
+@cindex Option @option{--bitclock} @var{bitclock}
+@cindex @option{-B} @var{bitclock}
+@cindex @option{--bitclock} @var{bitclock}
 Specify the bit clock period for the JTAG, PDI, TPI, UPDI, or ISP
 interface. The value is a floating-point number in microseconds.
 Alternatively, the value might be suffixed with Hz, kHz or
@@ -590,21 +590,21 @@ the computer.
 
 @item -c @var{programmer-id}
 @item --programmer @var{programmer-id}
-@cindex Option @code{-c} @var{programmer-id}
-@cindex Option @code{--programmer} @var{programmer-id}
-@cindex @code{-c} @var{programmer-id}
-@cindex @code{--programmer} @var{programmer-id}
+@cindex Option @option{-c} @var{programmer-id}
+@cindex Option @option{--programmer} @var{programmer-id}
+@cindex @option{-c} @var{programmer-id}
+@cindex @option{--programmer} @var{programmer-id}
 @cindex Programmer specification
 Specify the programmer to be used.  AVRDUDE knows about quite a few
 programmers. The @var{programmer-id} parameter is the programmer's id
-listed in the configuration file.  Specify @code{-c ?} to list all
+listed in the configuration file.  Specify @option{-c ?} to list all
 programmers in the configuration file. Depending on the used shell,
 @code{?} may need to be quoted as in @code{"?"} or @code{\?}. If you have
 a programmer that is unknown to AVRDUDE but related to a known programmer
 there is some chance that it can be added to the configuration file
 without any code changes to AVRDUDE: copy a similar entry and change those
-features that differ to match that of the unknown programmer. If @code{-c
-?} is specified with a specific part, see @code{-p} above, then only those
+features that differ to match that of the unknown programmer. If @option{-c
+?} is specified with a specific part, see @option{-p} above, then only those
 programmers are output that expect to be able to handle this part,
 together with the programming interface(s) that can be used in that
 combination. In reality there can be deviations from this list,
@@ -613,10 +613,10 @@ Programmers} for a full and detailed listing of known programmers.
 
 @item -c @var{wildcard/flags}
 @item --programmer @var{wildcard/flags}
-@cindex Option @code{-c} @var{wildcard/flags}
-@cindex Option @code{--programmer} @var{wildcard/flags}
-@cindex @code{-c} @var{wildcard/flags}
-@cindex @code{--programmer} @var{wildcard/flags}
+@cindex Option @option{-c} @var{wildcard/flags}
+@cindex Option @option{--programmer} @var{wildcard/flags}
+@cindex @option{-c} @var{wildcard/flags}
+@cindex @option{--programmer} @var{wildcard/flags}
 Run developer options for programmers that are matched by @var{wildcard}.
 Whilst their main use is for developers some @var{flags} can be of utility
 for users, e.g., @code{avrdude -c usbtiny/S} shows AVRDUDE's understanding of
@@ -624,10 +624,10 @@ usbtiny's properties; for more information run @code{avrdude -c x/h}.
 
 @item -C @var{config-file}
 @item --config @var{config-file}
-@cindex Option @code{-c} @var{config-file}
-@cindex Option @code{--config} @var{config-file}
-@cindex @code{-C} @var{config-file}
-@cindex @code{--config} @var{config-file}
+@cindex Option @option{-c} @var{config-file}
+@cindex Option @option{--config} @var{config-file}
+@cindex @option{-C} @var{config-file}
+@cindex @option{--config} @var{config-file}
 @cindex Configuration files
 Use the specified config file for configuration data.  This file
 contains all programmer and part definitions that AVRDUDE knows about.
@@ -657,38 +657,38 @@ line.
 
 @item -N
 @item --noconfig
-@cindex Option @code{-N}
-@cindex Option @code{--noconfig}
-@cindex @code{-N}
-@cindex @code{--noconfig}
+@cindex Option @option{-N}
+@cindex Option @option{--noconfig}
+@cindex @option{-N}
+@cindex @option{--noconfig}
 Do not load the personal configuration file that is usually located at
 @code{~/.config/avrdude/avrdude.rc}, @code{~/.avrduderc} or in the same
 directory as the avrdude executable.
 
 @item -A
 @item --keep-trailing-0xff
-@cindex Option @code{-A}
-@cindex Option @code{--keep-trailing-0xff}
-@cindex @code{-A}
-@cindex @code{--keep-trailing-0xff}
+@cindex Option @option{-A}
+@cindex Option @option{--keep-trailing-0xff}
+@cindex @option{-A}
+@cindex @option{--keep-trailing-0xff}
 @cindex @code{flash}
 Disable the automatic removal of trailing-0xFF sequences in file input
 that is to be programmed to flash and in AVR reads from flash memory.
 Normally, trailing 0xFFs can be discarded, as flash programming requires
-the memory be erased to 0xFF beforehand. @code{-A} should be used when the
+the memory be erased to 0xFF beforehand. @option{-A} should be used when the
 programmer hardware, or bootloader software for that matter, does not
 carry out chip erase and instead handles the memory erase on a page level.
 The popular Arduino bootloader exhibits this behaviour; for this reason
-@code{-A} is engaged by default when specifying @code{-c} arduino.
+@option{-A} is engaged by default when specifying @option{-c} arduino.
 
 @item -D
 @item --noerase
-@cindex Option @code{-D}
-@cindex Option @code{--noerase}
-@cindex @code{-D}
-@cindex @code{--noerase}
+@cindex Option @option{-D}
+@cindex Option @option{--noerase}
+@cindex @option{-D}
+@cindex @option{--noerase}
 @cindex @code{flash}
-Disable auto-erase for flash. When the @code{-U} option for writing to any
+Disable auto-erase for flash. When the @option{-U} option for writing to any
 flash memory is specified, avrdude will perform a chip erase before
 starting any of the programming operations, since it generally is a
 mistake to program the flash without performing an erase first.  This
@@ -696,14 +696,14 @@ option disables that. Auto-erase is not used for ATxmega parts nor for the
 UPDI (AVR8X family) parts as these can use page erase before writing each
 page so no explicit chip erase is required. Note, however, that any flash
 page not affected by the current operation will retain its previous
-contents. Setting @code{-D} implies @code{-A}.
+contents. Setting @option{-D} implies @option{-A}.
 
 @item -e
 @item --erase
-@cindex Option @code{-e}
-@cindex Option @code{--erase}
-@cindex @code{-e}
-@cindex @code{--erase}
+@cindex Option @option{-e}
+@cindex Option @option{--erase}
+@cindex @option{-e}
+@cindex @option{--erase}
 @cindex @code{flash}
 @cindex @code{eeprom}
 Causes a chip erase to be executed. This will reset the contents of the
@@ -713,19 +713,19 @@ page erase, it is basically a prerequisite command before the flash ROM
 can be reprogrammed again.  The only exception would be if the new
 contents would exclusively cause bits to be programmed from the value
 @code{1} to @code{0}.  This option carries out the chip erase at the
-beginning, before any of the @code{-U}, @code{-T} or @code{-t} options are
+beginning, before any of the @option{-U}, @option{-T} or @option{-t} options are
 processed. If a chip erase is required in at a certain position within the
-sequence of @code{-U}, @code{-T} or @code{-t} options it is recommended to
-use @code{-T} erase instead which is processed in the given command line
+sequence of @option{-U}, @option{-T} or @option{-t} options it is recommended to
+use @option{-T} erase instead which is processed in the given command line
 order.
 
 @cindex Auto-erase
 @cindex @code{flash}
-In absence of an explicit @code{-e} or @code{-D} option avrdude tries to
+In absence of an explicit @option{-e} or @option{-D} option avrdude tries to
 augur from the command line whether or not the chip should be auto-erased
-at the  beginning. If avrdude detects a @code{-U} command that writes to
+at the  beginning. If avrdude detects a @option{-U} command that writes to
 flash then auto-erase will be carried out before any other programming
-unless a @code{-T} erase command has been detected beforehand and unless
+unless a @option{-T} erase command has been detected beforehand and unless
 flash is read before writing to it. For the purpose of this analysis any
 terminal command is considered to possibly read flash.
 
@@ -736,10 +736,10 @@ programming the cell.
 
 @item -E @var{exitspec}[,@dots{}]
 @item --exitspecs @var{exitspec}[,@dots{}]
-@cindex Option @code{-E} @var{exitspec}[,@dots{}]
-@cindex Option @code{--exitspecs} @var{exitspec}[,@dots{}]
-@cindex @code{-E} @var{exitspec}[,@dots{}]
-@cindex @code{--exitspecs} @var{exitspec}[,@dots{}]
+@cindex Option @option{-E} @var{exitspec}[,@dots{}]
+@cindex Option @option{--exitspecs} @var{exitspec}[,@dots{}]
+@cindex @option{-E} @var{exitspec}[,@dots{}]
+@cindex @option{--exitspecs} @var{exitspec}[,@dots{}]
 Pass @var{exitspec} to the programmer. The interpretation of the exitspec
 parameter depends on the programmer itself. See below for a list of
 programmers accepting exitspec parameter options or issue
@@ -749,10 +749,10 @@ Multiple @var{exitspec} options can be separated with commas.
 
 @item -F
 @item --force
-@cindex Option @code{-F}
-@cindex Option @code{--force}
-@cindex @code{-F}
-@cindex @code{--force}
+@cindex Option @option{-F}
+@cindex Option @option{--force}
+@cindex @option{-F}
+@cindex @option{--force}
 @cindex @code{signature}
 Normally, AVRDUDE tries to verify that the device signature read from
 the part is reasonable before continuing.  Since it can happen from time
@@ -768,10 +768,10 @@ of connection between a programmer and a target.
 
 @item -i @var{delay}
 @item --isp-clock-delay @var{delay}
-@cindex Option @code{-i} @var{delay}
-@cindex Option @code{--isp-clock-delay} @var{delay}
-@cindex @code{-i} @var{delay}
-@cindex @code{--isp-clock-delay} @var{delay}
+@cindex Option @option{-i} @var{delay}
+@cindex Option @option{--isp-clock-delay} @var{delay}
+@cindex @option{-i} @var{delay}
+@cindex @option{--isp-clock-delay} @var{delay}
 For bitbang-type programmers, delay for approximately
 @var{delay}
 microseconds between each bit state change.
@@ -790,30 +790,30 @@ slow machines.
 
 @item -l @var{logfile}
 @item --logfile @var{logfile}
-@cindex Option @code{-l} @var{logfile}
-@cindex Option @code{--logfile} @var{logfile}
-@cindex @code{-l} @var{logfile}
-@cindex @code{--logfile} @var{logfile}
+@cindex Option @option{-l} @var{logfile}
+@cindex Option @option{--logfile} @var{logfile}
+@cindex @option{-l} @var{logfile}
+@cindex @option{--logfile} @var{logfile}
 Use @var{logfile} rather than @var{stderr} for diagnostics output.
 Note that initial diagnostic messages (during option parsing) are still
 written to @var{stderr} anyway.
 
 @item -n
 @item --test-memory
-@cindex Option @code{-n}
-@cindex Option @code{--test-memory}
-@cindex @code{-n}
-@cindex @code{--test-memory}
-No-write: disables writing data to the MCU whilst processing @code{-U}
+@cindex Option @option{-n}
+@cindex Option @option{--test-memory}
+@cindex @option{-n}
+@cindex @option{--test-memory}
+No-write: disables writing data to the MCU whilst processing @option{-U}
 (useful for debugging AVRDUDE). The terminal mode continues to write to
 the device.
 
 @item -O
 @item --osccal
-@cindex Option @code{-O}
-@cindex Option @code{--osccal}
-@cindex @code{-O}
-@cindex @code{--osccal}
+@cindex Option @option{-O}
+@cindex Option @option{--osccal}
+@cindex @option{-O}
+@cindex @option{--osccal}
 @cindex @code{calibration}
 Perform a RC oscillator run-time calibration according to Atmel
 application note AVR053.
@@ -824,10 +824,10 @@ Note that the result will be stored in the EEPROM cell at address 0.
 
 @item -P @var{port}
 @item --port @var{port}
-@cindex Option @code{-P} @var{port}
-@cindex Option @code{--port} @var{port}
-@cindex @code{-P} @var{port}
-@cindex @code{--port} @var{port}
+@cindex Option @option{-P} @var{port}
+@cindex Option @option{--port} @var{port}
+@cindex @option{-P} @var{port}
+@cindex @option{--port} @var{port}
 @cindex Port specification
 
 Use @var{port} to identify the connection through which the programmer is
@@ -835,7 +835,7 @@ attached. This can be a serial, spi, linuxgpio or, on a Linux or BSD
 system, parallel connection. The programmer configuration normally only
 ever specifies the connection type but an optional port entry can be added
 in the per-user configuration file @code{.avrduderc}, which is then used
-in absence of @code{-P}. If the programmer configuration does not specify
+in absence of @option{-P}. If the programmer configuration does not specify
 the @var{port}, system-dependent default values @code{default_serial},
 @code{default_spi}, @code{default_linuxgpio} or @code{default_parallel}
 from the configuration file are used. These, too, can be overwritten in
@@ -845,8 +845,8 @@ USB-only programmers normally do not need a @var{port} name as they are
 automatically identified via their vendor and product IDs from
 @code{avrdude.conf} or @code{.avrduderc}. Only when there are multiple
 programmers of the same type plugged in is the programmer's port
-configuration or the @code{-P} option needed, see below. Some @code{-c}
-programmers, e.g., pickit2, ignore the @code{-P} option altogether; these
+configuration or the @option{-P} option needed, see below. Some @option{-c}
+programmers, e.g., pickit2, ignore the @option{-P} option altogether; these
 cannot distinguish multiple plugged-in programmers.
 
 Most USB programmers, however, support the port name syntax
@@ -857,7 +857,7 @@ with @var{serialno}. The match is done after stripping any existing colons
 from the given serial number on the command line, and right-to-left, so
 only the least significant bytes from the serial number need to be given.
 The JTAG ICE mkII, JTAGICE3, SNAP, PICKit5, CH341A, teensy and avrftdi
-programmers are examples for this @code{-P} port syntax. Some of these in
+programmers are examples for this @option{-P} port syntax. Some of these in
 turn, e.g. the CH341A and teensy, are not capable of matching serial
 numbers.
 
@@ -876,8 +876,8 @@ avrdude, it can be specified using the hexadecimal USB vendor ID,
 hexadecimal product ID and an optional serial number, following the serial
 number matching rules described above, e.g., @code{usb:0x2341:0x0043} or
 @code{usb:2341:0043:12345678}. To see a list of currently plugged-in
-serial ports use @code{-P ?s}. In order to see a list of all possible
-serial adapters known to avrdude use @code{-P ?sa}. Depending on the used
+serial ports use @option{-P ?s}. In order to see a list of all possible
+serial adapters known to avrdude use @option{-P ?sa}. Depending on the used
 shell, @code{?} may need to be quoted as in @code{"?"} or @code{\?}.
 
 For the JTAG ICE mkII, if AVRDUDE has been built with libusb support, the
@@ -894,16 +894,16 @@ As the AVRISP mkII device can only be talked to over USB, the very same
 method of specifying the port is required there.
 
 For the USB programmer AVR-Doper running in HID mode, the port must be
-specified as @code{-P avrdoper}. Libhidapi support is required on Unix and
+specified as @option{-P avrdoper}. Libhidapi support is required on Unix and
 Mac OS but not on Windows. For more information about AVR-Doper see
 @url{https://www.obdev.at/products/vusb/avrdoper.html}.
 
 For the USBtinyISP, which is a simplistic device not implementing serial
 numbers, multiple devices can be distinguished by their location in the
-USB hierarchy using @code{-P usb:@var{busdir}:@var{devicefile}}.
+USB hierarchy using @option{-P usb:@var{busdir}:@var{devicefile}}.
 
-For USBasp, multiple devices can also be also distinguished using @code{-P
-usb:@var{busdir}:@var{devicefile}} or using the serial number @code{-P
+For USBasp, multiple devices can also be also distinguished using @option{-P
+usb:@var{busdir}:@var{devicefile}} or using the serial number @option{-P
 usb:@var{serialno}}. The USBasp serial number is matched from the end, so
 only the unique least significant bytes are needed. For examples, see the
 respective entry in @ref{Troubleshooting}.
@@ -941,59 +941,59 @@ Note: IPv6 hostnames and addresses are limited to Posix systems.
 
 @item -r
 @item --reconnect
-@cindex Option @code{-r}
-@cindex Option @code{--reconnect}
-@cindex @code{-r}
-@cindex @code{--reconnect}
+@cindex Option @option{-r}
+@cindex Option @option{--reconnect}
+@cindex @option{-r}
+@cindex @option{--reconnect}
 Opens the serial port at 1200 baud and immediately closes it, waits 400 ms
-for each @code{-r} on the command line and then establishes communication
+for each @option{-r} on the command line and then establishes communication
 with the programmer. This is commonly known as a "1200@w{ }bps touch", and is
 used to trigger programming mode for certain boards like Arduino Leonardo,
 Arduino Micro/Pro Micro and the Arduino Nano Every. Longer waits, and
-therefore multiple @code{-r} options, are sometimes needed for slower, less
+therefore multiple @option{-r} options, are sometimes needed for slower, less
 powerful hosts.
 
 @item -q
 @item --quell
-@cindex Option @code{-q}
-@cindex Option @code{--quell}
-@cindex @code{-q}
-@cindex @code{--quell}
+@cindex Option @option{-q}
+@cindex Option @option{--quell}
+@cindex @option{-q}
+@cindex @option{--quell}
 Disable (or quell) output of the progress bar while reading or writing
 to the device.  Specify it a second time for even quieter operation.
 
 @item -T @var{cmd}
 @item --command @var{cmd}
-@cindex Option @code{-T} @var{cmd}
-@cindex Option @code{--command} @var{cmd}
-@cindex @code{-T} @var{cmd}
-@cindex @code{--command} @var{cmd}
+@cindex Option @option{-T} @var{cmd}
+@cindex Option @option{--command} @var{cmd}
+@cindex @option{-T} @var{cmd}
+@cindex @option{--command} @var{cmd}
 Run terminal line @var{cmd} when it is its turn in relation to other
-@code{-t} interactive terminals, @code{-T} terminal commands and
-@code{-U} memory operations. Except for the simplest of terminal commands
+@option{-t} interactive terminals, @option{-T} terminal commands and
+@option{-U} memory operations. Except for the simplest of terminal commands
 the argument @var{cmd} will most likely need to be set in quotes, see your
 OS shell manual for details. See below for a detailed description of all
 terminal commands.
 
 @item -t
 @item --terminal
-@cindex Option @code{-t}
-@cindex Option @code{--terminal}
-@cindex @code{-t}
-@cindex @code{--terminal}
+@cindex Option @option{-t}
+@cindex Option @option{--terminal}
+@cindex @option{-t}
+@cindex @option{--terminal}
 Tells AVRDUDE to run an interactive terminal when it is its turn in
-relation to other @code{-t} interactive terminals, @code{-T}
-terminal commands and @code{-U} memory operations.
+relation to other @option{-t} interactive terminals, @option{-T}
+terminal commands and @option{-U} memory operations.
 
 @item -U @var{mem}:@var{op}:@var{file}[:@var{fmt}]
 @item --memory @var{mem}:@var{op}:@var{fil}[:@var{fmt}]
-@cindex Option @code{-U} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
-@cindex Option @code{--memory} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
-@cindex @code{-U} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
-@cindex @code{--memory} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
+@cindex Option @option{-U} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
+@cindex Option @option{--memory} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
+@cindex @option{-U} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
+@cindex @option{--memory} @var{mem}:@var{op}:@var{file}[:@var{fmt}]
 
 Perform a memory operation when it is its turn in relation to other
-@code{-t} interactive terminals, @code{-T} terminal commands and @code{-U}
+@option{-t} interactive terminals, @option{-T} terminal commands and @option{-U}
 memory operations. The @var{mem} field specifies the memory type to
 operate on. From version 8.0 the memory field can also be a
 comma-separated list of memories, eg, @code{flash,eeprom}; also, Intel Hex
@@ -1032,13 +1032,13 @@ in the sense that it is normally only possible to program bits to change
 from 1 to 0. Before reprogramming takes place normally flash memory has to
 be erased. Older parts would only offer a chip erase to do so, which also
 erases EEPROM unless a fuse configuration preserves its contents. If
-AVRDUDE detects a @code{-U} option that writes to a flash memory it might
+AVRDUDE detects a @option{-U} option that writes to a flash memory it might
 automatically trigger a chip erase for these older parts. See the
-description of auto-erase under the @code{-e} option above. ATxmegas or
+description of auto-erase under the @option{-e} option above. ATxmegas or
 UPDI parts (AVR8X family) offer a page erase, and AVRDUDE takes advantage
-of that by erasing pages before programming them unless @code{-e} (chip
-erase) or @code{-D} (do not erase before writing) was requested. It should
-be noted that in absence of the @code{-e} chip erase option any ATxmega or
+of that by erasing pages before programming them unless @option{-e} (chip
+erase) or @option{-D} (do not erase before writing) was requested. It should
+be noted that in absence of the @option{-e} chip erase option any ATxmega or
 UPDI flash pages not affected by the programming will retain their
 previous content.
 
@@ -1154,52 +1154,52 @@ When reading any kind of flash memory area (including the various sub-areas
 in Xmega devices), the resulting output file will be truncated to not contain
 trailing 0xFF bytes which indicate unprogrammed (erased) memory. Thus, if the
 entire memory is unprogrammed, this will result in an output file that has no
-contents at all. This behaviour can be overridden with the @code{-A} option.
+contents at all. This behaviour can be overridden with the @option{-A} option.
 
 @cindex @code{flash}
-As an abbreviation, the form @code{-U} @var{file}
+As an abbreviation, the form @option{-U} @var{file}
 is equivalent to specifying
-@code{-U} @emph{flash:w:}@var{file}@emph{:a} or
-@code{-U} @emph{application:w:}@var{file}@emph{:a} for ATxmegas.
+@option{-U} @emph{flash:w:}@var{file}@emph{:a} or
+@option{-U} @emph{application:w:}@var{file}@emph{:a} for ATxmegas.
 This will only work if @var{file} does not have a pair of colons in it
 that sandwich a single character as otherwise the first part might be
 interpreted as memory, and the single character as memory operation.
 
 A file  name  used for writing to flash that starts with @code{urboot:}
-autogenerates a read-only urboot bootloader file. Try for example @code{-c
+autogenerates a read-only urboot bootloader file. Try for example @option{-c
 dryrun -U urboot:help} for a list of features that determine the contents
 of the bootloader. @xref{Autogenerated Files} for detailed documentation.
-Writing @code{urboot:...} files to flash using @code{-U} has the desired
+Writing @code{urboot:...} files to flash using @option{-U} has the desired
 side-effect of also writing all necessary fuse configurations for the
 bootloader to work.
 
 @item -v
 @item --verbose
-@cindex Option @code{-v}
-@cindex Option @code{--verbose}
-@cindex @code{-v}
-@cindex @code{--verbose}
+@cindex Option @option{-v}
+@cindex Option @option{--verbose}
+@cindex @option{-v}
+@cindex @option{--verbose}
 Enable verbose output.
-More @code{-v} options increase verbosity level.
+More @option{-v} options increase verbosity level.
 
 @item -V
 @item --noverify-memory
-@cindex Option @code{-V}
-@cindex Option @code{--noverify-memory}
-@cindex @code{-V}
-@cindex @code{--noverify-memory}
-Disable automatic verify check when writing data to the AVR with @code{-U}.
+@cindex Option @option{-V}
+@cindex Option @option{--noverify-memory}
+@cindex @option{-V}
+@cindex @option{--noverify-memory}
+Disable automatic verify check when writing data to the AVR with @option{-U}.
 
 @item --version
-@cindex Option @code{--version}
+@cindex Option @option{--version}
 Print avrdude version and exit
 
 @item -x @var{parameter}
 @item --extended @var{parameter}
-@cindex Option @code{-x} @var{parameter}
-@cindex Option @code{--extended} @var{parameter}
-@cindex @code{-x} @var{parameter}
-@cindex @code{--extended} @var{parameter}
+@cindex Option @option{-x} @var{parameter}
+@cindex Option @option{--extended} @var{parameter}
+@cindex @option{-x} @var{parameter}
+@cindex @option{--extended} @var{parameter}
 Pass @var{parameter} to the chosen programmer implementation as
 an extended parameter.  The interpretation of the extended parameter
 depends on the programmer itself.  See below for a list of programmers
@@ -1209,10 +1209,10 @@ several times on the command line.
 
 @item -h
 @item --help
-@cindex Option @code{-h}
-@cindex Option @code{--help}
-@cindex @code{-h}
-@cindex @code{--help}
+@cindex Option @option{-h}
+@cindex Option @option{--help}
+@cindex @option{-h}
+@cindex @option{--help}
 Show a short help text and exit
 
 @end table
@@ -1226,22 +1226,22 @@ Show a short help text and exit
 @cindex Programmers accepting exitspec parameters
 
 @cindex FLIP bootloader
-@cindex Option @code{-x} flip2
-@cindex @code{-x} flip2
-@cindex Option @code{-x} linuxspi
-@cindex @code{-x} linuxspi
-@cindex Option @code{-x} linuxgpio
-@cindex @code{-x} linuxgpio
-@cindex Option @code{-x} raspberry_pi_gpio
-@cindex @code{-x} raspberry_pi_gpio
-@cindex Option @code{-x} parallel port programmers
-@cindex @code{-x} parallel port programmers
+@cindex Option @option{-x} flip2
+@cindex @option{-x} flip2
+@cindex Option @option{-x} linuxspi
+@cindex @option{-x} linuxspi
+@cindex Option @option{-x} linuxgpio
+@cindex @option{-x} linuxgpio
+@cindex Option @option{-x} raspberry_pi_gpio
+@cindex @option{-x} raspberry_pi_gpio
+@cindex Option @option{-x} parallel port programmers
+@cindex @option{-x} parallel port programmers
 
 Currently, the @code{flip2}, @code{linuxspi}, @code{linuxgpio}, @code{raspberry_pi_gpio},
 @code{pickit4_mplab}, @code{pickit5} and old-school parallel port programmers such
-as @code{stk200} and @code{dapa} support @code{-E} exitspec parameter options.
+as @code{stk200} and @code{dapa} support @option{-E} exitspec parameter options.
 These let the user decide in which state the programmer pins after ended
-programming session. AVRDUDE only allows one @code{-E} option. However,
+programming session. AVRDUDE only allows one @option{-E} option. However,
 multiple exitspec parameters can be specified as one comma-separated list.
 
 @table @code
@@ -1255,8 +1255,8 @@ multiple exitspec parameters can be specified as one comma-separated list.
 @item help
 Show help menu and exit.
 
-@cindex Option @code{-E} reset
-@cindex @code{-E} reset
+@cindex Option @option{-E} reset
+@cindex @option{-E} reset
 @item reset
 The `/RESET' signal will be left activated at program exit, that is it
 will be held low, in order to keep the MCU in reset state afterwards.
@@ -1267,8 +1267,8 @@ a previous invocation of AVRDUDE with this option specified is one of
 the possible ways to guarantee this condition. @code{flip2} will not
 exit bootloader mode at program exit if @code{reset} is used.
 
-@cindex Option @code{-E} noreset
-@cindex @code{-E} noreset
+@cindex Option @option{-E} noreset
+@cindex @option{-E} noreset
 @item noreset
 The `/RESET' line will be deactivated at program exit, thus allowing the
 MCU target program to run while the programming hardware remains
@@ -1277,44 +1277,44 @@ start the application if @code{noreset} is used, and this is the default
 behaviour for this bootloader.
 @end table
 
-@cindex Option @code{-x} parallel port programmers
-@cindex @code{-x} parallel port programmers
+@cindex Option @option{-x} parallel port programmers
+@cindex @option{-x} parallel port programmers
 @item Parallel port programmers
 
 @table @code
-@cindex Option @code{-E} vcc
-@cindex @code{-E} vcc
+@cindex Option @option{-E} vcc
+@cindex @option{-E} vcc
 @item vcc
 This option will leave those parallel port pins active (i. e. high) that
 can be used to supply `Vcc' power to the MCU.
 
-@cindex Option @code{-E} novcc
-@cindex @code{-E} novcc
+@cindex Option @option{-E} novcc
+@cindex @option{-E} novcc
 @item novcc
 This option will pull the `Vcc' pins of the parallel port down at
 program exit.
 
-@cindex Option @code{-E} d_high
-@cindex @code{-E} d_high
+@cindex Option @option{-E} d_high
+@cindex @option{-E} d_high
 @item d_high
 This option will leave the 8 data pins on the parallel port active
 (i.e. high).
 
-@cindex Option @code{-E} d_low
-@cindex @code{-E} d_low
+@cindex Option @option{-E} d_low
+@cindex @option{-E} d_low
 @item d_low
 This option will leave the 8 data pins on the parallel port inactive
 (i.e. low).
 @end table
 
-@cindex Option @code{-x} pickit4_mplab, pickit5
-@cindex @code{-x} pickit4_mplab, pickit5
+@cindex Option @option{-x} pickit4_mplab, pickit5
+@cindex @option{-x} pickit4_mplab, pickit5
 @item Pickit 4 (MPLAB)
 @itemx Pickit 5
 
 @table @code
-@cindex Option @code{-E} vcc
-@cindex @code{-E} vcc
+@cindex Option @option{-E} vcc
+@cindex @option{-E} vcc
 @item vcc
 This option will leave the power supply from the programmer enabled after
 avrdude finished the operation. Disabled by default.
@@ -1332,20 +1332,20 @@ avrdude finished the operation. Disabled by default.
 @cindex Programmers accepting extended parameters
 
 Extended parameters are programmer-specific options; they all start with
-@code{-x}. Generally, each programmer will allow @code{-x help}, which
+@option{-x}. Generally, each programmer will allow @option{-x help}, which
 will show a help menu of known extended parameters for this programmer, if
 any, and exit. The extended parameters below are all shown without the
-necessary @code{-x} option lead-in. AVRDUDE allows any number of @code{-x}
+necessary @option{-x} option lead-in. AVRDUDE allows any number of @option{-x}
 extended parameters to be specified on the command line.
 
 @table @code
 
 @cindex Emulating a bootloader (dryboot)
 @cindex Emulating a HW programmer (dryrun)
-@cindex Option @code{-x} dryboot
-@cindex @code{-x} dryboot
-@cindex Option @code{-x} dryrun
-@cindex @code{-x} dryrun
+@cindex Option @option{-x} dryboot
+@cindex @option{-x} dryboot
+@cindex Option @option{-x} dryrun
+@cindex @option{-x} dryrun
 @item dryrun
 @itemx dryboot
 
@@ -1388,13 +1388,13 @@ The dryrun and dryboot programmers accept the following parameters:
 The patterns that are used for initialising memories as detailed above are
 human-readable. These patterns can best be seen with a fixed-width font
 and the @code{:I} format by inspecting the generated hex file or by using,
-eg, @code{-U flash:r:-:I} to dump the patterns on screen.  @code{eeprom},
+eg, @option{-U flash:r:-:I} to dump the patterns on screen.  @code{eeprom},
 @code{userrow}/@code{usersig} and @code{bootrow} memories are filled with
 pangrams such as The quick brown fox jumps over the lazy dog. Choose a
 fixed seed for reproducible results.
 
 @item init=@var{n}
-Shortcut for @code{-x init -x seed=@var{n}} (see below)
+Shortcut for @option{-x init -x seed=@var{n}} (see below)
 
 @cindex @code{flash}
 @item random
@@ -1406,7 +1406,7 @@ seed for reproducible results.
 
 @cindex @code{flash}
 @item random=@var{n}
-Shortcut for @code{-x random -x seed=@var{n}}
+Shortcut for @option{-x random -x seed=@var{n}}
 
 @cindex @code{flash}
 @item holes
@@ -1423,18 +1423,18 @@ different avrdude runs.
 
 @end table
 
-@cindex Option @code{-x} JTAG ICE mkII/3
-@cindex @code{-x} JTAG ICE mkII/3
-@cindex Option @code{-x} Atmel-ICE
-@cindex @code{-x} Atmel-ICE
-@cindex Option @code{-x} PICkit 4
-@cindex @code{-x} PICkit 4
-@cindex Option @code{-x} MPLAB(R) SNAP
-@cindex @code{-x} MPLAB(R) SNAP
-@cindex Option @code{-x} Power Debugger
-@cindex @code{-x} Power Debugger
-@cindex Option @code{-x} AVR Dragon
-@cindex @code{-x} AVR Dragon
+@cindex Option @option{-x} JTAG ICE mkII/3
+@cindex @option{-x} JTAG ICE mkII/3
+@cindex Option @option{-x} Atmel-ICE
+@cindex @option{-x} Atmel-ICE
+@cindex Option @option{-x} PICkit 4
+@cindex @option{-x} PICkit 4
+@cindex Option @option{-x} MPLAB(R) SNAP
+@cindex @option{-x} MPLAB(R) SNAP
+@cindex Option @option{-x} Power Debugger
+@cindex @option{-x} Power Debugger
+@cindex Option @option{-x} AVR Dragon
+@cindex @option{-x} AVR Dragon
 @cindex Atmel JTAG ICE mkII
 @cindex JTAG ICE mkII
 @cindex Atmel AVR JTAGICE3
@@ -1475,7 +1475,7 @@ Other JTAG units might require a different bit shift count.
 @var{Power Debugger and Pickit 4 only}
 @*
 High-voltage UPDI programming is used to enable a UPDI pin that has previously
-been set to RESET or GPIO mode. Use @code{-x hvupdi} to enable high-voltage UPDI
+been set to RESET or GPIO mode. Use @option{-x hvupdi} to enable high-voltage UPDI
 initialization for supported targets.
 
 @item vtarg
@@ -1489,10 +1489,10 @@ The voltage generator can be enabled by setting a target voltage.
 
 @end table
 
-@cindex Option @code{-x} PICkit 4
-@cindex @code{-x} PICkit 4
-@cindex Option @code{-x} MPLAB(R) SNAP
-@cindex @code{-x} MPLAB(R) SNAP
+@cindex Option @option{-x} PICkit 4
+@cindex @option{-x} PICkit 4
+@cindex Option @option{-x} MPLAB(R) SNAP
+@cindex @option{-x} MPLAB(R) SNAP
 @cindex MPLAB(R) PICkit 4
 @cindex MPLAB(R) SNAP
 @cindex SNAP
@@ -1510,11 +1510,11 @@ Switch programmer to AVR mode, then exit unless it was already in AVR mode
 Switch programmer to MPLAB aka PIC mode, then exit
 @end table
 
-Use @code{-x mode=avr} for switching to AVR mode, or
-@code{-x mode=mplab} for switching (back) to MPLAB mode.
+Use @option{-x mode=avr} for switching to AVR mode, or
+@option{-x mode=mplab} for switching (back) to MPLAB mode.
 
-@cindex Option @code{-x} PICkit 5
-@cindex @code{-x} PICkit 5
+@cindex Option @option{-x} PICkit 5
+@cindex @option{-x} PICkit 5
 @cindex MPLAB(R) PICkit 4
 @cindex PICkit 4
 @cindex MPLAB(R) PICkit 5
@@ -1534,16 +1534,16 @@ of this range, it will terminate the operation. You can disable this check by
 setting the voltage to 0@w{ }V. If an XMEGA part was selected, a requested voltage
 above 3.49@w{ }V will lead to an abort of operation.
 Usually, the programmer will stop providing power when the session ends.
-To continue to power the target you can use the @code{-E vcc} option.
+To continue to power the target you can use the @option{-E vcc} option.
 @item hvupdi
 High-voltage UPDI programming is used to enable a UPDI pin that has previously
-been set to RESET or GPIO mode. Use @code{-x hvupdi} to enable high-voltage UPDI
+been set to RESET or GPIO mode. Use @option{-x hvupdi} to enable high-voltage UPDI
 initialization for supported targets. Depending on the target, the HV pulse will
 be applied either on the RST pin, or the UPDI pin.
 @end table
 
-@cindex Option @code{-x} Xplained Mini
-@cindex @code{-x} Xplained Mini
+@cindex Option @option{-x} Xplained Mini
+@cindex @option{-x} Xplained Mini
 @cindex Atmel XplainedMini
 @cindex XplainedMini
 @item Xplained Mini
@@ -1554,7 +1554,7 @@ following extended parameters:
 @table @code
 @item suffer=VALUE, @code{suffer}
 The SUFFER register allows the user to modify the behavior of the on-board mEDBG.
-The current state can be read by @code{-x suffer} alone.
+The current state can be read by @option{-x suffer} alone.
 @table @code
 @item Bit 7 ARDUINO:
 Adds control of extra LEDs when set to 0
@@ -1572,14 +1572,14 @@ Fuses are safe-masked when bit sent to 1. Fuses are unprotected when set to 0
 @table @code
 @item vtarg_switch=VALUE, @code{vtarg_switch}
 The on-board target voltage switch can be turned on or off by writing a 1 or
-a 0. The current state can be read by @code{-x vtarg_switch} alone.
+a 0. The current state can be read by @option{-x vtarg_switch} alone.
 Note that the target power switch will always be on after a power cycle.
 Also note that the smaller Xplained Nano boards does not have a target power switch.
 
 @end table
 
-@cindex Option @code{-x} Curiosity Nano
-@cindex @code{-x} Curiosity Nano
+@cindex Option @option{-x} Curiosity Nano
+@cindex @option{-x} Curiosity Nano
 @cindex Curiosity nano
 @item Curiosity Nano
 
@@ -1587,13 +1587,13 @@ The Curiosity Nano board accepts the following extended parameter:
 @table @code
 @item vtarg=VALUE, vtarg
 The generated on-board target voltage can be changed by specifying a new voltage.
-The current set-voltage can be read by @code{-x vtarg} alone.
+The current set-voltage can be read by @option{-x vtarg} alone.
 @end table
 
-@cindex Option @code{-x} STK500
-@cindex @code{-x} STK500
-@cindex Option @code{-x} STK600
-@cindex @code{-x} STK600
+@cindex Option @option{-x} STK500
+@cindex @option{-x} STK500
+@cindex Option @option{-x} STK600
+@cindex @option{-x} STK600
 @cindex Atmel STK500
 @cindex STK500
 @cindex Atmel STK600
@@ -1605,21 +1605,21 @@ The STK500 and STK600 boards accept the following extended parameters:
 @table @code
 @item vtarg=VALUE, vtarg
 The generated on-board target voltage can be changed by specifying a new voltage.
-The current set-voltage can be read by @code{-x vtarg} alone.
+The current set-voltage can be read by @option{-x vtarg} alone.
 @item fosc=VALUE[MHz|M|kHz|k|Hz|H], fosc
 Set the programmable oscillator frequency in MHz, kHz or Hz.
-The current frequency can be read by @code{-x fosc} alone.
+The current frequency can be read by @option{-x fosc} alone.
 @item varef=VALUE, varef
 The generated on-board analog reference voltage can be changed by specifying
 a new reference voltage. The current reference voltage can be read by
-@code{-x varef} alone.
+@option{-x varef} alone.
 @item varef[0,1]=VALUE, varef[0,1]
 @var{STK600 only}
 @*
 The generated on-board analog reference voltage for channel 0 or channel 1 can
 be changed by specifying a new reference voltage.
-The current reference voltage can be read by @code{-x varef0} or
-@code{-x varef1} alone.
+The current reference voltage can be read by @option{-x varef0} or
+@option{-x varef1} alone.
 @item attempts[=@var{1..99}]
 @var{STK500V1 only}
 @*
@@ -1632,8 +1632,8 @@ original STK500. Used by avrdude for the correct calculation of fosc and sck.
 
 @cindex Atmel bootloader (AVR109, AVR911)
 @cindex Bootloader (AVR109, AVR911)
-@cindex Option @code{-x} AVR109
-@cindex @code{-x} AVR109
+@cindex Option @option{-x} AVR109
+@cindex @option{-x} AVR109
 @item AVR109
 
 The AVR109 programmer type accepts the following extended parameter:
@@ -1642,8 +1642,8 @@ The AVR109 programmer type accepts the following extended parameter:
 Toggle RTS/DTR lines on port open to issue a hardware reset.
 @end table
 
-@cindex Option @code{-x} AVR910
-@cindex @code{-x} AVR910
+@cindex Option @option{-x} AVR910
+@cindex @option{-x} AVR910
 @cindex Atmel low-cost programmer AVR910
 @cindex Low-cost programmer AVR910
 @item AVR910
@@ -1666,8 +1666,8 @@ Use
 programmer creates errors during initial sequence.
 @end table
 
-@cindex Option @code{-x} Arduino
-@cindex @code{-x} Arduino
+@cindex Option @option{-x} Arduino
+@cindex @option{-x} Arduino
 @cindex Arduino bootloader
 @item Arduino
 
@@ -1683,14 +1683,14 @@ Do not toggle RTS/DTR lines on port open to prevent a hardware reset.
 @cindex Urboot bootloader
 @cindex Urclock programmer
 @cindex Urprotocol
-@cindex Option @code{-x} Urclock
-@cindex @code{-x} Urclock
+@cindex Option @option{-x} Urclock
+@cindex @option{-x} Urclock
 @item Urclock
 
 The urclock programmer type accepts the following extended parameters:
 @table @code
 @item showall
-Show all info for the connected part, then exit. The @code{-x show...} options
+Show all info for the connected part, then exit. The @option{-x show...} options
 below can be used to assemble a bespoke response consisting of a subset
 (or only one item) of all available relevant information about the
 connected part and bootloader.
@@ -1701,7 +1701,7 @@ Show a unique Urclock ID stored in either flash or EEPROM of the MCU, then exit.
 @item id=@var{E|F}.@var{addr}.@var{len}
 Historically, the Urclock ID was a six-byte unique little-endian number
 stored in Urclock boards at EEPROM address 257. The location of this
-number can be set by the @code{-x id=@var{E|F}.@var{addr}.@var{len}} extended parameter. @code{E}
+number can be set by the @option{-x id=@var{E|F}.@var{addr}.@var{len}} extended parameter. @code{E}
 stands for EEPROM and @code{F} stands for flash. A negative address addr counts
 from the end of EEPROM and flash, respectively. The length len of the
 Urclock ID can be between 1 and 8 bytes.
@@ -1712,7 +1712,7 @@ then exit. If the input file was stdin, the date will be that of the
 programming. Date and filename are part of the metadata that the urclock
 programmer stores by default in high flash just under the bootloader; see also
 @cindex @code{flash}
-@code{-x nometadata}.
+@option{-x nometadata}.
 @item showfilename
 Show the input filename (or title) of the last flash writing session, then exit.
 @item title=@var{string}
@@ -1775,7 +1775,7 @@ Write unchanged flash input files to the AVR and trim below the bootloader if
 needed. This is most useful when one has a backup of the full flash and
 wants to play that back onto the device. No metadata are written in this
 case and no vector patching happens either if it is a vector bootloader.
-However, for vector bootloaders, even under the option @code{-x restore} an
+However, for vector bootloaders, even under the option @option{-x restore} an
 input file will not be written to the AVR for which the reset vector does not point
 to the vector bootloader. This is to avoid loading an input file onto the
 device that would render the vector bootloader becoming unreachable after reset.
@@ -1802,14 +1802,14 @@ Do not support any metadata. The full flash besides the bootloader is
 available for the application. If the application is smaller than the
 available space then a metadata code byte @code{0xff} is stored
 nevertheless to indicate there are no further metadata available. In
-absence of @code{-x nometadata}, the default for the urclock programmer is
+absence of @option{-x nometadata}, the default for the urclock programmer is
 to write as much metadata (filename, data and store information) as the
 size of the application and the other extended options allow. The
-subtle difference between @code{-x nometadata} and @code{-x nostore} is that
+subtle difference between @option{-x nometadata} and @option{-x nostore} is that
 the latter always explicitly stores in flash that no further metadata are
 available, so that a such prepared flash can always be queried with
 @code{avrdude -x showall}. In contrast to this, it cannot be guaranteed
-that a @code{-x showall} query on flash prepared with @code{-x nometadata}
+that a @option{-x showall} query on flash prepared with @option{-x nometadata}
 yields useful results.
 @item noautoreset
 Do not toggle RTS/DTR lines on port open to prevent a hardware reset.
@@ -1821,11 +1821,11 @@ shortened accordingly.
 @item strict
 Urclock has a faster, but slightly different strategy than -c arduino to
 synchronise with the bootloader; some stk500v1 bootloaders cannot cope
-with this, and they need the @code{-x strict} option.
+with this, and they need the @option{-x strict} option.
 @end table
 
-@cindex Option @code{-x} BusPirate
-@cindex @code{-x} BusPirate
+@cindex Option @option{-x} BusPirate
+@cindex @option{-x} BusPirate
 @cindex The Bus Pirate
 @cindex BusPirate
 @item BusPirate
@@ -1930,8 +1930,8 @@ The default value is 100 ms. Using 10 ms might work in most cases.
 
 @end table
 
-@cindex Option @code{-x} Micronucleus bootloader
-@cindex @code{-x} Micronucleus bootloader
+@cindex Option @option{-x} Micronucleus bootloader
+@cindex @option{-x} Micronucleus bootloader
 @cindex Micronucleus bootloader
 @item Micronucleus bootloader
 
@@ -1944,8 +1944,8 @@ If no time-out is specified, AVRDUDE will wait indefinitely until the
 device is plugged in.
 @end table
 
-@cindex Option @code{-x} Teensy bootloader
-@cindex @code{-x} Teensy bootloader
+@cindex Option @option{-x} Teensy bootloader
+@cindex @option{-x} Teensy bootloader
 @cindex Teensy bootloader
 @item Teensy bootloader
 
@@ -1958,8 +1958,8 @@ If no time-out is specified, AVRDUDE will wait indefinitely until the
 device is plugged in.
 @end table
 
-@cindex Option @code{-x} Wiring
-@cindex @code{-x} Wiring
+@cindex Option @option{-x} Wiring
+@cindex @option{-x} Wiring
 @cindex Wiring bootloader
 @item Wiring
 
@@ -1976,8 +1976,8 @@ negative, in which case the default 100 ms delay after issuing reset will
 be shortened accordingly.
 @end table
 
-@cindex Option @code{-x} PICkit2
-@cindex @code{-x} PICkit2
+@cindex Option @option{-x} PICkit2
+@cindex @option{-x} PICkit2
 @cindex Microchip PICkit 2 programmer
 @cindex PICkit 2 programmer
 @item PICkit2
@@ -2001,8 +2001,8 @@ Sets the SPI clocking rate in Hz (default is 100@w{ }kHz). Alternately the -B or
 Sets the timeout for USB reads and writes in milliseconds (default is 1500 ms).
 @end table
 
-@cindex Option @code{-x} USBasp
-@cindex @code{-x} USBasp
+@cindex Option @option{-x} USBasp
+@cindex @option{-x} USBasp
 @cindex USBasp ISP and TPI programmer
 @item USBasp
 
@@ -2015,8 +2015,8 @@ rather than entire chip.
 Only applicable to TPI devices (ATtiny 4/5/9/10/20/40).
 @end table
 
-@cindex Option @code{-x} xbee
-@cindex @code{-x} xbee
+@cindex Option @option{-x} xbee
+@cindex @option{-x} xbee
 @cindex XBeeBoot OTA bootloader
 @item xbee
 
@@ -2036,10 +2036,10 @@ the MCU's TXD line.
 
 @end table
 
-@cindex Option @code{-x} jtag2updi
-@cindex @code{-x} jtag2updi
-@cindex Option @code{-x} serialupdi
-@cindex @code{-x} serialupdi
+@cindex Option @option{-x} jtag2updi
+@cindex @option{-x} jtag2updi
+@cindex Option @option{-x} serialupdi
+@cindex @option{-x} serialupdi
 @cindex JTAGv2 to UPDI bridge
 @cindex SerialUPDI
 @item jtag2updi
@@ -2057,8 +2057,8 @@ When not provided, driver/OS default value will be used.
 
 @end table
 
-@cindex Option @code{-x} linuxspi
-@cindex @code{-x} linuxspi
+@cindex Option @option{-x} linuxspi
+@cindex @option{-x} linuxspi
 @cindex Linux /dev/spidev* programmer
 @item linuxspi
 
@@ -2071,8 +2071,8 @@ the CS line being managed outside the application.
 @end table
 
 @cindex Flashcom serprog protocol
-@cindex Option @code{-x} serprog
-@cindex @code{-x} serprog
+@cindex Option @option{-x} serprog
+@cindex @option{-x} serprog
 @item serprog
 
 The serprog programmer type accepts the following extended parameter:
@@ -2095,8 +2095,8 @@ This option allows to choose these additional CSes (1, 2, ...) for programming t
 
 AVRDUDE error messages, warnings and progress reports are generally
 written to stderr which can, in bash, be turned off by @code{2>/dev/null}
-or by using increasingly more @code{-q} options to suppress them. Terminal
-output of commands or that of the @code{-U} command with an output file
+or by using increasingly more @option{-q} options to suppress them. Terminal
+output of commands or that of the @option{-U} command with an output file
 named @code{-} are written to stdout. In some examples empty lines are
 shown for clarity that are not printed by AVRDUDE or the shell.
 
@@ -2120,7 +2120,7 @@ Avrdude done.  Thank you.
 @end smallexample
 
 @noindent
-Same but in @strong{quell-progress-reporting (silent) mode @code{-qq}:}
+Same but in @strong{quell-progress-reporting (silent) mode @option{-qq}:}
 
 @cindex @code{flash}
 @smallexample
@@ -2268,7 +2268,7 @@ $ avrdude -qq -cusbasp -pattiny13 -Ueeprom:r:-:i
 @end smallexample
 
 @noindent
-@strong{Same but redirect stderr (standard error output) to @code{/dev/null} instead of using @code{-qq}:}
+@strong{Same but redirect stderr (standard error output) to @code{/dev/null} instead of using @option{-qq}:}
 
 @smallexample
 @cartouche
@@ -2767,30 +2767,30 @@ knows the following options:
 @table @code
 
 @item -g
-Generate avr-gcc source: this sets @code{-sOFQ} and outputs a .text preamble and
-a main symbol unless the disassembly emits one itself; @code{-G} (default)
-switches off @code{-g} and stops outputting a preamble
+Generate avr-gcc source: this sets @option{-sOFQ} and outputs a .text preamble and
+a main symbol unless the disassembly emits one itself; @option{-G} (default)
+switches off @option{-g} and stops outputting a preamble
 
 @item -A
-Do not show addresses; @code{-a} (the default) shows addresses
+Do not show addresses; @option{-a} (the default) shows addresses
 
 @item -O
-Do not show opcode bytes; @code{-o} (the default) show opcode bytes
+Do not show opcode bytes; @option{-o} (the default) show opcode bytes
 
 @item -C
-Do not show comments; @code{-c} (the default) show comments
+Do not show comments; @option{-c} (the default) show comments
 
 @item -f
-Show affected flags in SREG, eg, @code{---SVNZC} for the @code{sbiw}
-opcode; @code{-F} (the default) do not show SREG flags
+Show affected flags in SREG, eg, @option{---SVNZC} for the @code{sbiw}
+opcode; @option{-F} (the default) do not show SREG flags
 
 @item -q
-Show the number of machine cycles that an opcode takes; @code{-Q}
+Show the number of machine cycles that an opcode takes; @option{-Q}
 (the default) do not show the cycles
 
 @item -n
 Put the opcode full name into comment (eg, subtract immediate from word);
-@code{-N} (the default) do not show the full opcode names
+@option{-N} (the default) do not show the full opcode names
 
 @item -e
 Put a technical explanation of the opcode into the comment, eg,
@@ -2799,18 +2799,18 @@ default) do not show technical explanations
 
 @item -S
 Use AVR instruction set style: this means that register pairs are shown
-as, eg, in r31:30 instead of r30; @code{-s} (the default) use avr-gcc code
+as, eg, in r31:30 instead of r30; @option{-s} (the default) use avr-gcc code
 style
 
 @item -L
-Do not preprocess labels; @code{-l} (the default) preprocess jump/call
+Do not preprocess labels; @option{-l} (the default) preprocess jump/call
 labels
 
 @item -U
-Do not show unused labels; @code{-u} (the default) show unused tagged labels
+Do not show unused labels; @option{-u} (the default) show unused tagged labels
 
 @item -d
-Decode all opcodes including those that are undocumented; @code{-D} (the
+Decode all opcodes including those that are undocumented; @option{-D} (the
 default) decode only opcodes that are valid for the part
 
 @item -z
@@ -2961,7 +2961,7 @@ flash urboot:help} for a list of features that determine the contents of
 the bootloader. @xref{Autogenerated Files} for detailed documentation. It
 is worth noting here that writing @code{urboot:...} files to flash in the
 terminal does @emph{not} write the necessary fuses for the bootloader to
-work (in contrast to @code{-U} operations).
+work (in contrast to @option{-U} operations).
 
 For integers, an optional case-insensitive suffix specifies the data size:
 
@@ -3042,7 +3042,7 @@ Backup one or more memories to the specified file using the selected
 format. The default format for a single-memory backup is @code{:r} (raw
 binary); for multi-memory backups it is @code{:I} (Intel Hex with
 comments). @var{Memlist} can be a comma separated list of memories just as
-in the @code{-U} command line argument. @code{backup} flushes the cache
+in the @option{-U} command line argument. @code{backup} flushes the cache
 before reading memories.
 
 @item restore @var{memlist} @var{file[:format]}
@@ -3054,7 +3054,7 @@ cannot set bits to 1 (eg, flash under most programmers). These memories
 need to be erased beforehand using the erase command (see below). The
 format only needs to be specified if it cannot be automatically detected,
 eg, when the file is @code{-} for standard input. @var{Memlist} can be a
-comma separated list of memories just as in the @code{-U} command line
+comma separated list of memories just as in the @option{-U} command line
 argument. @code{restore} flushes the cache before writing memories and
 resets the cache after writing memories. Note that restoring read-only
 memories verifies file contents with the corresponding microprocessor's
@@ -3063,7 +3063,7 @@ memories.
 @item verify @var{memlist} @var{file[:format]}
 @cindex @code{verify} @var{memlist} @var{file[:format]}
 Compare one or more memories with the specified file. Memlist can be a
-comma separated list of memories just as in the @code{-U} command line
+comma separated list of memories just as in the @option{-U} command line
 argument. @code{verify} flushes the cache before verifying memories.
 
 @cindex @code{erase}
@@ -3118,12 +3118,12 @@ usersig cache.
 Show all configuration properties of the part; these are usually bitfields
 in fuses or lock bits bytes that can take on values, which typically have
 a mnemonic name. Each part has their own set of configurable items.  The
-option @code{-f} groups the configuration properties by the fuses and lock
+option @option{-f} groups the configuration properties by the fuses and lock
 bits byte they are housed in, and shows the current value of these
-memories as well. Config @code{-a} outputs an initialisation script with
+memories as well. Config @option{-a} outputs an initialisation script with
 all properties and all possible respective assignments. The currently
 assigned mnemonic values are the ones that are not commented out. The
-option @code{-v} increases the verbosity of the output of the config
+option @option{-v} increases the verbosity of the output of the config
 command.
 
 @item config @var{[-f|-v]} @var{property} @var{[-f|-v]}
@@ -3147,9 +3147,9 @@ point the fuses and lock bits are utilised. Value can either be a valid
 integer or one of the symbolic mnemonics, if known. Wildcards or initial
 strings are permitted for either the property or the assigned mnemonic
 value, but an assignment only happens if both the property and the name
-can be uniquely resolved. Option @code{-v} shows the value of the assigned
+can be uniquely resolved. Option @option{-v} shows the value of the assigned
 configuration property by reading it again from the fuse. In absence of
-@code{-v} the option @code{-c} confirms the new value of the configuration
+@option{-v} the option @option{-c} confirms the new value of the configuration
 property only if it has changed.
 
 It is quite possible, as is with direct writing to the underlying fuses
@@ -3175,10 +3175,10 @@ part, i.e., all register names and their contents in  @code{io} memory, if
 possible: note that external programming cannot read the registers of
 classic parts (ISP or TPI interfaces).
 
-Option @code{-a} displays the register I/O addresses in addition;
-@code{-m} displays the register memory addresses used for
+Option @option{-a} displays the register I/O addresses in addition;
+@option{-m} displays the register memory addresses used for
 @code{lds}/@code{sts} opcodes instead of the I/O addresses. Option
-@code{-s} also shows the size of the register in bytes whilst @code{-v}
+@option{-s} also shows the size of the register in bytes whilst @option{-v}
 shows a slightly expanded register explanation alongside each register.
 
 @item regfile @var{[opts]} @var{reg} @var{[opts]}
@@ -3206,7 +3206,7 @@ memory is volatile, the contents will be lost after reset.
 @cindex @code{include} @var{[opts]} @var{file}
 Include contents of the named file @var{file} as if it was typed. This is
 useful for batch scripts, e.g., recurring initialisation code for fuses. The
-include option @code{-e} prints the lines of the file as comments before
+include option @option{-e} prints the lines of the file as comments before
 processing them; on a non-zero verbosity level the line numbers are
 printed, too.
 
@@ -3219,20 +3219,20 @@ Display the device signature bytes.
 @cindex Programming mode
 @cindex Variants of parts
 Display the current part information, including supported programming modes,
-memory and variants tables. Use @code{-m} to only print the memory table,
-and @code{-v} to only print the variants table.
+memory and variants tables. Use @option{-m} to only print the memory table,
+and @option{-v} to only print the variants table.
 
 @item verbose @var{[level]}
 @cindex @code{verbose} @var{[level]}
 Change (when @var{level} is provided), or display the verbosity
 level.
-The initial verbosity level is the number of @code{-v} options on the command line.
+The initial verbosity level is the number of @option{-v} options on the command line.
 
 @item quell @var{[level]}
 @cindex @code{quell} @var{[level]}
 Change (when @var{level} is provided), or display the quell level. 1 is
 used to suppress progress reports. 2 or higher yields progressively
-quieter operations. The initial quell level is the number of @code{-q}
+quieter operations. The initial quell level is the number of @option{-q}
 options on the command line.
 
 @item help
@@ -3321,7 +3321,7 @@ Turn the programming oscillator off.
 Set the SCK clock period to @var{period} microseconds.
 Note that some official Microchip programmers store the bitclock setting and
 will continue to use it until a diferent value is provided. See
-@code{-B bitclock} for more information.
+@option{-B bitclock} for more information.
 
 @item parms
 @cindex @code{parms}
@@ -3677,7 +3677,7 @@ L026:  .fill   493, 2, 0xffff
 @page
 
 @noindent
-@strong{Mixing terminal commands and @code{-U} memory operations:} the
+@strong{Mixing terminal commands and @option{-U} memory operations:} the
 example below burns a bootloader, uses a terminal line to write
 application data to flash, loads the application, configures the brownout
 detection level to 2.7 V and, finally, stores the full flash as new hex
@@ -3882,7 +3882,7 @@ The @code{modify} keyword makes most sense in the per-user configuration
 file, where users may want to add specific properties of their programmer.
 This could be its USB serial number or default port, eg, a serialadapter
 such as @code{"ch340"}. This technique must not be used in the system
-@code{avrdude.conf} file, as the developer option @code{-c <programmer>/S}
+@code{avrdude.conf} file, as the developer option @option{-c <programmer>/S}
 that prints the programmer definition as AVRDUDE understands it will only
 consider the final definition; it will not print @code{modify} statements.
 
@@ -4003,7 +4003,7 @@ serialadapter
 @end smallexample
 
 Technically, a @code{serialadapter} is implemented as @code{programmer}
-that has only USB parameters defined. It can be used for a @code{-P
+that has only USB parameters defined. It can be used for a @option{-P
 <serialadapter>[:<serial number>]} port specification instead of the
 created serial port. Per-user serialadapter definitions in
 @code{~/.avrduderc} or @code{avrdude.rc} files can add a serial number to
@@ -4019,7 +4019,7 @@ serialadapter parent "ft232r"
 
 @noindent
 This is particularly useful for programming through a bootloader as it
-allows specifying the port as @code{-P bike-shed-door} rather than having
+allows specifying the port as @option{-P bike-shed-door} rather than having
 to figure out which serial port name the operating system has assigned to
 the plugged in bike-shed-door board at runtime. Note that each programmer
 that defines @code{usbpid} and sets @code{is_serialadapter = yes} can also
@@ -4169,7 +4169,7 @@ modify part <id>
 The @code{modify} keyword makes most sense in the per-user configuration
 file, where users may want to modify specific properties of a part for
 debugging. This technique must not be used in the system
-@code{avrdude.conf} file, as the developer option @code{-p <part>/S} that
+@code{avrdude.conf} file, as the developer option @option{-p <part>/S} that
 prints the part definition as AVRDUDE understands it will only consider
 the final definition; it will not print @code{modify} statements.
 
@@ -4402,7 +4402,7 @@ Avrdude done.  Thank you.
 @end smallexample
 
 @noindent
-Note that using @code{urboot:...} in @code{-U} options has the desired
+Note that using @code{urboot:...} in @option{-U} options has the desired
 side effect of also setting all necessary fuse configurations for the
 bootloader to work correctly. This does @emph{not} happen when using the
 terminal @code{write} command, where the necessary fuse configurations
@@ -4469,7 +4469,7 @@ must be a multiple of flash pages or minimal boot section. These can be
 selected with the @code{best} feature. The @code{show} feature displays
 the properties of the bootloader that would be written without actually
 writing it; removing @code{show} will then write the bootloader to flash
-and, using @code{-U}, also set the necessary fuses:
+and, using @option{-U}, also set the necessary fuses:
 
 @smallexample
 @cartouche
@@ -4563,7 +4563,7 @@ For details on urboot bootloaders and their features see @url{https://github.com
 @end multitable
 
 @*@noindent
-Baud rate quantification errors are displayed with @code{-v}. A 0.79% baud
+Baud rate quantification errors are displayed with @option{-v}. A 0.79% baud
 rate error is considered OK for external oscillators but too high for
 internal oscillators. Hence, AVRDUDE selects software I/O when neither
 @code{uart} nor @code{swio} are explicitly requested:
@@ -4670,9 +4670,9 @@ L7ffe:  .byte   0xe6, 0x40           ; _@
 @page
 
 @noindent
-It is noteworthy that @code{-c dryboot} allows uploading of one urboot
-bootloader and, from that point onwards, emulates @code{-c urclock -x
-nometadata}. This means, eg, @code{-c dryboot} will not allow the
+It is noteworthy that @option{-c dryboot} allows uploading of one urboot
+bootloader and, from that point onwards, emulates @option{-c urclock -x
+nometadata}. This means, eg, @option{-c dryboot} will not allow the
 bootloader be overwritten:
 
 @cindex Emulating a bootloader (dryboot)
@@ -4706,7 +4706,7 @@ Avrdude done.  Thank you.
 @end smallexample
 
 @noindent
-More importantly, @code{-c dryboot} patches the vector table of any
+More importantly, @option{-c dryboot} patches the vector table of any
 to-be-uploaded sketch if the previously installed bootloader is an urboot
 vector bootloader just like @code{avrdude -c urclock -x nometadata} would;
 this is needed for the vector bootloader to work (for details, see the
@@ -4723,7 +4723,7 @@ L0064: 0c 94 34 00  jmp     0x0068
 @end smallexample
 
 @noindent
-In contrast, using @code{-c dryrun} does not patch the vector table of a
+In contrast, using @option{-c dryrun} does not patch the vector table of a
 sketch as it emulates and behaves like an external programmer:
 
 @smallexample
@@ -4741,7 +4741,7 @@ The following example prepares a patched sketch for upload through a
 self-written uploader or through urboot's dual boot. Note that @code{385}
 is the size of the bootloader plus 1 and that the generated file
 @code{blink-patched.hex} has the size of flash minus 384. In absence of
-the option @code{-A} AVRDUDE drops all trailing 0xff from the patched
+the option @option{-A} AVRDUDE drops all trailing 0xff from the patched
 sketch.
 
 @cindex Dual boot
@@ -5008,7 +5008,7 @@ programmers have LEDs and expect the host downloader/uploader to handle
 them, for example bit-banging programmers, ftdi-based programmers or
 linuxgpio programmers. For those programmers AVRDUDE provides support of
 four LEDs (RDY, ERR, PGM and VFY) which can be set via corresponding
-subroutines in the code for the respective @code{-c} programmer.
+subroutines in the code for the respective @option{-c} programmer.
 
 The RDY LED is set once the programmer is initialised and switched off
 when AVRDUDE exits. During reading, writing or erasing the target the PGM
@@ -5250,7 +5250,7 @@ node making the device usable for the currently logged-in user. When used
 in anger, udev rules must appear on one line; above example was broken
 into two lines so it fits into the example box.
 
-AVRDUDE's developer option @code{-c }@var{programmer}@code{/u} will show
+AVRDUDE's developer option @option{-c }@var{programmer}@code{/u} will show
 above suggested udev rule for the named programmer. Wildcards are allowed:
 
 @smallexample
@@ -5428,7 +5428,7 @@ are several ways to identify the correct port name:
 @itemize @bullet{}
 @item In the Windows Device Manager under Ports, then COM & LPT
 @item Enquiring @code{avrdude -P "?s"} if compiled with libserialport
-@item Use the serial adapter name instead of COMx, e.g., @code{-P ft232r}
+@item Use the serial adapter name instead of COMx, e.g., @option{-P ft232r}
 @end itemize
 
 @c
@@ -5582,10 +5582,10 @@ The pin mapping for the JTAG-to-ISP adapter is:
 @item
 Problem: Differentiate multiple USBtinyISP (or USBasp) programmers
 
-Solution: The @code{-c usbtiny} programmer distinguishes multiple physical
+Solution: The @option{-c usbtiny} programmer distinguishes multiple physical
 USBtinyISP devices based on their busdir:devicefile pairs that describe
 their place in the USB hierarchy on a specific host.  This pair can be
-specified in the @code{-P usb:@var{busdir}:@var{devicefile}} option. The
+specified in the @option{-P usb:@var{busdir}:@var{devicefile}} option. The
 naming convention for the bus and device depends on the operating system.
 Examples for Linux, FreeBSD and Windows, respectively:
 
@@ -5597,12 +5597,12 @@ $ avrdude -c usbtiny -p atmega8 \
 @end example
 
 The Windows device name contains the backslash file separator, so the
-@code{-P} option will need appropriate quoting on the command line, eg,
+@option{-P} option will need appropriate quoting on the command line, eg,
 in bash with single quotes.
 
-For USBasp the same @code{-P usb:@var{busdir}:@var{devicefile}} as with
+For USBasp the same @option{-P usb:@var{busdir}:@var{devicefile}} as with
 USBtiny selects the right device. Alternatively, USBasp can select the
-device via its serial number using @code{-P usb:@var{serialno}}.
+device via its serial number using @option{-P usb:@var{serialno}}.
 
 Note that @code{avrdude -v -P usb:xyz} will print out suitable programmers
 on the bus assuming xyz does not match any device.
@@ -5775,8 +5775,8 @@ sequence will succeed.
 
 As that slows down the entire subsequent ISP session, it might make
 sense to just issue a @emph{chip erase} using the slow ISP clock
-(option @code{-e}), and then start a new session at higher speed.
-Option @code{-D} might be used there, to prevent another unneeded
+(option @option{-e}), and then start a new session at higher speed.
+Option @option{-D} might be used there, to prevent another unneeded
 erase cycle.
 
 @end itemize
@@ -5790,7 +5790,7 @@ erase cycle.
 @cindex Programmers supported
 
 AVRDUDE supports the programmers below: the left column lists the
-programmer's id as used for @code{-c}, whilst the right column contains a
+programmer's id as used for @option{-c}, whilst the right column contains a
 short description and the list of available programming interfaces in
 brackets; see @ref{Programmer Definitions}. There is more detail about
 each programmer in the AVRDUDE configuration file.
@@ -5888,9 +5888,9 @@ ATmega(64|128|256|644|1284|2564)RFR2, have a usersig memory. Usersig is
 different to flash in the sense that it can neither be accessed with ISP
 serial programming nor written to by bootloaders. AVRDUDE offers JTAG
 programming of classic-part usersig memories. As with all flash-type
-memories the @code{-U} option can only write 0-bits but not 1-bits.
+memories the @option{-U} option can only write 0-bits but not 1-bits.
 Hence, usersig needs to be erased before a file can be written to this
-memory region, e.g., using @code{-T "erase usersig" -U
+memory region, e.g., using @option{-T "erase usersig" -U
 usersig:w:parameters.hex:i}
 @item io
 Volatile register memory; it cannot be accessed by external programming

--- a/src/update.c
+++ b/src/update.c
@@ -283,6 +283,13 @@ static int is_backup_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *
     mem_is_in_fuses(mem)? mem_is_fuses(mem) || !avr_locate_fuses(p): is_interesting_mem(pgm, p, mem);
 }
 
+// Whether a memory should be included in a test:... file: writeable memories plus signature
+static int is_test_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM *mem) {
+  return
+    mem_is_readonly(mem)? mem_is_signature(mem):
+    is_interesting_mem(pgm, p, mem);
+}
+
 // Add (not == 0) or subtract (not == 1) a memory from list
 static int memadd(AVRMEM **mlist, int nm, int not, AVRMEM *m) {
   for(int i = 0; i < nm; i++)
@@ -297,8 +304,8 @@ static int memadd(AVRMEM **mlist, int nm, int not, AVRMEM *m) {
 }
 
 /*
- * Generate a memory list from string mstr, part p and intended programming
- * modes pm; then put number of memories into *np.
+ * Generate a memory list from string mstr, programmer pgm, and part p; then
+ * put number of memories into *np.
  *
  * Memory list can be sth like ee,fl,all,-cal,efuse. -mem or /mem removes it
  * from the list. Normal use is to pass NULL for dry and let the function write
@@ -325,6 +332,10 @@ AVRMEM **memory_list(const char *mstr, const PROGRAMMER *pgm, const AVRPART *p, 
     } else if(str_eq(s, "all") || str_eq(s, "etc")) {
       for(LNODEID lm = lfirst(p->mem); lm; lm = lnext(lm))
         if(is_backup_mem(pgm, p, (m = ldata(lm))))
+          nm = memadd(umemlist, nm, not, m);
+    } else if(str_eq(s, "test")) {
+      for(LNODEID lm = lfirst(p->mem); lm; lm = lnext(lm))
+        if(is_test_mem(pgm, p, (m = ldata(lm))))
           nm = memadd(umemlist, nm, not, m);
     } else if(!*s) {            // Ignore empty list elements
     } else {


### PR DESCRIPTION
This PR provides a special memory `test` that expands to a list of all writable memories plus `signature`. That is going to be a useful shortcut for testing AVRDUDE and `-c` programmers.