### PR TITLE
Silence MSVC C4146 in the verify loop

### DIFF
--- a/src/avr.c
+++ b/src/avr.c
@@ -1398,7 +1398,7 @@ int avr_verify_mem(const PROGRAMMER *pgm, const AVRPART *p, const AVRPART *v, co
       } else if((bdiff = (buf1[i] & bitmask) ^ (buf2[i] & bitmask))) {
         // Mismatch is not just in unused bits, loop over bit positions that differ
         for(unsigned int lbit; bdiff; bdiff ^= lbit) {
-           lbit = bdiff & -bdiff; // Lowest bit that differs
+           lbit = bdiff & (~bdiff + 1); // Lowest bit that differs (~x + 1 is -x without MSVC C4146)
            biterrs++;             // Number of bit mismatches
            bitsset += !!(lbit & buf1[i]); // The mismatched bit was set on device
         }


### PR DESCRIPTION
The MSVC build warns on the verify loop:

```
src\avr.c(1401,27): warning C4146: unary minus operator applied to unsigned type, result still unsigned
```

`bdiff & -bdiff` is the usual lowest-set-bit trick and `bdiff` is an `unsigned int`, so MSVC complains about the minus. `strutil.c` already works around the same warning with `~ret + 1`, so I used that spelling here too.

The value is the same for every input. I compared both versions over 0..0x1FFFF and a handful of edge cases including 0, 0x80000000 and 0xFFFFFFFF, and the loop walks the same bits in the same order.

Closes #2203
