### PR TITLE
Provide new testing tool  `test9`

### DIFF
--- a/tools/test9
+++ b/tools/test9
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Published under GNU General Public License, version 3 (GPL-3.0)
+# Author Stefan Rueger, 2026
+
+progname=$(basename "$0")
+adopts=()
+mem=test
+rand=$(shuf -i 1-1024 -n 1)
+avrdude_bin=avrdude
+
+Usage() {
+cat <<END
+Syntax: $progname [<opts>] <programmer> <part>
+Function: test AVRDUDE v 8.3 or later with -c programmer -p part; on
+  error leave the file log-<programmer>-<part>-<n>.txt for inspection
+Options:
+  -r <n>     Test using random contents seeded by <n>
+  -e <exe>   Path of the avrdude executable
+  -f         Emulate factory reset by erasing eeprom and flash only
+  -a <opt>   Pass option <opt> to avrdude; no space in <opt>, eg, -Pch340
+  -m <mlist> Use memory list <mlist> instead of test
+  -h         Show usage and exit
+
+Examples:
+    $ test9 avrisp2 t13a
+    $ test9 snap_isp m328p
+
+Note:
+  The contents of the chip will be overwritten with test data
+END
+}
+
+reset="factory reset"
+while getopts ":r:a:e:m:fh" opt; do
+  case ${opt} in
+     r) rand=0; [[ ! -z "$OPTARG" ]] && rand="$OPTARG"
+        ;;
+     a) if [[ ! -z "$OPTARG" ]]; then adopts+=("$OPTARG"); fi
+        ;;
+     e) avrdude_bin="$OPTARG"
+        ;;
+     f) reset="erase flash; erase eeprom; flush"
+        ;;
+     m) if [[ ! -z "$OPTARG" ]]; then mem="$OPTARG"; fi
+        ;;
+     h) Usage; exit 1
+        ;;
+    --) shift;
+        break
+        ;;
+   \?) echo "$progname: invalid option -$OPTARG" 1>&2
+       Usage; exit 1
+       ;;
+   : ) echo "$progname: invalid option -$OPTARG requires an argument" 1>&2
+       Usage; exit 1
+       ;;
+  esac
+done
+shift $((OPTIND -1))
+
+
+if [ $# -ne 2 ]; then
+  why=missing; [ $# -gt 2 ] && why="too many"
+  echo $progname: $why arguments
+  Usage
+  exit 1
+fi
+
+
+######
+# Test file
+
+how="random=$rand"
+tmem=${mem}_; [[ "$mem" == "test" ]] && tmem=""
+ftest="dry:$tmem${how}_holes"
+
+######
+# Actual test
+
+if ! $avrdude_bin "${adopts[@]}" -c "$1" -p "$2" -D -T "$reset" -U "$mem:w:$ftest"; then
+  echo -------------------------------
+  echo Re-running to create error logs
+  $avrdude_bin "${adopts[@]}" -vv -c "$1" -p "$2" -D -T "$reset" -U "$mem:w:$ftest" -l "log-$1-$2-$rand.txt"
+fi


### PR DESCRIPTION
`test9` uses autogenerated test files with holes. This makes programming more challenging and therefore testing more thorough. It also makes testing faster as only a fraction of flash is being written/read. The test protocol is easier than with `test8`. Just use `test9` *programmer* *part*  (no more preparing a part before testing):
```
$ test9 snap_isp m328p
```

I don't have *any* programmers or parts currently with me, but the output should look like
```
$ test9 dryrun m328p

Processing -T factory reset
performing chip erase; discarded pending writes to flash and EEPROM
Caching | ################################################## | 100% 0.00 s 
Caching | ################################################## | 100% 0.00 s 
after the next reset the part will have F_CPU = 1.000 MHz

Processing -U test:w:dry:random=631_holes:i
Reading 3259 bytes for multiple memories from input file dry:random=631_holes
Writing 518 bytes to eeprom
Writing | ################################################## | 100% 0.00 s 
Reading | ################################################## | 100% 0.00 s 
518 bytes of eeprom verified
Writing 2734 bytes to flash
Writing | ################################################## | 100% 0.00 s 
Reading | ################################################## | 100% 0.00 s 
2734 bytes of flash verified
Writing 1 byte (0x62) to lfuse, 1 byte written, 1 verified
Writing 1 byte (0xDF) to hfuse, 1 byte written, 1 verified
Writing 1 byte (0xFF) to efuse, 1 byte written, 1 verified
Writing 1 byte (0xFF) to lock, 1 byte written, 1 verified

Avrdude done.  Thank you.
```

Other than that, most options for `test8` carry over

```
$ test9 -h
Syntax: test9 [<opts>] <programmer> <part>
Function: test AVRDUDE v 8.3 or later with -c programmer -p part; on
  error leave the file log-<programmer>-<part>-<n>.txt for inspection
Options:
  -r <n>     Test using random contents seeded by <n>
  -e <exe>   Path of the avrdude executable
  -f         Emulate factory reset by erasing eeprom and flash only
  -a <opt>   Pass option <opt> to avrdude; no space in <opt>, eg, -Pch340
  -m <mlist> Use memory list <mlist> instead of test
  -h         Show usage and exit

Examples:
    $ test9 avrisp2 t13a
    $ test9 snap_isp m328p

Note:
  The contents of the chip will be overwritten with test data
```
Although one can still use `-r <n>` it is no longer recommended for standard testing. `test9` will use a random `<n>` for each test, and only if things go wrong write a log file (as before). As `<n>` is set randomly, testing sees a higher variety of flash configurations, and repeated tests do something slightly different (which is good), but as `<n>` is recorded, the failed tests can be reproduced (then using `-r <n>`).

@MCUdude and @mcuee, please try out the new tool and try to break it!